### PR TITLE
SEO-OPS-ZH-ARTICLE-QUALITY-DRY-RUN-ADAPTER-01: Add zh article quality dry-run adapter

### DIFF
--- a/backend/app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php
@@ -1,0 +1,505 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class SeoOpsZhArticleQualityRepairDryRunCommand extends Command
+{
+    private const INPUT_SCHEMA = 'fermatmind-zh-article-quality-cms-repair-package.v1';
+
+    private const OUTPUT_SCHEMA = 'seo-ops-zh-article-quality-repair-dry-run.v1';
+
+    private const EXPECTED_OPERATION_COUNT = 9;
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'Cookie:',
+        'Set-Cookie:',
+        'content_html',
+        'content_md',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-ops:zh-article-quality-repair-dry-run
+        {--package= : Path to fermatmind-zh-article-quality-cms-repair-package.v1 JSON package}
+        {--confirm-package-sha256= : Expected SHA-256 of the source package}
+        {--artifact-dir= : Directory for read-only evidence output}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only backend authority dry-run for the zh-CN article quality repair package; writes evidence only.';
+
+    public function handle(): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary(['artifact_dir_unwritable']));
+        }
+
+        $loaded = $this->loadPackage();
+        if (($loaded['ok'] ?? false) !== true) {
+            $summary = $this->failureSummary((array) ($loaded['issues'] ?? ['package_unreadable']), [
+                'source_package' => $loaded['source_package'] ?? null,
+            ]);
+            $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        $package = (array) $loaded['package'];
+        $operations = array_values((array) ($package['operations'] ?? []));
+        $issues = $this->validatePackageShape($package, $operations);
+        $plans = array_map(fn (array $operation): array => $this->operationPlan($operation), $operations);
+
+        foreach ($plans as $plan) {
+            foreach ((array) ($plan['issues'] ?? []) as $issue) {
+                $issues[] = (string) $issue;
+            }
+        }
+
+        $issues = array_values(array_unique($issues));
+        $resolvedCount = count(array_filter($plans, static fn (array $plan): bool => (bool) ($plan['resolved'] ?? false)));
+        $headingReplacementCount = array_sum(array_map(
+            static fn (array $plan): int => (int) data_get($plan, 'planned_repair_counts.heading_replacements', 0),
+            $plans
+        ));
+        $linkReplacementCount = array_sum(array_map(
+            static fn (array $plan): int => (int) data_get($plan, 'planned_repair_counts.link_replacements', 0),
+            $plans
+        ));
+
+        $summary = [
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:zh-article-quality-repair-dry-run',
+            'ok' => $issues === [],
+            'status' => $issues === [] ? 'planned' : 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->utc()->toIso8601String(),
+            'source_package' => [
+                'path' => (string) $loaded['source_package_path'],
+                'sha256' => (string) $loaded['source_package_sha256'],
+                'schema' => (string) ($package['schema'] ?? ''),
+                'source_scan' => (string) ($package['source_scan'] ?? ''),
+                'source_scan_sha256' => (string) ($package['source_scan_sha256'] ?? ''),
+            ],
+            'authority_sources' => [
+                'article_quality_repair' => 'backend.articles + article_seo_meta + article_translation_revisions',
+            ],
+            'candidate_counts' => [
+                'package_operations' => count($operations),
+                'resolved_article_operations' => $resolvedCount,
+                'unresolved_article_operations' => count($operations) - $resolvedCount,
+            ],
+            'planned_ops_count' => [
+                'article_quality_repair_operations' => $resolvedCount,
+                'heading_replacements' => $headingReplacementCount,
+                'link_replacements' => $linkReplacementCount,
+                'total_replacements' => $headingReplacementCount + $linkReplacementCount,
+            ],
+            'protected_diff_summary' => [
+                'slug' => 'no_change',
+                'canonical' => 'no_change',
+                'locale' => 'no_change',
+                'article_id' => $resolvedCount === count($operations) ? 'resolved_no_change' : 'unresolved',
+                'publication' => 'no_change',
+                'schema' => 'hold_no_change',
+                'hreflang' => 'hold_no_change',
+                'sitemap' => 'no_change',
+                'llms' => 'no_change',
+                'search_submission' => 'hold_no_change',
+            ],
+            'article_operation_plans' => $plans,
+            'issues' => $issues,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+        $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+        return $this->finish($summary);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadPackage(): array
+    {
+        $path = $this->readablePath((string) $this->option('package'));
+        if ($path === null) {
+            return ['ok' => false, 'issues' => ['package_unreadable']];
+        }
+
+        $raw = (string) file_get_contents($path);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return [
+                'ok' => false,
+                'source_package' => ['path' => $path],
+                'issues' => ['forbidden_input_field_present'],
+                'forbidden_matches' => $forbidden,
+            ];
+        }
+
+        $actualSha = hash('sha256', $raw);
+        $expectedSha = trim((string) $this->option('confirm-package-sha256'));
+        if ($expectedSha === '' || ! hash_equals($expectedSha, $actualSha)) {
+            return [
+                'ok' => false,
+                'source_package' => [
+                    'path' => $path,
+                    'sha256' => $actualSha,
+                    'expected_sha256' => $expectedSha,
+                ],
+                'issues' => ['package_sha_mismatch'],
+            ];
+        }
+
+        try {
+            $package = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [
+                'ok' => false,
+                'source_package' => ['path' => $path, 'sha256' => $actualSha],
+                'issues' => ['package_json_invalid'],
+            ];
+        }
+
+        if (! is_array($package)) {
+            return [
+                'ok' => false,
+                'source_package' => ['path' => $path, 'sha256' => $actualSha],
+                'issues' => ['package_json_not_object'],
+            ];
+        }
+
+        if (($package['schema'] ?? null) !== self::INPUT_SCHEMA) {
+            return [
+                'ok' => false,
+                'source_package' => ['path' => $path, 'sha256' => $actualSha],
+                'issues' => ['package_schema_invalid'],
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'package' => $package,
+            'source_package_path' => $path,
+            'source_package_sha256' => $actualSha,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @param  array<int, mixed>  $operations
+     * @return array<int, string>
+     */
+    private function validatePackageShape(array $package, array $operations): array
+    {
+        $issues = [];
+        if (($package['schema'] ?? null) !== self::INPUT_SCHEMA) {
+            $issues[] = 'package_schema_invalid';
+        }
+        if ((int) ($package['operation_count'] ?? -1) !== self::EXPECTED_OPERATION_COUNT) {
+            $issues[] = 'package_operation_count_field_unexpected';
+        }
+        if (count($operations) !== self::EXPECTED_OPERATION_COUNT) {
+            $issues[] = 'package_operation_count_unexpected';
+        }
+        if (($package['negative_guarantees'] ?? null) !== null) {
+            foreach ((array) $package['negative_guarantees'] as $key => $value) {
+                if ($value !== false) {
+                    $issues[] = 'negative_guarantee_not_false:'.$key;
+                }
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $operation
+     * @return array<string, mixed>
+     */
+    private function operationPlan(array $operation): array
+    {
+        $path = (string) ($operation['path'] ?? '');
+        $slug = $this->slugFromArticlePath($path);
+        $locale = 'zh-CN';
+        $issues = [];
+
+        if ($slug === null) {
+            $issues[] = 'article_path_invalid:'.$path;
+        }
+
+        $article = $slug !== null
+            ? Article::query()
+                ->withoutGlobalScopes()
+                ->with([
+                    'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+                    'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+                    'workingRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+                ])
+                ->where('slug', $slug)
+                ->where('locale', $locale)
+                ->first()
+            : null;
+
+        if (! $article instanceof Article && $slug !== null) {
+            $issues[] = 'article_not_found:'.$slug.':'.$locale;
+        }
+
+        if ((bool) ($operation['cms_write_allowed_now'] ?? true) !== false) {
+            $issues[] = 'operation_cms_write_allowed_now_not_false:'.$path;
+        }
+
+        $seoMeta = $article?->seoMeta;
+        $currentCanonical = $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->canonical_url : null;
+        $currentCanonicalPath = $this->canonicalPath($currentCanonical) ?: $path;
+        $headingReplacements = array_values((array) ($operation['heading_replacements'] ?? []));
+        $linkReplacements = array_values((array) ($operation['link_replacements'] ?? []));
+
+        return [
+            'target' => $article instanceof Article ? 'article:'.(int) $article->id.':'.$locale : 'article:unresolved:'.$locale,
+            'path' => $path,
+            'slug' => $slug,
+            'locale' => $locale,
+            'resolved' => $article instanceof Article,
+            'authority_source' => 'backend.articles + article_seo_meta + article_translation_revisions',
+            'source_snapshot' => [
+                'path' => (string) ($operation['snapshot_path'] ?? ''),
+                'sha256' => (string) ($operation['snapshot_sha256'] ?? ''),
+            ],
+            'issue_codes' => array_values(array_filter(explode(';', (string) ($operation['issue_codes'] ?? '')))),
+            'current' => $article instanceof Article ? [
+                'article_id' => (int) $article->id,
+                'translation_group_id' => (string) $article->translation_group_id,
+                'title' => (string) $article->title,
+                'excerpt' => (string) $article->excerpt,
+                'seo_title' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->seo_title : null,
+                'seo_description' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->seo_description : null,
+                'canonical_url' => $currentCanonical,
+                'canonical_path' => $currentCanonicalPath,
+                'robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
+                'jsonld_total' => $seoMeta instanceof ArticleSeoMeta && is_array($seoMeta->schema_json) ? count($seoMeta->schema_json) : 0,
+                'status' => (string) $article->status,
+                'lifecycle_state' => $article->lifecycle_state,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'sitemap_eligible' => (bool) $article->sitemap_eligible,
+                'llms_eligible' => (bool) $article->llms_eligible,
+                'working_revision_id' => $article->working_revision_id,
+                'published_revision_id' => $article->published_revision_id,
+                'published_revision_status' => $article->publishedRevision?->revision_status,
+                'published_at' => optional($article->published_at)->toIso8601String(),
+            ] : null,
+            'planned_repairs' => [
+                'heading_replacements' => $this->sanitizeReplacements($headingReplacements),
+                'link_replacements' => $this->sanitizeReplacements($linkReplacements),
+            ],
+            'planned_repair_counts' => [
+                'heading_replacements' => count($headingReplacements),
+                'link_replacements' => count($linkReplacements),
+            ],
+            'protected_fields_from_package' => (array) ($operation['protected_fields'] ?? []),
+            'protected_diff' => [
+                'slug' => $this->diffItem($article instanceof Article ? (string) $article->slug : $slug, $slug, 'no_change'),
+                'canonical' => $this->diffItem($currentCanonicalPath, $currentCanonicalPath, 'no_change'),
+                'locale' => $this->diffItem($article instanceof Article ? (string) $article->locale : $locale, $locale, 'no_change'),
+                'article_id' => $article instanceof Article
+                    ? $this->diffItem((int) $article->id, (int) $article->id, 'resolved_no_change')
+                    : $this->diffItem(null, 'unresolved', 'unresolved'),
+                'translation_group_id' => $article instanceof Article
+                    ? $this->diffItem((string) $article->translation_group_id, (string) $article->translation_group_id, 'no_change')
+                    : $this->diffItem(null, 'unresolved', 'unresolved'),
+                'publication' => $this->diffItem($article instanceof Article ? (string) $article->status : null, 'unchanged', 'no_change'),
+                'schema' => $this->diffItem('current_gate_preserved', 'hold', 'hold_no_change'),
+                'hreflang' => $this->diffItem('current_gate_preserved', 'hold', 'hold_no_change'),
+                'sitemap' => $this->diffItem($article instanceof Article ? (bool) $article->sitemap_eligible : null, 'unchanged', 'no_change'),
+                'llms' => $this->diffItem($article instanceof Article ? (bool) $article->llms_eligible : null, 'unchanged', 'no_change'),
+                'search_submission' => $this->diffItem('not_attempted', 'hold', 'hold_no_change'),
+            ],
+            'operator_review_required' => (bool) ($operation['operator_review_required'] ?? false),
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $replacements
+     * @return array<int, array<string, mixed>>
+     */
+    private function sanitizeReplacements(array $replacements): array
+    {
+        return array_map(static fn ($replacement): array => [
+            'find' => (string) data_get($replacement, 'find', ''),
+            'replace_with' => (string) data_get($replacement, 'replace_with', ''),
+            'scope' => (string) data_get($replacement, 'scope', ''),
+        ], $replacements);
+    }
+
+    /**
+     * @param  array<int, string>  $issues
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(array $issues, array $extra = []): array
+    {
+        return array_replace([
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:zh-article-quality-repair-dry-run',
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->utc()->toIso8601String(),
+            'issues' => array_values(array_unique($issues)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ], $extra);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function writeEvidence(string $artifactDir, array $summary): ?array
+    {
+        File::ensureDirectoryExists($artifactDir);
+        $path = rtrim($artifactDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR
+            .'seo-ops-zh-article-quality-repair-dry-run-'.now()->utc()->format('Ymd\THis\Z').'.json';
+
+        $artifact = $summary;
+        unset($artifact['evidence']);
+        File::put($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'path' => $path,
+            'sha256' => hash_file('sha256', $path),
+            'bytes' => filesize($path) ?: 0,
+        ];
+    }
+
+    private function finish(array $summary): int
+    {
+        if ($this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } elseif (($summary['ok'] ?? false) === true) {
+            $this->info('ZH article quality repair dry-run planned: '.json_encode($summary['planned_ops_count'] ?? []));
+        } else {
+            $this->error('ZH article quality repair dry-run blocked: '.implode(', ', (array) ($summary['issues'] ?? [])));
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0") || ! is_file($path) || ! is_readable($path)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            return null;
+        }
+        if (! is_dir($dir)) {
+            File::ensureDirectoryExists($dir);
+        }
+
+        return is_dir($dir) && is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    private function slugFromArticlePath(string $path): ?string
+    {
+        $prefix = '/zh/articles/';
+        if (! str_starts_with($path, $prefix)) {
+            return null;
+        }
+
+        $slug = trim(substr($path, strlen($prefix)), '/');
+
+        return $slug !== '' && ! str_contains($slug, '/') ? $slug : null;
+    }
+
+    private function canonicalPath(?string $canonical): ?string
+    {
+        if ($canonical === null || trim($canonical) === '') {
+            return null;
+        }
+        $path = parse_url($canonical, PHP_URL_PATH);
+        if (is_string($path) && $path !== '') {
+            return $path;
+        }
+
+        return str_starts_with($canonical, '/') ? $canonical : null;
+    }
+
+    /**
+     * @param  mixed  $current
+     * @param  mixed  $proposed
+     * @return array<string, mixed>
+     */
+    private function diffItem($current, $proposed, string $change): array
+    {
+        return [
+            'current' => $current,
+            'proposed' => $proposed,
+            'change' => $change,
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_draft_create' => false,
+            'cms_publish' => false,
+            'url_truth_write' => false,
+            'schema_enable' => false,
+            'hreflang_enable' => false,
+            'sitemap_write' => false,
+            'llms_write' => false,
+            'search_channel_enqueue' => false,
+            'indexnow_submit' => false,
+            'baidu_submit' => false,
+            'gsc_request_indexing' => false,
+            'scheduler_start' => false,
+            'queue_worker_start' => false,
+            'external_api_call' => false,
+            'revalidation' => false,
+            'deploy' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -223,6 +223,7 @@ use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
 use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
 use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
+use App\Console\Commands\SeoOpsZhArticleQualityRepairDryRunCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
@@ -469,6 +470,7 @@ class Kernel extends ConsoleKernel
         SeoAgentWeeklyDraftWriteAutoCommand::class,
         SeoAgentWeeklyReadonlyRunnerCommand::class,
         SeoOpsP0CtrArticleCmsUpdateWriterCommand::class,
+        SeoOpsZhArticleQualityRepairDryRunCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -7298,7 +7298,7 @@
     "SEO-OPS-ZH-ARTICLE-QUALITY-DRY-RUN-ADAPTER-01": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "ci_fix_pushed",
       "branch": "codex/seo-ops-zh-article-quality-dry-run-adapter-01",
       "commit_sha": "pending_after_push",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2425",
@@ -7307,7 +7307,8 @@
         "focused_phpunit": "passed",
         "pint_touched_files": "passed",
         "contract_json_tool": "passed",
-        "git_diff_check": "passed"
+        "git_diff_check": "passed",
+        "bigfive_freeze_classifier_focused": "passed"
       },
       "failure_reason": null,
       "resume_policy": "manual_only",
@@ -7334,9 +7335,17 @@
           "at": "2026-06-25T00:00:00+08:00",
           "status": "pr_open",
           "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/2425."
+        },
+        {
+          "at": "2026-06-25T00:00:00+08:00",
+          "status": "ci_fix_pushed",
+          "summary": "Added BigFive runtime freeze classifier allowlist/test for the read-only SEO Ops zh article quality dry-run adapter after verify-bigfive identified the new command and Kernel registration."
         }
       ],
-      "updated_at": "2026-06-25T00:00:00+08:00"
+      "updated_at": "2026-06-25T00:00:00+08:00",
+      "github_checks": {
+        "verify-bigfive": "failed_before_ci_fix_current_pr_scope"
+      }
     }
   },
   "career_display_surface": {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-06-22T15:57:46+08:00",
+  "updated_at": "2026-06-25T00:00:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -7294,6 +7294,44 @@
         "d23b_workbook_sha256": "c30f8743cfd0d8baa14ac931cc7270807425164952f6a44953b5b4ab448778ef",
         "d23b_validation": "/tmp/d23b_schema_repair_validation.json"
       }
+    },
+    "SEO-OPS-ZH-ARTICLE-QUALITY-DRY-RUN-ADAPTER-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "committed",
+      "branch": "codex/seo-ops-zh-article-quality-dry-run-adapter-01",
+      "commit_sha": "pending_after_push",
+      "pr_url": "",
+      "checks": {
+        "php_artisan_list_rg": "passed",
+        "focused_phpunit": "passed",
+        "pint_touched_files": "passed",
+        "contract_json_tool": "passed",
+        "git_diff_check": "passed"
+      },
+      "failure_reason": null,
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-25T00:00:00+08:00",
+          "status": "in_progress",
+          "summary": "Initialized P2-A ledger entry from FERMATMIND-SEO-OPS-P2-P4-PR-TRAIN-20260625-01 for backend read-only zh-CN article quality repair dry-run adapter."
+        },
+        {
+          "at": "2026-06-25T00:00:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Local command registration, focused PHPUnit, Pint, contract JSON, and git diff checks passed for P2-A."
+        },
+        {
+          "at": "2026-06-25T00:00:00+08:00",
+          "status": "committed",
+          "summary": "Committed P2-A backend dry-run adapter changes."
+        }
+      ],
+      "updated_at": "2026-06-25T00:00:00+08:00"
     }
   },
   "career_display_surface": {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -7298,10 +7298,10 @@
     "SEO-OPS-ZH-ARTICLE-QUALITY-DRY-RUN-ADAPTER-01": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "committed",
+      "status": "pr_open",
       "branch": "codex/seo-ops-zh-article-quality-dry-run-adapter-01",
       "commit_sha": "pending_after_push",
-      "pr_url": "",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/2425",
       "checks": {
         "php_artisan_list_rg": "passed",
         "focused_phpunit": "passed",
@@ -7329,6 +7329,11 @@
           "at": "2026-06-25T00:00:00+08:00",
           "status": "committed",
           "summary": "Committed P2-A backend dry-run adapter changes."
+        },
+        {
+          "at": "2026-06-25T00:00:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/2425."
         }
       ],
       "updated_at": "2026-06-25T00:00:00+08:00"

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -19,10 +19,13 @@ prs:
       SHA, resolve Article / ArticleTranslation authority, emit protected
       diff and planned operation evidence, and preserve no DB/CMS/publish,
       URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow,
-      Baidu, GSC, revalidation, or deploy side effects.
+      Baidu, GSC, revalidation, or deploy side effects. Include the narrow
+      BigFive runtime-freeze classifier allowlist required for this read-only
+      Artisan adapter and Kernel registration.
     checks:
       - "php artisan list | rg seo-ops:zh-article-quality-repair-dry-run"
       - "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsZhArticleQualityRepairDryRunCommandTest"
+      - "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_ops_zh_article_quality'"
       - "vendor/bin/pint --test app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php"
       - "python3 -m json.tool docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json >/dev/null"
       - "git diff --check"

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -6,6 +6,37 @@ require_clean_worktree: true
 execution_mode: local_clone_preferred
 
 prs:
+  - id: SEO-OPS-ZH-ARTICLE-QUALITY-DRY-RUN-ADAPTER-01
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/seo-ops-zh-article-quality-dry-run-adapter-01
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      P2-A backend-only read-only dry-run adapter for the existing 9-page
+      zh-CN article quality CMS repair package. Validate package schema and
+      SHA, resolve Article / ArticleTranslation authority, emit protected
+      diff and planned operation evidence, and preserve no DB/CMS/publish,
+      URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow,
+      Baidu, GSC, revalidation, or deploy side effects.
+    checks:
+      - "php artisan list | rg seo-ops:zh-article-quality-repair-dry-run"
+      - "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsZhArticleQualityRepairDryRunCommandTest"
+      - "vendor/bin/pint --test app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php"
+      - "python3 -m json.tool docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json >/dev/null"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-CANDIDATE-SEMANTICS-PREROUTE
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json
+++ b/backend/docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json
@@ -1,0 +1,55 @@
+{
+  "version": "seo-ops-zh-article-quality-repair-dry-run.v1",
+  "command": "php artisan seo-ops:zh-article-quality-repair-dry-run",
+  "input_schema": "fermatmind-zh-article-quality-cms-repair-package.v1",
+  "output_schema": "seo-ops-zh-article-quality-repair-dry-run.v1",
+  "purpose": "Read-only backend authority dry-run for the deterministic zh-CN article quality repair package.",
+  "inputs": {
+    "package": "Path to fermatmind-zh-article-quality-cms-repair-package.v1 JSON package.",
+    "confirm_package_sha256": "Required exact SHA-256 of the source package.",
+    "artifact_dir": "Directory where read-only evidence JSON is written.",
+    "json": "Emit JSON summary."
+  },
+  "resolves": {
+    "article_quality_repair": {
+      "expected_count": 9,
+      "authority_source": "backend.articles + article_seo_meta + article_translation_revisions",
+      "path_policy": "/zh/articles/<slug>",
+      "locale": "zh-CN"
+    }
+  },
+  "protected_diff": {
+    "slug": "no_change",
+    "canonical": "no_change",
+    "locale": "no_change",
+    "article_id": "resolved_no_change",
+    "publication": "no_change",
+    "schema": "hold_no_change",
+    "hreflang": "hold_no_change",
+    "sitemap": "no_change",
+    "llms": "no_change",
+    "search_submission": "hold_no_change"
+  },
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_draft_create": false,
+    "cms_publish": false,
+    "url_truth_write": false,
+    "schema_enable": false,
+    "hreflang_enable": false,
+    "sitemap_write": false,
+    "llms_write": false,
+    "search_channel_enqueue": false,
+    "indexnow_submit": false,
+    "baidu_submit": false,
+    "gsc_request_indexing": false,
+    "scheduler_start": false,
+    "queue_worker_start": false,
+    "external_api_call": false,
+    "revalidation": false,
+    "deploy": false
+  },
+  "write_behavior": "Writes only an evidence JSON file under artifact-dir. It does not mutate database, CMS, publish state, URL Truth, sitemap, llms, schema, hreflang, Search Channel, or external search providers.",
+  "next_gate": "A separate controlled writer/readback PR and exact operator approval are required before any CMS repair write."
+}

--- a/backend/tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoOpsZhArticleQualityRepairDryRunCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_resolves_zh_article_quality_package_without_business_writes(): void
+    {
+        $this->seedArticleAuthorityRows();
+        $source = $this->writeSourcePackage($this->sourcePackage());
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-repair-dry-run', [
+            '--package' => $source['path'],
+            '--confirm-package-sha256' => $source['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame(9, data_get($summary, 'candidate_counts.package_operations'));
+        $this->assertSame(9, data_get($summary, 'candidate_counts.resolved_article_operations'));
+        $this->assertSame(9, data_get($summary, 'planned_ops_count.article_quality_repair_operations'));
+        $this->assertSame(33, data_get($summary, 'planned_ops_count.heading_replacements'));
+        $this->assertSame(9, data_get($summary, 'planned_ops_count.link_replacements'));
+        $this->assertSame('backend.articles + article_seo_meta + article_translation_revisions', data_get($summary, 'authority_sources.article_quality_repair'));
+        $this->assertSame('no_change', data_get($summary, 'protected_diff_summary.slug'));
+        $this->assertSame('no_change', data_get($summary, 'protected_diff_summary.canonical'));
+        $this->assertSame('resolved_no_change', data_get($summary, 'protected_diff_summary.article_id'));
+        $this->assertSame('hold_no_change', data_get($summary, 'protected_diff_summary.schema'));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.database_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'evidence.path'));
+        $this->assertSame('seo-ops-zh-article-quality-repair-dry-run.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame($source['sha256'], data_get($artifact, 'source_package.sha256'));
+        $this->assertCount(9, $artifact['article_operation_plans'] ?? []);
+        $this->assertSame('article:1:zh-CN', data_get($artifact, 'article_operation_plans.0.target'));
+        $this->assertSame('/zh/articles/riasec-holland-career-interest-test-explained', data_get($artifact, 'article_operation_plans.0.current.canonical_path'));
+        $this->assertSame('下一步怎么做', data_get($artifact, 'article_operation_plans.0.planned_repairs.heading_replacements.0.replace_with'));
+    }
+
+    #[Test]
+    public function dry_run_blocks_wrong_package_sha(): void
+    {
+        $source = $this->writeSourcePackage($this->sourcePackage());
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-repair-dry-run', [
+            '--package' => $source['path'],
+            '--confirm-package-sha256' => str_repeat('0', 64),
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('package_sha_mismatch', $summary['issues'] ?? []);
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.database_write', true));
+    }
+
+    #[Test]
+    public function dry_run_blocks_missing_backend_authority_rows_without_business_writes(): void
+    {
+        $source = $this->writeSourcePackage($this->sourcePackage());
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-repair-dry-run', [
+            '--package' => $source['path'],
+            '--confirm-package-sha256' => $source['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertSame(0, data_get($summary, 'planned_ops_count.article_quality_repair_operations'));
+        $this->assertContains('article_not_found:riasec-holland-career-interest-test-explained:zh-CN', $summary['issues'] ?? []);
+        $this->assertSame($countsBefore, $this->rowCounts());
+    }
+
+    #[Test]
+    public function dry_run_rejects_forbidden_input_fields(): void
+    {
+        $package = $this->sourcePackage();
+        $package['content_html'] = '<p>must not be accepted</p>';
+        $source = $this->writeSourcePackage($package);
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-repair-dry-run', [
+            '--package' => $source['path'],
+            '--confirm-package-sha256' => $source['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_zh_article_quality_repair_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json'));
+
+        $this->assertSame('seo-ops-zh-article-quality-repair-dry-run.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-ops:zh-article-quality-repair-dry-run', $contract['command'] ?? null);
+        $this->assertSame('fermatmind-zh-article-quality-cms-repair-package.v1', $contract['input_schema'] ?? null);
+        $this->assertSame(9, data_get($contract, 'resolves.article_quality_repair.expected_count'));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.database_write', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.indexnow_submit', true));
+    }
+
+    private function seedArticleAuthorityRows(): void
+    {
+        foreach ($this->articleSlugs() as $slug) {
+            $this->createArticle($slug, 'zh-CN', 'Existing '.$slug, '/zh/articles/'.$slug);
+        }
+    }
+
+    private function createArticle(string $slug, string $locale, string $title, string $canonicalPath): void
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'translation_group_id' => (string) Str::uuid(),
+            'source_locale' => $locale,
+            'title' => $title,
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing markdown.',
+            'content_html' => '<p>Existing HTML.</p>',
+            'status' => 'published',
+            'lifecycle_state' => Article::LIFECYCLE_ACTIVE,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now()->subDay(),
+        ]);
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => $locale,
+            'source_locale' => $locale,
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => $title,
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing markdown.',
+            'seo_title' => $title.' | FermatMind',
+            'seo_description' => 'Existing SEO description.',
+            'published_at' => now()->subHour(),
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->save();
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => $locale,
+            'seo_title' => $title.' | FermatMind',
+            'seo_description' => 'Existing SEO description.',
+            'canonical_url' => 'https://fermatmind.com'.$canonicalPath,
+            'robots' => 'index,follow',
+            'schema_json' => [['@type' => 'Article']],
+            'is_indexable' => true,
+        ]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function articleSlugs(): array
+    {
+        return [
+            'riasec-holland-career-interest-test-explained',
+            'mbti-basics',
+            'big-five-tool-guide',
+            'iq-test-score-and-limits-explained',
+            'eq-test-tool-guide',
+            'enneagram-personality-test-explained',
+            'college-major-choice-holland-mbti-career-test',
+            'career-confusion-test-map',
+            'career-interest-vs-personality-test-differences',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourcePackage(): array
+    {
+        return [
+            'schema' => 'fermatmind-zh-article-quality-cms-repair-package.v1',
+            'generated_at' => now()->utc()->toIso8601String(),
+            'source_scan' => 'generated/seo-ops-zh-article-quality-localization-repair-scan-20260624-04/runtime_scan_analysis.json',
+            'source_scan_sha256' => str_repeat('a', 64),
+            'scope' => 'raw route leak pages plus all zh-CN article pages with English module heading remnants',
+            'operation_count' => 9,
+            'operations' => [
+                $this->operation('riasec-holland-career-interest-test-explained', ['Dynamic next steps', 'Frequently asked questions', 'Related reading']),
+                $this->operation('mbti-basics', ['Dynamic next steps', 'Frequently asked questions', 'Related reading']),
+                $this->operation('big-five-tool-guide', ['Dynamic next steps', 'Frequently asked questions', 'Related reading']),
+                $this->operation('iq-test-score-and-limits-explained', ['Dynamic next steps', 'Frequently asked questions', 'Related reading', 'Trust links']),
+                $this->operation('eq-test-tool-guide', ['Dynamic next steps', 'Frequently asked questions', 'Related reading', 'Related reading / internal links', 'Trust links']),
+                $this->operation('enneagram-personality-test-explained', ['Dynamic next steps', 'Frequently asked questions', 'Related reading', 'Related reading / internal links', 'Trust links']),
+                $this->operation('college-major-choice-holland-mbti-career-test', ['Dynamic next steps', 'Frequently asked questions', 'Related reading', 'Related reading / internal links', 'Trust links']),
+                $this->operation('career-confusion-test-map', ['Dynamic next steps', 'Frequently asked questions', 'Related reading'], [
+                    ['/tests/mbti-personality-test-16-personality-types', '/zh/tests/mbti-personality-test-16-personality-types'],
+                    ['/tests/holland-career-interest-test-riasec', '/zh/tests/holland-career-interest-test-riasec'],
+                    ['/science', '/zh/science'],
+                    ['/method-boundaries', '/zh/method-boundaries'],
+                    ['/reliability-validity', '/zh/reliability-validity'],
+                    ['/tests/big-five-personality-test-ocean-model', '/zh/tests/big-five-personality-test-ocean-model'],
+                ]),
+                $this->operation('career-interest-vs-personality-test-differences', ['Frequently asked questions', 'Related reading'], [
+                    ['/tests/mbti-personality-test-16-personality-types', '/zh/tests/mbti-personality-test-16-personality-types'],
+                    ['/tests/holland-career-interest-test-riasec', '/zh/tests/holland-career-interest-test-riasec'],
+                    ['/tests/big-five-personality-test-ocean-model', '/zh/tests/big-five-personality-test-ocean-model'],
+                ]),
+            ],
+            'negative_guarantees' => [
+                'cms_write' => false,
+                'publish' => false,
+                'search_submit' => false,
+                'sitemap_llms' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<int, string>  $headingFinds
+     * @param  array<int, array{0:string,1:string}>  $linkPairs
+     * @return array<string, mixed>
+     */
+    private function operation(string $slug, array $headingFinds, array $linkPairs = []): array
+    {
+        return [
+            'path' => '/zh/articles/'.$slug,
+            'snapshot_path' => 'generated/snapshots/zh__articles__'.$slug.'.html',
+            'snapshot_sha256' => hash('sha256', $slug),
+            'issue_codes' => 'english_heading_remnant;english_faq_heading',
+            'heading_replacements' => array_map(static fn (string $find): array => [
+                'find' => $find,
+                'replace_with' => match ($find) {
+                    'Dynamic next steps' => '下一步怎么做',
+                    'Frequently asked questions' => '常见问题',
+                    'Frequently Asked Questions' => '常见问题',
+                    'Related reading', 'Related reading / internal links' => '相关阅读',
+                    'Trust links' => '可信度与边界',
+                    default => '已本地化',
+                },
+                'scope' => 'cms_article_body_or_module_heading',
+            ], $headingFinds),
+            'link_replacements' => array_map(static fn (array $pair): array => [
+                'find' => $pair[0],
+                'replace_with' => $pair[1],
+                'scope' => 'cms_article_body_or_internal_link',
+            ], $linkPairs),
+            'protected_fields' => [
+                'slug' => 'unchanged',
+                'canonical' => 'unchanged',
+                'locale' => 'zh-CN unchanged',
+                'publication_state' => 'unchanged',
+                'schema' => 'hold_no_enablement',
+                'hreflang' => 'hold_no_enablement',
+                'sitemap_llms' => 'unchanged',
+                'search_submission' => 'hold',
+            ],
+            'cms_write_allowed_now' => false,
+            'operator_review_required' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return array{path:string,sha256:string}
+     */
+    private function writeSourcePackage(array $artifact): array
+    {
+        $dir = $this->artifactDir();
+        $path = $dir.'/source-package.json';
+        File::put($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return [
+            'path' => $path,
+            'sha256' => hash_file('sha256', $path),
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => DB::table('articles')->count(),
+            'article_seo_meta' => DB::table('article_seo_meta')->count(),
+            'article_translation_revisions' => DB::table('article_translation_revisions')->count(),
+        ];
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-ops-zh-article-quality-repair-dry-run-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true);
+        $this->assertIsArray($decoded, Artisan::output());
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) File::get($path), true);
+        $this->assertIsArray($decoded, $path);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1321,6 +1321,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_ops_zh_article_quality_repair_dry_run_adapter(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoOpsZhArticleQualityRepairDryRunCommand;',
+            '+        SeoOpsZhArticleQualityRepairDryRunCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_codex_review_runner_files(): void
     {
         $changed = [
@@ -4853,6 +4867,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoOpsZhArticleQualityRepairDryRunFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentCmsTdkGapReadonlyScannerFile($file)) {
                 continue;
             }
@@ -5750,6 +5768,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsBigFivePublicProfileAgentDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoOpsP0CtrArticleCmsUpdateWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoOpsZhArticleQualityRepairDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6508,6 +6527,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/SeoOpsP0CtrArticleCmsUpdateWriterCommand.php',
             'backend/app/Console/Commands/SeoOpsP0CtrRepairDryRunCommand.php',
         ], true);
+    }
+
+    private function isSeoOpsZhArticleQualityRepairDryRunFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php';
     }
 
     private function isSeoAgentCmsTdkGapReadonlyScannerFile(string $file): bool
@@ -8642,6 +8666,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoOpsP0CtrArticleCmsUpdateWriterCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoOpsZhArticleQualityRepairDryRunOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoOpsZhArticleQualityRepairDryRunCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-ops:zh-article-quality-repair-dry-run`, a backend-only read-only adapter for the 9-page zh-CN article quality CMS repair package.
- The command validates package schema/SHA, resolves backend Article/SEO/revision authority, emits protected diff and planned repair evidence, and writes only a dry-run artifact.
- Registered the command, added generated SEO contract docs, focused feature coverage, and the explicitly authorized PR-train manifest/state entry.

## Why
P2 needs a production-safe backend authority dry-run before any CMS write gate. This PR lets ops verify the package against real backend CMS authority while preserving all CMS/publish/search/schema/sitemap boundaries.

## Validation
- `php artisan list | rg seo-ops:zh-article-quality-repair-dry-run`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsZhArticleQualityRepairDryRunCommandTest`
- `vendor/bin/pint --test app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php`
- `python3 -m json.tool docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No CMS write or draft creation.
- No publish, URL Truth, sitemap/llms, schema/hreflang, Search Channel, IndexNow/Baidu/GSC, revalidation, deploy, scheduler, or queue worker action.
- P2-B controlled writer/readback remains a separate PR/gate.
