### PR TITLE
SEO-OPS-ZH-ARTICLE-QUALITY-CONTROLLED-WRITER-01: Add zh article quality writer/readback

### DIFF
--- a/backend/app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php
+++ b/backend/app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php
@@ -1,0 +1,528 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+
+final class SeoOpsZhArticleQualityControlledWriterCommand extends Command
+{
+    private const INPUT_SCHEMA = 'seo-ops-zh-article-quality-repair-dry-run.v1';
+
+    private const OUTPUT_SCHEMA = 'seo-ops-zh-article-quality-controlled-writer.v1';
+
+    private const EXPECTED_COUNT = 9;
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'Cookie:',
+        'Set-Cookie:',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-ops:zh-article-quality-controlled-writer
+        {--dry-run-evidence= : Path to seo-ops-zh-article-quality-repair-dry-run.v1 evidence}
+        {--confirm-dry-run-evidence-sha256= : Expected SHA-256 of the dry-run evidence}
+        {--artifact-dir= : Directory for writer evidence output}
+        {--execute : Apply deterministic heading/link repairs}
+        {--confirm-write= : Exact controlled writer approval phrase}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Controlled writer for zh-CN article quality heading/link repairs from verified dry-run evidence; defaults to dry-run.';
+
+    public function handle(): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary(['artifact_dir_unwritable']));
+        }
+
+        $loaded = $this->loadEvidence();
+        if (($loaded['ok'] ?? false) !== true) {
+            $summary = $this->failureSummary((array) ($loaded['issues'] ?? ['dry_run_evidence_unreadable']), [
+                'dry_run_evidence' => $loaded['dry_run_evidence'] ?? null,
+            ]);
+            $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        $payload = (array) $loaded['payload'];
+        $sha = (string) $loaded['sha256'];
+        $plans = array_values((array) ($payload['article_operation_plans'] ?? []));
+        $issues = $this->validateEvidence($payload, $plans);
+        $writePlans = array_map(fn (array $plan): array => $this->buildWritePlan($plan), $plans);
+
+        foreach ($writePlans as $plan) {
+            foreach ((array) ($plan['issues'] ?? []) as $issue) {
+                $issues[] = (string) $issue;
+            }
+        }
+
+        $issues = array_values(array_unique($issues));
+        $execute = (bool) $this->option('execute');
+        $requiredPhrase = $this->requiredConfirmationPhrase($sha);
+        if ($execute && ! hash_equals($requiredPhrase, trim((string) $this->option('confirm-write')))) {
+            $issues[] = 'confirm_write_phrase_mismatch';
+        }
+
+        $ok = $issues === [];
+        $writeResults = [];
+        if ($ok && $execute) {
+            $writeResults = $this->executePlans($writePlans, $sha);
+        }
+
+        $readyCount = count(array_filter($writePlans, static fn (array $plan): bool => ($plan['ready'] ?? false) === true));
+        $summary = [
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:zh-article-quality-controlled-writer',
+            'ok' => $ok,
+            'status' => $ok ? ($execute ? 'success' : 'planned') : 'blocked',
+            'dry_run' => ! $execute,
+            'execute' => $execute,
+            'generated_at' => now()->utc()->toIso8601String(),
+            'dry_run_evidence' => [
+                'path' => (string) $loaded['path'],
+                'sha256' => $sha,
+                'schema_version' => (string) ($payload['schema_version'] ?? ''),
+            ],
+            'planned_write_count' => [
+                'article_quality_repairs' => $readyCount,
+                'cms_publish' => 0,
+                'search_submission' => 0,
+                'total' => $readyCount,
+            ],
+            'target_lock' => [
+                'expected_count' => self::EXPECTED_COUNT,
+                'targets' => array_values(array_map(static fn (array $plan): string => (string) ($plan['target'] ?? ''), $writePlans)),
+            ],
+            'required_confirmation_phrase' => $requiredPhrase,
+            'article_repair_plans' => $writePlans,
+            'write_results' => $writeResults,
+            'protected_diff_summary' => [
+                'slug' => 'no_change',
+                'canonical' => 'no_change',
+                'locale' => 'no_change',
+                'publication' => 'no_change',
+                'schema' => 'hold_no_change',
+                'hreflang' => 'hold_no_change',
+                'sitemap' => 'no_change',
+                'llms' => 'no_change',
+                'search_submission' => 'hold_no_change',
+            ],
+            'side_effects' => [
+                'database_write' => $execute && $ok,
+                'cms_article_update' => $execute && $ok,
+                'cms_draft_create' => false,
+                'cms_publish' => false,
+                'url_truth_write' => false,
+                'schema_enable' => false,
+                'hreflang_enable' => false,
+                'sitemap_write' => false,
+                'llms_write' => false,
+                'search_channel_enqueue' => false,
+                'indexnow_submit' => false,
+                'baidu_submit' => false,
+                'gsc_request_indexing' => false,
+                'scheduler_start' => false,
+                'queue_worker_start' => false,
+                'external_api_call' => false,
+                'revalidation' => false,
+                'deploy' => false,
+            ],
+            'issues' => $issues,
+        ];
+        $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+        return $this->finish($summary);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadEvidence(): array
+    {
+        $path = $this->readablePath((string) $this->option('dry-run-evidence'));
+        if ($path === null) {
+            return ['ok' => false, 'issues' => ['dry_run_evidence_unreadable']];
+        }
+
+        $raw = (string) file_get_contents($path);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return [
+                'ok' => false,
+                'dry_run_evidence' => ['path' => $path],
+                'issues' => ['forbidden_input_field_present'],
+                'forbidden_matches' => $forbidden,
+            ];
+        }
+
+        $actualSha = hash('sha256', $raw);
+        $expectedSha = trim((string) $this->option('confirm-dry-run-evidence-sha256'));
+        if ($expectedSha === '' || ! hash_equals($expectedSha, $actualSha)) {
+            return [
+                'ok' => false,
+                'dry_run_evidence' => [
+                    'path' => $path,
+                    'sha256' => $actualSha,
+                    'expected_sha256' => $expectedSha,
+                ],
+                'issues' => ['dry_run_evidence_sha_mismatch'],
+            ];
+        }
+
+        try {
+            $payload = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return ['ok' => false, 'dry_run_evidence' => ['path' => $path, 'sha256' => $actualSha], 'issues' => ['dry_run_evidence_json_invalid']];
+        }
+
+        if (! is_array($payload)) {
+            return ['ok' => false, 'dry_run_evidence' => ['path' => $path, 'sha256' => $actualSha], 'issues' => ['dry_run_evidence_json_not_object']];
+        }
+
+        return ['ok' => true, 'payload' => $payload, 'path' => $path, 'sha256' => $actualSha];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<int, mixed>  $plans
+     * @return array<int, string>
+     */
+    private function validateEvidence(array $payload, array $plans): array
+    {
+        $issues = [];
+        if (($payload['schema_version'] ?? null) !== self::INPUT_SCHEMA) {
+            $issues[] = 'dry_run_evidence_schema_invalid';
+        }
+        if (($payload['ok'] ?? null) !== true || ($payload['status'] ?? null) !== 'planned') {
+            $issues[] = 'dry_run_evidence_not_planned';
+        }
+        if ((bool) ($payload['dry_run'] ?? false) !== true || (bool) ($payload['execute'] ?? true) !== false) {
+            $issues[] = 'dry_run_evidence_mode_invalid';
+        }
+        if (count($plans) !== self::EXPECTED_COUNT) {
+            $issues[] = 'article_plan_count_unexpected';
+        }
+        if ((int) data_get($payload, 'candidate_counts.resolved_article_operations') !== self::EXPECTED_COUNT) {
+            $issues[] = 'resolved_article_count_unexpected';
+        }
+        foreach (['database_write', 'cms_write', 'cms_publish', 'url_truth_write', 'schema_enable', 'hreflang_enable', 'sitemap_write', 'llms_write', 'search_channel_enqueue', 'indexnow_submit', 'baidu_submit', 'gsc_request_indexing', 'revalidation', 'deploy'] as $field) {
+            if ((bool) data_get($payload, 'negative_guarantees.'.$field) !== false) {
+                $issues[] = 'dry_run_negative_guarantee_invalid:'.$field;
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @return array<string, mixed>
+     */
+    private function buildWritePlan(array $plan): array
+    {
+        $articleId = (int) data_get($plan, 'current.article_id', 0);
+        $article = $articleId > 0
+            ? Article::query()->withoutGlobalScopes()->with(['publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(), 'seoMeta' => static fn ($query) => $query->withoutGlobalScopes()])->find($articleId)
+            : null;
+        $issues = [];
+        if (! $article instanceof Article) {
+            $issues[] = 'article_not_found:'.$articleId;
+        }
+        if ((string) data_get($plan, 'locale') !== 'zh-CN') {
+            $issues[] = 'locale_not_zh_cn';
+        }
+        if ((bool) data_get($plan, 'resolved') !== true) {
+            $issues[] = 'dry_run_plan_not_resolved';
+        }
+
+        $replacements = $this->validatedReplacements($plan);
+        if ($replacements === []) {
+            $issues[] = 'replacement_plan_empty';
+        }
+
+        $texts = $article instanceof Article ? $this->textsFor($article) : [];
+        $counts = $this->replacementCounts($texts, $replacements);
+
+        return [
+            'target' => (string) ($plan['target'] ?? ''),
+            'article_id' => $articleId,
+            'path' => (string) ($plan['path'] ?? ''),
+            'slug' => (string) ($plan['slug'] ?? ''),
+            'locale' => (string) ($plan['locale'] ?? ''),
+            'ready' => $issues === [],
+            'replacements' => $replacements,
+            'replacement_counts_before' => $counts,
+            'protected_snapshot' => $article instanceof Article ? $this->protectedSnapshot($article) : null,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @return array<int, array{find:string,replace_with:string,scope:string}>
+     */
+    private function validatedReplacements(array $plan): array
+    {
+        $allowed = [
+            'Dynamic next steps' => '下一步怎么做',
+            'Frequently asked questions' => '常见问题',
+            'Frequently Asked Questions' => '常见问题',
+            'Related reading' => '相关阅读',
+            'Related reading / internal links' => '相关阅读',
+            'Trust links' => '可信度与边界',
+            '/tests/mbti-personality-test-16-personality-types' => '/zh/tests/mbti-personality-test-16-personality-types',
+            '/tests/holland-career-interest-test-riasec' => '/zh/tests/holland-career-interest-test-riasec',
+            '/tests/big-five-personality-test-ocean-model' => '/zh/tests/big-five-personality-test-ocean-model',
+            '/science' => '/zh/science',
+            '/method-boundaries' => '/zh/method-boundaries',
+            '/reliability-validity' => '/zh/reliability-validity',
+        ];
+        $raw = array_merge(
+            array_values((array) data_get($plan, 'planned_repairs.heading_replacements', [])),
+            array_values((array) data_get($plan, 'planned_repairs.link_replacements', [])),
+        );
+
+        $out = [];
+        foreach ($raw as $replacement) {
+            $find = (string) data_get($replacement, 'find', '');
+            $replace = (string) data_get($replacement, 'replace_with', '');
+            if (($allowed[$find] ?? null) !== $replace) {
+                continue;
+            }
+            $out[] = [
+                'find' => $find,
+                'replace_with' => $replace,
+                'scope' => (string) data_get($replacement, 'scope', ''),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $plans
+     * @return array<int, array<string, mixed>>
+     */
+    private function executePlans(array $plans, string $dryRunSha): array
+    {
+        return DB::transaction(function () use ($plans, $dryRunSha): array {
+            $results = [];
+            foreach ($plans as $plan) {
+                if (($plan['ready'] ?? false) !== true) {
+                    continue;
+                }
+                /** @var Article $article */
+                $article = Article::query()->withoutGlobalScopes()->with(['publishedRevision' => static fn ($query) => $query->withoutGlobalScopes()])->findOrFail((int) $plan['article_id']);
+                $revision = $article->publishedRevision;
+                $before = $this->protectedSnapshot($article);
+                $articleMd = (string) $article->content_md;
+                $articleHtml = (string) $article->content_html;
+                $revisionMd = $revision instanceof ArticleTranslationRevision ? (string) $revision->content_md : null;
+                $applied = ['article_content_md' => 0, 'article_content_html' => 0, 'published_revision_content_md' => 0];
+
+                foreach ((array) $plan['replacements'] as $replacement) {
+                    [$articleMd, $count] = $this->replaceText($articleMd, (string) $replacement['find'], (string) $replacement['replace_with']);
+                    $applied['article_content_md'] += $count;
+                    [$articleHtml, $count] = $this->replaceText($articleHtml, (string) $replacement['find'], (string) $replacement['replace_with']);
+                    $applied['article_content_html'] += $count;
+                    if ($revisionMd !== null) {
+                        [$revisionMd, $count] = $this->replaceText($revisionMd, (string) $replacement['find'], (string) $replacement['replace_with']);
+                        $applied['published_revision_content_md'] += $count;
+                    }
+                }
+
+                $article->forceFill([
+                    'content_md' => $articleMd,
+                    'content_html' => $articleHtml,
+                ])->save();
+                if ($revision instanceof ArticleTranslationRevision && $revisionMd !== null) {
+                    $revision->forceFill(['content_md' => $revisionMd])->save();
+                }
+
+                $article->refresh();
+                $results[] = [
+                    'target' => (string) $plan['target'],
+                    'article_id' => (int) $article->id,
+                    'applied_replacement_count' => array_sum($applied),
+                    'applied_replacement_counts' => $applied,
+                    'protected_before' => $before,
+                    'protected_after' => $this->protectedSnapshot($article),
+                    'source_dry_run_evidence_sha256' => $dryRunSha,
+                ];
+            }
+
+            return $results;
+        });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function textsFor(Article $article): array
+    {
+        return [
+            'article_content_md' => (string) $article->content_md,
+            'article_content_html' => (string) $article->content_html,
+            'published_revision_content_md' => (string) $article->publishedRevision?->content_md,
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $texts
+     * @param  array<int, array<string, mixed>>  $replacements
+     * @return array<string, int>
+     */
+    private function replacementCounts(array $texts, array $replacements): array
+    {
+        $counts = [];
+        foreach ($texts as $field => $text) {
+            $counts[$field] = 0;
+            foreach ($replacements as $replacement) {
+                $counts[$field] += substr_count($text, (string) $replacement['find']);
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function protectedSnapshot(Article $article): array
+    {
+        $article->loadMissing(['seoMeta' => static fn ($query) => $query->withoutGlobalScopes()]);
+
+        return [
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'status' => (string) $article->status,
+            'published_revision_id' => $article->published_revision_id,
+            'working_revision_id' => $article->working_revision_id,
+            'canonical_url' => (string) $article->seoMeta?->canonical_url,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+        ];
+    }
+
+    /**
+     * @return array{0:string,1:int}
+     */
+    private function replaceText(string $text, string $find, string $replace): array
+    {
+        $count = 0;
+        $updated = str_replace($find, $replace, $text, $count);
+
+        return [$updated, $count];
+    }
+
+    private function requiredConfirmationPhrase(string $sha): string
+    {
+        return 'I explicitly approve SEO-OPS-ZH-ARTICLE-QUALITY-CONTROLLED-WRITER-01 to write 9 zh-CN article quality deterministic heading/link repairs from dry-run evidence sha256 '.$sha.'; no publish, no URL Truth, no sitemap/llms, no schema/hreflang, no Search Channel, no IndexNow/Baidu/GSC, no deploy/revalidation.';
+    }
+
+    /**
+     * @param  array<int, string>  $issues
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(array $issues, array $extra = []): array
+    {
+        return array_replace([
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:zh-article-quality-controlled-writer',
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => ! (bool) $this->option('execute'),
+            'execute' => (bool) $this->option('execute'),
+            'generated_at' => now()->utc()->toIso8601String(),
+            'issues' => array_values(array_unique($issues)),
+            'side_effects' => [
+                'database_write' => false,
+                'cms_article_update' => false,
+                'cms_publish' => false,
+                'search_channel_enqueue' => false,
+                'indexnow_submit' => false,
+            ],
+        ], $extra);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function writeEvidence(string $artifactDir, array $summary): ?array
+    {
+        File::ensureDirectoryExists($artifactDir);
+        $path = rtrim($artifactDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR
+            .'seo-ops-zh-article-quality-controlled-writer-'.now()->utc()->format('Ymd\THis\Z').'.json';
+        $artifact = $summary;
+        unset($artifact['evidence']);
+        File::put($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return ['path' => $path, 'sha256' => hash_file('sha256', $path), 'bytes' => filesize($path) ?: 0];
+    }
+
+    private function finish(array $summary): int
+    {
+        if ($this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } elseif (($summary['ok'] ?? false) === true) {
+            $this->info('ZH article quality controlled writer '.($summary['status'] ?? 'planned'));
+        } else {
+            $this->error('ZH article quality controlled writer blocked: '.implode(', ', (array) ($summary['issues'] ?? [])));
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0") || ! is_file($path) || ! is_readable($path)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            return null;
+        }
+        File::ensureDirectoryExists($dir);
+
+        return is_dir($dir) && is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+}

--- a/backend/app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php
+++ b/backend/app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class SeoOpsZhArticleQualityReadbackCommand extends Command
+{
+    private const INPUT_SCHEMA = 'seo-ops-zh-article-quality-controlled-writer.v1';
+
+    private const OUTPUT_SCHEMA = 'seo-ops-zh-article-quality-readback.v1';
+
+    protected $signature = 'seo-ops:zh-article-quality-readback
+        {--writer-evidence= : Path to seo-ops-zh-article-quality-controlled-writer.v1 evidence}
+        {--confirm-writer-evidence-sha256= : Expected SHA-256 of writer evidence}
+        {--artifact-dir= : Directory for readback evidence output}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only readback QA for zh-CN article quality deterministic heading/link repairs.';
+
+    public function handle(): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary(['artifact_dir_unwritable']));
+        }
+
+        $loaded = $this->loadEvidence();
+        if (($loaded['ok'] ?? false) !== true) {
+            $summary = $this->failureSummary((array) ($loaded['issues'] ?? ['writer_evidence_unreadable']), [
+                'writer_evidence' => $loaded['writer_evidence'] ?? null,
+            ]);
+            $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        $payload = (array) $loaded['payload'];
+        $plans = array_values((array) ($payload['article_repair_plans'] ?? []));
+        $issues = $this->validateWriterEvidence($payload, $plans);
+        $readbacks = array_map(fn (array $plan): array => $this->readbackPlan($plan), $plans);
+        foreach ($readbacks as $readback) {
+            foreach ((array) ($readback['issues'] ?? []) as $issue) {
+                $issues[] = (string) $issue;
+            }
+        }
+        $issues = array_values(array_unique($issues));
+
+        $summary = [
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:zh-article-quality-readback',
+            'ok' => $issues === [],
+            'status' => $issues === [] ? 'success' : 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->utc()->toIso8601String(),
+            'writer_evidence' => [
+                'path' => (string) $loaded['path'],
+                'sha256' => (string) $loaded['sha256'],
+                'schema_version' => (string) ($payload['schema_version'] ?? ''),
+            ],
+            'readback_count' => [
+                'targets' => count($readbacks),
+                'passed' => count(array_filter($readbacks, static fn (array $readback): bool => ($readback['status'] ?? null) === 'success')),
+                'blocked' => count(array_filter($readbacks, static fn (array $readback): bool => ($readback['status'] ?? null) !== 'success')),
+            ],
+            'article_readbacks' => $readbacks,
+            'protected_diff_summary' => [
+                'slug' => 'no_change',
+                'canonical' => 'no_change',
+                'locale' => 'no_change',
+                'publication' => 'no_change',
+                'schema' => 'hold_no_change',
+                'hreflang' => 'hold_no_change',
+                'sitemap' => 'no_change',
+                'llms' => 'no_change',
+                'search_submission' => 'hold_no_change',
+            ],
+            'side_effects' => [
+                'database_write' => false,
+                'cms_article_update' => false,
+                'cms_publish' => false,
+                'url_truth_write' => false,
+                'schema_enable' => false,
+                'hreflang_enable' => false,
+                'sitemap_write' => false,
+                'llms_write' => false,
+                'search_channel_enqueue' => false,
+                'indexnow_submit' => false,
+                'baidu_submit' => false,
+                'gsc_request_indexing' => false,
+                'scheduler_start' => false,
+                'queue_worker_start' => false,
+                'external_api_call' => false,
+                'revalidation' => false,
+                'deploy' => false,
+            ],
+            'issues' => $issues,
+        ];
+        $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+        return $this->finish($summary);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadEvidence(): array
+    {
+        $path = $this->readablePath((string) $this->option('writer-evidence'));
+        if ($path === null) {
+            return ['ok' => false, 'issues' => ['writer_evidence_unreadable']];
+        }
+        $raw = (string) file_get_contents($path);
+        $actualSha = hash('sha256', $raw);
+        $expectedSha = trim((string) $this->option('confirm-writer-evidence-sha256'));
+        if ($expectedSha === '' || ! hash_equals($expectedSha, $actualSha)) {
+            return ['ok' => false, 'writer_evidence' => ['path' => $path, 'sha256' => $actualSha, 'expected_sha256' => $expectedSha], 'issues' => ['writer_evidence_sha_mismatch']];
+        }
+        try {
+            $payload = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return ['ok' => false, 'writer_evidence' => ['path' => $path, 'sha256' => $actualSha], 'issues' => ['writer_evidence_json_invalid']];
+        }
+        if (! is_array($payload)) {
+            return ['ok' => false, 'writer_evidence' => ['path' => $path, 'sha256' => $actualSha], 'issues' => ['writer_evidence_json_not_object']];
+        }
+
+        return ['ok' => true, 'payload' => $payload, 'path' => $path, 'sha256' => $actualSha];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<int, mixed>  $plans
+     * @return array<int, string>
+     */
+    private function validateWriterEvidence(array $payload, array $plans): array
+    {
+        $issues = [];
+        if (($payload['schema_version'] ?? null) !== self::INPUT_SCHEMA) {
+            $issues[] = 'writer_evidence_schema_invalid';
+        }
+        if (($payload['ok'] ?? null) !== true || ($payload['status'] ?? null) !== 'success' || (bool) ($payload['execute'] ?? false) !== true) {
+            $issues[] = 'writer_evidence_not_success_execute';
+        }
+        if (count($plans) !== 9) {
+            $issues[] = 'writer_plan_count_unexpected';
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @return array<string, mixed>
+     */
+    private function readbackPlan(array $plan): array
+    {
+        $article = Article::query()->withoutGlobalScopes()->with(['publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(), 'seoMeta' => static fn ($query) => $query->withoutGlobalScopes()])->find((int) ($plan['article_id'] ?? 0));
+        $issues = [];
+        if (! $article instanceof Article) {
+            return [
+                'target' => (string) ($plan['target'] ?? ''),
+                'status' => 'blocked',
+                'issues' => ['article_not_found'],
+            ];
+        }
+
+        $texts = [
+            'article_content_md' => (string) $article->content_md,
+            'article_content_html' => (string) $article->content_html,
+            'published_revision_content_md' => (string) $article->publishedRevision?->content_md,
+        ];
+        $replacementReadback = [];
+        foreach ((array) ($plan['replacements'] ?? []) as $replacement) {
+            $find = (string) ($replacement['find'] ?? '');
+            $replace = (string) ($replacement['replace_with'] ?? '');
+            $fieldReadback = [];
+            foreach ($texts as $field => $text) {
+                $present = substr_count($text, $replace);
+                $findCount = substr_count($text, $find);
+                $remaining = str_contains($replace, $find)
+                    ? max(0, $findCount - $present)
+                    : $findCount;
+                $fieldReadback[$field] = [
+                    'find_remaining_count' => $remaining,
+                    'replacement_present_count' => $present,
+                ];
+                if ($remaining > 0) {
+                    $issues[] = 'replacement_find_still_present:'.$field.':'.$find;
+                }
+            }
+            $replacementReadback[] = [
+                'find' => $find,
+                'replace_with' => $replace,
+                'fields' => $fieldReadback,
+            ];
+        }
+
+        $protectedBefore = (array) ($plan['protected_snapshot'] ?? []);
+        $protectedAfter = $this->protectedSnapshot($article);
+        if ($protectedBefore !== [] && $protectedBefore !== $protectedAfter) {
+            $issues[] = 'protected_snapshot_changed';
+        }
+
+        return [
+            'target' => (string) ($plan['target'] ?? ''),
+            'article_id' => (int) $article->id,
+            'status' => $issues === [] ? 'success' : 'blocked',
+            'replacement_readback' => $replacementReadback,
+            'protected_before' => $protectedBefore,
+            'protected_after' => $protectedAfter,
+            'issues' => array_values(array_unique($issues)),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function protectedSnapshot(Article $article): array
+    {
+        $article->loadMissing(['seoMeta' => static fn ($query) => $query->withoutGlobalScopes()]);
+
+        return [
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'status' => (string) $article->status,
+            'published_revision_id' => $article->published_revision_id,
+            'working_revision_id' => $article->working_revision_id,
+            'canonical_url' => (string) $article->seoMeta?->canonical_url,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+        ];
+    }
+
+    /**
+     * @param  array<int, string>  $issues
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(array $issues, array $extra = []): array
+    {
+        return array_replace([
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:zh-article-quality-readback',
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->utc()->toIso8601String(),
+            'issues' => array_values(array_unique($issues)),
+        ], $extra);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function writeEvidence(string $artifactDir, array $summary): ?array
+    {
+        File::ensureDirectoryExists($artifactDir);
+        $path = rtrim($artifactDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR
+            .'seo-ops-zh-article-quality-readback-'.now()->utc()->format('Ymd\THis\Z').'.json';
+        $artifact = $summary;
+        unset($artifact['evidence']);
+        File::put($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return ['path' => $path, 'sha256' => hash_file('sha256', $path), 'bytes' => filesize($path) ?: 0];
+    }
+
+    private function finish(array $summary): int
+    {
+        if ($this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } elseif (($summary['ok'] ?? false) === true) {
+            $this->info('ZH article quality readback success');
+        } else {
+            $this->error('ZH article quality readback blocked: '.implode(', ', (array) ($summary['issues'] ?? [])));
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0") || ! is_file($path) || ! is_readable($path)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            return null;
+        }
+        File::ensureDirectoryExists($dir);
+
+        return is_dir($dir) && is_writable($dir) ? $dir : null;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -223,7 +223,9 @@ use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
 use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
 use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
+use App\Console\Commands\SeoOpsZhArticleQualityControlledWriterCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityRepairDryRunCommand;
+use App\Console\Commands\SeoOpsZhArticleQualityReadbackCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
@@ -470,7 +472,9 @@ class Kernel extends ConsoleKernel
         SeoAgentWeeklyDraftWriteAutoCommand::class,
         SeoAgentWeeklyReadonlyRunnerCommand::class,
         SeoOpsP0CtrArticleCmsUpdateWriterCommand::class,
+        SeoOpsZhArticleQualityControlledWriterCommand::class,
         SeoOpsZhArticleQualityRepairDryRunCommand::class,
+        SeoOpsZhArticleQualityReadbackCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -7350,10 +7350,10 @@
     "SEO-OPS-ZH-ARTICLE-QUALITY-CONTROLLED-WRITER-01": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/seo-ops-zh-article-quality-controlled-writer-01",
       "commit_sha": "",
-      "pr_url": "",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/2426",
       "checks": {
         "php_artisan_list_rg": "passed",
         "focused_phpunit": "passed",
@@ -7377,6 +7377,11 @@
           "at": "2026-06-25T00:00:00+08:00",
           "status": "local_checks_passed",
           "summary": "P2-B local command registration, focused writer/readback PHPUnit, BigFive freeze classifier, Pint, contract JSON, and diff checks passed."
+        },
+        {
+          "at": "2026-06-25T00:00:00+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/2426."
         }
       ],
       "updated_at": "2026-06-25T00:00:00+08:00"

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -7346,6 +7346,40 @@
       "github_checks": {
         "verify-bigfive": "failed_before_ci_fix_current_pr_scope"
       }
+    },
+    "SEO-OPS-ZH-ARTICLE-QUALITY-CONTROLLED-WRITER-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/seo-ops-zh-article-quality-controlled-writer-01",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "php_artisan_list_rg": "passed",
+        "focused_phpunit": "passed",
+        "bigfive_freeze_classifier_focused": "passed",
+        "pint_touched_files": "passed",
+        "contract_json_tool": "passed",
+        "git_diff_check": "passed"
+      },
+      "failure_reason": null,
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-25T00:00:00+08:00",
+          "status": "in_progress",
+          "summary": "Initialized P2-B ledger entry for zh-CN article quality controlled writer/readback support."
+        },
+        {
+          "at": "2026-06-25T00:00:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "P2-B local command registration, focused writer/readback PHPUnit, BigFive freeze classifier, Pint, contract JSON, and diff checks passed."
+        }
+      ],
+      "updated_at": "2026-06-25T00:00:00+08:00"
     }
   },
   "career_display_surface": {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -40,6 +40,41 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: SEO-OPS-ZH-ARTICLE-QUALITY-CONTROLLED-WRITER-01
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/seo-ops-zh-article-quality-controlled-writer-01
+    base: main
+    depends_on:
+      - SEO-OPS-ZH-ARTICLE-QUALITY-DRY-RUN-ADAPTER-01
+    mode: execute
+    scope: >
+      P2-B backend controlled writer and readback support for the existing
+      9-page zh-CN article quality repair package. Consume verified P2-A
+      dry-run evidence, allow only deterministic package heading/link
+      replacements, preserve slug/canonical/locale/publication/schema,
+      hreflang, sitemap, llms, URL Truth, Search Channel, IndexNow, Baidu,
+      GSC, revalidation, and deploy boundaries, and include the narrow
+      BigFive runtime-freeze classifier allowlist for the read-only/writer
+      Artisan adapters and Kernel registration.
+    checks:
+      - "php artisan list | rg 'seo-ops:zh-article-quality'"
+      - "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsZhArticleQualityControlledWriterTest"
+      - "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_ops_zh_article_quality'"
+      - "vendor/bin/pint --test app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php tests/Feature/SeoIntel/SeoOpsZhArticleQualityControlledWriterTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      - "python3 -m json.tool docs/seo/generated/seo-ops-zh-article-quality-controlled-writer.v1.json >/dev/null"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-CANDIDATE-SEMANTICS-PREROUTE
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/docs/seo/generated/seo-ops-zh-article-quality-controlled-writer.v1.json
+++ b/backend/docs/seo/generated/seo-ops-zh-article-quality-controlled-writer.v1.json
@@ -1,0 +1,70 @@
+{
+  "version": "seo-ops-zh-article-quality-controlled-writer.v1",
+  "commands": [
+    "php artisan seo-ops:zh-article-quality-controlled-writer",
+    "php artisan seo-ops:zh-article-quality-readback"
+  ],
+  "input_schema": "seo-ops-zh-article-quality-repair-dry-run.v1",
+  "scope": {
+    "repo": "fap-api",
+    "page_entity_type": "article",
+    "locale": "zh-CN",
+    "expected_article_count": 9,
+    "source_family": "seo_ops_zh_article_quality_repair"
+  },
+  "allowed_replacements": {
+    "Dynamic next steps": "下一步怎么做",
+    "Frequently asked questions": "常见问题",
+    "Frequently Asked Questions": "常见问题",
+    "Related reading": "相关阅读",
+    "Related reading / internal links": "相关阅读",
+    "Trust links": "可信度与边界",
+    "/tests/mbti-personality-test-16-personality-types": "/zh/tests/mbti-personality-test-16-personality-types",
+    "/tests/holland-career-interest-test-riasec": "/zh/tests/holland-career-interest-test-riasec",
+    "/tests/big-five-personality-test-ocean-model": "/zh/tests/big-five-personality-test-ocean-model",
+    "/science": "/zh/science",
+    "/method-boundaries": "/zh/method-boundaries",
+    "/reliability-validity": "/zh/reliability-validity"
+  },
+  "protected_fields": {
+    "slug": "no_change",
+    "canonical": "no_change",
+    "locale": "no_change",
+    "publication": "no_change",
+    "schema": "hold_no_change",
+    "hreflang": "hold_no_change",
+    "sitemap": "no_change",
+    "llms": "no_change",
+    "search_submission": "hold_no_change"
+  },
+  "execute_gate": {
+    "default_mode": "dry_run",
+    "requires_execute_flag": true,
+    "requires_confirm_dry_run_evidence_sha256": true,
+    "requires_exact_confirmation_phrase": true
+  },
+  "readback": {
+    "requires_writer_evidence_sha256": true,
+    "verifies_replacement_find_absent": true,
+    "verifies_protected_snapshot_unchanged": true,
+    "writes_evidence_only": true
+  },
+  "negative_guarantees": {
+    "cms_draft_create": false,
+    "cms_publish": false,
+    "url_truth_write": false,
+    "schema_enable": false,
+    "hreflang_enable": false,
+    "sitemap_write": false,
+    "llms_write": false,
+    "search_channel_enqueue": false,
+    "indexnow_submit": false,
+    "baidu_submit": false,
+    "gsc_request_indexing": false,
+    "scheduler_start": false,
+    "queue_worker_start": false,
+    "external_api_call": false,
+    "revalidation": false,
+    "deploy": false
+  }
+}

--- a/backend/tests/Feature/SeoIntel/SeoOpsZhArticleQualityControlledWriterTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoOpsZhArticleQualityControlledWriterTest.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoOpsZhArticleQualityControlledWriterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_plans_nine_deterministic_article_repairs_without_writes(): void
+    {
+        $this->seedArticleAuthorityRows();
+        $dryRun = $this->writeJson($this->dryRunEvidence());
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-controlled-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => $dryRun['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame(9, data_get($summary, 'planned_write_count.article_quality_repairs'));
+        $this->assertStringContainsString('SEO-OPS-ZH-ARTICLE-QUALITY-CONTROLLED-WRITER-01', (string) ($summary['required_confirmation_phrase'] ?? ''));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.database_write', true));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.search_channel_enqueue', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+    }
+
+    #[Test]
+    public function execute_repairs_article_content_and_readback_passes_without_publish_or_search_side_effects(): void
+    {
+        $articles = $this->seedArticleAuthorityRows();
+        $dryRun = $this->writeJson($this->dryRunEvidence());
+        $phrase = $this->confirmationPhrase($dryRun['sha256']);
+        $countsBefore = $this->rowCounts();
+        $protectedBefore = $this->protectedSnapshots($articles);
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-controlled-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => $dryRun['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--execute' => true,
+            '--confirm-write' => $phrase,
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertTrue((bool) data_get($summary, 'side_effects.database_write'));
+        $this->assertTrue((bool) data_get($summary, 'side_effects.cms_article_update'));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.indexnow_submit', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+        $this->assertSame($protectedBefore, $this->protectedSnapshots($articles));
+
+        $first = Article::query()->withoutGlobalScopes()->with('publishedRevision')->findOrFail((int) $articles[0]->id);
+        $this->assertStringNotContainsString('Dynamic next steps', (string) $first->content_md);
+        $this->assertStringContainsString('下一步怎么做', (string) $first->content_md);
+        $this->assertStringContainsString('常见问题', (string) $first->publishedRevision?->content_md);
+
+        $writerArtifact = $this->readJson((string) data_get($summary, 'evidence.path'));
+        $writerPath = (string) data_get($summary, 'evidence.path');
+        $writerSha = (string) data_get($summary, 'evidence.sha256');
+        $this->assertSame('seo-ops-zh-article-quality-controlled-writer.v1', $writerArtifact['schema_version'] ?? null);
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-readback', [
+            '--writer-evidence' => $writerPath,
+            '--confirm-writer-evidence-sha256' => $writerSha,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $readback = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, json_encode($readback, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue((bool) ($readback['ok'] ?? false));
+        $this->assertSame('success', $readback['status'] ?? null);
+        $this->assertSame(9, data_get($readback, 'readback_count.passed'));
+        $this->assertSame(0, data_get($readback, 'readback_count.blocked'));
+        $this->assertFalse((bool) data_get($readback, 'side_effects.database_write', true));
+    }
+
+    #[Test]
+    public function execute_requires_exact_confirmation_phrase(): void
+    {
+        $this->seedArticleAuthorityRows();
+        $dryRun = $this->writeJson($this->dryRunEvidence());
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-controlled-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => $dryRun['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--execute' => true,
+            '--confirm-write' => 'wrong',
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('confirm_write_phrase_mismatch', $summary['issues'] ?? []);
+        $this->assertSame(9, Article::query()->withoutGlobalScopes()->where('content_md', 'like', '%Dynamic next steps%')->count());
+    }
+
+    #[Test]
+    public function writer_blocks_wrong_dry_run_evidence_sha(): void
+    {
+        $this->seedArticleAuthorityRows();
+        $dryRun = $this->writeJson($this->dryRunEvidence());
+
+        $exitCode = Artisan::call('seo-ops:zh-article-quality-controlled-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => str_repeat('0', 64),
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('dry_run_evidence_sha_mismatch', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_controlled_writer_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-ops-zh-article-quality-controlled-writer.v1.json'));
+
+        $this->assertSame('seo-ops-zh-article-quality-controlled-writer.v1', $contract['version'] ?? null);
+        $this->assertContains('php artisan seo-ops:zh-article-quality-controlled-writer', $contract['commands'] ?? []);
+        $this->assertSame(9, data_get($contract, 'scope.expected_article_count'));
+        $this->assertSame('下一步怎么做', data_get($contract, 'allowed_replacements.Dynamic next steps'));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.indexnow_submit', true));
+    }
+
+    /**
+     * @return list<Article>
+     */
+    private function seedArticleAuthorityRows(): array
+    {
+        $articles = [];
+        foreach ($this->articleSlugs() as $slug) {
+            $articles[] = $this->createArticle($slug, 'zh-CN', '现有标题 '.$slug, '/zh/articles/'.$slug);
+        }
+
+        return $articles;
+    }
+
+    private function createArticle(string $slug, string $locale, string $title, string $canonicalPath): Article
+    {
+        $content = "# {$title}\n\n## Dynamic next steps\n\n## Frequently asked questions\n\n## Related reading\n\n## Trust links\n\n[/tests/mbti-personality-test-16-personality-types](/tests/mbti-personality-test-16-personality-types)\n[/science](/science)\n";
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'translation_group_id' => (string) Str::uuid(),
+            'source_locale' => $locale,
+            'title' => $title,
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => $content,
+            'content_html' => '<h2>Dynamic next steps</h2><h2>Frequently asked questions</h2><a href="/tests/mbti-personality-test-16-personality-types">test</a>',
+            'status' => 'published',
+            'lifecycle_state' => Article::LIFECYCLE_ACTIVE,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now()->subDay(),
+        ]);
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => $locale,
+            'source_locale' => $locale,
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => $title,
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => $content,
+            'seo_title' => $title.' | FermatMind',
+            'seo_description' => 'Existing SEO description.',
+            'published_at' => now()->subHour(),
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->save();
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => $locale,
+            'seo_title' => $title.' | FermatMind',
+            'seo_description' => 'Existing SEO description.',
+            'canonical_url' => 'https://fermatmind.com'.$canonicalPath,
+            'robots' => 'index,follow',
+            'schema_json' => [['@type' => 'Article']],
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh(['publishedRevision', 'seoMeta']) ?? $article;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function articleSlugs(): array
+    {
+        return [
+            'riasec-holland-career-interest-test-explained',
+            'mbti-basics',
+            'big-five-tool-guide',
+            'iq-test-score-and-limits-explained',
+            'eq-test-tool-guide',
+            'enneagram-personality-test-explained',
+            'college-major-choice-holland-mbti-career-test',
+            'career-confusion-test-map',
+            'career-interest-vs-personality-test-differences',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function dryRunEvidence(): array
+    {
+        $plans = [];
+        foreach (Article::query()->withoutGlobalScopes()->orderBy('id')->get() as $article) {
+            $plans[] = [
+                'target' => 'article:'.(int) $article->id.':zh-CN',
+                'path' => '/zh/articles/'.$article->slug,
+                'slug' => (string) $article->slug,
+                'locale' => 'zh-CN',
+                'resolved' => true,
+                'current' => [
+                    'article_id' => (int) $article->id,
+                    'canonical_path' => '/zh/articles/'.$article->slug,
+                ],
+                'planned_repairs' => [
+                    'heading_replacements' => [
+                        ['find' => 'Dynamic next steps', 'replace_with' => '下一步怎么做', 'scope' => 'cms_article_body_or_module_heading'],
+                        ['find' => 'Frequently asked questions', 'replace_with' => '常见问题', 'scope' => 'cms_article_body_or_module_heading'],
+                        ['find' => 'Related reading', 'replace_with' => '相关阅读', 'scope' => 'cms_article_body_or_module_heading'],
+                        ['find' => 'Trust links', 'replace_with' => '可信度与边界', 'scope' => 'cms_article_body_or_module_heading'],
+                    ],
+                    'link_replacements' => [
+                        ['find' => '/tests/mbti-personality-test-16-personality-types', 'replace_with' => '/zh/tests/mbti-personality-test-16-personality-types', 'scope' => 'cms_article_body_or_module_link'],
+                        ['find' => '/science', 'replace_with' => '/zh/science', 'scope' => 'cms_article_body_or_module_link'],
+                    ],
+                ],
+                'issues' => [],
+            ];
+        }
+
+        return [
+            'schema_version' => 'seo-ops-zh-article-quality-repair-dry-run.v1',
+            'ok' => true,
+            'status' => 'planned',
+            'dry_run' => true,
+            'execute' => false,
+            'candidate_counts' => [
+                'package_operations' => 9,
+                'resolved_article_operations' => 9,
+                'unresolved_article_operations' => 0,
+            ],
+            'article_operation_plans' => $plans,
+            'negative_guarantees' => [
+                'database_write' => false,
+                'cms_write' => false,
+                'cms_publish' => false,
+                'url_truth_write' => false,
+                'schema_enable' => false,
+                'hreflang_enable' => false,
+                'sitemap_write' => false,
+                'llms_write' => false,
+                'search_channel_enqueue' => false,
+                'indexnow_submit' => false,
+                'baidu_submit' => false,
+                'gsc_request_indexing' => false,
+                'revalidation' => false,
+                'deploy' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{path:string,sha256:string}
+     */
+    private function writeJson(array $payload): array
+    {
+        $path = $this->artifactDir().'/input-'.Str::uuid()->toString().'.json';
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return ['path' => $path, 'sha256' => hash_file('sha256', $path)];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => DB::table('articles')->count(),
+            'article_translation_revisions' => DB::table('article_translation_revisions')->count(),
+            'article_seo_meta' => DB::table('article_seo_meta')->count(),
+        ];
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @return array<int, array<string, mixed>>
+     */
+    private function protectedSnapshots(array $articles): array
+    {
+        $snapshots = [];
+        foreach ($articles as $article) {
+            $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail((int) $article->id);
+            $snapshots[(int) $fresh->id] = [
+                'slug' => (string) $fresh->slug,
+                'locale' => (string) $fresh->locale,
+                'status' => (string) $fresh->status,
+                'published_revision_id' => $fresh->published_revision_id,
+                'working_revision_id' => $fresh->working_revision_id,
+                'canonical_url' => (string) $fresh->seoMeta?->canonical_url,
+                'is_public' => (bool) $fresh->is_public,
+                'is_indexable' => (bool) $fresh->is_indexable,
+                'sitemap_eligible' => (bool) $fresh->sitemap_eligible,
+                'llms_eligible' => (bool) $fresh->llms_eligible,
+            ];
+        }
+
+        return $snapshots;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonOutput(): array
+    {
+        return json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    private function confirmationPhrase(string $sha): string
+    {
+        return 'I explicitly approve SEO-OPS-ZH-ARTICLE-QUALITY-CONTROLLED-WRITER-01 to write 9 zh-CN article quality deterministic heading/link repairs from dry-run evidence sha256 '.$sha.'; no publish, no URL Truth, no sitemap/llms, no schema/hreflang, no Search Channel, no IndexNow/Baidu/GSC, no deploy/revalidation.';
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-ops-zh-article-quality-controlled-writer-'.Str::uuid()->toString());
+        if (! is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        return $dir;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1335,6 +1335,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_ops_zh_article_quality_writer_and_readback_adapters(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php',
+            'backend/app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoOpsZhArticleQualityControlledWriterCommand;',
+            '+use App\\Console\\Commands\\SeoOpsZhArticleQualityReadbackCommand;',
+            '+        SeoOpsZhArticleQualityControlledWriterCommand::class,',
+            '+        SeoOpsZhArticleQualityReadbackCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_codex_review_runner_files(): void
     {
         $changed = [
@@ -4871,6 +4888,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoOpsZhArticleQualityWriterOrReadbackFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentCmsTdkGapReadonlyScannerFile($file)) {
                 continue;
             }
@@ -5769,6 +5790,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsBigFivePublicProfileAgentPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoOpsP0CtrArticleCmsUpdateWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoOpsZhArticleQualityRepairDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoOpsZhArticleQualityWriterOrReadbackOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6532,6 +6554,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isSeoOpsZhArticleQualityRepairDryRunFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php';
+    }
+
+    private function isSeoOpsZhArticleQualityWriterOrReadbackFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php',
+            'backend/app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php',
+        ], true);
     }
 
     private function isSeoAgentCmsTdkGapReadonlyScannerFile(string $file): bool
@@ -8688,6 +8718,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoOpsZhArticleQualityRepairDryRunCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoOpsZhArticleQualityWriterOrReadbackOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoOpsZhArticleQuality(ControlledWriter|Readback)Command\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-ops:zh-article-quality-controlled-writer`, a gated writer for the verified P2-A zh-CN article quality dry-run evidence.
- Added `seo-ops:zh-article-quality-readback`, a read-only post-write QA command for the same 9 article targets.
- The writer allows only deterministic package replacements for Chinese module headings and non-/zh internal route leaks.
- Registered both commands, added generated contract docs, focused feature tests, and the BigFive runtime-freeze classifier allowlist/test for these scoped adapters.

## Why
P2 needs a controlled CMS write gate after backend authority dry-run, but still must preserve slug/canonical/locale/publication/schema/hreflang/sitemap/llms/search boundaries.

## Validation
- `php artisan list | rg 'seo-ops:zh-article-quality'`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsZhArticleQualityControlledWriterTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_ops_zh_article_quality'`
- `vendor/bin/pint --test app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php tests/Feature/SeoIntel/SeoOpsZhArticleQualityControlledWriterTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `python3 -m json.tool docs/seo/generated/seo-ops-zh-article-quality-controlled-writer.v1.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production CMS write/import in this PR.
- No publish, URL Truth, sitemap/llms, schema/hreflang, Search Channel, IndexNow/Baidu/GSC, revalidation, deploy, scheduler, or queue worker action.
- P2-C frontend renderer/contract fix remains conditional on post-write runtime readback.
