### PR TITLE
SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01: Add Gaokao v5 CMS draft gate

### DIFF
--- a/backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php
+++ b/backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\SeoContentPackage\SeoContentPackageDraftImporter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class SeoOpsGaokaoV5CmsDraftGateCommand extends Command
+{
+    private const OUTPUT_SCHEMA = 'seo-ops-gaokao-v5-cms-draft-gate.v1';
+
+    private const EXPECTED_LOCALE = 'zh-CN';
+
+    protected $signature = 'seo-ops:gaokao-v5-cms-draft-gate
+        {--package= : Path to the repaired Gaokao v5 SEO content package directory}
+        {--confirm-package-sha256= : Expected SHA-256 of the package directory}
+        {--translation-group-id= : Expected package translation_group_id}
+        {--expected-zh-slug= : Expected zh-CN article slug}
+        {--artifact-dir= : Directory for read-only evidence output}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only gate evidence for Gaokao v5 CMS draft package readiness; writes evidence only.';
+
+    public function handle(SeoContentPackageDraftImporter $importer): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary(['artifact_dir_unwritable']));
+        }
+
+        $packageRoot = $this->packageRoot();
+        $packageSha = $packageRoot !== null ? $this->packageSha256($packageRoot) : '';
+        $expectedSha = trim((string) $this->option('confirm-package-sha256'));
+        $issues = [];
+
+        if ($packageRoot === null) {
+            $issues[] = 'package_unreadable';
+        } elseif ($expectedSha === '' || ! hash_equals($expectedSha, $packageSha)) {
+            $issues[] = 'package_sha_mismatch';
+        }
+
+        $translationGroupId = trim((string) $this->option('translation-group-id'));
+        $expectedSlug = trim((string) $this->option('expected-zh-slug'));
+        if ($translationGroupId === '') {
+            $issues[] = 'translation_group_id_required';
+        }
+        if ($expectedSlug === '') {
+            $issues[] = 'expected_zh_slug_required';
+        }
+
+        $plan = [];
+        if ($issues === [] && $packageRoot !== null) {
+            $plan = $importer->planFromDirectory([
+                'package' => $packageRoot,
+                'translation_group_id' => $translationGroupId,
+                'locales' => [self::EXPECTED_LOCALE],
+                'dry_run' => true,
+                'json' => true,
+                'draft_only' => true,
+                'no_publish' => true,
+                'no_index' => true,
+                'no_sitemap' => true,
+                'no_llms' => true,
+                'schema_hold' => true,
+                'hreflang_hold' => true,
+                'expected_slugs' => [
+                    self::EXPECTED_LOCALE => $expectedSlug,
+                    'en' => '',
+                ],
+            ]);
+            if (($plan['ok'] ?? false) !== true) {
+                foreach ((array) ($plan['errors'] ?? []) as $error) {
+                    $issues[] = is_array($error)
+                        ? (string) (($error['code'] ?? 'importer_plan_error'))
+                        : 'importer_plan_error';
+                }
+            }
+        }
+
+        $articles = array_values(array_filter(
+            (array) ($plan['articles'] ?? []),
+            static fn (mixed $article): bool => is_array($article)
+        ));
+        if ($issues === [] && count($articles) !== 1) {
+            $issues[] = 'planned_article_count_not_one';
+        }
+        foreach ($articles as $article) {
+            if (($article['article_id'] ?? null) !== null) {
+                $issues[] = 'existing_article_authority_found_new_article_gate_blocked';
+            }
+            if ((string) ($article['action'] ?? '') !== 'would_create_draft') {
+                $issues[] = 'unexpected_draft_action';
+            }
+        }
+
+        $summary = $this->summary($packageRoot, $packageSha, $translationGroupId, $expectedSlug, $plan, $articles, $issues);
+        $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+        return $this->finish($summary);
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @param  list<array<string, mixed>>  $articles
+     * @param  list<string>  $issues
+     * @return array<string, mixed>
+     */
+    private function summary(?string $packageRoot, string $packageSha, string $translationGroupId, string $expectedSlug, array $plan, array $articles, array $issues): array
+    {
+        $ok = $issues === [];
+        $article = $articles[0] ?? [];
+
+        return [
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:gaokao-v5-cms-draft-gate',
+            'ok' => $ok,
+            'status' => $ok ? 'planned' : 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->utc()->toIso8601String(),
+            'source_package' => [
+                'path' => $packageRoot,
+                'sha256' => $packageSha,
+                'translation_group_id' => $translationGroupId,
+                'expected_zh_slug' => $expectedSlug,
+            ],
+            'authority_sources' => [
+                'cms_draft_gate' => 'backend SeoContentPackageDraftImporter dry-run',
+                'article_authority' => 'backend.articles + article_translation_revisions + article_seo_meta',
+                'package_authority' => 'repaired generated Gaokao v5 SEO content package',
+            ],
+            'candidate_counts' => [
+                'package_articles' => count($articles),
+                'planned_draft_articles' => $ok ? count($articles) : 0,
+                'blocked_articles' => $ok ? 0 : count($articles),
+            ],
+            'planned_write_count' => [
+                'article_drafts' => $ok ? count($articles) : 0,
+                'article_revisions' => $ok ? count($articles) : 0,
+                'article_seo_meta_rows' => $ok ? count($articles) : 0,
+                'article_editorial_package_import_rows' => $ok ? count($articles) : 0,
+            ],
+            'protected_diff_summary' => [
+                'operation_type' => 'new_article_draft_only',
+                'slug' => (string) ($article['slug'] ?? '') === $expectedSlug ? 'no_change' : 'mismatch',
+                'canonical' => 'no_change',
+                'locale' => (string) ($article['locale'] ?? '') === self::EXPECTED_LOCALE ? 'no_change' : 'mismatch',
+                'article_id' => ($article['article_id'] ?? null) === null ? 'new_article_no_existing_authority' : 'resolved_existing',
+                'publication' => 'hold_no_change',
+                'schema' => 'hold_no_change',
+                'hreflang' => 'hold_no_change',
+                'sitemap' => 'no_change',
+                'llms' => 'no_change',
+                'search_submission' => 'hold_no_change',
+            ],
+            'article_plans' => array_map(fn (array $planned): array => $this->articlePlan($planned, $expectedSlug), $articles),
+            'delegate_dry_run_command' => $this->delegateCommand($packageRoot, $translationGroupId, $expectedSlug, true, $packageSha),
+            'delegate_write_command_after_separate_approval' => $this->delegateCommand($packageRoot, $translationGroupId, $expectedSlug, false, $packageSha),
+            'required_confirmation_phrase' => $this->confirmationPhrase($packageSha, $translationGroupId, $expectedSlug),
+            'importer_plan' => [
+                'ok' => (bool) ($plan['ok'] ?? false),
+                'action' => (string) ($plan['action'] ?? ''),
+                'active_surface_guard_scan' => $plan['active_surface_guard_scan'] ?? null,
+                'contract_integrity_scan' => $plan['contract_integrity_scan'] ?? null,
+                'safety_flags' => $plan['safety_flags'] ?? null,
+                'errors' => $plan['errors'] ?? [],
+                'warnings' => $plan['warnings'] ?? [],
+            ],
+            'issues' => array_values(array_unique($issues)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $article
+     * @return array<string, mixed>
+     */
+    private function articlePlan(array $article, string $expectedSlug): array
+    {
+        $slug = (string) ($article['slug'] ?? '');
+        $locale = (string) ($article['locale'] ?? '');
+
+        return [
+            'target' => 'article:new:'.$locale.':'.$slug,
+            'locale' => $locale,
+            'slug' => $slug,
+            'expected_slug' => $expectedSlug,
+            'action' => (string) ($article['action'] ?? ''),
+            'article_id' => $article['article_id'] ?? null,
+            'working_revision_status' => (string) ($article['working_revision_status'] ?? ''),
+            'status' => (string) ($article['status'] ?? ''),
+            'is_public' => (bool) ($article['is_public'] ?? true),
+            'is_indexable' => (bool) ($article['is_indexable'] ?? true),
+            'sitemap_eligible' => (bool) ($article['sitemap_eligible'] ?? true),
+            'llms_eligible' => (bool) ($article['llms_eligible'] ?? true),
+            'protected_diff' => [
+                'slug' => $slug === $expectedSlug ? 'no_change' : 'mismatch',
+                'locale' => $locale === self::EXPECTED_LOCALE ? 'no_change' : 'mismatch',
+                'publication' => 'hold_no_change',
+                'schema' => 'hold_no_change',
+                'hreflang' => 'hold_no_change',
+                'sitemap' => 'no_change',
+                'llms' => 'no_change',
+                'search_submission' => 'hold_no_change',
+            ],
+        ];
+    }
+
+    private function packageRoot(): ?string
+    {
+        $path = trim((string) $this->option('package'));
+        if ($path === '' || ! is_dir($path)) {
+            return null;
+        }
+
+        $real = realpath($path);
+
+        return is_string($real) ? $real : null;
+    }
+
+    private function packageSha256(string $root): string
+    {
+        $files = collect(File::allFiles($root))
+            ->filter(static fn (\SplFileInfo $file): bool => $file->isFile())
+            ->map(static fn (\SplFileInfo $file): string => $file->getPathname())
+            ->sort()
+            ->values();
+
+        $hash = hash_init('sha256');
+        foreach ($files as $path) {
+            $relative = ltrim(str_replace($root, '', $path), DIRECTORY_SEPARATOR);
+            hash_update($hash, $relative."\0".hash_file('sha256', $path)."\n");
+        }
+
+        return hash_final($hash);
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '') {
+            return null;
+        }
+
+        File::ensureDirectoryExists($dir);
+        $real = realpath($dir);
+
+        return is_string($real) && is_dir($real) ? $real : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    private function writeEvidence(string $artifactDir, array $summary): array
+    {
+        $path = $artifactDir.'/seo-ops-gaokao-v5-cms-draft-gate-'.now()->utc()->format('Ymd\THis\Z').'.json';
+        File::put($path, json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE));
+
+        return [
+            'path' => $path,
+            'sha256' => hash_file('sha256', $path),
+            'bytes' => filesize($path),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function delegateCommand(?string $packageRoot, string $translationGroupId, string $expectedSlug, bool $dryRun, string $packageSha): array
+    {
+        $parts = [
+            'php artisan articles:import-seo-content-package-draft',
+            '--package='.escapeshellarg((string) $packageRoot),
+            '--translation-group-id='.escapeshellarg($translationGroupId),
+            '--locales=zh-CN',
+            '--draft-only',
+            '--no-publish',
+            '--no-index',
+            '--no-sitemap',
+            '--no-llms',
+            '--schema-hold',
+            '--hreflang-hold',
+            '--expected-zh-slug='.escapeshellarg($expectedSlug),
+            '--expected-en-slug='."''",
+            '--json',
+        ];
+        if ($dryRun) {
+            $parts[] = '--dry-run';
+        } else {
+            $parts[] = '# execute only after exact approval: '.$this->confirmationPhrase($packageSha, $translationGroupId, $expectedSlug);
+        }
+
+        return $parts;
+    }
+
+    private function confirmationPhrase(string $packageSha, string $translationGroupId, string $expectedSlug): string
+    {
+        return 'I explicitly approve articles:import-seo-content-package-draft draft-only write for Gaokao v5 package sha256 '.$packageSha.' translation_group_id '.$translationGroupId.' slug '.$expectedSlug.'; no publish, no URL Truth, no sitemap/llms, no schema/hreflang, no Search Channel, no deploy/revalidation.';
+    }
+
+    /**
+     * @param  list<string>  $issues
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(array $issues, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:gaokao-v5-cms-draft-gate',
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->utc()->toIso8601String(),
+            'issues' => $issues,
+            'negative_guarantees' => $this->negativeGuarantees(),
+            ...$extra,
+        ];
+    }
+
+    /**
+     * @return array<string, false>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'url_truth_write' => false,
+            'schema_hreflang_write' => false,
+            'sitemap_llms_mutation' => false,
+            'search_channel_enqueue' => false,
+            'indexnow_submit' => false,
+            'baidu_submit' => false,
+            'gsc_request_indexing' => false,
+            'scheduler_activation' => false,
+            'queue_worker_start' => false,
+            'deploy' => false,
+            'revalidation' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+        } else {
+            $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+            $this->line('status='.(string) ($summary['status'] ?? ''));
+            $this->line('planned_article_drafts='.(string) data_get($summary, 'planned_write_count.article_drafts', 0));
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -223,6 +223,7 @@ use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
 use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
 use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
+use App\Console\Commands\SeoOpsGaokaoV5CmsDraftGateCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityControlledWriterCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityRepairDryRunCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityReadbackCommand;
@@ -472,6 +473,7 @@ class Kernel extends ConsoleKernel
         SeoAgentWeeklyDraftWriteAutoCommand::class,
         SeoAgentWeeklyReadonlyRunnerCommand::class,
         SeoOpsP0CtrArticleCmsUpdateWriterCommand::class,
+        SeoOpsGaokaoV5CmsDraftGateCommand::class,
         SeoOpsZhArticleQualityControlledWriterCommand::class,
         SeoOpsZhArticleQualityRepairDryRunCommand::class,
         SeoOpsZhArticleQualityReadbackCommand::class,

--- a/backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json
+++ b/backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json
@@ -1,0 +1,75 @@
+{
+  "version": "seo-ops-gaokao-v5-cms-draft-gate.v1",
+  "command": "php artisan seo-ops:gaokao-v5-cms-draft-gate",
+  "purpose": "Read-only gate evidence for the repaired Gaokao v5 SEO content package before any CMS draft write approval.",
+  "inputs": {
+    "package": "Directory containing the repaired generated Gaokao v5 SEO content package.",
+    "confirm_package_sha256": "Deterministic SHA-256 over sorted package file paths and file hashes.",
+    "translation_group_id": "Expected article translation group lock.",
+    "expected_zh_slug": "Expected zh-CN article slug lock.",
+    "artifact_dir": "Evidence output directory.",
+    "json": "Emit JSON summary."
+  },
+  "delegates_to": {
+    "dry_run": "articles:import-seo-content-package-draft --dry-run",
+    "future_write_gate": "articles:import-seo-content-package-draft without --dry-run after separate exact approval"
+  },
+  "resolves": {
+    "article_draft": {
+      "expected_count": 1,
+      "locale": "zh-CN",
+      "operation_type": "new_article_draft_only"
+    },
+    "authority_sources": [
+      "backend SeoContentPackageDraftImporter dry-run",
+      "backend.articles + article_translation_revisions + article_seo_meta",
+      "repaired generated Gaokao v5 SEO content package"
+    ]
+  },
+  "protected_diff": {
+    "operation_type": "new_article_draft_only",
+    "slug": "no_change",
+    "canonical": "no_change",
+    "locale": "no_change",
+    "publication": "hold_no_change",
+    "schema": "hold_no_change",
+    "hreflang": "hold_no_change",
+    "sitemap": "no_change",
+    "llms": "no_change",
+    "search_submission": "hold_no_change"
+  },
+  "blocking_conditions": [
+    "package_unreadable",
+    "package_sha_mismatch",
+    "translation_group_id_required",
+    "expected_zh_slug_required",
+    "planned_article_count_not_one",
+    "existing_article_authority_found_new_article_gate_blocked",
+    "unexpected_draft_action",
+    "importer plan errors"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "url_truth_write": false,
+    "schema_hreflang_write": false,
+    "sitemap_llms_mutation": false,
+    "search_channel_enqueue": false,
+    "indexnow_submit": false,
+    "baidu_submit": false,
+    "gsc_request_indexing": false,
+    "scheduler_activation": false,
+    "queue_worker_start": false,
+    "deploy": false,
+    "revalidation": false
+  },
+  "separate_approvals_required_after_success": [
+    "CMS draft write",
+    "preview QA",
+    "publish",
+    "URL Truth",
+    "sitemap/llms",
+    "Search Channel / IndexNow"
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleEditorialPackageImport;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoOpsGaokaoV5CmsDraftGateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TRANSLATION_GROUP_ID = 'tg_article_gaokao_major_choice_parent_conflict_riasec_2026v5';
+
+    private const SLUG = 'gaokao-major-choice-parent-conflict-riasec-course-checklist';
+
+    #[Test]
+    public function dry_run_plans_one_gaokao_article_draft_without_database_writes(): void
+    {
+        $package = $this->writePackage();
+        $sha = $this->packageSha256($package);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-cms-draft-gate', [
+            '--package' => $package,
+            '--confirm-package-sha256' => $sha,
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--expected-zh-slug' => self::SLUG,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame(1, data_get($summary, 'planned_write_count.article_drafts'));
+        $this->assertSame('new_article_draft_only', data_get($summary, 'protected_diff_summary.operation_type'));
+        $this->assertSame('no_change', data_get($summary, 'protected_diff_summary.slug'));
+        $this->assertSame('hold_no_change', data_get($summary, 'protected_diff_summary.schema'));
+        $this->assertSame('hold_no_change', data_get($summary, 'protected_diff_summary.search_submission'));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.database_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'evidence.path'));
+        $this->assertSame('seo-ops-gaokao-v5-cms-draft-gate.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame($sha, data_get($artifact, 'source_package.sha256'));
+        $this->assertSame(self::SLUG, data_get($artifact, 'article_plans.0.slug'));
+        $this->assertStringContainsString('no publish, no URL Truth', (string) ($artifact['required_confirmation_phrase'] ?? ''));
+    }
+
+    #[Test]
+    public function dry_run_blocks_wrong_package_sha(): void
+    {
+        $package = $this->writePackage();
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-cms-draft-gate', [
+            '--package' => $package,
+            '--confirm-package-sha256' => str_repeat('0', 64),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--expected-zh-slug' => self::SLUG,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('package_sha_mismatch', $summary['issues'] ?? []);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    #[Test]
+    public function dry_run_blocks_existing_article_authority_for_new_article_gate(): void
+    {
+        $this->createPublishedArticle();
+        $package = $this->writePackage();
+        $sha = $this->packageSha256($package);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-cms-draft-gate', [
+            '--package' => $package,
+            '--confirm-package-sha256' => $sha,
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--expected-zh-slug' => self::SLUG,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('existing_article_authority_found_new_article_gate_blocked', $summary['issues'] ?? []);
+        $this->assertSame($countsBefore, $this->rowCounts());
+    }
+
+    #[Test]
+    public function generated_contract_documents_gaokao_v5_draft_gate_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json'));
+
+        $this->assertSame('seo-ops-gaokao-v5-cms-draft-gate.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-ops:gaokao-v5-cms-draft-gate', $contract['command'] ?? null);
+        $this->assertSame('new_article_draft_only', data_get($contract, 'protected_diff.operation_type'));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.database_write', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.indexnow_submit', true));
+    }
+
+    private function writePackage(): string
+    {
+        $root = sys_get_temp_dir().'/fm-gaokao-v5-package-'.Str::random(12);
+        foreach (['pages', 'cms', 'contracts', 'review', 'codex'] as $directory) {
+            File::ensureDirectoryExists($root.'/'.$directory);
+        }
+
+        foreach ($this->packageFiles() as $relativePath => $contents) {
+            $path = $root.'/'.$relativePath;
+            File::ensureDirectoryExists(dirname($path));
+            File::put($path, is_array($contents)
+                ? json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+                : $contents);
+        }
+
+        return $root;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function packageFiles(): array
+    {
+        $social = [
+            'media_library_asset_key' => 'article.gaokao.riasec.parent-conflict.cover.v1',
+            'media_library_status' => 'published',
+            'is_public' => true,
+            'cover_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/gaokao/hero_1600x900.jpg',
+            'og_1200x630_variant' => [
+                'url' => 'https://api.fermatmind.com/storage/media-library/variants/gaokao/og_1200x630.jpg',
+                'width' => 1200,
+                'height' => 630,
+            ],
+            'twitter_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/gaokao/og_1200x630.jpg',
+            'alt_text' => '高考专业选择与霍兰德职业兴趣结构示意图',
+            'width' => 1600,
+            'height' => 900,
+        ];
+        $base = [
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'locale' => 'zh-CN',
+            'status' => 'draft',
+            'publish_allowed' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'category_name' => '高考志愿',
+            'category_slug' => 'gaokao-major-choice',
+            'title' => '孩子不听家长建议怎么选专业？用霍兰德兴趣做一次课程核对',
+            'slug' => self::SLUG,
+            'canonical_url' => '/zh/articles/'.self::SLUG,
+            'meta_title' => '高考选专业亲子冲突：用霍兰德兴趣做课程核对',
+            'meta_description' => '当孩子和家长在高考专业选择上意见不同，可以用霍兰德兴趣、课程偏好和信息核对表把讨论变得更具体。',
+            'primary_keyword' => '高考选专业 家长 孩子 冲突',
+            'secondary_keywords' => ['霍兰德职业兴趣测试', '高考志愿专业选择'],
+            'primary_hub_url' => '/zh/tests/holland-career-interest-test-riasec',
+            'secondary_hub_urls' => ['/zh/tests/mbti-personality-test-16-personality-types'],
+            'schema_eligibility' => ['article_schema' => 'review_required', 'faq_schema' => false],
+            'cover_media_asset_key' => 'article.gaokao.riasec.parent-conflict.cover.v1',
+            'cover_image_url' => $social['cover_image_url'],
+            'cover_image_alt' => $social['alt_text'],
+            'cover_image_width' => 1600,
+            'cover_image_height' => 900,
+            'cover_image_variants' => ['hero' => ['url' => $social['cover_image_url'], 'width' => 1600, 'height' => 900]],
+            'og_image_url' => $social['og_1200x630_variant']['url'],
+            'twitter_image_url' => $social['twitter_image_url'],
+            'social_image_metadata' => $social,
+        ];
+
+        return [
+            'manifest.json' => [
+                'package_name' => 'gaokao-major-choice-parent-conflict-riasec-course-checklist',
+                'translation_group_id' => self::TRANSLATION_GROUP_ID,
+                'locale_scope' => ['zh-CN'],
+                'publish_allowed' => false,
+                'schema_hold' => true,
+                'hreflang_hold' => true,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'search_submission_hold' => true,
+                'pages' => [[
+                    'locale' => 'zh-CN',
+                    'slug' => self::SLUG,
+                    'canonical_url_draft' => '/zh/articles/'.self::SLUG,
+                    'title' => $base['title'],
+                    'file' => 'pages/zh-CN-'.self::SLUG.'.md',
+                    'category_name' => '高考志愿',
+                ]],
+            ],
+            'pages/zh-CN-'.self::SLUG.'.md' => $this->markdownPage(),
+            'cms/CMS_FIELDS_zh-CN_'.self::SLUG.'.json' => $base,
+            'cms/CMS_IMPORT_DRAFT_zh-CN_'.self::SLUG.'.json' => array_replace($base, [
+                'body_markdown_file' => 'pages/zh-CN-'.self::SLUG.'.md',
+            ]),
+            'contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json' => ['canonical_path' => '/zh/articles/'.self::SLUG],
+            'contracts/ROUTE_ALIAS_CONTRACT.json' => ['known_aliases' => []],
+            'contracts/SOCIAL_IMAGE_METADATA_REQUIREMENTS.json' => ['asset_key' => 'article.gaokao.riasec.parent-conflict.cover.v1', 'required' => true],
+            'contracts/DYNAMIC_CTA_CONTRACT.json' => [
+                'primary' => '/zh/tests/holland-career-interest-test-riasec',
+                'forbidden_tracking_params' => ['result_id', 'order_id', 'payment_id', 'token', 'score', 'user_id', 'report_id'],
+            ],
+            'contracts/INTERNAL_LINK_PLAN.json' => ['links' => ['/zh/tests/holland-career-interest-test-riasec']],
+            'contracts/PRIVATE_URL_GUARD.json' => [
+                'forbidden_paths' => ['/result', '/results', '/orders', '/order', '/share', '/pay', '/payment', '/history', '/take'],
+                'forbidden_query_keys' => ['result_id', 'order_id', 'payment_id', 'token', 'score', 'user_id', 'report_id'],
+            ],
+            'review/claim_gate.md' => "claim_gate_status: not_reviewed\n",
+            'review/operator_review.md' => "operator_review_required: true\n",
+            'codex/qa_checklist.md' => "- no publish\n- no search\n",
+        ];
+    }
+
+    private function markdownPage(): string
+    {
+        $translationGroupId = self::TRANSLATION_GROUP_ID;
+        $slug = self::SLUG;
+
+        return <<<MD
+---
+translation_group_id: {$translationGroupId}
+locale: zh-CN
+title: 孩子不听家长建议怎么选专业？用霍兰德兴趣做一次课程核对
+slug: {$slug}
+canonical_url_draft: /zh/articles/{$slug}
+primary_keyword: 高考选专业 家长 孩子 冲突
+claim_gate_status: not_reviewed
+publish_allowed: false
+sitemap_eligible: false
+llms_eligible: false
+---
+
+## 先把争论改成信息核对
+
+高考专业选择不应该靠一次测试决定，但可以用霍兰德兴趣把讨论拆成可核对的问题。
+
+## 下一步
+
+[做霍兰德职业兴趣测试](/zh/tests/holland-career-interest-test-riasec)
+MD;
+    }
+
+    private function createPublishedArticle(): void
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => self::SLUG,
+            'locale' => 'zh-CN',
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'source_locale' => 'zh-CN',
+            'title' => 'Existing',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing markdown.',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now()->subDay(),
+        ]);
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => 'Existing',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing markdown.',
+            'seo_title' => 'Existing | FermatMind',
+            'seo_description' => 'Existing SEO description.',
+            'published_at' => now()->subHour(),
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->save();
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'article_seo_meta' => ArticleSeoMeta::query()->withoutGlobalScopes()->count(),
+            'article_translation_revisions' => ArticleTranslationRevision::query()->withoutGlobalScopes()->count(),
+            'article_editorial_package_imports' => ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    private function packageSha256(string $root): string
+    {
+        $files = collect(File::allFiles($root))
+            ->filter(static fn (\SplFileInfo $file): bool => $file->isFile())
+            ->map(static fn (\SplFileInfo $file): string => $file->getPathname())
+            ->sort()
+            ->values();
+
+        $hash = hash_init('sha256');
+        foreach ($files as $path) {
+            $relative = ltrim(str_replace($root, '', $path), DIRECTORY_SEPARATOR);
+            hash_update($hash, $relative."\0".hash_file('sha256', $path)."\n");
+        }
+
+        return hash_final($hash);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-ops-gaokao-v5-cms-draft-gate-'.Str::random(12));
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload, $path);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1352,6 +1352,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_ops_gaokao_v5_cms_draft_gate_adapter(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoOpsGaokaoV5CmsDraftGateCommand;',
+            '+        SeoOpsGaokaoV5CmsDraftGateCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_codex_review_runner_files(): void
     {
         $changed = [
@@ -4892,6 +4906,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoOpsGaokaoV5CmsDraftGateFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentCmsTdkGapReadonlyScannerFile($file)) {
                 continue;
             }
@@ -5791,6 +5809,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoOpsP0CtrArticleCmsUpdateWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoOpsZhArticleQualityRepairDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoOpsZhArticleQualityWriterOrReadbackOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoOpsGaokaoV5CmsDraftGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6562,6 +6581,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php',
             'backend/app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php',
         ], true);
+    }
+
+    private function isSeoOpsGaokaoV5CmsDraftGateFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php';
     }
 
     private function isSeoAgentCmsTdkGapReadonlyScannerFile(string $file): bool
@@ -8740,6 +8764,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoOpsZhArticleQuality(ControlledWriter|Readback)Command\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoOpsGaokaoV5CmsDraftGateOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoOpsGaokaoV5CmsDraftGateCommand\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61640,7 +61640,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-norm-claim-policy-02a",
     "base": "main",
-    "status": "local_validated",
+    "status": "github_checks_pending",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-NORM-CLAIM-POLICY-02A: Bind owner IQ 30 raw-score-only claim policy",
     "depends_on": [
@@ -62175,8 +62175,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "60b652737a42554c7f11b809272e784cb822ad29",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2427",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62407,6 +62407,11 @@
         "at": "2026-06-25T20:35:00+08:00",
         "status": "local_validated",
         "note": "Implemented read-only Gaokao v5 CMS draft gate adapter. Local scoped checks passed with command registration, focused feature test, existing importer regression, scoped Pint, generated contract JSON parse, train YAML/JSON parse, and diff checks. No write or runtime mutation path added."
+      },
+      {
+        "at": "2026-06-25T20:40:00+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2427 at https://github.com/fermatmind/fap-api/pull/2427 from commit 60b652737a42554c7f11b809272e784cb822ad29. Waiting for GitHub checks; no staging wait, production deploy, CMS write, publish, search, sitemap, llms, schema, hreflang, URL Truth, or revalidation."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62353,7 +62353,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-ops-gaokao-v5-cms-draft-gate-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "ready_to_merge",
     "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
     "title": "SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01: Add Gaokao v5 CMS draft gate",
     "depends_on": [],
@@ -62388,13 +62388,13 @@
         "evidence": "Changed files are limited to SeoOpsGaokaoV5CmsDraftGateCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist test for this read-only command, and authorized docs/codex train metadata. No production CMS write/import, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, frontend runtime, deploy, or revalidation changes."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2427 at head d4a42a7127f91bd0ac1a0d00c925c2c815bc7628 after the scoped BigFive freeze-classifier allowlist fix: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed. mergeStateStatus=CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "d4a42a7127f91bd0ac1a0d00c925c2c815bc7628",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2427",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62423,6 +62423,11 @@
         "at": "2026-06-25T20:52:00+08:00",
         "status": "github_checks_retry_pending",
         "note": "Local retry checks passed after the BigFive freeze classifier allowlist fix, including the previously failing focused runtime-freeze test, scoped Pint, train YAML/JSON parse, and diff check. Pushing the fix to rerun GitHub checks."
+      },
+      {
+        "at": "2026-06-25T21:05:00+08:00",
+        "status": "ready_to_merge",
+        "note": "All GitHub checks passed for PR #2427 at head d4a42a7127f91bd0ac1a0d00c925c2c815bc7628 and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61640,7 +61640,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-norm-claim-policy-02a",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "github_checks_retry_pending",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-NORM-CLAIM-POLICY-02A: Bind owner IQ 30 raw-score-only claim policy",
     "depends_on": [
@@ -62374,17 +62374,18 @@
           "cd backend && php artisan list | rg seo-ops:gaokao-v5-cms-draft-gate",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5CmsDraftGateCommandTest --no-ansi",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_ops_gaokao_v5_cms_draft_gate_adapter' --no-ansi",
           "cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php",
           "python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json >/dev/null",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
           "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
           "git diff --check && git diff --cached --check"
         ],
-        "evidence": "PASS: PHP syntax; artisan command registration; focused SeoOpsGaokaoV5CmsDraftGateCommandTest (4 warnings from existing temp file_get_contents pattern, 35 assertions, exit 0); ArticleImportSeoContentPackageDraftCommandTest regression (24 warnings from existing temp file_get_contents pattern, 173 assertions, exit 0); scoped Pint; generated contract JSON parse; train state JSON parse; train manifest YAML parse; git diff checks."
+        "evidence": "PASS: PHP syntax; artisan command registration; focused SeoOpsGaokaoV5CmsDraftGateCommandTest (4 warnings from existing temp file_get_contents pattern, 35 assertions, exit 0); ArticleImportSeoContentPackageDraftCommandTest regression (24 warnings from existing temp file_get_contents pattern, 173 assertions, exit 0); BigFive freeze classifier focused test for the Gaokao gate allowlist (1 warning from existing pattern, 1 assertion, exit 0); scoped Pint; generated contract JSON parse; train state JSON parse; train manifest YAML parse; git diff checks."
       },
       "scope_validation": {
         "status": "pass",
-        "evidence": "Changed files are limited to SeoOpsGaokaoV5CmsDraftGateCommand.php, Kernel registration, generated command contract doc, focused Feature test, and authorized docs/codex train metadata. No production CMS write/import, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, frontend runtime, deploy, or revalidation changes."
+        "evidence": "Changed files are limited to SeoOpsGaokaoV5CmsDraftGateCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist test for this read-only command, and authorized docs/codex train metadata. No production CMS write/import, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, frontend runtime, deploy, or revalidation changes."
       },
       "github": {
         "status": "pending",
@@ -62412,6 +62413,16 @@
         "at": "2026-06-25T20:40:00+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2427 at https://github.com/fermatmind/fap-api/pull/2427 from commit 60b652737a42554c7f11b809272e784cb822ad29. Waiting for GitHub checks; no staging wait, production deploy, CMS write, publish, search, sitemap, llms, schema, hreflang, URL Truth, or revalidation."
+      },
+      {
+        "at": "2026-06-25T20:48:00+08:00",
+        "status": "github_checks_failed_fixing",
+        "note": "GitHub verify-bigfive failed only because the runtime freeze classifier treated the scoped read-only SeoOpsGaokaoV5CmsDraftGateCommand and Kernel registration as BigFive runtime-sensitive. Added a narrow classifier allowlist test and helper for this command only."
+      },
+      {
+        "at": "2026-06-25T20:52:00+08:00",
+        "status": "github_checks_retry_pending",
+        "note": "Local retry checks passed after the BigFive freeze classifier allowlist fix, including the previously failing focused runtime-freeze test, scoped Pint, train YAML/JSON parse, and diff check. Pushing the fix to rerun GitHub checks."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61640,7 +61640,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-norm-claim-policy-02a",
     "base": "main",
-    "status": "in_progress",
+    "status": "local_validated",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-NORM-CLAIM-POLICY-02A: Bind owner IQ 30 raw-score-only claim policy",
     "depends_on": [
@@ -62346,6 +62346,67 @@
         "at": "2026-06-25T18:51:42+08:00",
         "status": "ready_to_merge",
         "note": "PR #2424 GitHub checks passed and mergeStateStatus was CLEAN. Ready for squash merge; no staging wait, production deploy, CMS write, SEO, frontend, runtime scoring bind, or production norm data import included."
+      }
+    ]
+  },
+  "SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-ops-gaokao-v5-cms-draft-gate-01",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
+    "title": "SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01: Add Gaokao v5 CMS draft gate",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User provided /goal FERMATMIND-SEO-OPS-P2-P4-PR-TRAIN-20260625-01 and explicitly authorized adding missing docs/codex/pr-train.yaml and docs/codex/pr-train-state.json entries for this PR train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "P3-A fap-web package contract repair PR #1451 merged with merge commit 812dbcdc33c22b07c8390e778af743085837c679 before P3-B implementation."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php",
+          "php -l backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php",
+          "cd backend && php artisan list | rg seo-ops:gaokao-v5-cms-draft-gate",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5CmsDraftGateCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check && git diff --cached --check"
+        ],
+        "evidence": "PASS: PHP syntax; artisan command registration; focused SeoOpsGaokaoV5CmsDraftGateCommandTest (4 warnings from existing temp file_get_contents pattern, 35 assertions, exit 0); ArticleImportSeoContentPackageDraftCommandTest regression (24 warnings from existing temp file_get_contents pattern, 173 assertions, exit 0); scoped Pint; generated contract JSON parse; train state JSON parse; train manifest YAML parse; git diff checks."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to SeoOpsGaokaoV5CmsDraftGateCommand.php, Kernel registration, generated command contract doc, focused Feature test, and authorized docs/codex train metadata. No production CMS write/import, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, frontend runtime, deploy, or revalidation changes."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T20:20:00+08:00",
+        "status": "in_progress",
+        "note": "Started P3-B in isolated clean worktree /private/tmp/fap-api-p3b-gaokao-cms-draft-gate-01 from fap-api origin/main 26c842ba6baf870d9f5601a3122dd44f362887d6. Scope is backend-only read-only Gaokao v5 CMS draft gate evidence; no production CMS write/import, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, deploy, or revalidation."
+      },
+      {
+        "at": "2026-06-25T20:35:00+08:00",
+        "status": "local_validated",
+        "note": "Implemented read-only Gaokao v5 CMS draft gate adapter. Local scoped checks passed with command registration, focused feature test, existing importer regression, scoped Pint, generated contract JSON parse, train YAML/JSON parse, and diff checks. No write or runtime mutation path added."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -28850,6 +28850,7 @@ prs:
       - backend/app/Console/Kernel.php
       - backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json
       - backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
@@ -28861,6 +28862,7 @@ prs:
       - cd backend && php artisan list | rg seo-ops:gaokao-v5-cms-draft-gate
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5CmsDraftGateCommandTest --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_ops_gaokao_v5_cms_draft_gate_adapter' --no-ansi
       - cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php
       - python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json >/dev/null
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -28832,3 +28832,45 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/seo-ops-gaokao-v5-cms-draft-gate-01
+    title: "SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01: Add Gaokao v5 CMS draft gate"
+    train_scope: fermatmind_seo_ops_p2_p4_20260625
+    status: user_authorized
+    scope:
+      - Add a backend-only read-only command that consumes the repaired Gaokao v5 SEO content package directory.
+      - Delegate package validation to articles:import-seo-content-package-draft dry-run with zh-CN, draft-only, no-publish, no-index, no-sitemap, no-llms, schema-hold, and hreflang-hold flags.
+      - Emit gate evidence with protected diff, planned draft counts, future approval phrase, and no-side-effect guarantees.
+      - Block if an existing article authority row is found because this gate is only for a new article draft.
+    allowed_paths:
+      - backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php
+      - backend/app/Console/Kernel.php
+      - backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json
+      - backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production CMS import/write, create production drafts, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, Baidu, GSC, scheduler, queue worker, frontend runtime, staging deploy, or production deploy.
+      - Modify article importer write semantics outside this gate adapter.
+    validation:
+      - php -l backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php
+      - php -l backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php
+      - cd backend && php artisan list | rg seo-ops:gaokao-v5-cms-draft-gate
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5CmsDraftGateCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php
+      - python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added backend-only read-only `seo-ops:gaokao-v5-cms-draft-gate` command.
- The command delegates validation to existing `articles:import-seo-content-package-draft` dry-run with zh-CN draft-only/no-publish/no-index/no-sitemap/no-llms/schema-hold/hreflang-hold boundaries.
- Added generated command contract doc and focused feature coverage.
- Registered the PR train manifest/state entry authorized by the goal.

## Why
P3-B needs a reproducible gate artifact before any Gaokao v5 CMS draft write can be separately approved. This PR only plans and records evidence; it does not write CMS rows.

## Validation
- `php -l backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php`
- `php -l backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php`
- `cd backend && php artisan list | rg seo-ops:gaokao-v5-cms-draft-gate`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5CmsDraftGateCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5CmsDraftGateCommandTest.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-cms-draft-gate.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No production CMS import/write or draft creation.
- No publish, URL Truth, sitemap/llms, schema/hreflang, Search Channel, IndexNow/Baidu/GSC, scheduler/worker, frontend runtime, deploy, or revalidation.
- Actual draft write remains a later exact approval gate.