### PR TITLE
SEO-OPS-GAOKAO-V5-PROPAGATION-GATE-READINESS-01: Add Gaokao v5 propagation gate readiness

### DIFF
--- a/backend/app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php
+++ b/backend/app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php
@@ -1,0 +1,374 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class SeoOpsGaokaoV5PropagationGateReadinessCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-ops-gaokao-v5-propagation-gate-readiness.v1';
+
+    private const TARGET_LOCALE = 'zh-CN';
+
+    private const TARGET_SLUG = 'gaokao-major-choice-parent-conflict-riasec-course-checklist';
+
+    private const TARGET_PATH = '/zh/articles/'.self::TARGET_SLUG;
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'Cookie:',
+        'Set-Cookie:',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-ops:gaokao-v5-propagation-gate-readiness
+        {--draft-gate-evidence= : Optional seo-ops-gaokao-v5-cms-draft-gate.v1 dry-run artifact}
+        {--draft-write-evidence= : Optional future draft write evidence artifact}
+        {--readback-qa= : Optional future draft readback QA artifact}
+        {--preview-qa= : Optional future preview QA artifact}
+        {--publish-evidence= : Optional future publish canary evidence artifact}
+        {--artifact-dir= : Directory for sanitized gate readiness evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only Gaokao v5 preview, publish, URL Truth, and search propagation gate readiness evidence.';
+
+    public function handle(): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $loaded = $this->loadOptionalArtifacts([
+            'draft_gate_evidence' => (string) $this->option('draft-gate-evidence'),
+            'draft_write_evidence' => (string) $this->option('draft-write-evidence'),
+            'readback_qa' => (string) $this->option('readback-qa'),
+            'preview_qa' => (string) $this->option('preview-qa'),
+            'publish_evidence' => (string) $this->option('publish-evidence'),
+        ]);
+        if (($loaded['issue'] ?? null) !== null) {
+            $summary = $this->failureSummary((string) $loaded['issue'], (array) ($loaded['extra'] ?? []));
+            $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        $evidence = $this->evidence((array) ($loaded['artifacts'] ?? []));
+        $evidence['artifact'] = $this->writeArtifact($artifactDir, $evidence);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => (string) ($evidence['status'] ?? 'review_required'),
+            'target' => $evidence['target'],
+            'gate_statuses' => $evidence['gate_statuses'],
+            'artifact' => $evidence['artifact'],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $artifacts
+     * @return array<string, mixed>
+     */
+    private function evidence(array $artifacts): array
+    {
+        $draftGate = $artifacts['draft_gate_evidence']['payload'] ?? null;
+        $draftGatePlanned = is_array($draftGate)
+            && ($draftGate['schema_version'] ?? null) === 'seo-ops-gaokao-v5-cms-draft-gate.v1'
+            && ($draftGate['status'] ?? null) === 'planned';
+        $draftWritten = isset($artifacts['draft_write_evidence']);
+        $readbackPassing = $this->artifactPassing($artifacts['readback_qa']['payload'] ?? null);
+        $previewPassing = $this->artifactPassing($artifacts['preview_qa']['payload'] ?? null);
+        $publishCompleted = $this->artifactPassing($artifacts['publish_evidence']['payload'] ?? null);
+
+        $publishDryRunReady = $draftWritten && $readbackPassing && $previewPassing;
+        $postPublishReady = $publishCompleted;
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $postPublishReady ? 'post_publish_gate_ready' : ($publishDryRunReady ? 'publish_dry_run_ready' : 'review_required'),
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => Carbon::now('UTC')->toIso8601String(),
+            'target' => [
+                'model' => 'article',
+                'locale' => self::TARGET_LOCALE,
+                'slug' => self::TARGET_SLUG,
+                'canonical_path' => self::TARGET_PATH,
+                'canonical_url' => 'https://fermatmind.com'.self::TARGET_PATH,
+            ],
+            'artifact_inputs' => $this->artifactSummary($artifacts),
+            'gate_statuses' => [
+                'cms_draft_gate_planned' => $draftGatePlanned,
+                'draft_write_evidence_present' => $draftWritten,
+                'readback_qa_passing' => $readbackPassing,
+                'preview_qa_passing' => $previewPassing,
+                'publish_dry_run_ready' => $publishDryRunReady,
+                'publish_evidence_present_and_passing' => $publishCompleted,
+                'url_truth_ready_after_publish' => $postPublishReady,
+                'search_bridge_ready_after_url_truth' => $postPublishReady,
+                'indexnow_gate_ready_after_enqueue' => $postPublishReady,
+            ],
+            'required_evidence_checklist' => [
+                'preview_qa' => [
+                    'required_before_publish_execute' => true,
+                    'must_confirm' => [
+                        'draft preview resolves the Gaokao article draft',
+                        'public runtime does not expose draft before publish',
+                        'canonical remains '.self::TARGET_PATH,
+                    ],
+                ],
+                'publish_dry_run' => [
+                    'required_before_publish_execute' => true,
+                    'approval_phrase_template' => 'I explicitly approve production CMS publish canary for article:<id>:zh-CN revision <revision_id> using write evidence sha256 <write_evidence_sha256>; no URL Truth, no sitemap, no IndexNow, no search, no indexing, no scheduler.',
+                ],
+                'post_publish_url_truth' => [
+                    'required_after_publish' => true,
+                    'approval_phrase_template' => 'I explicitly approve bounded URL Truth handoff import write for article page_entity_type using artifact sha256 <url_truth_artifact_sha256> generated at <url_truth_artifact_path>; no search submission, no CMS content changes, no publish, no schema/hreflang writes.',
+                ],
+                'search_bridge' => [
+                    'required_after_url_truth' => true,
+                    'enqueue_approval_phrase_template' => 'I explicitly approve SEO Agent post-publish Search Channel enqueue for Gaokao article publish evidence sha256 <publish_evidence_sha256> channels indexnow limit=1; no live submit, no Google Indexing API, no sitemap submit, no scheduler.',
+                    'indexnow_live_submit_approval_template' => 'I explicitly approve SEARCH-CHANNEL-BOUNDED-LIVE-EXECUTOR live submission for queue items <queue_item_id> channels indexnow.',
+                ],
+            ],
+            'future_command_templates' => [
+                'preview_qa' => [
+                    'php artisan <future-gaokao-preview-qa-command>',
+                    '--target=article:<id>:zh-CN',
+                    '--revision-id=<draft_revision_id>',
+                    '--json',
+                ],
+                'publish_dry_run' => [
+                    'php artisan seo-agent:article-cms-publish-canary',
+                    '--target=article:<id>:zh-CN',
+                    '--revision-id=<draft_revision_id>',
+                    '--json',
+                    '# no --execute until exact approval',
+                ],
+                'post_publish_propagation_dry_run' => [
+                    'php artisan seo-agent:article-post-publish-propagation-dry-run',
+                    '--publish-evidence=<publish_evidence>',
+                    '--target=article:<id>:zh-CN',
+                    '--revision-id=<source_revision_id>',
+                    '--limit=1',
+                    '--json',
+                ],
+                'url_truth_export_import_dry_run' => [
+                    'php artisan seo-intel:url-truth-handoff --export=<artifact> --dry-run --limit=1 --page-type=article --canonical-path='.self::TARGET_PATH.' --json',
+                    'php artisan seo-intel:url-truth-handoff --import=<artifact> --dry-run --limit=1 --page-type=article --json',
+                ],
+                'search_bridge_dry_run' => [
+                    'php artisan seo-agent:post-publish-search-submit',
+                    '--publish-evidence=<publish_evidence>',
+                    '--channels=indexnow',
+                    '--limit=1',
+                    '--base-url=https://fermatmind.com',
+                    '--json',
+                    '# no --execute until exact approval',
+                ],
+            ],
+            'approval_boundaries' => [
+                'draft_write_is_separate_from_publish' => true,
+                'publish_is_separate_from_url_truth' => true,
+                'url_truth_is_separate_from_search_enqueue' => true,
+                'search_enqueue_is_separate_from_indexnow_live_submit' => true,
+                'no_approval_phrase_is_execution' => true,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    private function artifactPassing(mixed $payload): bool
+    {
+        return is_array($payload)
+            && ($payload['ok'] ?? false) === true
+            && in_array((string) ($payload['status'] ?? ''), ['success', 'planned', 'publish_ready', 'post_publish_gate_ready'], true);
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $artifacts
+     * @return array<string, array<string, mixed>>
+     */
+    private function artifactSummary(array $artifacts): array
+    {
+        $summary = [];
+        foreach ($artifacts as $key => $artifact) {
+            $payload = $artifact['payload'] ?? [];
+            $summary[$key] = [
+                'path' => $artifact['path'] ?? null,
+                'sha256' => $artifact['sha256'] ?? null,
+                'schema_version' => is_array($payload) ? ($payload['schema_version'] ?? ($payload['version'] ?? null)) : null,
+                'status' => is_array($payload) ? ($payload['status'] ?? null) : null,
+                'ok' => is_array($payload) ? ($payload['ok'] ?? null) : null,
+            ];
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string, string>  $pathsByKind
+     * @return array<string, mixed>
+     */
+    private function loadOptionalArtifacts(array $pathsByKind): array
+    {
+        $artifacts = [];
+        foreach ($pathsByKind as $kind => $rawPath) {
+            $rawPath = trim($rawPath);
+            if ($rawPath === '') {
+                continue;
+            }
+            $path = $this->readablePath($rawPath);
+            if ($path === null) {
+                return ['issue' => $kind.'_unreadable'];
+            }
+            $raw = (string) file_get_contents($path);
+            $forbidden = $this->forbiddenStringsPresent($raw);
+            if ($forbidden !== []) {
+                return ['issue' => 'forbidden_input_field_present', 'extra' => ['kind' => $kind, 'forbidden_matches' => $forbidden]];
+            }
+            $payload = json_decode($raw, true);
+            if (! is_array($payload)) {
+                return ['issue' => $kind.'_json_invalid'];
+            }
+            $artifacts[$kind] = [
+                'path' => $path,
+                'sha256' => hash_file('sha256', $path) ?: '',
+                'payload' => $payload,
+            ];
+        }
+
+        return ['artifacts' => $artifacts];
+    }
+
+    private function readablePath(string $rawPath): ?string
+    {
+        $path = trim($rawPath);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-ops/gaokao-v5-propagation-gate-readiness');
+        }
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        File::ensureDirectoryExists($dir);
+
+        return is_dir($dir) && is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $payload): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($payload, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $dir, array $payload): array
+    {
+        $path = rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'seo-ops-gaokao-v5-propagation-gate-readiness-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json';
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('Failed to encode Gaokao v5 propagation gate readiness artifact.');
+        }
+        file_put_contents($path, $encoded."\n");
+
+        return [
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @return array<string, false>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_import' => false,
+            'cms_publish' => false,
+            'url_truth_write' => false,
+            'schema_hreflang_write' => false,
+            'sitemap_llms_mutation' => false,
+            'search_channel_enqueue' => false,
+            'indexnow_submit' => false,
+            'baidu_submit' => false,
+            'gsc_request_indexing' => false,
+            'scheduler_activation' => false,
+            'queue_worker_start' => false,
+            'deploy' => false,
+            'revalidation' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE));
+        } else {
+            $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+            $this->line('status='.(string) ($summary['status'] ?? ''));
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -224,6 +224,7 @@ use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
 use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
 use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
 use App\Console\Commands\SeoOpsGaokaoV5CmsDraftGateCommand;
+use App\Console\Commands\SeoOpsGaokaoV5PropagationGateReadinessCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityControlledWriterCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityRepairDryRunCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityReadbackCommand;
@@ -474,6 +475,7 @@ class Kernel extends ConsoleKernel
         SeoAgentWeeklyReadonlyRunnerCommand::class,
         SeoOpsP0CtrArticleCmsUpdateWriterCommand::class,
         SeoOpsGaokaoV5CmsDraftGateCommand::class,
+        SeoOpsGaokaoV5PropagationGateReadinessCommand::class,
         SeoOpsZhArticleQualityControlledWriterCommand::class,
         SeoOpsZhArticleQualityRepairDryRunCommand::class,
         SeoOpsZhArticleQualityReadbackCommand::class,

--- a/backend/docs/seo/generated/seo-ops-gaokao-v5-propagation-gate-readiness.v1.json
+++ b/backend/docs/seo/generated/seo-ops-gaokao-v5-propagation-gate-readiness.v1.json
@@ -1,0 +1,62 @@
+{
+  "version": "seo-ops-gaokao-v5-propagation-gate-readiness.v1",
+  "command": "php artisan seo-ops:gaokao-v5-propagation-gate-readiness",
+  "purpose": "Read-only preview, publish, URL Truth, Search Channel, and IndexNow gate readiness evidence for the Gaokao v5 article after CMS draft creation.",
+  "inputs": {
+    "draft_gate_evidence": "Optional seo-ops-gaokao-v5-cms-draft-gate.v1 dry-run artifact.",
+    "draft_write_evidence": "Optional future draft write evidence artifact.",
+    "readback_qa": "Optional future draft readback QA artifact.",
+    "preview_qa": "Optional future preview QA artifact.",
+    "publish_evidence": "Optional future publish canary evidence artifact.",
+    "artifact_dir": "Evidence output directory.",
+    "json": "Emit JSON summary."
+  },
+  "target": {
+    "model": "article",
+    "locale": "zh-CN",
+    "canonical_path": "/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist",
+    "canonical_url": "https://fermatmind.com/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist"
+  },
+  "gate_sequence": [
+    "CMS draft write after separate exact approval",
+    "draft readback QA",
+    "preview/runtime QA",
+    "publish dry-run",
+    "publish execute after separate exact approval",
+    "post-publish URL Truth export/import dry-run",
+    "URL Truth bounded write after separate exact approval",
+    "Search Channel bridge dry-run",
+    "Search Channel enqueue after separate exact approval",
+    "queue approval",
+    "IndexNow live submit after separate exact approval"
+  ],
+  "status_semantics": {
+    "review_required": "Required future evidence is missing or not passing.",
+    "publish_dry_run_ready": "Draft write, readback QA, and preview QA evidence are present and passing.",
+    "post_publish_gate_ready": "Publish evidence is present and passing; URL Truth and Search bridge gates may be planned separately."
+  },
+  "approval_boundaries": {
+    "draft_write_is_separate_from_publish": true,
+    "publish_is_separate_from_url_truth": true,
+    "url_truth_is_separate_from_search_enqueue": true,
+    "search_enqueue_is_separate_from_indexnow_live_submit": true,
+    "no_approval_phrase_is_execution": true
+  },
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_import": false,
+    "cms_publish": false,
+    "url_truth_write": false,
+    "schema_hreflang_write": false,
+    "sitemap_llms_mutation": false,
+    "search_channel_enqueue": false,
+    "indexnow_submit": false,
+    "baidu_submit": false,
+    "gsc_request_indexing": false,
+    "scheduler_activation": false,
+    "queue_worker_start": false,
+    "deploy": false,
+    "revalidation": false
+  }
+}

--- a/backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoOpsGaokaoV5PropagationGateReadinessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_emits_read_only_gate_checklist_without_required_future_artifacts(): void
+    {
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-propagation-gate-readiness', [
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('review_required', $summary['status'] ?? null);
+        $this->assertSame('/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist', data_get($summary, 'target.canonical_path'));
+        $this->assertFalse((bool) data_get($summary, 'gate_statuses.publish_dry_run_ready'));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame('seo-ops-gaokao-v5-propagation-gate-readiness.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('review_required', $artifact['status'] ?? null);
+        $this->assertTrue((bool) data_get($artifact, 'approval_boundaries.publish_is_separate_from_url_truth'));
+    }
+
+    #[Test]
+    public function it_marks_publish_dry_run_ready_when_draft_write_readback_and_preview_pass(): void
+    {
+        $draftWrite = $this->writeArtifact('draft-write', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'ok' => true,
+            'status' => 'success',
+        ]);
+        $readback = $this->writeArtifact('readback', [
+            'schema_version' => 'seo-agent-cms-draft-readback-qa.v1',
+            'ok' => true,
+            'status' => 'success',
+        ]);
+        $preview = $this->writeArtifact('preview', [
+            'schema_version' => 'seo-agent-article-draft-preview-runtime-qa.v1',
+            'ok' => true,
+            'status' => 'success',
+        ]);
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-propagation-gate-readiness', [
+            '--draft-write-evidence' => $draftWrite,
+            '--readback-qa' => $readback,
+            '--preview-qa' => $preview,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('publish_dry_run_ready', $summary['status'] ?? null);
+        $this->assertTrue((bool) data_get($summary, 'gate_statuses.publish_dry_run_ready'));
+        $this->assertFalse((bool) data_get($summary, 'gate_statuses.url_truth_ready_after_publish'));
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame(hash_file('sha256', $draftWrite), data_get($artifact, 'artifact_inputs.draft_write_evidence.sha256'));
+        $this->assertStringContainsString('production CMS publish canary', data_get($artifact, 'required_evidence_checklist.publish_dry_run.approval_phrase_template'));
+    }
+
+    #[Test]
+    public function it_blocks_forbidden_payload_fields(): void
+    {
+        $forbidden = $this->writeArtifact('forbidden', [
+            'schema_version' => 'example.v1',
+            'ok' => true,
+            'status' => 'success',
+            'raw_url' => 'https://example.test/private',
+        ]);
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-propagation-gate-readiness', [
+            '--readback-qa' => $forbidden,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+        $this->assertContains('raw_url', data_get($summary, 'forbidden_matches', []));
+    }
+
+    #[Test]
+    public function generated_contract_documents_gate_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-ops-gaokao-v5-propagation-gate-readiness.v1.json'));
+
+        $this->assertSame('seo-ops-gaokao-v5-propagation-gate-readiness.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-ops:gaokao-v5-propagation-gate-readiness', $contract['command'] ?? null);
+        $this->assertContains('IndexNow live submit after separate exact approval', $contract['gate_sequence'] ?? []);
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.indexnow_submit', true));
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => \App\Models\Article::query()->withoutGlobalScopes()->count(),
+            'article_revisions' => \App\Models\ArticleRevision::query()->withoutGlobalScopes()->count(),
+            'article_translation_revisions' => \App\Models\ArticleTranslationRevision::query()->withoutGlobalScopes()->count(),
+            'article_seo_meta' => \App\Models\ArticleSeoMeta::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = sys_get_temp_dir().'/fm-gaokao-v5-propagation-gate-'.Str::random(12);
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeArtifact(string $name, array $payload): string
+    {
+        $dir = sys_get_temp_dir().'/fm-gaokao-v5-propagation-input-'.Str::random(12);
+        File::ensureDirectoryExists($dir);
+        $path = $dir.'/'.$name.'.json';
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true);
+        $this->assertIsArray($decoded, Artisan::output());
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, $path);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1352,15 +1352,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
-    public function test_runtime_freeze_classifier_ignores_seo_ops_gaokao_v5_cms_draft_gate_adapter(): void
+    public function test_runtime_freeze_classifier_ignores_seo_ops_gaokao_v5_gate_adapters(): void
     {
         $changed = [
             'backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php',
+            'backend/app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php',
             'backend/app/Console/Kernel.php',
         ];
         $kernelChangedLines = [
             '+use App\\Console\\Commands\\SeoOpsGaokaoV5CmsDraftGateCommand;',
+            '+use App\\Console\\Commands\\SeoOpsGaokaoV5PropagationGateReadinessCommand;',
             '+        SeoOpsGaokaoV5CmsDraftGateCommand::class,',
+            '+        SeoOpsGaokaoV5PropagationGateReadinessCommand::class,',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
@@ -4906,7 +4909,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
-            if ($this->isSeoOpsGaokaoV5CmsDraftGateFile($file)) {
+            if ($this->isSeoOpsGaokaoV5GateFile($file)) {
                 continue;
             }
 
@@ -5809,7 +5812,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoOpsP0CtrArticleCmsUpdateWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoOpsZhArticleQualityRepairDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoOpsZhArticleQualityWriterOrReadbackOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
-                    || $this->kernelDiffIsSeoOpsGaokaoV5CmsDraftGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoOpsGaokaoV5GateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6583,9 +6586,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
-    private function isSeoOpsGaokaoV5CmsDraftGateFile(string $file): bool
+    private function isSeoOpsGaokaoV5GateFile(string $file): bool
     {
-        return $file === 'backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php';
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoOpsGaokaoV5CmsDraftGateCommand.php',
+            'backend/app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php',
+        ], true);
     }
 
     private function isSeoAgentCmsTdkGapReadonlyScannerFile(string $file): bool
@@ -8774,7 +8780,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     /**
      * @param  list<string>  $changedLines
      */
-    private function kernelDiffIsSeoOpsGaokaoV5CmsDraftGateOnly(array $changedLines): bool
+    private function kernelDiffIsSeoOpsGaokaoV5GateOnly(array $changedLines): bool
     {
         if ($changedLines === []) {
             return false;
@@ -8785,7 +8791,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\bSeoOpsGaokaoV5CmsDraftGateCommand\b/u', $line) !== 1) {
+            if (preg_match('/\bSeoOpsGaokaoV5(CmsDraftGate|PropagationGateReadiness)Command\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62353,7 +62353,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-ops-gaokao-v5-cms-draft-gate-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
     "title": "SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01: Add Gaokao v5 CMS draft gate",
     "depends_on": [],
@@ -62389,15 +62389,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "GitHub checks passed for PR #2427 at head d4a42a7127f91bd0ac1a0d00c925c2c815bc7628 after the scoped BigFive freeze-classifier allowlist fix: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed. mergeStateStatus=CLEAN."
+        "evidence": "GitHub checks passed for PR #2427 at final head c833f530b2c6c56f568c7857c7a9c95a7b120d3f. Squash merge commit 42ef31190f68ebda879a9362bad511052d50a7a9 is contained in origin/main; remote branch was deleted and local task branch/worktree cleanup completed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "d4a42a7127f91bd0ac1a0d00c925c2c815bc7628",
+    "commit_sha": "42ef31190f68ebda879a9362bad511052d50a7a9",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2427",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-25T21:12:00+08:00",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-25T20:20:00+08:00",
@@ -62428,6 +62428,74 @@
         "at": "2026-06-25T21:05:00+08:00",
         "status": "ready_to_merge",
         "note": "All GitHub checks passed for PR #2427 at head d4a42a7127f91bd0ac1a0d00c925c2c815bc7628 and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
+      },
+      {
+        "at": "2026-06-25T21:12:00+08:00",
+        "status": "merged",
+        "note": "PR #2427 was squash merged as 42ef31190f68ebda879a9362bad511052d50a7a9. origin/main contains the merge commit; local main worktree /private/tmp/fap-api-p2a-zh-quality-dry-run was fast-forwarded to origin/main; local and remote task branches were cleaned."
+      }
+    ]
+  },
+  "SEO-OPS-GAOKAO-V5-PROPAGATION-GATE-READINESS-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-ops-gaokao-v5-propagation-gate-readiness-01",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
+    "title": "SEO-OPS-GAOKAO-V5-PROPAGATION-GATE-READINESS-01: Add Gaokao v5 propagation gate readiness",
+    "depends_on": [
+      "SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User provided /goal FERMATMIND-SEO-OPS-P2-P4-PR-TRAIN-20260625-01 and explicitly authorized adding missing docs/codex/pr-train.yaml and docs/codex/pr-train-state.json entries for this PR train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "P3-B PR #2427 merged with squash merge commit 42ef31190f68ebda879a9362bad511052d50a7a9 before P3-C implementation."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php",
+          "php -l backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php",
+          "cd backend && php artisan list | rg seo-ops:gaokao-v5-propagation-gate-readiness",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5PropagationGateReadinessTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_ops_gaokao_v5_gate_adapters' --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-propagation-gate-readiness.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check && git diff --cached --check"
+        ],
+        "evidence": "PASS: PHP syntax; artisan command registration; focused SeoOpsGaokaoV5PropagationGateReadinessTest (4 tests, 32 assertions); BigFive freeze classifier focused test for Gaokao v5 gate adapters (1 assertion); scoped Pint; generated contract JSON parse; train state JSON parse; train manifest YAML parse; diff checks."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to SeoOpsGaokaoV5PropagationGateReadinessCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist for Gaokao v5 gate adapters, and authorized docs/codex train metadata. No production CMS write/import, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, frontend runtime, deploy, or revalidation changes."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T21:16:00+08:00",
+        "status": "in_progress",
+        "note": "Started P3-C from synced fap-api main 42ef31190f68ebda879a9362bad511052d50a7a9. Scope is backend-only read-only Gaokao v5 propagation gate readiness; no production CMS write/import, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, deploy, or revalidation."
+      },
+      {
+        "at": "2026-06-25T21:24:00+08:00",
+        "status": "local_validated",
+        "note": "Implemented read-only Gaokao v5 propagation gate readiness command and focused tests. Local scoped checks passed; no execution path for CMS write/import, publish, URL Truth, sitemap/llms, schema/hreflang, Search Channel, IndexNow, deploy, or revalidation was added."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62440,7 +62440,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-ops-gaokao-v5-propagation-gate-readiness-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_opened",
     "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
     "title": "SEO-OPS-GAOKAO-V5-PROPAGATION-GATE-READINESS-01: Add Gaokao v5 propagation gate readiness",
     "depends_on": [
@@ -62477,12 +62477,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "Opened PR #2428 and waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "c99c508db3c8b6d407df6f6d2f135fb488fda16a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2428",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62496,6 +62496,11 @@
         "at": "2026-06-25T21:24:00+08:00",
         "status": "local_validated",
         "note": "Implemented read-only Gaokao v5 propagation gate readiness command and focused tests. Local scoped checks passed; no execution path for CMS write/import, publish, URL Truth, sitemap/llms, schema/hreflang, Search Channel, IndexNow, deploy, or revalidation was added."
+      },
+      {
+        "at": "2026-06-25T21:28:00+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2428 at https://github.com/fermatmind/fap-api/pull/2428 from commit c99c508db3c8b6d407df6f6d2f135fb488fda16a. Waiting for GitHub checks; no staging wait, production deploy, CMS write/import, publish, URL Truth, search, sitemap, llms, schema, hreflang, or revalidation."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62440,7 +62440,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-ops-gaokao-v5-propagation-gate-readiness-01",
     "base": "main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
     "title": "SEO-OPS-GAOKAO-V5-PROPAGATION-GATE-READINESS-01: Add Gaokao v5 propagation gate readiness",
     "depends_on": [
@@ -62476,12 +62476,12 @@
         "evidence": "Changed files are limited to SeoOpsGaokaoV5PropagationGateReadinessCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist for Gaokao v5 gate adapters, and authorized docs/codex train metadata. No production CMS write/import, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, frontend runtime, deploy, or revalidation changes."
       },
       "github": {
-        "status": "pending",
-        "evidence": "Opened PR #2428 and waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2428 at head 2bf5c0440aaa9b6b613be5e4c022faf11d282ae4: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed. mergeStateStatus=CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "c99c508db3c8b6d407df6f6d2f135fb488fda16a",
+    "commit_sha": "2bf5c0440aaa9b6b613be5e4c022faf11d282ae4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2428",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -62501,6 +62501,11 @@
         "at": "2026-06-25T21:28:00+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2428 at https://github.com/fermatmind/fap-api/pull/2428 from commit c99c508db3c8b6d407df6f6d2f135fb488fda16a. Waiting for GitHub checks; no staging wait, production deploy, CMS write/import, publish, URL Truth, search, sitemap, llms, schema, hreflang, or revalidation."
+      },
+      {
+        "at": "2026-06-25T21:36:00+08:00",
+        "status": "ready_to_merge",
+        "note": "All GitHub checks passed for PR #2428 at head 2bf5c0440aaa9b6b613be5e4c022faf11d282ae4 and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -28876,3 +28876,47 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: SEO-OPS-GAOKAO-V5-PROPAGATION-GATE-READINESS-01
+    repo: fap-api
+    depends_on:
+      - SEO-OPS-GAOKAO-V5-CMS-DRAFT-GATE-01
+    branch: codex/seo-ops-gaokao-v5-propagation-gate-readiness-01
+    title: "SEO-OPS-GAOKAO-V5-PROPAGATION-GATE-READINESS-01: Add Gaokao v5 propagation gate readiness"
+    train_scope: fermatmind_seo_ops_p2_p4_20260625
+    status: user_authorized
+    scope:
+      - Add a backend-only read-only command that emits the future Gaokao v5 preview, publish, URL Truth, Search Channel, and IndexNow gate checklist.
+      - Consume optional future draft gate, draft write, readback QA, preview QA, and publish artifacts as sanitized evidence inputs.
+      - Emit gate statuses, approval phrase templates, future command templates, and no-side-effect guarantees.
+      - Preserve all execution actions as later separate exact approvals.
+    allowed_paths:
+      - backend/app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php
+      - backend/app/Console/Kernel.php
+      - backend/docs/seo/generated/seo-ops-gaokao-v5-propagation-gate-readiness.v1.json
+      - backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production CMS import/write, create production drafts, publish, URL Truth, sitemap, llms, schema, hreflang, Search Channel, IndexNow, Baidu, GSC, scheduler, queue worker, frontend runtime, staging deploy, production deploy, or revalidation.
+      - Add any command execution path for publish, URL Truth write, Search Channel enqueue, or live submission.
+    validation:
+      - php -l backend/app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php
+      - php -l backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php
+      - cd backend && php artisan list | rg seo-ops:gaokao-v5-propagation-gate-readiness
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5PropagationGateReadinessTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_ops_gaokao_v5_gate_adapters' --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-propagation-gate-readiness.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added backend read-only `seo-ops:gaokao-v5-propagation-gate-readiness` command.
- The command emits Gaokao v5 preview, publish, URL Truth, Search Channel, and IndexNow gate readiness evidence from optional future artifacts.
- Added generated command contract doc and focused feature tests.
- Extended the BigFive runtime freeze classifier allowlist for the Gaokao v5 SEO Ops gate command family.
- Reconciled P3-B ledger status and added P3-C train metadata.

## Why
P3-C needs a backend authority artifact for the Gaokao article's future post-draft sequence without executing CMS write, publish, URL Truth, sitemap/llms, Search Channel, or IndexNow work.

## Validation
- `php -l backend/app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php`
- `php -l backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php`
- `cd backend && php artisan list | rg seo-ops:gaokao-v5-propagation-gate-readiness`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5PropagationGateReadinessTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_ops_gaokao_v5_gate_adapters' --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5PropagationGateReadinessCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5PropagationGateReadinessTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-propagation-gate-readiness.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No production CMS import/write or draft creation.
- No publish execution.
- No URL Truth write.
- No sitemap/llms/schema/hreflang mutation.
- No Search Channel enqueue or IndexNow/Baidu/GSC submit.
- No deploy or revalidation.
