### PR TITLE
PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01: Add personality TDK next-batch approval draft gate

### DIFF
--- a/backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php
+++ b/backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php
@@ -1,0 +1,369 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class PersonalityTdkNextBatchApprovalDraftGateCommand extends Command
+{
+    private const SCHEMA_VERSION = 'personality-tdk-next-batch-approval-draft-gate.v1';
+
+    private const EXPECTED_TARGETS = [
+        '/zh/personality/intp-a',
+        '/zh/personality/esfp-a',
+        '/en/personality/enfj-a',
+    ];
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'Cookie:',
+        'Set-Cookie:',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'personality:tdk-next-batch-approval-draft-gate
+        {--recommendations= : Path to personality next-batch recommendations JSON artifact}
+        {--qa= : Path to personality next-batch QA JSON artifact}
+        {--artifact-dir= : Directory for sanitized gate evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only gate evidence for the 3 personality TDK next-batch approval queue and CMS draft dry-run sequence.';
+
+    public function handle(): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $loaded = $this->loadInputs();
+        if (($loaded['issue'] ?? null) !== null) {
+            $summary = $this->failureSummary((string) $loaded['issue'], (array) ($loaded['extra'] ?? []));
+            $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        $summary = $this->evidence(
+            (array) $loaded['recommendations'],
+            (array) $loaded['qa'],
+            (string) $loaded['recommendations_path'],
+            (string) $loaded['qa_path'],
+            (string) $loaded['recommendations_sha256'],
+            (string) $loaded['qa_sha256']
+        );
+        $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => (bool) $summary['ok'],
+            'status' => (string) $summary['status'],
+            'candidate_count' => (int) data_get($summary, 'counts.candidate_count', 0),
+            'approval_queue_dry_run_ready' => (bool) data_get($summary, 'gate_statuses.approval_queue_dry_run_ready', false),
+            'cms_projection_draft_dry_run_ready' => (bool) data_get($summary, 'gate_statuses.cms_projection_draft_dry_run_ready', false),
+            'artifact' => $summary['artifact'],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $recommendations
+     * @param  array<string, mixed>  $qa
+     * @return array<string, mixed>
+     */
+    private function evidence(array $recommendations, array $qa, string $recommendationsPath, string $qaPath, string $recommendationsSha, string $qaSha): array
+    {
+        $recommendationRows = array_values(array_filter((array) ($recommendations['recommendations'] ?? []), 'is_array'));
+        $qaRows = array_values(array_filter((array) ($qa['page_results'] ?? []), 'is_array'));
+        $qaByPath = [];
+        foreach ($qaRows as $row) {
+            $qaByPath[(string) ($row['path'] ?? '')] = $row;
+        }
+
+        $issues = [];
+        if (($recommendations['artifact'] ?? null) !== 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-RECOMMENDATIONS-01') {
+            $issues[] = 'recommendations_artifact_invalid';
+        }
+        if (($qa['artifact'] ?? null) !== 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-QA-01') {
+            $issues[] = 'qa_artifact_invalid';
+        }
+        if (($qa['final_decision'] ?? null) !== 'PASS_READY_FOR_APPROVAL_REVIEW') {
+            $issues[] = 'qa_final_decision_not_ready_for_approval_review';
+        }
+
+        $candidates = [];
+        foreach ($recommendationRows as $row) {
+            $path = (string) ($row['path'] ?? '');
+            if (! in_array($path, self::EXPECTED_TARGETS, true)) {
+                continue;
+            }
+            $qaRow = $qaByPath[$path] ?? [];
+            $candidateIssues = [];
+            if (($row['framework'] ?? null) !== 'mbti64') {
+                $candidateIssues[] = 'framework_not_mbti64';
+            }
+            if (($row['page_type'] ?? null) !== 'variant') {
+                $candidateIssues[] = 'page_type_not_variant';
+            }
+            if (($qaRow['decision'] ?? null) !== 'PASS_READY_FOR_APPROVAL_REVIEW') {
+                $candidateIssues[] = 'qa_decision_not_ready';
+            }
+            foreach ((array) ($qaRow['gates'] ?? []) as $gate => $status) {
+                if ($status !== 'pass') {
+                    $candidateIssues[] = 'qa_gate_not_passing:'.$gate;
+                }
+            }
+            $candidates[] = [
+                'path' => $path,
+                'target_url_hash' => hash('sha256', (string) ($row['target_url'] ?? '')),
+                'locale' => (string) ($row['locale'] ?? ''),
+                'framework' => (string) ($row['framework'] ?? ''),
+                'page_type' => (string) ($row['page_type'] ?? ''),
+                'mbti_type' => (string) ($row['mbti_type'] ?? ''),
+                'recommendation_id' => (string) ($row['recommendation_id'] ?? ''),
+                'qa_decision' => (string) ($qaRow['decision'] ?? 'missing'),
+                'recommended_title_length' => mb_strlen((string) data_get($row, 'recommendations.title.recommended')),
+                'recommended_description_length' => mb_strlen((string) data_get($row, 'recommendations.description.recommended')),
+                'candidate_issues' => $candidateIssues,
+            ];
+        }
+
+        $actualTargets = array_map(static fn (array $candidate): string => (string) $candidate['path'], $candidates);
+        sort($actualTargets);
+        $expectedTargets = self::EXPECTED_TARGETS;
+        sort($expectedTargets);
+        if ($actualTargets !== $expectedTargets) {
+            $issues[] = 'expected_target_set_mismatch';
+        }
+        foreach ($candidates as $candidate) {
+            foreach ((array) ($candidate['candidate_issues'] ?? []) as $issue) {
+                $issues[] = (string) $issue;
+            }
+        }
+
+        $ok = $issues === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'planned' : 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => Carbon::now('UTC')->toIso8601String(),
+            'source_artifacts' => [
+                'recommendations' => ['path' => $recommendationsPath, 'sha256' => $recommendationsSha],
+                'qa' => ['path' => $qaPath, 'sha256' => $qaSha],
+            ],
+            'counts' => [
+                'candidate_count' => count($candidates),
+                'expected_candidate_count' => 3,
+                'blocked_candidate_count' => count(array_filter($candidates, static fn (array $candidate): bool => ($candidate['candidate_issues'] ?? []) !== [])),
+            ],
+            'targets' => $candidates,
+            'gate_statuses' => [
+                'approval_queue_dry_run_ready' => $ok,
+                'cms_projection_draft_dry_run_ready' => $ok,
+                'production_approval_queue_write_ready' => false,
+                'production_cms_draft_write_ready' => false,
+            ],
+            'future_command_templates' => [
+                'approval_queue_dry_run' => [
+                    'php artisan personality:agent-approval-queue',
+                    '--package='.escapeshellarg($recommendationsPath),
+                    '--qa='.escapeshellarg($qaPath),
+                    '--dry-run',
+                    '--json',
+                ],
+                'cms_projection_draft_dry_run' => [
+                    'php artisan personality:mbti64-cms-projection-draft',
+                    '--package='.escapeshellarg($recommendationsPath),
+                    '--qa='.escapeshellarg($qaPath),
+                    '--dry-run',
+                    '--agent-batch-size=5',
+                    '--agent-batch-offset=0',
+                    '--json',
+                ],
+            ],
+            'separate_approval_templates' => [
+                'approval_queue_write' => 'I explicitly approve PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01 for the 3 personality TDK next-batch targets using recommendations sha256 '.$recommendationsSha.' and QA sha256 '.$qaSha.'; no CMS draft write, no promotion, no publish, no index/search, no sitemap/llms.',
+                'cms_projection_draft_write' => 'I explicitly approve MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01 for the 3 personality TDK next-batch targets after approval queue evidence; draft-only, no publish, no index, no sitemap, no llms, no search release.',
+            ],
+            'issues' => array_values(array_unique($issues)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadInputs(): array
+    {
+        $recommendations = $this->loadJsonInput((string) $this->option('recommendations'), 'recommendations');
+        if (($recommendations['issue'] ?? null) !== null) {
+            return $recommendations;
+        }
+        $qa = $this->loadJsonInput((string) $this->option('qa'), 'qa');
+        if (($qa['issue'] ?? null) !== null) {
+            return $qa;
+        }
+
+        return [
+            'recommendations_path' => $recommendations['path'],
+            'recommendations_sha256' => $recommendations['sha256'],
+            'recommendations' => $recommendations['payload'],
+            'qa_path' => $qa['path'],
+            'qa_sha256' => $qa['sha256'],
+            'qa' => $qa['payload'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadJsonInput(string $rawPath, string $kind): array
+    {
+        $path = $this->readablePath($rawPath);
+        if ($path === null) {
+            return ['issue' => $kind.'_unreadable'];
+        }
+        $raw = (string) File::get($path);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return ['issue' => 'forbidden_input_field_present', 'extra' => ['kind' => $kind, 'forbidden_matches' => $forbidden]];
+        }
+        $payload = json_decode($raw, true);
+        if (! is_array($payload)) {
+            return ['issue' => $kind.'_json_invalid'];
+        }
+
+        return [
+            'path' => $path,
+            'sha256' => hash('sha256', $raw),
+            'payload' => $payload,
+        ];
+    }
+
+    private function readablePath(string $rawPath): ?string
+    {
+        $path = trim($rawPath);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return File::isFile($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/personality/tdk-next-batch-approval-draft-gate');
+        }
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        File::ensureDirectoryExists($dir);
+
+        return is_dir($dir) && is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $payload): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($payload, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $dir, array $payload): array
+    {
+        $path = rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'personality-tdk-next-batch-approval-draft-gate-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json';
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('Failed to encode personality TDK next-batch gate artifact.');
+        }
+        File::put($path, $encoded.PHP_EOL);
+
+        return [
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @return array<string, false>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'approval_queue_write' => false,
+            'cms_draft_write' => false,
+            'cms_promotion' => false,
+            'cms_publish' => false,
+            'indexability_change' => false,
+            'sitemap_llms_mutation' => false,
+            'search_channel_enqueue' => false,
+            'live_submit' => false,
+            'frontend_metadata_edit' => false,
+            'deploy' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE));
+        } else {
+            $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+            $this->line('status='.(string) ($summary['status'] ?? ''));
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -185,6 +185,7 @@ use App\Console\Commands\PersonalityMbti64CmsInternalLinkDraft;
 use App\Console\Commands\PersonalityMbti64CmsProjectionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionPromote;
+use App\Console\Commands\PersonalityTdkNextBatchApprovalDraftGateCommand;
 use App\Console\Commands\PersonalityEnneagramCmsPromote;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
@@ -267,6 +268,7 @@ class Kernel extends ConsoleKernel
         PersonalityMbti64CmsProjectionDraft::class,
         PersonalityMbti64CmsRevisionDraft::class,
         PersonalityMbti64CmsRevisionPromote::class,
+        PersonalityTdkNextBatchApprovalDraftGateCommand::class,
         PersonalityMbti64BackendImportContract::class,
         MetricsWeeklyValidity::class,
         MbtiPrewarm::class,

--- a/backend/docs/seo/generated/personality-tdk-next-batch-approval-draft-gate.v1.json
+++ b/backend/docs/seo/generated/personality-tdk-next-batch-approval-draft-gate.v1.json
@@ -1,0 +1,37 @@
+{
+  "version": "personality-tdk-next-batch-approval-draft-gate.v1",
+  "command": "php artisan personality:tdk-next-batch-approval-draft-gate",
+  "purpose": "Read-only backend gate evidence for the 3 personality TDK next-batch targets before any approval queue write or CMS projection draft write.",
+  "inputs": {
+    "recommendations": "personality-agent-operations-next-batch-recommendations-2026-06-25.json",
+    "qa": "personality-agent-operations-next-batch-qa-2026-06-25.json",
+    "artifact_dir": "Evidence output directory.",
+    "json": "Emit JSON summary."
+  },
+  "expected_targets": [
+    "/zh/personality/intp-a",
+    "/zh/personality/esfp-a",
+    "/en/personality/enfj-a"
+  ],
+  "accepted_qa_decision": "PASS_READY_FOR_APPROVAL_REVIEW",
+  "gate_sequence": [
+    "personality:agent-approval-queue --dry-run",
+    "approval queue write after separate exact approval",
+    "personality:mbti64-cms-projection-draft --dry-run",
+    "CMS projection draft write after separate exact approval",
+    "runtime readback and promotion gates in later PR"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "approval_queue_write": false,
+    "cms_draft_write": false,
+    "cms_promotion": false,
+    "cms_publish": false,
+    "indexability_change": false,
+    "sitemap_llms_mutation": false,
+    "search_channel_enqueue": false,
+    "live_submit": false,
+    "frontend_metadata_edit": false,
+    "deploy": false
+  }
+}

--- a/backend/tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PersonalityTdkNextBatchApprovalDraftGateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_plans_the_three_next_batch_targets_without_writes(): void
+    {
+        $countsBefore = $this->rowCounts();
+        $recommendations = $this->writeJson('recommendations', $this->recommendationsFixture());
+        $qa = $this->writeJson('qa', $this->qaFixture());
+
+        $exitCode = Artisan::call('personality:tdk-next-batch-approval-draft-gate', [
+            '--recommendations' => $recommendations,
+            '--qa' => $qa,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame(3, $summary['candidate_count'] ?? null);
+        $this->assertTrue((bool) ($summary['approval_queue_dry_run_ready'] ?? false));
+        $this->assertTrue((bool) ($summary['cms_projection_draft_dry_run_ready'] ?? false));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.approval_queue_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_draft_write', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame('personality-tdk-next-batch-approval-draft-gate.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame(['/zh/personality/intp-a', '/zh/personality/esfp-a', '/en/personality/enfj-a'], array_column($artifact['targets'] ?? [], 'path'));
+        $this->assertStringContainsString('personality:agent-approval-queue', implode(' ', data_get($artifact, 'future_command_templates.approval_queue_dry_run', [])));
+    }
+
+    #[Test]
+    public function it_blocks_forbidden_input_fields(): void
+    {
+        $recommendations = $this->recommendationsFixture();
+        $recommendations['raw_url'] = 'https://example.test/private';
+        $path = $this->writeJson('recommendations-forbidden', $recommendations);
+
+        $exitCode = Artisan::call('personality:tdk-next-batch-approval-draft-gate', [
+            '--recommendations' => $path,
+            '--qa' => $this->writeJson('qa', $this->qaFixture()),
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+        $this->assertContains('raw_url', data_get($summary, 'forbidden_matches', []));
+    }
+
+    #[Test]
+    public function generated_contract_documents_personality_tdk_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/personality-tdk-next-batch-approval-draft-gate.v1.json'));
+
+        $this->assertSame('personality-tdk-next-batch-approval-draft-gate.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan personality:tdk-next-batch-approval-draft-gate', $contract['command'] ?? null);
+        $this->assertContains('/zh/personality/intp-a', $contract['expected_targets'] ?? []);
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.approval_queue_write', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.frontend_metadata_edit', true));
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'approval_batches' => DB::table('personality_agent_approval_batches')->count(),
+            'approval_items' => DB::table('personality_agent_approval_items')->count(),
+            'profile_revisions' => DB::table('personality_profile_revisions')->count(),
+            'variant_revisions' => DB::table('personality_profile_variant_revisions')->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function recommendationsFixture(): array
+    {
+        return [
+            'artifact' => 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-RECOMMENDATIONS-01',
+            'final_decision' => 'PASS_NEXT_BATCH_RECOMMENDATIONS_READY_FOR_QA',
+            'recommendations' => [
+                $this->recommendation('/zh/personality/intp-a', 'zh-CN', 'INTP'),
+                $this->recommendation('/zh/personality/esfp-a', 'zh-CN', 'ESFP'),
+                $this->recommendation('/en/personality/enfj-a', 'en', 'ENFJ'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function qaFixture(): array
+    {
+        return [
+            'artifact' => 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-QA-01',
+            'final_decision' => 'PASS_READY_FOR_APPROVAL_REVIEW',
+            'page_results' => [
+                $this->qaRow('/zh/personality/intp-a', 'zh-CN'),
+                $this->qaRow('/zh/personality/esfp-a', 'zh-CN'),
+                $this->qaRow('/en/personality/enfj-a', 'en'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function recommendation(string $path, string $locale, string $mbtiType): array
+    {
+        return [
+            'recommendation_id' => 'personality-agent-next-batch:'.$path,
+            'target_url' => 'https://fermatmind.com'.$path,
+            'path' => $path,
+            'framework' => 'mbti64',
+            'locale' => $locale,
+            'page_type' => 'variant',
+            'mbti_type' => $mbtiType,
+            'recommendations' => [
+                'title' => ['recommended' => $mbtiType.' title | FermatMind'],
+                'description' => ['recommended' => $mbtiType.' public-safe description.'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function qaRow(string $path, string $locale): array
+    {
+        return [
+            'target_url' => 'https://fermatmind.com'.$path,
+            'path' => $path,
+            'framework' => 'mbti64',
+            'locale' => $locale,
+            'page_type' => 'variant',
+            'decision' => 'PASS_READY_FOR_APPROVAL_REVIEW',
+            'gates' => [
+                'schema_validation' => 'pass',
+                'trademark_claim_gate' => 'pass',
+                'claim_risk_gate' => 'pass',
+                'duplicate_template_gate' => 'pass',
+                'private_route_gate' => 'pass',
+                'result_page_leakage_gate' => 'pass',
+                'seo_projection_gate' => 'pass',
+                'bilingual_consistency_gate' => 'pass',
+            ],
+        ];
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = sys_get_temp_dir().'/fm-personality-tdk-next-batch-gate-'.Str::random(12);
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $dir = sys_get_temp_dir().'/fm-personality-tdk-next-batch-input-'.Str::random(12);
+        File::ensureDirectoryExists($dir);
+        $path = $dir.'/'.$name.'.json';
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true);
+        $this->assertIsArray($decoded, Artisan::output());
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, $path);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -394,6 +394,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_personality_tdk_next_batch_gate_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityTdkNextBatchApprovalDraftGateCommand;',
+            '+        PersonalityTdkNextBatchApprovalDraftGateCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_cms_draft_writer_files(): void
     {
         $changed = [
@@ -4647,6 +4661,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isPersonalityTdkNextBatchGateFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramCmsDraftFile($file)) {
                 continue;
             }
@@ -5805,6 +5823,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64GscReadonlyExportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsPersonalityAgentApprovalQueueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsPersonalityTdkNextBatchGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramCmsDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramCmsPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6037,6 +6056,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php',
             'backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php',
         ], true);
+    }
+
+    private function isPersonalityTdkNextBatchGateFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php';
     }
 
     private function isEnneagramCmsDraftFile(string $file): bool
@@ -10007,6 +10031,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityAgentApprovalQueue(?:Review)?Command\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsPersonalityTdkNextBatchGateOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityTdkNextBatchApprovalDraftGateCommand\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60567,7 +60567,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-04-report-locale-v16",
     "base": "main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "eq_v16_content_asset_productization",
     "title": "PR-EQ-ASSET-04 Fix EQ v1.6 report locale resolved assets",
     "depends_on": [
@@ -62554,12 +62554,12 @@
         "evidence": "Changed files are limited to PersonalityTdkNextBatchApprovalDraftGateCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist test for this read-only command, and authorized docs/codex train metadata. No production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation changes."
       },
       "github": {
-        "status": "pending",
-        "evidence": "Opened PR #2429 and waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "GitHub checks are green for PR #2429: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed. Merge state is CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "3e96f907d5e58280431378bc4046c38ff353fbbb",
+    "commit_sha": "e842142a6bdc59a268cd979a61b9bd915a5a276b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2429",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -62579,6 +62579,11 @@
         "at": "2026-06-25T22:01:00+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2429 at https://github.com/fermatmind/fap-api/pull/2429 from commit 3e96f907d5e58280431378bc4046c38ff353fbbb. Waiting for GitHub checks; no staging wait, production deploy, approval queue write, CMS draft write, promotion, publish, search, sitemap, llms, frontend metadata edit, or revalidation."
+      },
+      {
+        "at": "2026-06-25T22:07:00+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2429 GitHub checks passed and mergeStateStatus is CLEAN at head e842142a6bdc59a268cd979a61b9bd915a5a276b. Ready for squash merge under repo policy."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62518,7 +62518,7 @@
     "repo": "fap-api",
     "branch": "codex/personality-tdk-next-batch-approval-draft-gate-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_opened",
     "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
     "title": "PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01: Add personality TDK next-batch approval draft gate",
     "depends_on": [],
@@ -62555,12 +62555,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "Opened PR #2429 and waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "3e96f907d5e58280431378bc4046c38ff353fbbb",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2429",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62574,6 +62574,11 @@
         "at": "2026-06-25T21:58:00+08:00",
         "status": "local_validated",
         "note": "Implemented read-only personality TDK next-batch approval/draft gate adapter. Local scoped checks passed; no production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation path was added."
+      },
+      {
+        "at": "2026-06-25T22:01:00+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2429 at https://github.com/fermatmind/fap-api/pull/2429 from commit 3e96f907d5e58280431378bc4046c38ff353fbbb. Waiting for GitHub checks; no staging wait, production deploy, approval queue write, CMS draft write, promotion, publish, search, sitemap, llms, frontend metadata edit, or revalidation."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62440,7 +62440,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-ops-gaokao-v5-propagation-gate-readiness-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
     "title": "SEO-OPS-GAOKAO-V5-PROPAGATION-GATE-READINESS-01: Add Gaokao v5 propagation gate readiness",
     "depends_on": [
@@ -62477,15 +62477,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "GitHub checks passed for PR #2428 at head 2bf5c0440aaa9b6b613be5e4c022faf11d282ae4: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed. mergeStateStatus=CLEAN."
+        "evidence": "GitHub checks passed for PR #2428 at final head f0f6dc7a18ef76e1eb3ca1a0b1685b0aa7944fa5. Squash merge commit 6a779c543dec95447d3512382d55c097e0a91051 is contained in origin/main; remote branch was deleted and local task branch cleanup completed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "2bf5c0440aaa9b6b613be5e4c022faf11d282ae4",
+    "commit_sha": "6a779c543dec95447d3512382d55c097e0a91051",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2428",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-25T21:42:00+08:00",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-25T21:16:00+08:00",
@@ -62506,6 +62506,74 @@
         "at": "2026-06-25T21:36:00+08:00",
         "status": "ready_to_merge",
         "note": "All GitHub checks passed for PR #2428 at head 2bf5c0440aaa9b6b613be5e4c022faf11d282ae4 and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
+      },
+      {
+        "at": "2026-06-25T21:42:00+08:00",
+        "status": "merged",
+        "note": "PR #2428 was squash merged as 6a779c543dec95447d3512382d55c097e0a91051. origin/main contains the merge commit; local main was fast-forwarded to origin/main; local and remote task branches were cleaned."
+      }
+    ]
+  },
+  "PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/personality-tdk-next-batch-approval-draft-gate-01",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
+    "title": "PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01: Add personality TDK next-batch approval draft gate",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User provided /goal FERMATMIND-SEO-OPS-P2-P4-PR-TRAIN-20260625-01 and explicitly authorized adding missing docs/codex/pr-train.yaml and docs/codex/pr-train-state.json entries for this PR train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "No PR dependency declared for P4-A; P3-C already merged before starting this branch."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php",
+          "php -l backend/tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php",
+          "cd backend && php artisan list | rg personality:tdk-next-batch-approval-draft-gate",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityTdkNextBatchApprovalDraftGateCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityAgentApprovalQueueCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbti64CmsProjectionDraftCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_personality_tdk_next_batch_gate_files' --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/personality-tdk-next-batch-approval-draft-gate.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check && git diff --cached --check"
+        ],
+        "evidence": "PASS: PHP syntax; artisan command registration; focused PersonalityTdkNextBatchApprovalDraftGateCommandTest (3 tests, 25 assertions); PersonalityAgentApprovalQueueCommandTest (12 tests, 188 assertions); PersonalityMbti64CmsProjectionDraftCommandTest (35 tests, 674 assertions); BigFive freeze classifier focused test for this command; scoped Pint; JSON/YAML parse; diff checks."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to PersonalityTdkNextBatchApprovalDraftGateCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist test for this read-only command, and authorized docs/codex train metadata. No production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation changes."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T21:47:00+08:00",
+        "status": "in_progress",
+        "note": "Started P4-A from synced fap-api main 6a779c543dec95447d3512382d55c097e0a91051. Scope is backend-only read-only personality TDK next-batch approval/draft gate; no approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation."
+      },
+      {
+        "at": "2026-06-25T21:58:00+08:00",
+        "status": "local_validated",
+        "note": "Implemented read-only personality TDK next-batch approval/draft gate adapter. Local scoped checks passed; no production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation path was added."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -28920,3 +28920,48 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/personality-tdk-next-batch-approval-draft-gate-01
+    title: "PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01: Add personality TDK next-batch approval draft gate"
+    train_scope: fermatmind_seo_ops_p2_p4_20260625
+    status: user_authorized
+    scope:
+      - Add a backend-only read-only adapter for the three personality TDK next-batch recommendation and QA artifacts.
+      - Validate the exact target set and PASS_READY_FOR_APPROVAL_REVIEW state.
+      - Emit approval queue and CMS projection draft dry-run command templates plus separate approval templates.
+      - Keep approval queue writes and CMS draft writes as later separate exact approvals.
+    allowed_paths:
+      - backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php
+      - backend/app/Console/Kernel.php
+      - backend/docs/seo/generated/personality-tdk-next-batch-approval-draft-gate.v1.json
+      - backend/tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production approval queue write, production CMS draft write, promotion, publish, index/search, sitemap, llms, Search Channel, live submit, frontend metadata edit, staging deploy, production deploy, or revalidation.
+      - Edit frontend TDK metadata directly.
+    validation:
+      - php -l backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php
+      - php -l backend/tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php
+      - cd backend && php artisan list | rg personality:tdk-next-batch-approval-draft-gate
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityTdkNextBatchApprovalDraftGateCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityAgentApprovalQueueCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbti64CmsProjectionDraftCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_personality_tdk_next_batch_gate_files' --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - python3 -m json.tool backend/docs/seo/generated/personality-tdk-next-batch-approval-draft-gate.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added backend read-only `personality:tdk-next-batch-approval-draft-gate` command.
- The command consumes the 3-target personality TDK next-batch recommendations/QA artifacts and emits backend gate evidence plus future approval queue / CMS projection draft dry-run command templates.
- Added generated contract doc and focused command tests.
- Added a narrow BigFive runtime-freeze classifier allowlist for this read-only gate command.
- Reconciled P3-C ledger status and added P4-A train metadata.

## Why
P4-A moves the next-batch TDK recommendations into backend authority gates without editing frontend metadata and without writing approval queue or CMS draft rows.

## Validation
- `php -l backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php`
- `php -l backend/tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php`
- `cd backend && php artisan list | rg personality:tdk-next-batch-approval-draft-gate`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityTdkNextBatchApprovalDraftGateCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityAgentApprovalQueueCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbti64CmsProjectionDraftCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_personality_tdk_next_batch_gate_files' --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php tests/Feature/Console/PersonalityTdkNextBatchApprovalDraftGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `python3 -m json.tool backend/docs/seo/generated/personality-tdk-next-batch-approval-draft-gate.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No production approval queue write.
- No CMS draft write.
- No promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation.
