### PR TITLE
PR-EQ-AGENT-RUNTIME-V2-04 EQ Agent staging LLM smoke report

### DIFF
--- a/docs/audits/eq/eq_agent_runtime_v2_staging_llm_smoke_2026-06-25.md
+++ b/docs/audits/eq/eq_agent_runtime_v2_staging_llm_smoke_2026-06-25.md
@@ -1,0 +1,203 @@
+# EQ Agent Runtime V2 Staging LLM Smoke Report
+
+Date: 2026-06-25
+
+## 1. Executive Summary
+
+Verdict: **blocked for live LLM mode; deterministic fallback accepted**.
+
+The EQ Agent Runtime V2 provider code was present on staging and staging had OpenAI provider configuration present, but direct outbound access from staging to the OpenAI Responses API timed out. The runtime correctly failed closed into deterministic read-only mode, kept all report/content authority guardrails intact, and did not expose paywall, SKU, SJT entry, or raw technical tags.
+
+This report should be merged as evidence for `PR-EQ-AGENT-RUNTIME-V2-04`, but it does **not** approve live LLM rollout.
+
+## 2. Scope
+
+This was a staging-only smoke of EQ Agent Runtime V2 provider behavior.
+
+In scope:
+- Verify deployed staging backend contains the V2 provider abstraction.
+- Verify EQ report, Agent context, and Agent runtime remain deliverable.
+- Verify OpenAI provider configuration presence without exposing secrets.
+- Verify safe deterministic fallback when provider access fails.
+- Record blocker and next actions.
+
+Out of scope:
+- No production LLM enablement.
+- No frontend changes.
+- No report, score, formulation, SJT, commerce, or content mutation.
+- No persistent chat history.
+- No raw prompt/response storage in business data.
+
+## 3. Environment
+
+| Item | Value |
+| --- | --- |
+| Web | `https://staging.fermatmind.com` |
+| API | `https://staging-api.fermatmind.com` |
+| Staging revision observed | `fed95c351d57ed918d9f025100ec693f8fb9ac5d` |
+| Required V2-03 merge commit | `c0f0169ca1d61bed029198095c57772b5eb4bebf` |
+| V2-03 included in staging revision | Yes |
+| Artifact directory | `/tmp/eq_agent_runtime_v2_staging_smoke_20260625_110117` |
+
+## 4. Staging LLM Configuration
+
+The staging environment was configured for an LLM smoke attempt, then returned to a safe disabled state after the connectivity blocker was confirmed.
+
+During smoke:
+- `EQ_AGENT_LLM_ENABLED=true`
+- `EQ_AGENT_LLM_PROVIDER=openai`
+- `EQ_AGENT_LLM_STAGING_ONLY=true`
+- `EQ_AGENT_OPENAI_API_KEY` present
+- `EQ_AGENT_OPENAI_MODEL=gpt-4.1-mini`
+
+Final safe state after smoke:
+- `EQ_AGENT_LLM_ENABLED=false`
+- `EQ_AGENT_LLM_PROVIDER=openai`
+- `EQ_AGENT_LLM_STAGING_ONLY=true`
+- `EQ_AGENT_OPENAI_API_KEY` present
+- `EQ_AGENT_OPENAI_MODEL=gpt-4.1-mini`
+
+No secret value is recorded in this report.
+
+## 5. Credential Hygiene
+
+An initial UI-created key named `eq-agent-staging` was exposed during setup and was treated as compromised.
+
+Final credential status:
+- `eq-agent-staging`: **deleted / revoked by user**
+- `eq-agent-staging-v2`: retained as the staging key
+
+Required policy going forward:
+- Do not use `eq-agent-staging`.
+- Keep `eq-agent-staging-v2` as the only staging OpenAI key for this lane.
+- Do not paste API keys into chat, logs, reports, PR bodies, or repo files.
+
+## 6. Smoke Attempt
+
+| Item | Value |
+| --- | --- |
+| Attempt ID | `7024cad3-9414-4921-b7a2-45183850e91b` |
+| Anonymous ID | `eq-agent-v2-staging-smoke-20260625-110117` |
+| Question count | 60 |
+| Submit behavior | Async submit accepted; report became deliverable after polling |
+| Quality level | `C` |
+| Quality flags | `INCONSISTENT` |
+| Confidence | `low` |
+
+The low-confidence result is acceptable for this smoke because the purpose was provider/runtime safety, not normal-confidence acceptance.
+
+## 7. Report And Access Checks
+
+`report-access` summary:
+- `access_state=ready`
+- `report_state=ready`
+- `variant=full`
+- `access_level=full`
+- `locked=false`
+- `upgrade_sku=null`
+- `offers=[]`
+- `view_policy.blur_others=false`
+
+`report` summary:
+- `eq_report_mode=self_report`
+- `measurement_type=self_report_trait_mixed_ei`
+- `methodology.report_version=eq_report_v5_assets_commercial_ready_v1_6`
+- `scores.global` present
+- `scores.dimensions` present
+- `dimension_summary` present
+- `quality` present
+- `interpretation` present
+- resolved assets present
+- `next_module.available=false`
+- `next_module.status=planned`
+
+## 8. Agent Context Checks
+
+Both English and Chinese context calls returned ready, localized payloads with read-only guardrails.
+
+Required guardrails passed:
+- `read_only=true`
+- `can_mutate_report=false`
+- `can_mutate_scores=false`
+- `can_override_formulation=false`
+- `can_enable_sjt=false`
+- `can_create_paid_unlock_language=false`
+- `can_use_paid_unlock_language=false`
+- `can_expose_raw_technical_tags=false`
+- `content_authority=backend_content_pack_and_report_composer`
+
+SJT remained:
+- `module_code=EQ_SJT_16`
+- `status=planned`
+- `available=false`
+
+## 9. Runtime Checks
+
+Runtime calls returned successfully, but in deterministic fallback mode:
+
+| Locale / Prompt | HTTP | Ready | Mode | Provider |
+| --- | ---: | --- | --- | --- |
+| `en` normal runtime prompt | 200 | true | `deterministic_read_only` | null |
+| `zh-CN` normal runtime prompt | 200 | true | `deterministic_read_only` | null |
+| forbidden ability-test prompt | 200 | true | `deterministic_read_only` | null |
+
+Forbidden prompt handling:
+- detected `true_emotional_ability`
+- applied boundary metadata
+- kept no-paywall, no-SJT-entry, no-raw-tag flags true
+
+## 10. OpenAI Connectivity Blocker
+
+Direct staging diagnostic to the OpenAI Responses API failed:
+
+```text
+http_status=0
+curl_error=Connection timed out after 60001 milliseconds
+json=false
+```
+
+Laravel logs also showed provider fallback for OpenAI with a runtime exception. This points to staging outbound connectivity, proxy, firewall, DNS, or network egress policy as the blocker. The runtime code path correctly fell back to deterministic read-only behavior.
+
+Root-cause classification:
+- Code guardrail failure: **no**
+- Provider configuration missing: **no**
+- Staging outbound connectivity failure: **yes**
+- Production issue: **not tested / not changed**
+
+## 11. Forbidden Text / Field Scan
+
+The redacted smoke artifacts did not expose these forbidden values:
+
+- `SKU_EQ_60_FULL_299`
+- `EQ_60_FULL`
+- `"locked":true`
+- `"paywall":true`
+- `"blur_others":true`
+- `profile:`
+- `quality_level:`
+- `focus:`
+- `bucket:`
+- `MSCEIT-like`
+- `certified emotional intelligence`
+- `predicts hiring performance`
+
+## 12. Acceptance Decision
+
+| Decision | Result |
+| --- | --- |
+| Deterministic fallback accepted | yes |
+| Live LLM staging smoke accepted | no |
+| Proceed to controlled live LLM rollout | no |
+| Production LLM enablement allowed | no |
+
+Final verdict:
+
+`Live LLM staging smoke blocked by staging outbound timeout to OpenAI Responses API. Deterministic fallback accepted. Exposed old key has been revoked.`
+
+## 13. Required Next Actions
+
+1. Keep `EQ_AGENT_LLM_ENABLED=false` on staging until egress is fixed.
+2. Investigate staging outbound connectivity to `https://api.openai.com/v1/responses`.
+3. Confirm whether staging requires proxy, firewall allowlist, DNS change, or VPC/NAT egress adjustment.
+4. After connectivity is fixed, temporarily re-enable staging-only LLM flag.
+5. Re-run V2-04 smoke and require `mode=llm_provider_read_only` before approving any controlled rollout.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62205,8 +62205,8 @@
       }
     },
     "failure_reason": "Live LLM staging smoke blocked by staging outbound timeout to OpenAI Responses API; deterministic fallback passed. Exposed UI-created eq-agent-staging key has been deleted/revoked.",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "2b132f4335e7edd7f3aac7d586a3c9d2c817011b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2430",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62228,6 +62228,12 @@
         "from": "local_validated_blocked_smoke_report",
         "to": "local_validated_blocked_smoke_report",
         "notes": "Updated docs-only smoke report to record eq-agent-staging revoked, eq-agent-staging-v2 retained, staging LLM disabled, and live LLM blocked by OpenAI outbound timeout while deterministic fallback passed."
+      },
+      {
+        "at": "2026-06-25T21:25:00+08:00",
+        "from": "local_validated_blocked_smoke_report",
+        "to": "pr_opened",
+        "notes": "Opened docs-only PR #2430 for V2-04 blocked staging LLM smoke report."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62168,7 +62168,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-runtime-v2-04-staging-smoke-report",
     "base": "main",
-    "status": "local_validated_blocked_smoke_report",
+    "status": "ready_to_merge",
     "train_scope": "eq_agent_runtime_v2",
     "title": "PR-EQ-AGENT-RUNTIME-V2-04 EQ Agent staging LLM smoke report",
     "depends_on": [
@@ -62202,10 +62202,14 @@
       "staging_safe_state": {
         "status": "pass",
         "evidence": "Staging was returned to EQ_AGENT_LLM_ENABLED=false after the OpenAI outbound timeout was confirmed; provider/key/model may remain configured but live calls are disabled until connectivity is fixed."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PR #2430 checks passed on head a06d8a8cfa1182fd197d67167fe1c0d82de1d70a: hygiene, supply-chain, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, Semgrep blocking secrets, semgrep SARIF upload, and Semgrep OSS. mergeStateStatus=CLEAN."
       }
     },
     "failure_reason": "Live LLM staging smoke blocked by staging outbound timeout to OpenAI Responses API; deterministic fallback passed. Exposed UI-created eq-agent-staging key has been deleted/revoked.",
-    "commit_sha": "2b132f4335e7edd7f3aac7d586a3c9d2c817011b",
+    "commit_sha": "a06d8a8cfa1182fd197d67167fe1c0d82de1d70a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2430",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -62234,6 +62238,12 @@
         "from": "local_validated_blocked_smoke_report",
         "to": "pr_opened",
         "notes": "Opened docs-only PR #2430 for V2-04 blocked staging LLM smoke report."
+      },
+      {
+        "at": "2026-06-25T21:26:00+08:00",
+        "from": "pr_opened",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks passed and mergeStateStatus was CLEAN for PR #2430."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62075,7 +62075,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-runtime-v2-03-provider-abstraction",
     "base": "main",
-    "status": "pr_opened",
+    "status": "merged",
     "train_scope": "eq_agent_runtime_v2",
     "title": "PR-EQ-AGENT-RUNTIME-V2-03 EQ Agent provider abstraction and feature flag",
     "depends_on": [
@@ -62119,14 +62119,18 @@
       "ci_fix": {
         "status": "pass",
         "evidence": "Added BigFive runtime freeze exception for default-off EQ Agent provider abstraction files and verified focused freeze tests locally."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2423 checks passed and mergeStateStatus was CLEAN before squash merge."
       }
     },
     "failure_reason": null,
-    "commit_sha": "9ca71110ef9b8b7fa0d06c159050cf6c0db9a260",
+    "commit_sha": "c0f0169ca1d61bed029198095c57772b5eb4bebf",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2423",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-25T10:37:49Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-25T17:48:04+08:00",
@@ -62151,6 +62155,12 @@
         "from": "pr_opened",
         "to": "pr_opened_ci_fix_pushed",
         "notes": "Fixed verify-bigfive failure by adding a scoped runtime freeze classifier exception for default-off EQ Agent provider abstraction files."
+      },
+      {
+        "at": "2026-06-25T19:20:00+08:00",
+        "from": "pr_opened",
+        "to": "merged",
+        "notes": "Reconciled after GitHub PR #2423 squash merge; origin/main contains c0f0169ca1d61bed029198095c57772b5eb4bebf and remote branch was deleted."
       }
     ]
   },
@@ -62158,7 +62168,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-runtime-v2-04-staging-smoke-report",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_validated_blocked_smoke_report",
     "train_scope": "eq_agent_runtime_v2",
     "title": "PR-EQ-AGENT-RUNTIME-V2-04 EQ Agent staging LLM smoke report",
     "depends_on": [
@@ -62170,13 +62180,33 @@
         "evidence": "User explicitly requested the EQ Agent Runtime V2 four-PR plan and authorized adding the PRs to manifest/state before execution."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for PR-EQ-AGENT-RUNTIME-V2-03 to merge."
+        "status": "pass",
+        "evidence": "PR-EQ-AGENT-RUNTIME-V2-03 merged at c0f0169ca1d61bed029198095c57772b5eb4bebf and is included in staging revision fed95c351d57ed918d9f025100ec693f8fb9ac5d."
+      },
+      "staging_smoke": {
+        "status": "blocked",
+        "evidence": "Staging deployed provider code and had OpenAI config present, but direct request to https://api.openai.com/v1/responses timed out after 60001 ms; runtime fell back to deterministic_read_only."
+      },
+      "safety_fallback": {
+        "status": "pass",
+        "evidence": "EQ report/context/runtime stayed ready/read-only, no paywall/SKU/raw tags/SJT entry, and forbidden prompt remained bounded."
+      },
+      "docs": {
+        "status": "pass",
+        "evidence": "Added docs/audits/eq/eq_agent_runtime_v2_staging_llm_smoke_2026-06-25.md with blocked LLM smoke evidence and next required actions."
+      },
+      "credential_hygiene": {
+        "status": "pass",
+        "evidence": "The exposed UI-created eq-agent-staging key was deleted/revoked by the user; eq-agent-staging-v2 remains the staging key. No secret value is recorded in repo artifacts."
+      },
+      "staging_safe_state": {
+        "status": "pass",
+        "evidence": "Staging was returned to EQ_AGENT_LLM_ENABLED=false after the OpenAI outbound timeout was confirmed; provider/key/model may remain configured but live calls are disabled until connectivity is fixed."
       }
     },
-    "failure_reason": null,
-    "commit_sha": "60b652737a42554c7f11b809272e784cb822ad29",
-    "pr_url": "https://github.com/fermatmind/fap-api/pull/2427",
+    "failure_reason": "Live LLM staging smoke blocked by staging outbound timeout to OpenAI Responses API; deterministic fallback passed. Exposed UI-created eq-agent-staging key has been deleted/revoked.",
+    "commit_sha": null,
+    "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62186,6 +62216,18 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-RUNTIME-V2-03."
+      },
+      {
+        "at": "2026-06-25T19:20:00+08:00",
+        "from": "pending_dependency",
+        "to": "local_validated_blocked_smoke_report",
+        "notes": "Ran staging smoke after deploying provider code and enabling staging OpenAI config; live provider mode blocked by OpenAI connectivity timeout, fallback passed, docs-only report added."
+      },
+      {
+        "at": "2026-06-25T21:20:00+08:00",
+        "from": "local_validated_blocked_smoke_report",
+        "to": "local_validated_blocked_smoke_report",
+        "notes": "Updated docs-only smoke report to record eq-agent-staging revoked, eq-agent-staging-v2 retained, staging LLM disabled, and live LLM blocked by OpenAI outbound timeout while deterministic fallback passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added `docs/audits/eq/eq_agent_runtime_v2_staging_llm_smoke_2026-06-25.md`.
- Updated `docs/codex/pr-train-state.json` for `PR-EQ-AGENT-RUNTIME-V2-04` with the blocked staging smoke result, credential hygiene status, and staging safe-state evidence.

## Why
- Staging contained the EQ Agent Runtime V2 provider code and OpenAI provider configuration, but outbound access to the OpenAI Responses API timed out.
- The runtime correctly failed closed to `deterministic_read_only` mode, preserving read-only guardrails, no paywall/SKU/raw tag exposure, and SJT planned/unavailable state.
- The initially exposed UI-created `eq-agent-staging` key has been deleted/revoked; `eq-agent-staging-v2` remains the staging key.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml-ok'"`
- `git diff --check`
- `git diff --cached --check`
- Secret scan over changed report/state for API key patterns: no key value recorded.

## Acceptance result
- Live LLM staging smoke: **blocked** by staging outbound timeout to `https://api.openai.com/v1/responses`.
- Deterministic fallback: **accepted**.
- Controlled live LLM rollout: **not allowed yet**.

## Intentionally deferred
- No staging egress/proxy/firewall repair in this PR.
- No production LLM enablement.
- No frontend changes.
- No EQ report, score, formulation, SJT, commerce, or content mutation.
- No live LLM rollout until staging can return `mode=llm_provider_read_only` safely.

## Repository rule impact
Docs-only evidence PR. Backend content pack/report composer remain the EQ authority layer. No runtime authority, CMS, frontend content, SJT, commerce, deployment, or secret-handling rules changed.
