### PR TITLE
PERSONALITY-TDK-RUNTIME-PROMOTION-SEARCH-GATE-READINESS-01: Add personality TDK runtime promotion search gate readiness

### DIFF
--- a/backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php
+++ b/backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php
@@ -1,0 +1,499 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class PersonalityTdkRuntimePromotionSearchGateReadinessCommand extends Command
+{
+    private const SCHEMA_VERSION = 'personality-tdk-runtime-promotion-search-gate-readiness.v1';
+
+    private const EXPECTED_TARGETS = [
+        '/zh/personality/intp-a',
+        '/zh/personality/esfp-a',
+        '/en/personality/enfj-a',
+    ];
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'Cookie:',
+        'Set-Cookie:',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'personality:tdk-runtime-promotion-search-gate-readiness
+        {--approval-draft-gate= : Path to personality TDK next-batch approval/draft gate evidence}
+        {--draft-readback= : Optional path to post-draft runtime/readback QA evidence}
+        {--promotion-dry-run= : Optional path to MBTI64 promotion dry-run evidence}
+        {--artifact-dir= : Directory for sanitized gate readiness evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only gate readiness for personality TDK runtime QA, promotion dry-run, and later search propagation gates.';
+
+    public function handle(): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $loaded = $this->loadInputs();
+        if (($loaded['issue'] ?? null) !== null) {
+            $summary = $this->failureSummary((string) $loaded['issue'], (array) ($loaded['extra'] ?? []));
+            $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        $summary = $this->evidence($loaded);
+        $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => (bool) $summary['ok'],
+            'status' => (string) $summary['status'],
+            'target_count' => (int) data_get($summary, 'counts.target_count', 0),
+            'runtime_readback_ready' => (bool) data_get($summary, 'gate_statuses.runtime_readback_ready', false),
+            'promotion_dry_run_ready' => (bool) data_get($summary, 'gate_statuses.promotion_dry_run_ready', false),
+            'promotion_execute_approval_ready' => (bool) data_get($summary, 'gate_statuses.promotion_execute_approval_ready', false),
+            'artifact' => $summary['artifact'],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $loaded
+     * @return array<string, mixed>
+     */
+    private function evidence(array $loaded): array
+    {
+        $approvalGate = (array) $loaded['approval_draft_gate']['payload'];
+        $readback = $loaded['draft_readback']['payload'] ?? null;
+        $promotion = $loaded['promotion_dry_run']['payload'] ?? null;
+        $issues = [];
+
+        if (($approvalGate['schema_version'] ?? null) !== 'personality-tdk-next-batch-approval-draft-gate.v1') {
+            $issues[] = 'approval_draft_gate_schema_invalid';
+        }
+        if (($approvalGate['ok'] ?? false) !== true || ($approvalGate['status'] ?? null) !== 'planned') {
+            $issues[] = 'approval_draft_gate_not_planned';
+        }
+        if ((bool) data_get($approvalGate, 'gate_statuses.approval_queue_dry_run_ready') !== true) {
+            $issues[] = 'approval_queue_dry_run_not_ready';
+        }
+        if ((bool) data_get($approvalGate, 'gate_statuses.cms_projection_draft_dry_run_ready') !== true) {
+            $issues[] = 'cms_projection_draft_dry_run_not_ready';
+        }
+
+        $targets = $this->targetsFromApprovalGate($approvalGate);
+        if ($this->sortedPaths($targets) !== $this->sortedPaths(self::EXPECTED_TARGETS)) {
+            $issues[] = 'expected_target_set_mismatch';
+        }
+
+        $readbackReady = false;
+        $promotionReady = false;
+        $readbackStatus = 'missing';
+        $promotionStatus = 'missing';
+        $reviewIssues = [];
+
+        if (is_array($readback)) {
+            $readbackStatus = $this->readbackReady($readback) ? 'pass' : 'blocked';
+            $readbackReady = $readbackStatus === 'pass';
+            if (! $readbackReady) {
+                $reviewIssues[] = 'draft_readback_not_passing';
+            }
+        } else {
+            $reviewIssues[] = 'draft_readback_evidence_missing';
+        }
+
+        if (is_array($promotion)) {
+            $promotionStatus = $this->promotionDryRunReady($promotion) ? 'pass' : 'blocked';
+            $promotionReady = $promotionStatus === 'pass';
+            if (! $promotionReady) {
+                $reviewIssues[] = 'promotion_dry_run_not_passing';
+            }
+        } else {
+            $reviewIssues[] = 'promotion_dry_run_evidence_missing';
+        }
+
+        $blocked = $issues !== [];
+        $ready = ! $blocked && $readbackReady && $promotionReady;
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => ! $blocked,
+            'status' => $blocked ? 'blocked' : ($ready ? 'ready_for_separate_promotion_approval' : 'review_required'),
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => Carbon::now('UTC')->toIso8601String(),
+            'source_artifacts' => $this->sourceArtifacts($loaded),
+            'counts' => [
+                'target_count' => count($targets),
+                'expected_target_count' => 3,
+            ],
+            'targets' => $targets,
+            'evidence_statuses' => [
+                'approval_draft_gate' => $blocked ? 'blocked' : 'pass',
+                'draft_readback' => $readbackStatus,
+                'promotion_dry_run' => $promotionStatus,
+            ],
+            'gate_statuses' => [
+                'runtime_readback_ready' => $readbackReady,
+                'promotion_dry_run_ready' => $promotionReady,
+                'promotion_execute_approval_ready' => $ready,
+                'post_promotion_search_gate_ready' => false,
+                'sitemap_llms_gate_ready' => false,
+                'search_channel_enqueue_ready' => false,
+            ],
+            'future_command_templates' => [
+                'draft_readback_after_cms_draft' => [
+                    'php artisan personality:tdk-runtime-promotion-search-gate-readiness',
+                    '--approval-draft-gate=<approval-draft-gate-evidence>',
+                    '--draft-readback=<draft-readback-qa-evidence>',
+                    '--promotion-dry-run=<promotion-dry-run-evidence>',
+                    '--json',
+                ],
+                'promotion_dry_run' => [
+                    'php artisan personality:mbti64-cms-revision-promote',
+                    '--package=<cms-draft-package-or-agent-package>',
+                    '--dry-run',
+                    '--fresh-query-backed-5',
+                    '--json',
+                ],
+                'post_promotion_search_gate_readiness' => [
+                    'Run only after separate promotion approval and post-promotion runtime QA pass.',
+                    'Then evaluate sitemap/llms/search propagation with a separate gate and approval.',
+                ],
+            ],
+            'separate_approval_templates' => $ready ? [
+                'promotion_execute' => 'I explicitly approve MBTI64-BACKEND-PROMOTION-CONTRACT-01 promotion execute for the 3 personality TDK next-batch targets after passing readback and promotion dry-run evidence; no index, no sitemap, no llms, no search release.',
+            ] : [],
+            'issues' => array_values(array_unique($issues)),
+            'review_required_issues' => array_values(array_unique($reviewIssues)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $approvalGate
+     * @return list<array<string, mixed>>
+     */
+    private function targetsFromApprovalGate(array $approvalGate): array
+    {
+        $targets = [];
+        foreach ((array) ($approvalGate['targets'] ?? []) as $target) {
+            if (! is_array($target)) {
+                continue;
+            }
+            $path = (string) ($target['path'] ?? '');
+            if ($path === '') {
+                continue;
+            }
+            $targets[] = [
+                'path' => $path,
+                'locale' => (string) ($target['locale'] ?? ''),
+                'framework' => (string) ($target['framework'] ?? ''),
+                'page_type' => (string) ($target['page_type'] ?? ''),
+                'mbti_type' => (string) ($target['mbti_type'] ?? ''),
+            ];
+        }
+
+        return $targets;
+    }
+
+    /**
+     * @param  array<string, mixed>  $readback
+     */
+    private function readbackReady(array $readback): bool
+    {
+        if (($readback['ok'] ?? false) !== true) {
+            return false;
+        }
+        if (! in_array((string) ($readback['status'] ?? ''), ['success', 'pass', 'ready'], true)) {
+            return false;
+        }
+        $paths = $this->extractPaths($readback);
+        if ($this->sortedPaths($paths) !== $this->sortedPaths(self::EXPECTED_TARGETS)) {
+            return false;
+        }
+
+        foreach ($this->extractRows($readback) as $row) {
+            if (($row['status'] ?? 'success') !== 'success' && ($row['decision'] ?? 'pass') !== 'pass') {
+                return false;
+            }
+            if (($row['public_runtime_changed'] ?? false) === true) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $promotion
+     */
+    private function promotionDryRunReady(array $promotion): bool
+    {
+        if (($promotion['ok'] ?? false) !== true) {
+            return false;
+        }
+        if ((bool) ($promotion['dry_run'] ?? false) !== true || (bool) ($promotion['write'] ?? false) !== false) {
+            return false;
+        }
+        if (! in_array((string) ($promotion['status'] ?? ''), ['planned', 'success', 'ready'], true)) {
+            return false;
+        }
+        $paths = $this->extractPaths($promotion);
+        if ($this->sortedPaths($paths) !== $this->sortedPaths(self::EXPECTED_TARGETS)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<string>
+     */
+    private function extractPaths(array $payload): array
+    {
+        $paths = [];
+        foreach ($this->extractRows($payload) as $row) {
+            $path = (string) ($row['path'] ?? $row['safe_path'] ?? $row['canonical_path'] ?? '');
+            if ($path !== '') {
+                $paths[] = $path;
+            }
+        }
+
+        return array_values(array_unique($paths));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<array<string, mixed>>
+     */
+    private function extractRows(array $payload): array
+    {
+        foreach (['targets', 'items', 'candidates', 'promotion_candidates', 'planned_items', 'results'] as $key) {
+            $rows = array_values(array_filter((array) ($payload[$key] ?? []), 'is_array'));
+            if ($rows !== []) {
+                return $rows;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<string>|list<array<string, mixed>>  $paths
+     * @return list<string>
+     */
+    private function sortedPaths(array $paths): array
+    {
+        $values = [];
+        foreach ($paths as $path) {
+            $values[] = is_array($path) ? (string) ($path['path'] ?? '') : (string) $path;
+        }
+        $values = array_values(array_filter($values, static fn (string $path): bool => $path !== ''));
+        sort($values);
+
+        return $values;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadInputs(): array
+    {
+        $approval = $this->loadJsonInput((string) $this->option('approval-draft-gate'), 'approval_draft_gate', true);
+        if (($approval['issue'] ?? null) !== null) {
+            return $approval;
+        }
+        $readback = $this->loadJsonInput((string) $this->option('draft-readback'), 'draft_readback', false);
+        if (($readback['issue'] ?? null) !== null) {
+            return $readback;
+        }
+        $promotion = $this->loadJsonInput((string) $this->option('promotion-dry-run'), 'promotion_dry_run', false);
+        if (($promotion['issue'] ?? null) !== null) {
+            return $promotion;
+        }
+
+        return [
+            'approval_draft_gate' => $approval,
+            'draft_readback' => $readback,
+            'promotion_dry_run' => $promotion,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadJsonInput(string $rawPath, string $kind, bool $required): array
+    {
+        $path = trim($rawPath);
+        if ($path === '') {
+            return $required ? ['issue' => $kind.'_required'] : ['path' => null, 'sha256' => null, 'payload' => null];
+        }
+        $path = $this->readablePath($path);
+        if ($path === null) {
+            return ['issue' => $kind.'_unreadable'];
+        }
+        $raw = (string) File::get($path);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return ['issue' => 'forbidden_input_field_present', 'extra' => ['kind' => $kind, 'forbidden_matches' => $forbidden]];
+        }
+        $payload = json_decode($raw, true);
+        if (! is_array($payload)) {
+            return ['issue' => $kind.'_json_invalid'];
+        }
+
+        return [
+            'path' => $path,
+            'sha256' => hash('sha256', $raw),
+            'payload' => $payload,
+        ];
+    }
+
+    private function readablePath(string $rawPath): ?string
+    {
+        $path = trim($rawPath);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return File::isFile($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/personality/tdk-runtime-promotion-search-gate-readiness');
+        }
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        File::ensureDirectoryExists($dir);
+
+        return is_dir($dir) && is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $payload): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($payload, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $loaded
+     * @return array<string, mixed>
+     */
+    private function sourceArtifacts(array $loaded): array
+    {
+        $artifacts = [];
+        foreach (['approval_draft_gate', 'draft_readback', 'promotion_dry_run'] as $key) {
+            $artifacts[$key] = [
+                'path' => $loaded[$key]['path'] ?? null,
+                'sha256' => $loaded[$key]['sha256'] ?? null,
+            ];
+        }
+
+        return $artifacts;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $dir, array $payload): array
+    {
+        $path = rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'personality-tdk-runtime-promotion-search-gate-readiness-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json';
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('Failed to encode personality TDK runtime/promotion/search gate readiness artifact.');
+        }
+        File::put($path, $encoded.PHP_EOL);
+
+        return [
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @return array<string, false>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'approval_queue_write' => false,
+            'cms_draft_write' => false,
+            'cms_promotion' => false,
+            'cms_publish' => false,
+            'indexability_change' => false,
+            'sitemap_llms_mutation' => false,
+            'search_channel_enqueue' => false,
+            'live_submit' => false,
+            'frontend_metadata_edit' => false,
+            'deploy' => false,
+            'revalidation' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE));
+        } else {
+            $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+            $this->line('status='.(string) ($summary['status'] ?? ''));
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -186,6 +186,7 @@ use App\Console\Commands\PersonalityMbti64CmsProjectionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionPromote;
 use App\Console\Commands\PersonalityTdkNextBatchApprovalDraftGateCommand;
+use App\Console\Commands\PersonalityTdkRuntimePromotionSearchGateReadinessCommand;
 use App\Console\Commands\PersonalityEnneagramCmsPromote;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
@@ -269,6 +270,7 @@ class Kernel extends ConsoleKernel
         PersonalityMbti64CmsRevisionDraft::class,
         PersonalityMbti64CmsRevisionPromote::class,
         PersonalityTdkNextBatchApprovalDraftGateCommand::class,
+        PersonalityTdkRuntimePromotionSearchGateReadinessCommand::class,
         PersonalityMbti64BackendImportContract::class,
         MetricsWeeklyValidity::class,
         MbtiPrewarm::class,

--- a/backend/docs/seo/generated/personality-tdk-runtime-promotion-search-gate-readiness.v1.json
+++ b/backend/docs/seo/generated/personality-tdk-runtime-promotion-search-gate-readiness.v1.json
@@ -1,0 +1,61 @@
+{
+  "version": "personality-tdk-runtime-promotion-search-gate-readiness.v1",
+  "command": "php artisan personality:tdk-runtime-promotion-search-gate-readiness",
+  "purpose": "Read-only gate readiness evidence for the personality TDK next-batch runtime readback, MBTI64 promotion dry-run, and later sitemap/llms/search propagation gates.",
+  "inputs": {
+    "approval_draft_gate": "Required path to personality-tdk-next-batch-approval-draft-gate.v1 evidence.",
+    "draft_readback": "Optional path to post-draft runtime/readback QA evidence. Missing evidence yields review_required and no promotion approval phrase.",
+    "promotion_dry_run": "Optional path to MBTI64 promotion dry-run evidence. Missing evidence yields review_required and no promotion approval phrase.",
+    "artifact_dir": "Optional output directory for sanitized readiness evidence."
+  },
+  "expected_targets": [
+    "/zh/personality/intp-a",
+    "/zh/personality/esfp-a",
+    "/en/personality/enfj-a"
+  ],
+  "ready_state": {
+    "status": "ready_for_separate_promotion_approval",
+    "requires": [
+      "approval/draft gate evidence is planned and target set matches",
+      "runtime/readback QA evidence passes for all three targets",
+      "promotion dry-run evidence is planned for all three targets"
+    ],
+    "approval_phrase_emitted_only_when_ready": true
+  },
+  "review_required_state": {
+    "status": "review_required",
+    "common_reasons": [
+      "draft_readback_evidence_missing",
+      "promotion_dry_run_evidence_missing"
+    ],
+    "approval_phrase_emitted": false
+  },
+  "forbidden_input_strings": [
+    "raw_url",
+    "raw_query",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "Bearer ",
+    "Cookie:",
+    "Set-Cookie:",
+    "content_md",
+    "content_html",
+    "cms_draft_body"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "approval_queue_write": false,
+    "cms_draft_write": false,
+    "cms_promotion": false,
+    "cms_publish": false,
+    "indexability_change": false,
+    "sitemap_llms_mutation": false,
+    "search_channel_enqueue": false,
+    "live_submit": false,
+    "frontend_metadata_edit": false,
+    "deploy": false,
+    "revalidation": false
+  }
+}

--- a/backend/tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php
+++ b/backend/tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PersonalityTdkRuntimePromotionSearchGateReadinessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_marks_promotion_ready_only_after_runtime_and_promotion_dry_run_evidence_pass(): void
+    {
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('personality:tdk-runtime-promotion-search-gate-readiness', [
+            '--approval-draft-gate' => $this->writeJson('approval-gate', $this->approvalGateFixture()),
+            '--draft-readback' => $this->writeJson('readback', $this->readbackFixture()),
+            '--promotion-dry-run' => $this->writeJson('promotion', $this->promotionDryRunFixture()),
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('ready_for_separate_promotion_approval', $summary['status'] ?? null);
+        $this->assertSame(3, $summary['target_count'] ?? null);
+        $this->assertTrue((bool) ($summary['runtime_readback_ready'] ?? false));
+        $this->assertTrue((bool) ($summary['promotion_dry_run_ready'] ?? false));
+        $this->assertTrue((bool) ($summary['promotion_execute_approval_ready'] ?? false));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_promotion', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame('personality-tdk-runtime-promotion-search-gate-readiness.v1', $artifact['schema_version'] ?? null);
+        $this->assertArrayHasKey('promotion_execute', data_get($artifact, 'separate_approval_templates', []));
+        $this->assertFalse((bool) data_get($artifact, 'gate_statuses.post_promotion_search_gate_ready', true));
+    }
+
+    #[Test]
+    public function it_requires_review_and_suppresses_approval_phrase_when_followup_evidence_is_missing(): void
+    {
+        $exitCode = Artisan::call('personality:tdk-runtime-promotion-search-gate-readiness', [
+            '--approval-draft-gate' => $this->writeJson('approval-gate', $this->approvalGateFixture()),
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('review_required', $summary['status'] ?? null);
+        $this->assertFalse((bool) ($summary['promotion_execute_approval_ready'] ?? true));
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame([], data_get($artifact, 'separate_approval_templates', []));
+        $this->assertContains('draft_readback_evidence_missing', data_get($artifact, 'review_required_issues', []));
+        $this->assertContains('promotion_dry_run_evidence_missing', data_get($artifact, 'review_required_issues', []));
+    }
+
+    #[Test]
+    public function it_blocks_forbidden_input_fields(): void
+    {
+        $gate = $this->approvalGateFixture();
+        $gate['raw_query'] = 'private';
+
+        $exitCode = Artisan::call('personality:tdk-runtime-promotion-search-gate-readiness', [
+            '--approval-draft-gate' => $this->writeJson('approval-gate-forbidden', $gate),
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+        $this->assertContains('raw_query', data_get($summary, 'forbidden_matches', []));
+    }
+
+    #[Test]
+    public function generated_contract_documents_runtime_promotion_search_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/personality-tdk-runtime-promotion-search-gate-readiness.v1.json'));
+
+        $this->assertSame('personality-tdk-runtime-promotion-search-gate-readiness.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan personality:tdk-runtime-promotion-search-gate-readiness', $contract['command'] ?? null);
+        $this->assertContains('/zh/personality/intp-a', $contract['expected_targets'] ?? []);
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.cms_promotion', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.search_channel_enqueue', true));
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'approval_batches' => DB::table('personality_agent_approval_batches')->count(),
+            'approval_items' => DB::table('personality_agent_approval_items')->count(),
+            'profile_revisions' => DB::table('personality_profile_revisions')->count(),
+            'variant_revisions' => DB::table('personality_profile_variant_revisions')->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function approvalGateFixture(): array
+    {
+        return [
+            'schema_version' => 'personality-tdk-next-batch-approval-draft-gate.v1',
+            'ok' => true,
+            'status' => 'planned',
+            'targets' => [
+                $this->target('/zh/personality/intp-a', 'zh-CN', 'INTP'),
+                $this->target('/zh/personality/esfp-a', 'zh-CN', 'ESFP'),
+                $this->target('/en/personality/enfj-a', 'en', 'ENFJ'),
+            ],
+            'gate_statuses' => [
+                'approval_queue_dry_run_ready' => true,
+                'cms_projection_draft_dry_run_ready' => true,
+                'production_approval_queue_write_ready' => false,
+                'production_cms_draft_write_ready' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readbackFixture(): array
+    {
+        return [
+            'schema_version' => 'personality-tdk-runtime-readback-qa.v1',
+            'ok' => true,
+            'status' => 'success',
+            'targets' => [
+                ['path' => '/zh/personality/intp-a', 'status' => 'success', 'public_runtime_changed' => false],
+                ['path' => '/zh/personality/esfp-a', 'status' => 'success', 'public_runtime_changed' => false],
+                ['path' => '/en/personality/enfj-a', 'status' => 'success', 'public_runtime_changed' => false],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function promotionDryRunFixture(): array
+    {
+        return [
+            'artifact' => 'MBTI64-BACKEND-PROMOTION-CONTRACT-01',
+            'ok' => true,
+            'status' => 'planned',
+            'dry_run' => true,
+            'write' => false,
+            'promotion_candidates' => [
+                ['path' => '/zh/personality/intp-a'],
+                ['path' => '/zh/personality/esfp-a'],
+                ['path' => '/en/personality/enfj-a'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function target(string $path, string $locale, string $mbtiType): array
+    {
+        return [
+            'path' => $path,
+            'locale' => $locale,
+            'framework' => 'mbti64',
+            'page_type' => 'variant',
+            'mbti_type' => $mbtiType,
+        ];
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = sys_get_temp_dir().'/fm-personality-tdk-runtime-promotion-gate-'.Str::random(12);
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $name, array $payload): string
+    {
+        $dir = sys_get_temp_dir().'/fm-personality-tdk-runtime-promotion-input-'.Str::random(12);
+        File::ensureDirectoryExists($dir);
+        $path = $dir.'/'.$name.'.json';
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true);
+        $this->assertIsArray($decoded, Artisan::output());
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, $path);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -398,11 +398,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php',
+            'backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php',
             'backend/app/Console/Kernel.php',
         ];
         $kernelChangedLines = [
             '+use App\\Console\\Commands\\PersonalityTdkNextBatchApprovalDraftGateCommand;',
+            '+use App\\Console\\Commands\\PersonalityTdkRuntimePromotionSearchGateReadinessCommand;',
             '+        PersonalityTdkNextBatchApprovalDraftGateCommand::class,',
+            '+        PersonalityTdkRuntimePromotionSearchGateReadinessCommand::class,',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
@@ -6060,7 +6063,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isPersonalityTdkNextBatchGateFile(string $file): bool
     {
-        return $file === 'backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php';
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php',
+            'backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php',
+        ], true);
     }
 
     private function isEnneagramCmsDraftFile(string $file): bool
@@ -10049,7 +10055,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
-            if (preg_match('/\bPersonalityTdkNextBatchApprovalDraftGateCommand\b/u', $normalized) !== 1) {
+            if (preg_match('/\bPersonalityTdk(?:NextBatchApprovalDraftGate|RuntimePromotionSearchGateReadiness)Command\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62596,7 +62596,7 @@
     "repo": "fap-api",
     "branch": "codex/personality-tdk-runtime-promotion-search-gate-readiness-01",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_opened",
     "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
     "title": "PERSONALITY-TDK-RUNTIME-PROMOTION-SEARCH-GATE-READINESS-01: Add personality TDK runtime promotion search gate readiness",
     "depends_on": [
@@ -62633,13 +62633,13 @@
         "evidence": "Changed files are limited to PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist for this read-only command, and authorized docs/codex train metadata. No production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation changes."
       },
       "github": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pending",
+        "evidence": "Opened PR #2431 at https://github.com/fermatmind/fap-api/pull/2431 from commit d97c5318e235665b1d36d9069ffc0316c37ee394. Waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "d97c5318e235665b1d36d9069ffc0316c37ee394",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2431",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62653,6 +62653,11 @@
         "at": "2026-06-25T22:37:00+08:00",
         "status": "local_validated",
         "note": "Implemented read-only personality TDK runtime/promotion/search gate readiness command and focused tests. Local scoped checks passed; no production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation path was added."
+      },
+      {
+        "at": "2026-06-25T22:40:00+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2431 at https://github.com/fermatmind/fap-api/pull/2431 from commit d97c5318e235665b1d36d9069ffc0316c37ee394. Waiting for GitHub checks; no staging wait, production deploy, approval queue write, CMS draft write, promotion, publish, search, sitemap, llms, frontend metadata edit, or revalidation."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62075,7 +62075,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-runtime-v2-03-provider-abstraction",
     "base": "main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "eq_agent_runtime_v2",
     "title": "PR-EQ-AGENT-RUNTIME-V2-03 EQ Agent provider abstraction and feature flag",
     "depends_on": [
@@ -62633,12 +62633,12 @@
         "evidence": "Changed files are limited to PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist for this read-only command, and authorized docs/codex train metadata. No production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation changes."
       },
       "github": {
-        "status": "pending",
-        "evidence": "Opened PR #2431 at https://github.com/fermatmind/fap-api/pull/2431 from commit d97c5318e235665b1d36d9069ffc0316c37ee394. Waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "GitHub checks are green for PR #2431: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed. Merge state is CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "d97c5318e235665b1d36d9069ffc0316c37ee394",
+    "commit_sha": "e0a7f66867342369b60d983d6c0e7b9f96460fab",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2431",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -62658,6 +62658,11 @@
         "at": "2026-06-25T22:40:00+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2431 at https://github.com/fermatmind/fap-api/pull/2431 from commit d97c5318e235665b1d36d9069ffc0316c37ee394. Waiting for GitHub checks; no staging wait, production deploy, approval queue write, CMS draft write, promotion, publish, search, sitemap, llms, frontend metadata edit, or revalidation."
+      },
+      {
+        "at": "2026-06-25T22:48:00+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2431 GitHub checks passed and mergeStateStatus is CLEAN at head e0a7f66867342369b60d983d6c0e7b9f96460fab. Ready for squash merge under repo policy."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61253,7 +61253,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-runtime-02-response-evals",
     "base": "main",
-    "status": "pr_opened",
+    "status": "merged",
     "train_scope": "eq_agent_runtime",
     "title": "PR-EQ-AGENT-RUNTIME-02 EQ Agent response safety eval fixtures",
     "depends_on": [
@@ -62555,15 +62555,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "GitHub checks are green for PR #2429: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed. Merge state is CLEAN."
+        "evidence": "GitHub checks passed for PR #2429; squash merge commit ec0ee01f84204e64f9891f33d6126a7de344a97d is contained in origin/main. Remote branch was deleted and local task branch cleanup completed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "e842142a6bdc59a268cd979a61b9bd915a5a276b",
+    "commit_sha": "ec0ee01f84204e64f9891f33d6126a7de344a97d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2429",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-25T22:19:24+08:00",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-25T21:47:00+08:00",
@@ -62584,6 +62584,75 @@
         "at": "2026-06-25T22:07:00+08:00",
         "status": "ready_to_merge",
         "note": "PR #2429 GitHub checks passed and mergeStateStatus is CLEAN at head e842142a6bdc59a268cd979a61b9bd915a5a276b. Ready for squash merge under repo policy."
+      },
+      {
+        "at": "2026-06-25T22:21:00+08:00",
+        "status": "merged",
+        "note": "PR #2429 was squash merged as ec0ee01f84204e64f9891f33d6126a7de344a97d. origin/main contains the merge commit; local main was fast-forwarded to origin/main; local and remote task branches were cleaned."
+      }
+    ]
+  },
+  "PERSONALITY-TDK-RUNTIME-PROMOTION-SEARCH-GATE-READINESS-01": {
+    "repo": "fap-api",
+    "branch": "codex/personality-tdk-runtime-promotion-search-gate-readiness-01",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "fermatmind_seo_ops_p2_p4_20260625",
+    "title": "PERSONALITY-TDK-RUNTIME-PROMOTION-SEARCH-GATE-READINESS-01: Add personality TDK runtime promotion search gate readiness",
+    "depends_on": [
+      "PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User provided /goal FERMATMIND-SEO-OPS-P2-P4-PR-TRAIN-20260625-01 and explicitly authorized adding missing docs/codex/pr-train.yaml and docs/codex/pr-train-state.json entries for this PR train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01 merged as ec0ee01f84204e64f9891f33d6126a7de344a97d and local main is synced to origin/main before starting P4-B."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php",
+          "php -l backend/tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php",
+          "cd backend && php artisan list | rg personality:tdk-runtime-promotion-search-gate-readiness",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityTdkRuntimePromotionSearchGateReadinessTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbti64CmsRevisionPromoteCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_personality_tdk_next_batch_gate_files' --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/personality-tdk-runtime-promotion-search-gate-readiness.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: PHP syntax; artisan command registration; focused PersonalityTdkRuntimePromotionSearchGateReadinessTest (4 tests, 35 assertions); PersonalityMbti64CmsRevisionPromoteCommandTest (19 tests, 232 assertions); BigFive freeze classifier focused test for this read-only gate; scoped Pint; generated contract JSON parse; train state JSON parse; train manifest YAML parse; diff checks."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php, Kernel registration, generated command contract doc, focused Feature test, BigFive freeze classifier allowlist for this read-only command, and authorized docs/codex train metadata. No production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation changes."
+      },
+      "github": {
+        "status": "not_started",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T22:22:00+08:00",
+        "status": "in_progress",
+        "note": "Started P4-B from synced fap-api main ec0ee01f84204e64f9891f33d6126a7de344a97d. Scope is backend-only read-only runtime/promotion/search gate readiness; no production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation."
+      },
+      {
+        "at": "2026-06-25T22:37:00+08:00",
+        "status": "local_validated",
+        "note": "Implemented read-only personality TDK runtime/promotion/search gate readiness command and focused tests. Local scoped checks passed; no production approval queue write, CMS draft write, promotion, publish, index/search, sitemap/llms, frontend metadata edit, deploy, or revalidation path was added."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -28965,3 +28965,49 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: PERSONALITY-TDK-RUNTIME-PROMOTION-SEARCH-GATE-READINESS-01
+    repo: fap-api
+    depends_on:
+      - PERSONALITY-TDK-NEXT-BATCH-APPROVAL-DRAFT-GATE-01
+    branch: codex/personality-tdk-runtime-promotion-search-gate-readiness-01
+    title: "PERSONALITY-TDK-RUNTIME-PROMOTION-SEARCH-GATE-READINESS-01: Add personality TDK runtime promotion search gate readiness"
+    train_scope: fermatmind_seo_ops_p2_p4_20260625
+    status: user_authorized
+    scope:
+      - Add a backend-only read-only gate readiness adapter for the three personality TDK next-batch targets after CMS draft/readback evidence exists.
+      - Consume approval/draft gate evidence plus optional runtime readback and promotion dry-run evidence.
+      - Emit promotion readiness, later sitemap/llms/search gate sequencing, future command templates, and approval templates only when required evidence is present and passing.
+      - Keep CMS draft writes, promotion executes, sitemap/llms, and search propagation as later separate exact approvals.
+    allowed_paths:
+      - backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php
+      - backend/app/Console/Kernel.php
+      - backend/docs/seo/generated/personality-tdk-runtime-promotion-search-gate-readiness.v1.json
+      - backend/tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production approval queue write, production CMS draft write, promotion, publish, index/search, sitemap, llms, Search Channel, live submit, frontend metadata edit, staging deploy, production deploy, or revalidation.
+      - Emit promotion approval when runtime readback or promotion dry-run evidence is missing or failing.
+      - Edit frontend TDK metadata directly.
+    validation:
+      - php -l backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php
+      - php -l backend/tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php
+      - cd backend && php artisan list | rg personality:tdk-runtime-promotion-search-gate-readiness
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityTdkRuntimePromotionSearchGateReadinessTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbti64CmsRevisionPromoteCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_personality_tdk_next_batch_gate_files' --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - python3 -m json.tool backend/docs/seo/generated/personality-tdk-runtime-promotion-search-gate-readiness.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added `personality:tdk-runtime-promotion-search-gate-readiness`, a backend-only read-only gate readiness command for the three personality TDK next-batch targets.
- Added generated contract docs and focused tests covering ready/review-required/forbidden-input behavior.
- Registered the command and extended the Big Five runtime freeze classifier allowlist for this read-only gate.
- Added/reconciled PR train metadata for P4-B and P4-A post-merge truth.

## Why
P4-B needs an evidence-only gate between CMS draft/readback, MBTI64 promotion dry-run, and later sitemap/search propagation. The command emits promotion approval text only when required runtime readback and promotion dry-run evidence are present and passing.

## Validation
- `php -l backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php`
- `php -l backend/tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php`
- `cd backend && php artisan list | rg personality:tdk-runtime-promotion-search-gate-readiness`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityTdkRuntimePromotionSearchGateReadinessTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbti64CmsRevisionPromoteCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_personality_tdk_next_batch_gate_files' --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php tests/Feature/Console/PersonalityTdkRuntimePromotionSearchGateReadinessTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `python3 -m json.tool backend/docs/seo/generated/personality-tdk-runtime-promotion-search-gate-readiness.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No production approval queue write.
- No CMS draft write.
- No promotion execute or publish.
- No sitemap/llms mutation.
- No Search Channel enqueue, IndexNow/Baidu/GSC, live submit, deploy, or revalidation.

## Repository rule impact
This is a backend-authoritative evidence/gate command only. It does not move content authority to frontend or create runtime editorial fallback content.