### PR TITLE
IQ-OWNER-30-NORM-RUNTIME-BIND-04B: Bind owner IQ 30 runtime norms

### DIFF
--- a/backend/app/Services/Assessment/Drivers/IqTestDriver.php
+++ b/backend/app/Services/Assessment/Drivers/IqTestDriver.php
@@ -11,6 +11,8 @@ class IqTestDriver implements DriverInterface
 {
     private const DIMENSIONS = ['VSPR', 'VSI', 'NPR'];
 
+    private const OWNER_ORIGINAL_BANK_ID = 'IQ_OWNER_ORIGINAL_30';
+
     /**
      * @var array<string,string>
      */
@@ -71,7 +73,8 @@ class IqTestDriver implements DriverInterface
             'status' => 'scored',
             'scoring_mode' => 'scored',
             'answer_key_version' => $contract['answer_key_version'],
-            'norm_table_version' => $contract['norm_table_version'],
+            'norm_table_version' => $this->nullableTrimmedString($norms['norm_table_version'] ?? null)
+                ?? $contract['norm_table_version'],
             'score_claim_level' => $scoreClaimLevel !== '' ? $scoreClaimLevel : 'raw_score_only',
             'claim_policy' => $claimPolicy,
             'claim_warnings' => $claimWarnings,
@@ -534,6 +537,7 @@ class IqTestDriver implements DriverInterface
      */
     private function resolveNorms(string $scaleCode, string $bankId, ?string $normTableVersion, float $rawScore, array $ctx): array
     {
+        $normTableVersion = $this->resolveRuntimeNormTableVersion($scaleCode, $bankId, $normTableVersion, $ctx);
         $base = [
             'status' => $this->resolveNormStatus($normTableVersion),
             'iq_estimate' => null,
@@ -657,6 +661,62 @@ class IqTestDriver implements DriverInterface
         ];
 
         return $base;
+    }
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     */
+    private function resolveRuntimeNormTableVersion(
+        string $scaleCode,
+        string $bankId,
+        ?string $normTableVersion,
+        array $ctx
+    ): ?string {
+        $normalizedVersion = strtolower(trim((string) $normTableVersion));
+        if ($normalizedVersion !== '' && ! in_array($normalizedVersion, ['unavailable', 'not_found', 'pending'], true)) {
+            return $normTableVersion;
+        }
+
+        if (
+            $scaleCode !== IqNormAuthorityContract::SCALE_CODE
+            || strtoupper(trim($bankId)) !== self::OWNER_ORIGINAL_BANK_ID
+            || ! Schema::hasTable('iq_norm_authorities')
+        ) {
+            return $normTableVersion;
+        }
+
+        $locale = trim((string) ($ctx['locale'] ?? 'zh-CN'));
+        $locale = $locale === '' ? 'zh-CN' : $locale;
+        $populationKey = trim((string) ($ctx['population_key'] ?? IqNormAuthorityContract::DEFAULT_POPULATION_KEY));
+        $populationKey = $populationKey === '' ? IqNormAuthorityContract::DEFAULT_POPULATION_KEY : $populationKey;
+
+        $records = DB::table('iq_norm_authorities')
+            ->where('org_id', (int) ($ctx['org_id'] ?? 0))
+            ->where('scale_code', IqNormAuthorityContract::SCALE_CODE)
+            ->where('bank_id', self::OWNER_ORIGINAL_BANK_ID)
+            ->where('population_key', $populationKey)
+            ->where('locale', $locale)
+            ->whereNull('retired_at')
+            ->whereIn('status', IqNormAuthorityContract::claimEligibleStatuses())
+            ->orderByDesc('effective_at')
+            ->orderByDesc('updated_at')
+            ->limit(10)
+            ->get();
+
+        foreach ($records as $record) {
+            $authority = (array) $record;
+            $gate = IqNormAuthorityContract::publicClaimGate($authority);
+            if (! (bool) ($gate['claim_eligible'] ?? false)) {
+                continue;
+            }
+
+            $boundVersion = $this->nullableTrimmedString($authority['norm_table_version'] ?? null);
+            if ($boundVersion !== null) {
+                return $boundVersion;
+            }
+        }
+
+        return $normTableVersion;
     }
 
     private function normalCdf(float $zScore): float

--- a/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+++ b/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
@@ -256,6 +256,65 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         $this->assertPayloadHasNoPrivateIqFields($response->json());
     }
 
+    #[Test]
+    public function owner_original_submit_emits_iq_claims_when_claim_eligible_norm_authority_exists(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        $this->insertClaimEligibleIqNormAuthority();
+
+        $anonId = 'anon_iq_owner_runtime_normed_score';
+        $token = $this->issueAnonToken($anonId);
+        $attempt = $this->createOwnerAttempt($anonId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit?mode=sync_legacy', [
+            'attempt_id' => (string) $attempt->id,
+            'answers' => $this->perfectAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'result' => [
+                'raw_score' => 30,
+                'final_score' => 30,
+                'normed_json' => [
+                    'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+                    'bank_id' => 'IQ_OWNER_ORIGINAL_30',
+                    'status' => 'scored',
+                    'raw_score' => 30,
+                    'norm_table_version' => 'iq_owner30_norm_fixture_v1',
+                    'score_claim_level' => 'iq_estimate',
+                    'claim_policy' => [
+                        'claim_eligible' => true,
+                        'score_claim_level' => 'iq_estimate',
+                        'iq_estimate_allowed' => true,
+                    ],
+                    'claim_warnings' => [],
+                    'norms' => [
+                        'status' => 'production_normed',
+                        'iq_estimate' => 145.0,
+                        'percentile' => 99.87,
+                        'confidence_interval' => [140.5, 149.5],
+                        'norm_table_version' => 'iq_owner30_norm_fixture_v1',
+                        'score_claim_level' => 'iq_estimate',
+                        'claim_warnings' => [],
+                        'claim_policy' => [
+                            'claim_eligible' => true,
+                            'score_claim_level' => 'iq_estimate',
+                            'iq_estimate_allowed' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertSame('iq_owner_original_30_runtime_scoring_v1', $response->json('meta.scoring_spec_version'));
+        $this->assertPayloadHasNoPrivateIqFields($response->json());
+    }
+
     private function issueAnonToken(string $anonId): string
     {
         $token = 'fm_'.(string) Str::uuid();
@@ -307,6 +366,34 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         $attempt->saveOrFail();
 
         return $attempt;
+    }
+
+    private function insertClaimEligibleIqNormAuthority(): void
+    {
+        DB::table('iq_norm_authorities')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'bank_id' => 'IQ_OWNER_ORIGINAL_30',
+            'norm_table_version' => 'iq_owner30_norm_fixture_v1',
+            'status' => 'production_normed',
+            'population_key' => 'general_adult_online',
+            'locale' => 'zh-CN',
+            'sample_size' => 1200,
+            'mean' => 15.0,
+            'standard_deviation' => 5.0,
+            'min_raw_score' => 0.0,
+            'max_raw_score' => 30.0,
+            'source_kind' => 'internal_calibration',
+            'source_ref' => 'iq-owner30-runtime-bind-test-fixture',
+            'license_verified' => true,
+            'locked' => true,
+            'effective_at' => now(),
+            'retired_at' => null,
+            'metadata' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 
     /**

--- a/backend/tests/Unit/Assessment/IqTestDriverTest.php
+++ b/backend/tests/Unit/Assessment/IqTestDriverTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Assessment;
 
 use App\Services\Assessment\Drivers\IqTestDriver;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -92,6 +93,88 @@ final class IqTestDriverTest extends TestCase
         $this->assertSame('blocked_unscored', data_get($result->normedJson, 'status'));
     }
 
+    public function test_owner_original_runtime_binds_claim_eligible_norm_authority(): void
+    {
+        $this->migrateIqNormAuthority();
+        $this->insertIqNormAuthority([
+            'norm_table_version' => 'iq_owner30_norm_fixture_v1',
+            'mean' => 2.0,
+            'standard_deviation' => 1.0,
+            'min_raw_score' => 0.0,
+            'max_raw_score' => 3.0,
+        ]);
+
+        $driver = new IqTestDriver;
+        $result = $driver->score(
+            [
+                ['question_id' => 'IQ001', 'code' => 'A'],
+                ['question_id' => 'IQ002', 'code' => 'C'],
+                ['question_id' => 'IQ003', 'code' => 'D'],
+            ],
+            $this->ownerOriginalScoringSpec(),
+            [
+                'org_id' => 0,
+                'locale' => 'zh-CN',
+                'population_key' => 'general_adult_online',
+                'duration_ms' => 45000,
+                'pack_id' => 'default',
+                'content_package_version' => 'iq_owner_original_30_v1',
+                'scoring_spec_version' => 'iq_owner_original_30_runtime_scoring_v1',
+            ]
+        );
+
+        $this->assertSame(2.0, $result->rawScore);
+        $this->assertSame('iq_estimate', data_get($result->normedJson, 'score_claim_level'));
+        $this->assertSame('iq_owner30_norm_fixture_v1', data_get($result->normedJson, 'norm_table_version'));
+        $this->assertSame('production_normed', data_get($result->normedJson, 'norms.status'));
+        $this->assertSame('iq_estimate', data_get($result->normedJson, 'norms.score_claim_level'));
+        $this->assertTrue((bool) data_get($result->normedJson, 'norms.claim_policy.claim_eligible'));
+        $this->assertSame('iq_owner30_norm_fixture_v1', data_get($result->normedJson, 'norms.norm_table_version'));
+        $this->assertSame(100.0, data_get($result->normedJson, 'norms.iq_estimate'));
+        $this->assertSame(50.0, data_get($result->normedJson, 'norms.percentile'));
+        $this->assertSame([95.5, 104.5], data_get($result->normedJson, 'norms.confidence_interval'));
+        $this->assertStringNotContainsString('correct_answer', json_encode($result->toArray(), JSON_THROW_ON_ERROR));
+    }
+
+    public function test_owner_original_runtime_without_claim_eligible_authority_stays_raw_score_only(): void
+    {
+        $this->migrateIqNormAuthority();
+        $this->insertIqNormAuthority([
+            'norm_table_version' => 'iq_owner30_draft_fixture_v1',
+            'status' => 'draft',
+            'license_verified' => false,
+            'locked' => false,
+        ]);
+
+        $driver = new IqTestDriver;
+        $result = $driver->score(
+            [
+                ['question_id' => 'IQ001', 'code' => 'A'],
+                ['question_id' => 'IQ002', 'code' => 'C'],
+                ['question_id' => 'IQ003', 'code' => 'D'],
+            ],
+            $this->ownerOriginalScoringSpec(),
+            [
+                'org_id' => 0,
+                'locale' => 'zh-CN',
+                'population_key' => 'general_adult_online',
+                'duration_ms' => 45000,
+                'pack_id' => 'default',
+                'content_package_version' => 'iq_owner_original_30_v1',
+                'scoring_spec_version' => 'iq_owner_original_30_runtime_scoring_v1',
+            ]
+        );
+
+        $this->assertSame(2.0, $result->rawScore);
+        $this->assertSame('raw_score_only', data_get($result->normedJson, 'score_claim_level'));
+        $this->assertSame('unavailable', data_get($result->normedJson, 'norm_table_version'));
+        $this->assertSame('unavailable_without_norm_table', data_get($result->normedJson, 'norms.status'));
+        $this->assertNull(data_get($result->normedJson, 'norms.iq_estimate'));
+        $this->assertFalse((bool) data_get($result->normedJson, 'norms.claim_policy.claim_eligible'));
+        $this->assertContains('no_norm_table', data_get($result->normedJson, 'norms.claim_warnings'));
+        $this->assertStringNotContainsString('correct_answer', json_encode($result->toArray(), JSON_THROW_ON_ERROR));
+    }
+
     private function completeScoringSpec(): array
     {
         return [
@@ -138,8 +221,20 @@ final class IqTestDriverTest extends TestCase
         ];
     }
 
+    private function ownerOriginalScoringSpec(): array
+    {
+        $spec = $this->completeScoringSpec();
+        $spec['item_bank']['bank_id'] = 'IQ_OWNER_ORIGINAL_30';
+        $spec['answer_key_version'] = 'iq_owner_original_30_answer_key_v1';
+        $spec['scoring_engine_version'] = 'iq_scoring_v2';
+
+        return $spec;
+    }
+
     private function migrateIqNormAuthority(): void
     {
+        Schema::dropIfExists('iq_norm_authorities');
+
         $migration = require base_path('database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php');
         $migration->up();
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T18:51:42+08:00",
+  "updated_at": "2026-06-25T21:42:05+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -62600,7 +62600,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-norm-runtime-bind-04b",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-NORM-RUNTIME-BIND-04B: Bind owner IQ 30 runtime norms",
     "depends_on": [
@@ -62636,12 +62636,12 @@
         "evidence": "Changed files are limited to IQ-OWNER-30-NORM-RUNTIME-BIND-04B scope: IqTestDriver runtime authority binding, focused Owner 30 driver/session delivery tests, and authorized docs/codex train metadata. No frontend, question bank assets, answer keys, norm import command behavior, production data import, CMS, SEO, staging deploy, or production deploy changes."
       },
       "github": {
-        "status": "pending",
-        "evidence": "Opened PR #2432 at https://github.com/fermatmind/fap-api/pull/2432; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2432 GitHub checks passed at head eb406a80b5b5e6092e87d69bde5b906f9794ec9e: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed; mergeStateStatus is CLEAN and PR is mergeable."
       }
     },
     "failure_reason": null,
-    "commit_sha": "2672436e04b0a262c431d0b27ed1d069bf322e6c",
+    "commit_sha": "eb406a80b5b5e6092e87d69bde5b906f9794ec9e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2432",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -62666,6 +62666,11 @@
         "at": "2026-06-25T13:30:18.180Z",
         "status": "github_checks_pending",
         "note": "Opened PR #2432 at https://github.com/fermatmind/fap-api/pull/2432. Waiting for required GitHub checks; no staging deploy wait, production deploy, CMS write, SEO, frontend, question asset, answer-key, norm import, or production norm data import included."
+      },
+      {
+        "at": "2026-06-25T21:42:05+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2432 GitHub checks passed at head eb406a80b5b5e6092e87d69bde5b906f9794ec9e and mergeStateStatus is CLEAN. Ready for squash merge under repo policy; no staging deploy wait, production deploy, CMS write, SEO, frontend, question asset, answer-key, norm import behavior, or production norm data import included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62276,7 +62276,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-norm-authority-04a",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-NORM-AUTHORITY-04A: Add owner IQ 30 norm authority activation",
     "depends_on": [
@@ -62312,15 +62312,19 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "PR #2424 GitHub checks passed for head 745b140a41acd530a3519e5bab4367d33cb02777 and mergeStateStatus was CLEAN."
+        "evidence": "PR #2424 was merged on GitHub with squash merge commit fed95c351d57ed918d9f025100ec693f8fb9ac5d; origin/main contains that merge commit and the remote task branch is deleted."
+      },
+      "post_merge_cleanup": {
+        "status": "pass",
+        "evidence": "Post-merge cleanup completed in the prior run: origin/main contained fed95c351d57ed918d9f025100ec693f8fb9ac5d, local main was synced, worktree was clean, and local/remote task branches were deleted."
       }
     },
     "failure_reason": null,
-    "commit_sha": "745b140a41acd530a3519e5bab4367d33cb02777",
+    "commit_sha": "fed95c351d57ed918d9f025100ec693f8fb9ac5d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2424",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-25T10:57:40Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-25T10:32:26Z",
@@ -62346,6 +62350,11 @@
         "at": "2026-06-25T18:51:42+08:00",
         "status": "ready_to_merge",
         "note": "PR #2424 GitHub checks passed and mergeStateStatus was CLEAN. Ready for squash merge; no staging wait, production deploy, CMS write, SEO, frontend, runtime scoring bind, or production norm data import included."
+      },
+      {
+        "at": "2026-06-25T13:20:02.467Z",
+        "status": "merged_reconciled_for_04b_dependency",
+        "note": "Reconciled stale 04A ledger while starting IQ-OWNER-30-NORM-RUNTIME-BIND-04B. GitHub shows PR #2424 merged with squash commit fed95c351d57ed918d9f025100ec693f8fb9ac5d; origin/main contains it and branches are cleaned. This is bookkeeping needed to satisfy the 04B dependency, not a retry of 04A."
       }
     ]
   },
@@ -62584,6 +62593,79 @@
         "at": "2026-06-25T22:07:00+08:00",
         "status": "ready_to_merge",
         "note": "PR #2429 GitHub checks passed and mergeStateStatus is CLEAN at head e842142a6bdc59a268cd979a61b9bd915a5a276b. Ready for squash merge under repo policy."
+      }
+    ]
+  },
+  "IQ-OWNER-30-NORM-RUNTIME-BIND-04B": {
+    "repo": "fap-api",
+    "branch": "codex/iq-owner-30-norm-runtime-bind-04b",
+    "base": "main",
+    "status": "github_checks_pending",
+    "train_scope": "iq_owner_original_30_launch",
+    "title": "IQ-OWNER-30-NORM-RUNTIME-BIND-04B: Bind owner IQ 30 runtime norms",
+    "depends_on": [
+      "IQ-OWNER-30-NORM-AUTHORITY-04A"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json updates for IQ-OWNER-30-NORM-RUNTIME-BIND-04B and requested backend Owner 30 runtime scoring spec binding to an activated norm version, with raw_score_only fallback and no answer leakage."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "IQ-OWNER-30-NORM-AUTHORITY-04A is reconciled as merged with squash commit fed95c351d57ed918d9f025100ec693f8fb9ac5d before this branch started."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Services/Assessment/Drivers/IqTestDriver.php",
+          "php -l backend/tests/Unit/Assessment/IqTestDriverTest.php",
+          "php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php",
+          "cd backend && php artisan test tests/Unit/Assessment/IqTestDriverTest.php --no-ansi",
+          "cd backend && php artisan test tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php --filter='owner_original_submit_scores_with_private_answer_key_without_public_answer_leak|owner_original_submit_emits_iq_claims_when_claim_eligible_norm_authority_exists' --no-ansi",
+          "cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/Assessment/Drivers/IqTestDriver.php tests/Unit/Assessment/IqTestDriverTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS after rebase to latest origin/main: PHP syntax checks for IqTestDriver.php, IqTestDriverTest.php, and IqOwnerOriginal30SessionDeliveryTest.php; IqTestDriverTest.php (4 tests, 43 assertions, exit 0 with existing file_get_contents warnings); focused Owner 30 submit tests (2 tests, 2420 assertions, exit 0 with existing file_get_contents warnings); php artisan test --filter=IqOwnerOriginal30 (12 tests, 6535 assertions, exit 0 with existing file_get_contents warnings); scoped Pint; docs/codex state JSON parse; pr-train YAML parse; git diff --check."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to IQ-OWNER-30-NORM-RUNTIME-BIND-04B scope: IqTestDriver runtime authority binding, focused Owner 30 driver/session delivery tests, and authorized docs/codex train metadata. No frontend, question bank assets, answer keys, norm import command behavior, production data import, CMS, SEO, staging deploy, or production deploy changes."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "Opened PR #2432 at https://github.com/fermatmind/fap-api/pull/2432; waiting for required GitHub checks."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": "2672436e04b0a262c431d0b27ed1d069bf322e6c",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2432",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T13:20:02.467Z",
+        "status": "in_progress",
+        "note": "Started backend-only Owner 30 runtime norm binding from latest fap-api origin/main in an isolated clean worktree. Scope is IqTestDriver runtime authority binding, focused Owner 30 tests, and authorized docs/codex train metadata. No frontend, question assets, answer-key changes, norm import behavior, production data import, CMS, SEO, staging deploy, or production deploy."
+      },
+      {
+        "at": "2026-06-25T13:24:42.448Z",
+        "status": "local_validated",
+        "note": "Local checks and scope validation passed. Owner 30 runtime scoring now binds an unavailable scoring spec to the latest activated claim-eligible norm authority for the same org/locale/population, emits IQ estimate only when that authority passes the public claim gate, and preserves raw_score_only fallback plus private-answer redaction otherwise."
+      },
+      {
+        "at": "2026-06-25T13:28:12.915Z",
+        "status": "rebased_revalidated_committed",
+        "note": "Rebased onto latest origin/main and reran required local checks successfully. Scoped commit prepared from 3f3c72873b621c4a1e2ff4e286d79d35c4c5edac; no frontend, deploy, CMS, SEO, or production norm import included."
+      },
+      {
+        "at": "2026-06-25T13:30:18.180Z",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2432 at https://github.com/fermatmind/fap-api/pull/2432. Waiting for required GitHub checks; no staging deploy wait, production deploy, CMS write, SEO, frontend, question asset, answer-key, norm import, or production norm data import included."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -281,6 +281,50 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: IQ-OWNER-30-NORM-RUNTIME-BIND-04B
+    repo: fap-api
+    depends_on:
+      - IQ-OWNER-30-NORM-AUTHORITY-04A
+    branch: codex/iq-owner-30-norm-runtime-bind-04b
+    title: "IQ-OWNER-30-NORM-RUNTIME-BIND-04B: Bind owner IQ 30 runtime norms"
+    train_scope: iq_owner_original_30_launch
+    status: user_authorized
+    scope:
+      - Bind Owner 30 runtime scoring to an activated, claim-eligible iq_norm_authorities version when the scoring spec has no fixed norm table.
+      - Emit IQ estimate, percentile, confidence interval, and norm table version only when backend authority passes the public claim gate.
+      - Keep raw_score_only fallback with no IQ claim when no eligible authority exists.
+      - Preserve private answer-key and solution metadata redaction from public submit/report payloads.
+    allowed_paths:
+      - backend/app/Services/Assessment/Drivers/IqTestDriver.php
+      - backend/tests/Unit/Assessment/IqTestDriverTest.php
+      - backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend rendering, question bank assets, answer keys, norm import command behavior, CMS, SEO runtime, sitemap, llms, JSON-LD, staging deploy, or production deploy.
+      - Import production norm data or trigger production writes.
+      - Show IQ estimate, percentile, ranking, or confidence interval without an activated claim-eligible backend norm authority.
+      - Emit correct answers, answer keys, solution rules, generator metadata, private provenance, or source capture URLs in public payloads.
+    validation:
+      - php -l backend/app/Services/Assessment/Drivers/IqTestDriver.php
+      - php -l backend/tests/Unit/Assessment/IqTestDriverTest.php
+      - php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - cd backend && php artisan test tests/Unit/Assessment/IqTestDriverTest.php --no-ansi
+      - cd backend && php artisan test tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php --filter='owner_original_submit_scores_with_private_answer_key_without_public_answer_leak|owner_original_submit_emits_iq_claims_when_claim_eligible_norm_authority_exists' --no-ansi
+      - cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Assessment/Drivers/IqTestDriver.php tests/Unit/Assessment/IqTestDriverTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01
     repo: fap-api
     depends_on: []


### PR DESCRIPTION
## What changed
- Added `IQ-OWNER-30-NORM-RUNTIME-BIND-04B` to the fap-api PR train manifest/state and reconciled the stale 04A ledger as merged for dependency truth.
- Updated `IqTestDriver` so Owner 30 runtime scoring binds an `unavailable` scoring spec to the latest activated, claim-eligible `iq_norm_authorities` record for the same org / locale / population.
- Preserved `raw_score_only` fallback when no eligible norm authority exists.
- Added unit and feature coverage for claim-eligible IQ estimate output, fallback behavior, and no private answer leakage in public submit payloads.

## Why
Owner 30 now has a guarded norm authority import path, but runtime scoring still needed to consult that activated authority before public IQ claims could be emitted. This PR keeps the backend as the authority: IQ estimate, percentile, CI, and norm table version only appear when the authority passes the public claim gate.

## Validation
- `php -l backend/app/Services/Assessment/Drivers/IqTestDriver.php`
- `php -l backend/tests/Unit/Assessment/IqTestDriverTest.php`
- `php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php`
- `cd backend && php artisan test tests/Unit/Assessment/IqTestDriverTest.php --no-ansi`  
  PASS: 4 tests, 43 assertions, exit 0 with existing `file_get_contents` warnings.
- `cd backend && php artisan test tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php --filter='owner_original_submit_scores_with_private_answer_key_without_public_answer_leak|owner_original_submit_emits_iq_claims_when_claim_eligible_norm_authority_exists' --no-ansi`  
  PASS: 2 tests, 2420 assertions, exit 0 with existing `file_get_contents` warnings.
- `cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi`  
  PASS: 12 tests, 6535 assertions, exit 0 with existing `file_get_contents` warnings.
- `cd backend && vendor/bin/pint --test app/Services/Assessment/Drivers/IqTestDriver.php tests/Unit/Assessment/IqTestDriverTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No frontend rendering changes.
- No question bank asset or answer-key changes.
- No norm import command behavior changes.
- No production norm data import.
- No CMS, SEO, sitemap, llms, JSON-LD, staging deploy, or production deploy changes.
