### PR TITLE
docs(eq): defer EQ Agent LLM runtime lane

### DIFF
--- a/docs/audits/eq/eq_agent_runtime_v2_staging_llm_smoke_2026-06-25.md
+++ b/docs/audits/eq/eq_agent_runtime_v2_staging_llm_smoke_2026-06-25.md
@@ -4,11 +4,11 @@ Date: 2026-06-25
 
 ## 1. Executive Summary
 
-Verdict: **blocked for live LLM mode; deterministic fallback accepted**.
+Verdict: **LLM mode deferred by product decision; deterministic fallback accepted**.
 
 The EQ Agent Runtime V2 provider code was present on staging and staging had OpenAI provider configuration present, but direct outbound access from staging to the OpenAI Responses API timed out. The runtime correctly failed closed into deterministic read-only mode, kept all report/content authority guardrails intact, and did not expose paywall, SKU, SJT entry, or raw technical tags.
 
-This report should be merged as evidence for `PR-EQ-AGENT-RUNTIME-V2-04`, but it does **not** approve live LLM rollout.
+This report was merged as evidence for `PR-EQ-AGENT-RUNTIME-V2-04`, but it does **not** approve live LLM rollout. On 2026-06-25, the product decision changed: keep EQ Agent on deterministic/read-only runtime and do not continue the LLM smoke lane now.
 
 ## 2. Scope
 
@@ -59,18 +59,28 @@ Final safe state after smoke:
 
 No secret value is recorded in this report.
 
+Latest closeout state after the 2026-06-25 manual follow-up:
+- `EQ_AGENT_LLM_ENABLED=false`
+- `EQ_AGENT_LLM_PROVIDER=openai`
+- `EQ_AGENT_OPENAI_API_KEY` present in staging configuration
+- `EQ_AGENT_OPENAI_MODEL=gpt-4.1-mini`
+- `EQ_AGENT_OPENAI_BASE_URL=https://api.openai.com/v1`
+
+The provider configuration may remain present, but live LLM calls must remain disabled unless a later product decision explicitly reopens this lane.
+
 ## 5. Credential Hygiene
 
 An initial UI-created key named `eq-agent-staging` was exposed during setup and was treated as compromised.
 
 Final credential status:
 - `eq-agent-staging`: **deleted / revoked by user**
-- `eq-agent-staging-v2`: retained as the staging key
+- `eq-agent-staging-v2`: retained but not used for active LLM runtime
+- `eq-agent-staging-v3`: created by the user for the manual follow-up, written to staging, and kept with `EQ_AGENT_LLM_ENABLED=false`
 
 Required policy going forward:
 - Do not use `eq-agent-staging`.
-- Keep `eq-agent-staging-v2` as the only staging OpenAI key for this lane.
 - Do not paste API keys into chat, logs, reports, PR bodies, or repo files.
+- Do not re-enable EQ Agent LLM mode without a new explicit product decision and a scoped smoke plan.
 
 ## 6. Smoke Attempt
 
@@ -164,6 +174,12 @@ Root-cause classification:
 - Staging outbound connectivity failure: **yes**
 - Production issue: **not tested / not changed**
 
+Manual follow-up after this report found an additional constraint:
+- A temporary local relay plus SSH reverse tunnel proved that staging could reach the OpenAI Responses API through the relay path.
+- OpenAI then returned `429 insufficient_quota`.
+- This means the original direct staging timeout was not the only blocker; the OpenAI project/key also lacked usable quota for live smoke.
+- The product decision is now to stop pursuing LLM mode, so quota remediation is not required for the current EQ Agent path.
+
 ## 11. Forbidden Text / Field Scan
 
 The redacted smoke artifacts did not expose these forbidden values:
@@ -189,15 +205,17 @@ The redacted smoke artifacts did not expose these forbidden values:
 | Live LLM staging smoke accepted | no |
 | Proceed to controlled live LLM rollout | no |
 | Production LLM enablement allowed | no |
+| Continue EQ Agent Runtime V2 LLM smoke | no |
+| Keep deterministic/read-only EQ Agent runtime | yes |
 
 Final verdict:
 
-`Live LLM staging smoke blocked by staging outbound timeout to OpenAI Responses API. Deterministic fallback accepted. Exposed old key has been revoked.`
+`LLM mode is deferred / not pursuing now. Keep EQ_AGENT_LLM_ENABLED=false. Deterministic/read-only EQ Agent runtime remains the accepted product path.`
 
 ## 13. Required Next Actions
 
-1. Keep `EQ_AGENT_LLM_ENABLED=false` on staging until egress is fixed.
-2. Investigate staging outbound connectivity to `https://api.openai.com/v1/responses`.
-3. Confirm whether staging requires proxy, firewall allowlist, DNS change, or VPC/NAT egress adjustment.
-4. After connectivity is fixed, temporarily re-enable staging-only LLM flag.
-5. Re-run V2-04 smoke and require `mode=llm_provider_read_only` before approving any controlled rollout.
+1. Keep `EQ_AGENT_LLM_ENABLED=false` on staging and production.
+2. Do not continue EQ Agent Runtime V2 live LLM smoke.
+3. Treat the LLM provider lane as `deferred / not pursuing now`.
+4. Continue improving the deterministic/read-only Agent path through structured assets, intent routing, playbooks, safety fixtures, locale quality, and result-page integration.
+5. If a future decision reopens LLM mode, create a new explicit PR train and smoke gate instead of resuming this one implicitly.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62168,7 +62168,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-runtime-v2-04-staging-smoke-report",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged_deferred_followup",
     "train_scope": "eq_agent_runtime_v2",
     "title": "PR-EQ-AGENT-RUNTIME-V2-04 EQ Agent staging LLM smoke report",
     "depends_on": [
@@ -62206,14 +62206,30 @@
       "github_checks": {
         "status": "pass",
         "evidence": "PR #2430 checks passed on head a06d8a8cfa1182fd197d67167fe1c0d82de1d70a: hygiene, supply-chain, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, Semgrep blocking secrets, semgrep SARIF upload, and Semgrep OSS. mergeStateStatus=CLEAN."
+      },
+      "merge_reconciliation": {
+        "status": "pass",
+        "evidence": "PR #2430 was squash merged into origin/main as 8b28204a0b2bc9ef6172885b50cec3f2e8c44751; current branch is based on origin/main cf53d5f57."
+      },
+      "user_policy_decision": {
+        "status": "deferred",
+        "evidence": "User explicitly instructed to keep EQ_AGENT_LLM_ENABLED=false, stop EQ Agent Runtime V2 LLM smoke, and mark the V2 LLM train as deferred / not pursuing now."
+      },
+      "staging_safe_state_latest": {
+        "status": "pass",
+        "evidence": "Staging was returned to EQ_AGENT_LLM_ENABLED=false after a manual eq-agent-staging-v3 credential test. Provider/key/model may remain configured, but live LLM calls are disabled."
+      },
+      "latest_blocker": {
+        "status": "deferred",
+        "evidence": "Temporary relay proved the network path could reach OpenAI, but OpenAI returned 429 insufficient_quota. This is no longer pursued because the user chose not to use LLM mode."
       }
     },
-    "failure_reason": "Live LLM staging smoke blocked by staging outbound timeout to OpenAI Responses API; deterministic fallback passed. Exposed UI-created eq-agent-staging key has been deleted/revoked.",
-    "commit_sha": "a06d8a8cfa1182fd197d67167fe1c0d82de1d70a",
+    "failure_reason": "Live LLM staging smoke is deferred by user decision on 2026-06-25. Deterministic/read-only Agent runtime remains the accepted path; EQ_AGENT_LLM_ENABLED must stay false. A later manual decision is required before any LLM smoke or rollout resumes.",
+    "commit_sha": "8b28204a0b2bc9ef6172885b50cec3f2e8c44751",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2430",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-25T13:16:08Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-25T17:48:04+08:00",


### PR DESCRIPTION
## What changed
- Updated the EQ Agent Runtime V2 staging smoke report to record the product decision to defer / not pursue LLM mode now.
- Reconciled `PR-EQ-AGENT-RUNTIME-V2-04` state as merged and added the user policy decision: keep `EQ_AGENT_LLM_ENABLED=false` and continue with deterministic/read-only Agent runtime.

## Why
- The current product direction is to keep EQ Agent deterministic and content-asset-driven.
- LLM mode is not required for the current EQ commercialization path.
- A manual follow-up proved the relay path can reach OpenAI, but OpenAI returned `429 insufficient_quota`; this is not being pursued because LLM mode is now deferred by product decision.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml_ok'"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No LLM smoke retry.
- No staging or production deploy.
- No code changes.
- No OpenAI quota/billing remediation.
- No frontend changes.
- No changes to EQ scores, report authority, SJT, or commerce.
