### PR TITLE
fix(seo-ops): preserve zh article link repairs

### DIFF
--- a/backend/app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php
+++ b/backend/app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php
@@ -298,8 +298,8 @@ final class SeoOpsZhArticleQualityControlledWriterCommand extends Command
 
         $out = [];
         foreach ($raw as $replacement) {
-            $find = (string) data_get($replacement, 'find', '');
-            $replace = (string) data_get($replacement, 'replace_with', '');
+            $find = (string) (data_get($replacement, 'find') ?? data_get($replacement, 'find_href', ''));
+            $replace = (string) (data_get($replacement, 'replace_with') ?? data_get($replacement, 'replace_with_href', ''));
             if (($allowed[$find] ?? null) !== $replace) {
                 continue;
             }

--- a/backend/app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php
+++ b/backend/app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php
@@ -177,8 +177,8 @@ final class SeoOpsZhArticleQualityReadbackCommand extends Command
         ];
         $replacementReadback = [];
         foreach ((array) ($plan['replacements'] ?? []) as $replacement) {
-            $find = (string) ($replacement['find'] ?? '');
-            $replace = (string) ($replacement['replace_with'] ?? '');
+            $find = (string) (($replacement['find'] ?? null) ?? ($replacement['find_href'] ?? ''));
+            $replace = (string) (($replacement['replace_with'] ?? null) ?? ($replacement['replace_with_href'] ?? ''));
             $fieldReadback = [];
             foreach ($texts as $field => $text) {
                 $present = substr_count($text, $replace);

--- a/backend/app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php
@@ -340,8 +340,8 @@ final class SeoOpsZhArticleQualityRepairDryRunCommand extends Command
     private function sanitizeReplacements(array $replacements): array
     {
         return array_map(static fn ($replacement): array => [
-            'find' => (string) data_get($replacement, 'find', ''),
-            'replace_with' => (string) data_get($replacement, 'replace_with', ''),
+            'find' => (string) (data_get($replacement, 'find') ?? data_get($replacement, 'find_href', '')),
+            'replace_with' => (string) (data_get($replacement, 'replace_with') ?? data_get($replacement, 'replace_with_href', '')),
             'scope' => (string) data_get($replacement, 'scope', ''),
         ], $replacements);
     }

--- a/backend/docs/seo/generated/seo-ops-zh-article-quality-controlled-writer.v1.json
+++ b/backend/docs/seo/generated/seo-ops-zh-article-quality-controlled-writer.v1.json
@@ -26,6 +26,10 @@
     "/method-boundaries": "/zh/method-boundaries",
     "/reliability-validity": "/zh/reliability-validity"
   },
+  "replacement_input_fields": {
+    "writer": "Consumes normalized find + replace_with pairs and remains compatible with find_href + replace_with_href pairs.",
+    "readback": "Checks both text and href replacement pairs so raw href values are reported if still present."
+  },
   "protected_fields": {
     "slug": "no_change",
     "canonical": "no_change",

--- a/backend/docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json
+++ b/backend/docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json
@@ -18,6 +18,10 @@
       "locale": "zh-CN"
     }
   },
+  "replacement_input_fields": {
+    "heading_replacements": "Uses find + replace_with.",
+    "link_replacements": "Accepts find + replace_with or package-native find_href + replace_with_href and normalizes both to find + replace_with in dry-run evidence."
+  },
   "protected_diff": {
     "slug": "no_change",
     "canonical": "no_change",

--- a/backend/tests/Feature/SeoIntel/SeoOpsZhArticleQualityControlledWriterTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoOpsZhArticleQualityControlledWriterTest.php
@@ -74,7 +74,12 @@ final class SeoOpsZhArticleQualityControlledWriterTest extends TestCase
 
         $first = Article::query()->withoutGlobalScopes()->with('publishedRevision')->findOrFail((int) $articles[0]->id);
         $this->assertStringNotContainsString('Dynamic next steps', (string) $first->content_md);
+        $this->assertStringNotContainsString('](/tests/mbti-personality-test-16-personality-types)', (string) $first->content_md);
+        $this->assertStringNotContainsString('href="/tests/mbti-personality-test-16-personality-types"', (string) $first->content_html);
+        $this->assertStringNotContainsString('](/tests/mbti-personality-test-16-personality-types)', (string) $first->publishedRevision?->content_md);
         $this->assertStringContainsString('下一步怎么做', (string) $first->content_md);
+        $this->assertStringContainsString('/zh/tests/mbti-personality-test-16-personality-types', (string) $first->content_md);
+        $this->assertStringContainsString('href="/zh/tests/mbti-personality-test-16-personality-types"', (string) $first->content_html);
         $this->assertStringContainsString('常见问题', (string) $first->publishedRevision?->content_md);
 
         $writerArtifact = $this->readJson((string) data_get($summary, 'evidence.path'));
@@ -263,8 +268,8 @@ final class SeoOpsZhArticleQualityControlledWriterTest extends TestCase
                         ['find' => 'Trust links', 'replace_with' => '可信度与边界', 'scope' => 'cms_article_body_or_module_heading'],
                     ],
                     'link_replacements' => [
-                        ['find' => '/tests/mbti-personality-test-16-personality-types', 'replace_with' => '/zh/tests/mbti-personality-test-16-personality-types', 'scope' => 'cms_article_body_or_module_link'],
-                        ['find' => '/science', 'replace_with' => '/zh/science', 'scope' => 'cms_article_body_or_module_link'],
+                        ['find_href' => '/tests/mbti-personality-test-16-personality-types', 'replace_with_href' => '/zh/tests/mbti-personality-test-16-personality-types', 'scope' => 'cms_article_body_or_module_link'],
+                        ['find_href' => '/science', 'replace_with_href' => '/zh/science', 'scope' => 'cms_article_body_or_module_link'],
                     ],
                 ],
                 'issues' => [],

--- a/backend/tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php
@@ -60,6 +60,18 @@ final class SeoOpsZhArticleQualityRepairDryRunCommandTest extends TestCase
         $this->assertSame('article:1:zh-CN', data_get($artifact, 'article_operation_plans.0.target'));
         $this->assertSame('/zh/articles/riasec-holland-career-interest-test-explained', data_get($artifact, 'article_operation_plans.0.current.canonical_path'));
         $this->assertSame('下一步怎么做', data_get($artifact, 'article_operation_plans.0.planned_repairs.heading_replacements.0.replace_with'));
+        $linkRepairs = data_get($artifact, 'article_operation_plans.7.planned_repairs.link_replacements');
+        $this->assertIsArray($linkRepairs);
+        $this->assertContains([
+            'find' => '/tests/mbti-personality-test-16-personality-types',
+            'replace_with' => '/zh/tests/mbti-personality-test-16-personality-types',
+            'scope' => 'cms_article_body_or_internal_link',
+        ], $linkRepairs);
+        $this->assertNotContains([
+            'find' => '',
+            'replace_with' => '',
+            'scope' => 'cms_article_body_or_internal_link',
+        ], $linkRepairs);
     }
 
     #[Test]
@@ -280,8 +292,8 @@ final class SeoOpsZhArticleQualityRepairDryRunCommandTest extends TestCase
                 'scope' => 'cms_article_body_or_module_heading',
             ], $headingFinds),
             'link_replacements' => array_map(static fn (array $pair): array => [
-                'find' => $pair[0],
-                'replace_with' => $pair[1],
+                'find_href' => $pair[0],
+                'replace_with_href' => $pair[1],
                 'scope' => 'cms_article_body_or_internal_link',
             ], $linkPairs),
             'protected_fields' => [


### PR DESCRIPTION
## Summary
- Preserve package-native `find_href` / `replace_with_href` pairs in the zh article quality repair dry-run evidence.
- Let the controlled writer and readback consume both normalized text replacement pairs and href replacement pairs.
- Add focused regression coverage so raw `/tests/...` href targets are actually rewritten to `/zh/tests/...`.

## Why
P2 production evidence showed headings were repaired, but raw links remained because the dry-run adapter normalized href replacements into empty `find` / `replace_with` fields.

## Validation
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php tests/Feature/SeoIntel/SeoOpsZhArticleQualityControlledWriterTest.php`
- `vendor/bin/pint --test app/Console/Commands/SeoOpsZhArticleQualityRepairDryRunCommand.php app/Console/Commands/SeoOpsZhArticleQualityControlledWriterCommand.php app/Console/Commands/SeoOpsZhArticleQualityReadbackCommand.php tests/Feature/SeoIntel/SeoOpsZhArticleQualityRepairDryRunCommandTest.php tests/Feature/SeoIntel/SeoOpsZhArticleQualityControlledWriterTest.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-ops-zh-article-quality-repair-dry-run.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/generated/seo-ops-zh-article-quality-controlled-writer.v1.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

Note: PHPUnit reported warnings but exited 0; no test failures.

## Deferred
- No production deploy.
- No production CMS write.
- No publish, URL Truth, sitemap/llms, schema/hreflang, Search Channel, IndexNow/Baidu/GSC, or revalidation.