### PR TITLE
fix(iq): redact answer key version from public payloads

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -284,6 +284,7 @@ class AttemptReadController extends Controller
         if (IqResultPayloadRedactor::isIqScale($responseCodes['scale_code_legacy'], $responseCodes['scale_code_v2'])) {
             $payload = IqResultPayloadRedactor::redactAnswerKeys($payload);
             $compatScores = IqResultPayloadRedactor::redactAnswerKeys($compatScores);
+            $compatScoresPct = IqResultPayloadRedactor::redactAnswerKeys($compatScoresPct);
         }
 
         $hasBigFiveProjectionFullAccess = $scaleCode === 'BIG5_OCEAN'
@@ -419,6 +420,10 @@ class AttemptReadController extends Controller
         }
         if (is_array($riasecFormSummary)) {
             $responsePayload['riasec_form_v1'] = $riasecFormSummary;
+        }
+
+        if (IqResultPayloadRedactor::isIqScale($responseCodes['scale_code_legacy'], $responseCodes['scale_code_v2'])) {
+            $responsePayload = IqResultPayloadRedactor::redactAnswerKeys($responsePayload);
         }
 
         return response()->json($responsePayload);
@@ -709,6 +714,10 @@ class AttemptReadController extends Controller
                 $result,
                 is_array($responsePayload['enneagram_public_projection_v2'] ?? null) ? $responsePayload['enneagram_public_projection_v2'] : null,
             ));
+        }
+
+        if (IqResultPayloadRedactor::isIqScale($responseCodes['scale_code_legacy'], $responseCodes['scale_code_v2'])) {
+            $responsePayload = IqResultPayloadRedactor::redactAnswerKeys($responsePayload);
         }
 
         return response()->json($responsePayload);

--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -294,7 +294,6 @@ class AttemptSubmitService
         if (IqResultPayloadRedactor::isIqScale($responseCodes['scale_code_legacy'], $responseCodes['scale_code_v2'])) {
             $payload = IqResultPayloadRedactor::redactAnswerKeys($payload);
             $compatScores = IqResultPayloadRedactor::redactAnswerKeys($compatScores);
-            $compatScoresPct = IqResultPayloadRedactor::redactAnswerKeys($compatScoresPct);
         }
 
         return [

--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -294,6 +294,7 @@ class AttemptSubmitService
         if (IqResultPayloadRedactor::isIqScale($responseCodes['scale_code_legacy'], $responseCodes['scale_code_v2'])) {
             $payload = IqResultPayloadRedactor::redactAnswerKeys($payload);
             $compatScores = IqResultPayloadRedactor::redactAnswerKeys($compatScores);
+            $compatScoresPct = IqResultPayloadRedactor::redactAnswerKeys($compatScoresPct);
         }
 
         return [

--- a/backend/app/Services/Iq/IqResultPayloadRedactor.php
+++ b/backend/app/Services/Iq/IqResultPayloadRedactor.php
@@ -14,6 +14,8 @@ final class IqResultPayloadRedactor
     private const ANSWER_KEY_FIELDS = [
         'answer_key',
         'answerKey',
+        'answer_key_version',
+        'answerKeyVersion',
         'correct_answer',
         'correctAnswer',
         'solution_rule',
@@ -28,8 +30,18 @@ final class IqResultPayloadRedactor
 
     public static function isIqScale(?string $scaleCode, ?string $scaleCodeV2 = null): bool
     {
-        return in_array(strtoupper(trim((string) $scaleCode)), self::IQ_SCALE_CODES, true)
-            || in_array(strtoupper(trim((string) $scaleCodeV2)), self::IQ_SCALE_CODES, true);
+        foreach ([$scaleCode, $scaleCodeV2] as $candidate) {
+            $normalized = strtoupper(trim((string) $candidate));
+            if ($normalized === '') {
+                continue;
+            }
+
+            if (in_array($normalized, self::IQ_SCALE_CODES, true) || str_starts_with($normalized, 'IQ_')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/app/Services/Report/IqReportBuilder.php
+++ b/backend/app/Services/Report/IqReportBuilder.php
@@ -144,7 +144,6 @@ final class IqReportBuilder
                 'reason_code' => $reasonCode,
                 'scoring_mode' => $this->stringOrNull($score['scoring_mode'] ?? null),
                 'bank_id' => $this->stringOrNull($score['bank_id'] ?? null),
-                'answer_key_version' => $this->stringOrNull($score['answer_key_version'] ?? null),
                 'norm_table_version' => $this->stringOrNull($summary['norm_table_version'] ?? null),
                 'score_claim_level' => $this->stringOrNull($summary['score_claim_level'] ?? null) ?? 'raw_score_only',
                 'claim_policy' => is_array($summary['claim_policy'] ?? null) ? $summary['claim_policy'] : [],

--- a/backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
+++ b/backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
@@ -99,6 +99,7 @@ final class IqOwnerOriginal30PrivateScoringTest extends TestCase
         $redacted = IqResultPayloadRedactor::redactAnswerKeys([
             'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
             'bank_id' => 'IQ_OWNER_ORIGINAL_30',
+            'answer_key_version' => 'owner_original_30_answer_key_2026_06_23',
             'items' => [$items[0]],
             'answer_key' => $this->readJson('answer_key.json'),
             'scoring_spec' => $this->readJson('scoring_spec.json'),
@@ -108,11 +109,13 @@ final class IqOwnerOriginal30PrivateScoringTest extends TestCase
         $this->assertPayloadHasNoPrivateIqFields($redacted);
     }
 
-    private function assertPayloadHasNoPrivateIqFields(array $payload): void
+    private function assertPayloadHasNoPrivateIqFields(array $payload, string $path = '$'): void
     {
         $forbidden = [
             'answer_key',
             'answerKey',
+            'answer_key_version',
+            'answerKeyVersion',
             'correct_answer',
             'correctAnswer',
             'solution_rule',
@@ -124,10 +127,10 @@ final class IqOwnerOriginal30PrivateScoringTest extends TestCase
         ];
 
         foreach ($payload as $key => $value) {
-            $this->assertNotContains($key, $forbidden);
+            $this->assertNotContains($key, $forbidden, 'Forbidden IQ private field leaked at '.$path.'.'.$key);
 
             if (is_array($value)) {
-                $this->assertPayloadHasNoPrivateIqFields($value);
+                $this->assertPayloadHasNoPrivateIqFields($value, $path.'.'.$key);
             }
         }
     }

--- a/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+++ b/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
@@ -435,11 +435,13 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         return $answers;
     }
 
-    private function assertPayloadHasNoPrivateIqFields(array $payload): void
+    private function assertPayloadHasNoPrivateIqFields(array $payload, string $path = '$'): void
     {
         $forbidden = [
             'answer_key',
             'answerKey',
+            'answer_key_version',
+            'answerKeyVersion',
             'correct_answer',
             'correctAnswer',
             'solution_rule',
@@ -453,10 +455,10 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         ];
 
         foreach ($payload as $key => $value) {
-            $this->assertNotContains($key, $forbidden);
+            $this->assertNotContains($key, $forbidden, 'Forbidden IQ private field leaked at '.$path.'.'.$key);
 
             if (is_array($value)) {
-                $this->assertPayloadHasNoPrivateIqFields($value);
+                $this->assertPayloadHasNoPrivateIqFields($value, $path.'.'.$key);
             }
         }
     }

--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -253,6 +253,7 @@ final class IqReportContractTest extends TestCase
         $this->assertIsArray(data_get($payload, 'report.quality'));
         $this->assertIsArray(data_get($payload, 'report.scoring'));
         $this->assertIsArray(data_get($payload, 'report.iq_pro'));
+        $this->assertNull(data_get($payload, 'report.scoring.answer_key_version'));
         $this->assertEquals(21.0, data_get($payload, 'report.summary.raw_score'));
         $this->assertSame('A', data_get($payload, 'report.quality.level'));
         $this->assertSame('contract_defined_not_implemented', data_get($payload, 'report.iq_pro.pdf_payload.status'));
@@ -277,6 +278,9 @@ final class IqReportContractTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertPayloadHasNoAnswerKeyFields($response->json());
+        $this->assertNull(data_get($response->json(), 'result.normed_json.answer_key_version'));
+        $this->assertNull(data_get($response->json(), 'result.breakdown_json.score_result.answer_key_version'));
+        $this->assertNull(data_get($response->json(), 'result.axis_scores_json.score_result.answer_key_version'));
         $this->assertSame('B', data_get($response->json(), 'result.normed_json.items.0.selected_code'));
         $this->assertFalse((bool) data_get($response->json(), 'result.normed_json.items.0.is_correct'));
     }
@@ -354,13 +358,20 @@ final class IqReportContractTest extends TestCase
     /**
      * @param  array<string,mixed>  $payload
      */
-    private function assertPayloadHasNoAnswerKeyFields(array $payload): void
+    private function assertPayloadHasNoAnswerKeyFields(array $payload, string $path = '$'): void
     {
         foreach ($payload as $key => $value) {
-            $this->assertNotContains($key, ['answer_key', 'answerKey', 'correct_answer', 'correctAnswer']);
+            $this->assertNotContains($key, [
+                'answer_key',
+                'answerKey',
+                'answer_key_version',
+                'answerKeyVersion',
+                'correct_answer',
+                'correctAnswer',
+            ], 'Forbidden IQ answer key field leaked at '.$path.'.'.$key);
 
             if (is_array($value)) {
-                $this->assertPayloadHasNoAnswerKeyFields($value);
+                $this->assertPayloadHasNoAnswerKeyFields($value, $path.'.'.$key);
             }
         }
     }


### PR DESCRIPTION
## What changed
- Redacts `answer_key_version` / `answerKeyVersion` through the shared IQ public payload redactor.
- Applies final IQ redaction at `/result` and `/report` response-envelope exits, plus `scores_pct` compatibility payloads.
- Removes `answer_key_version` from the public IQ report `scoring` block.
- Tightens IQ result/report and Owner 30 tests to assert `answer_key_version` is not emitted.

## Why
`answer_key_version` is internal answer-key lineage. Public IQ result/report payloads should not expose it alongside already-redacted answer keys, correct answers, or solution metadata.

## Validation
- `composer dump-autoload` in the temporary worktree after replacing a stale symlinked vendor with an ignored local vendor copy
- `php artisan test --filter=IqReportContractTest --no-ansi`
- `php artisan test --filter=IqOwnerOriginal30 --no-ansi`
- `php -l backend/app/Services/Iq/IqResultPayloadRedactor.php`
- `php -l backend/app/Services/Report/IqReportBuilder.php`
- `php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `php -l backend/app/Services/Attempts/AttemptSubmitService.php`
- `php -l backend/tests/Feature/V0_3/IqReportContractTest.php`
- `php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php`
- `php -l backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php`
- `./vendor/bin/pint app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/Attempts/AttemptSubmitService.php app/Services/Iq/IqResultPayloadRedactor.php app/Services/Report/IqReportBuilder.php tests/Feature/V0_3/IqReportContractTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php`
- `git diff --check`

## Intentionally deferred
- No frontend changes.
- No PR-train metadata changes.
- No CMS, SEO, staging, production deploy, or manual deployment changes.
