### PR TITLE
PERSONALITY-AGENT-OPS-REVIEW-SURFACE-ONLY-FULL-GROUP-BY-FIX-01

### DIFF
--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueReadModel.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueReadModel.php
@@ -58,10 +58,10 @@ final class PersonalityAgentApprovalQueueReadModel
             'summary' => [
                 'matched_item_count' => (int) (clone $baseQuery)->count(),
                 'returned_item_count' => count($items),
-                'by_framework' => $this->countsBy($baseQuery, 'items.framework'),
-                'by_approval_state' => $this->countsBy($baseQuery, 'items.approval_state'),
-                'by_qa_decision' => $this->countsBy($baseQuery, 'items.qa_decision'),
-                'by_blocked_reason' => $this->countsBy($baseQuery, 'items.blocked_reason'),
+                'by_framework' => $this->countsBy($framework, $approvalState, 'items.framework'),
+                'by_approval_state' => $this->countsBy($framework, $approvalState, 'items.approval_state'),
+                'by_qa_decision' => $this->countsBy($framework, $approvalState, 'items.qa_decision'),
+                'by_blocked_reason' => $this->countsBy($framework, $approvalState, 'items.blocked_reason'),
             ],
             'items' => $items,
             'safety_boundary' => $this->safetyBoundary(),
@@ -116,10 +116,24 @@ final class PersonalityAgentApprovalQueueReadModel
     /**
      * @return array<string,int>
      */
-    private function countsBy(Builder $baseQuery, string $column): array
+    private function countsBy(?string $framework, string $approvalState, string $column): array
     {
-        return (clone $baseQuery)
-            ->selectRaw($column.' as bucket, count(*) as aggregate')
+        $query = DB::table('personality_agent_approval_items as items')
+            ->join('personality_agent_approval_batches as batches', 'batches.id', '=', 'items.batch_id');
+
+        if ($framework !== null && $framework !== '') {
+            $query->where('items.framework', $framework);
+        }
+
+        if ($approvalState !== 'all') {
+            $query->where('items.approval_state', $approvalState);
+        }
+
+        return $query
+            ->select([
+                DB::raw($column.' as bucket'),
+                DB::raw('count(*) as aggregate'),
+            ])
             ->groupBy($column)
             ->orderBy($column)
             ->get()

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueReviewCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueReviewCommandTest.php
@@ -138,6 +138,56 @@ final class PersonalityAgentApprovalQueueReviewCommandTest extends TestCase
         );
     }
 
+    public function test_review_aggregate_queries_do_not_select_detail_columns_for_mysql_strict_group_by(): void
+    {
+        $batchId = $this->createBatch('mbti64');
+        $this->createItem($batchId, [
+            'framework' => 'mbti64',
+            'target_url' => 'https://fermatmind.com/zh/personality/intp-a',
+            'path' => '/zh/personality/intp-a',
+            'locale' => 'zh-CN',
+            'page_type' => 'personality_profile_variant',
+            'recommendation_id' => 'mbti64-next:/zh/personality/intp-a',
+            'qa_decision' => 'PASS_READY_FOR_APPROVAL_REVIEW',
+            'approval_state' => 'pending',
+            'recommendation_json' => $this->recommendation('https://fermatmind.com/zh/personality/intp-a'),
+            'qa_json' => [
+                'decision' => 'PASS_READY_FOR_APPROVAL_REVIEW',
+                'eligible_for_approval_queue' => true,
+                'eligible_for_cms_draft_path' => false,
+            ],
+        ]);
+
+        $queries = [];
+        DB::listen(static function ($query) use (&$queries): void {
+            $sql = (string) $query->sql;
+            if (str_contains(strtolower($sql), 'group by')) {
+                $queries[] = $sql;
+            }
+        });
+
+        $exitCode = Artisan::call('personality:agent-approval-queue-review', [
+            '--framework' => 'mbti64',
+            '--approval-state' => 'pending',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame(1, $payload['summary']['matched_item_count']);
+        $this->assertGreaterThanOrEqual(4, count($queries));
+
+        foreach ($queries as $sql) {
+            $normalized = strtolower(str_replace(['`', '"'], '', $sql));
+            $this->assertStringContainsString('count(*) as aggregate', $normalized);
+            $this->assertStringNotContainsString('select items.id', $normalized);
+            $this->assertStringNotContainsString(' items.id,', $normalized);
+            $this->assertStringNotContainsString('items.recommendation_json', $normalized);
+            $this->assertStringNotContainsString('items.qa_json', $normalized);
+        }
+    }
+
     public function test_review_fails_closed_for_unsupported_filters_without_mutating_queue(): void
     {
         $beforeItems = DB::table('personality_agent_approval_items')->count();


### PR DESCRIPTION
## What changed
- Rebuilt the personality agent approval queue read-model aggregate queries from a clean aggregate query instead of cloning the detail query.
- Added a regression test that captures the generated group-by SQL and verifies aggregate queries do not select detail columns that break MySQL ONLY_FULL_GROUP_BY.

## Why
Production MySQL rejected the approval queue review read model because the aggregate queries inherited detail select columns such as items.id while grouping by framework/state/risk columns.

## Validation
- php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueReviewCommandTest.php --display-warnings
- php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php --display-warnings
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

## Deferred / not included
- No approval queue writes.
- No CMS draft or live content mutation.
- No publish, index/search, sitemap/llms, queue enqueue/approve/submit, deploy, or external API calls.