### PR TITLE
[codex] fix IQ owner active norm binding

### DIFF
--- a/backend/app/Services/Assessment/Drivers/IqTestDriver.php
+++ b/backend/app/Services/Assessment/Drivers/IqTestDriver.php
@@ -192,13 +192,21 @@ class IqTestDriver implements DriverInterface
             $scaleCode = 'IQ_INTELLIGENCE_QUOTIENT';
         }
 
+        $bankId = trim((string) ($spec['bank_id'] ?? data_get($spec, 'item_bank.bank_id', '')));
+        $normTableVersion = $this->nullableTrimmedString(
+            $spec['norm_table_version']
+                ?? data_get($spec, 'runtime_binding.norm_table_version')
+                ?? data_get($spec, 'norm_policy.norm_table_version')
+                ?? null
+        );
+
         $contract = [
             'status' => 'blocked_unscored',
             'reason_code' => 'ANSWER_KEY_MISSING',
             'scale_code' => $scaleCode,
-            'bank_id' => trim((string) data_get($spec, 'item_bank.bank_id', '')),
+            'bank_id' => $bankId,
             'answer_key_version' => trim((string) ($spec['answer_key_version'] ?? '')),
-            'norm_table_version' => $this->nullableTrimmedString($spec['norm_table_version'] ?? null),
+            'norm_table_version' => $normTableVersion,
             'scoring_engine_version' => trim((string) ($spec['scoring_engine_version'] ?? ($spec['engine_version'] ?? ''))),
             'expected_item_count' => (int) data_get($spec, 'item_bank.item_count', 0),
             'quality_rules' => $qualityRules,

--- a/backend/tests/Unit/Assessment/IqTestDriverTest.php
+++ b/backend/tests/Unit/Assessment/IqTestDriverTest.php
@@ -136,6 +136,49 @@ final class IqTestDriverTest extends TestCase
         $this->assertStringNotContainsString('correct_answer', json_encode($result->toArray(), JSON_THROW_ON_ERROR));
     }
 
+    public function test_owner_original_runtime_binds_active_norm_when_bank_id_is_top_level(): void
+    {
+        $this->migrateIqNormAuthority();
+        $this->insertIqNormAuthority([
+            'norm_table_version' => 'iq_owner30_norm_fixture_v1',
+            'mean' => 2.0,
+            'standard_deviation' => 1.0,
+            'min_raw_score' => 0.0,
+            'max_raw_score' => 3.0,
+        ]);
+
+        $spec = $this->ownerOriginalScoringSpec();
+        $spec['bank_id'] = 'IQ_OWNER_ORIGINAL_30';
+        unset($spec['item_bank']['bank_id']);
+
+        $driver = new IqTestDriver;
+        $result = $driver->score(
+            [
+                ['question_id' => 'IQ001', 'code' => 'A'],
+                ['question_id' => 'IQ002', 'code' => 'C'],
+                ['question_id' => 'IQ003', 'code' => 'D'],
+            ],
+            $spec,
+            [
+                'org_id' => 0,
+                'locale' => 'zh-CN',
+                'population_key' => 'general_adult_online',
+                'duration_ms' => 45000,
+                'pack_id' => 'default',
+                'content_package_version' => 'iq_owner_original_30_v1',
+                'scoring_spec_version' => 'iq_owner_original_30_runtime_scoring_v1',
+            ]
+        );
+
+        $this->assertSame(2.0, $result->rawScore);
+        $this->assertSame('IQ_OWNER_ORIGINAL_30', data_get($result->normedJson, 'bank_id'));
+        $this->assertSame('iq_estimate', data_get($result->normedJson, 'score_claim_level'));
+        $this->assertSame('iq_owner30_norm_fixture_v1', data_get($result->normedJson, 'norm_table_version'));
+        $this->assertTrue((bool) data_get($result->normedJson, 'norms.claim_policy.claim_eligible'));
+        $this->assertSame(100.0, data_get($result->normedJson, 'norms.iq_estimate'));
+        $this->assertStringNotContainsString('correct_answer', json_encode($result->toArray(), JSON_THROW_ON_ERROR));
+    }
+
     public function test_owner_original_runtime_without_claim_eligible_authority_stays_raw_score_only(): void
     {
         $this->migrateIqNormAuthority();


### PR DESCRIPTION
## What changed
- Updated `IqTestDriver` contract resolution to accept Owner 30 `bank_id` from either top-level `bank_id` or `item_bank.bank_id`.
- Updated norm table resolution to accept top-level `norm_table_version`, `runtime_binding.norm_table_version`, or `norm_policy.norm_table_version`.
- Added a regression test proving Owner 30 can bind an active claim-eligible norm when the scoring spec carries `bank_id` at the top level.

## Why
Owner 30 runtime scoring can receive normalized scoring specs where the active norm binding fields are not only in the older nested locations. The driver should still resolve `IQ_OWNER_ORIGINAL_30`, hit active claim-eligible authority, and return `score_claim_level=iq_estimate` without exposing answer keys.

## Validation
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqTestDriverTest --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqOwnerOriginal30 --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqNormsImportDryRunTest --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqOwnerOriginal30SessionDeliveryTest --no-ansi`
- `php -l app/Services/Assessment/Drivers/IqTestDriver.php`
- `php -l tests/Unit/Assessment/IqTestDriverTest.php`
- `./vendor/bin/pint app/Services/Assessment/Drivers/IqTestDriver.php tests/Unit/Assessment/IqTestDriverTest.php --test`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No frontend changes.
- No route, migration, CMS, SEO, deployment, or production norm import changes.
- No changes to Owner 30 question assets or answer keys.
