### PR TITLE
Add Gaokao URL Truth eligibility gate

### DIFF
--- a/backend/app/Console/Commands/SeoOpsGaokaoV5UrlTruthEligibilityGateCommand.php
+++ b/backend/app/Console/Commands/SeoOpsGaokaoV5UrlTruthEligibilityGateCommand.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Audit\AuditLogger;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class SeoOpsGaokaoV5UrlTruthEligibilityGateCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-ops-gaokao-v5-url-truth-eligibility-gate.v1';
+
+    private const ARTICLE_ID = 55;
+
+    private const CANONICAL_PATH = '/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist';
+
+    protected $signature = 'seo-ops:gaokao-v5-url-truth-eligibility-gate
+        {--article=55 : Exact supported article id; only 55 is allowed}
+        {--expected-canonical-path=/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist : Exact canonical path lock}
+        {--artifact-dir= : Directory for eligibility gate evidence}
+        {--execute : Enable sitemap/llms eligibility for the locked article}
+        {--confirm-eligibility= : Exact confirmation phrase required with --execute}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Gaokao v5 article 55 post-publish URL Truth eligibility gate; no content, publish, schema, hreflang, search, or revalidation side effects.';
+
+    public function handle(AuditLogger $auditLogger): int
+    {
+        try {
+            $summary = $this->buildSummary($auditLogger);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $artifact = $this->writeEvidence($summary);
+        if ($artifact !== null) {
+            $summary['artifact'] = $artifact;
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildSummary(AuditLogger $auditLogger): array
+    {
+        $execute = (bool) $this->option('execute');
+        $articleId = (int) $this->option('article');
+        $expectedCanonicalPath = $this->normalizePath((string) $this->option('expected-canonical-path'));
+        $expectedConfirmation = $this->expectedConfirmation($articleId, $expectedCanonicalPath);
+        $confirmation = trim((string) $this->option('confirm-eligibility'));
+        $issues = [];
+
+        if ($articleId !== self::ARTICLE_ID) {
+            $issues[] = $this->issue('article', 'unsupported_article_id', 'This gate only supports article 55.');
+        }
+        if ($expectedCanonicalPath !== self::CANONICAL_PATH) {
+            $issues[] = $this->issue('expected_canonical_path', 'unsupported_canonical_path', 'This gate only supports the Gaokao v5 article 55 canonical path.');
+        }
+        if ($execute && ! hash_equals($expectedConfirmation, $confirmation)) {
+            $issues[] = $this->issue(
+                'confirm_eligibility',
+                'confirmation_mismatch',
+                'Exact confirmation phrase is required before enabling URL Truth eligibility.',
+                ['expected_confirmation' => $expectedConfirmation],
+            );
+        }
+
+        $plan = $this->preflight($articleId, $expectedCanonicalPath);
+        if ($plan === null) {
+            $issues[] = $this->issue('article', 'article_not_found', 'Article 55 was not found.');
+        } else {
+            foreach ((array) ($plan['issues'] ?? []) as $issue) {
+                if (is_array($issue)) {
+                    $issues[] = $issue;
+                }
+            }
+        }
+
+        if ($issues !== []) {
+            return $this->summary(
+                ok: false,
+                status: 'blocked',
+                execute: $execute,
+                action: 'will_skip',
+                articleId: $articleId,
+                expectedCanonicalPath: $expectedCanonicalPath,
+                expectedConfirmation: $expectedConfirmation,
+                plan: $plan,
+                issues: $issues,
+            );
+        }
+
+        if (! $execute) {
+            return $this->summary(
+                ok: true,
+                status: 'planned',
+                execute: false,
+                action: 'would_enable_url_truth_eligibility',
+                articleId: $articleId,
+                expectedCanonicalPath: $expectedCanonicalPath,
+                expectedConfirmation: $expectedConfirmation,
+                plan: $plan,
+                issues: [],
+            );
+        }
+
+        $executedPlan = DB::transaction(function () use ($articleId, $expectedCanonicalPath): array {
+            $lockedPlan = $this->preflight($articleId, $expectedCanonicalPath, lockForUpdate: true);
+            if ($lockedPlan === null) {
+                throw new RuntimeException('planned article disappeared before URL Truth eligibility write.');
+            }
+            if ((array) ($lockedPlan['issues'] ?? []) !== []) {
+                $codes = collect((array) $lockedPlan['issues'])
+                    ->map(static fn (mixed $issue): string => is_array($issue) ? (string) ($issue['code'] ?? '') : '')
+                    ->filter()
+                    ->implode(',');
+
+                throw new RuntimeException('URL Truth eligibility preflight failed before write: '.$codes);
+            }
+
+            DB::table('articles')
+                ->where('id', $articleId)
+                ->update([
+                    'sitemap_eligible' => true,
+                    'llms_eligible' => true,
+                    'updated_at' => now(),
+                ]);
+
+            return $this->preflight($articleId, $expectedCanonicalPath) ?? $lockedPlan;
+        });
+
+        $auditLogger->log(
+            Request::create('/ops/seo/gaokao-v5/url-truth-eligibility-gate', 'POST'),
+            'seo_ops_gaokao_v5_url_truth_eligibility_gate',
+            'article',
+            (string) $articleId,
+            [
+                'command' => 'seo-ops:gaokao-v5-url-truth-eligibility-gate',
+                'article_id' => $articleId,
+                'canonical_path' => $expectedCanonicalPath,
+                'confirmation_sha256' => hash('sha256', $confirmation),
+                'updates_scope' => ['articles.sitemap_eligible', 'articles.llms_eligible'],
+                'no_content_change' => true,
+                'no_publish' => true,
+                'no_url_truth_write' => true,
+                'no_search' => true,
+                'no_schema_hreflang' => true,
+                'no_revalidation' => true,
+                'before' => $plan['before'] ?? null,
+                'after' => $executedPlan['after'] ?? null,
+            ],
+            reason: 'seo_ops_gaokao_v5_url_truth_eligibility_gate',
+            result: 'success',
+        );
+
+        return $this->summary(
+            ok: true,
+            status: 'success',
+            execute: true,
+            action: 'enabled_url_truth_eligibility',
+            articleId: $articleId,
+            expectedCanonicalPath: $expectedCanonicalPath,
+            expectedConfirmation: $expectedConfirmation,
+            plan: $executedPlan,
+            issues: [],
+        );
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function preflight(int $articleId, string $expectedCanonicalPath, bool $lockForUpdate = false): ?array
+    {
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+                'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+            ])
+            ->when($lockForUpdate, static fn ($query) => $query->lockForUpdate())
+            ->find($articleId);
+
+        if (! $article instanceof Article) {
+            return null;
+        }
+
+        $before = $this->snapshot($article);
+        $after = $before;
+        $after['sitemap_eligible'] = true;
+        $after['llms_eligible'] = true;
+        $issues = [];
+        $actualCanonicalPath = $this->canonicalPathFromSeoMeta($article);
+
+        if ((int) $article->id !== self::ARTICLE_ID) {
+            $issues[] = $this->issue('article.id', 'unsupported_article_id', 'This gate only supports article 55.');
+        }
+        if ((string) $article->locale !== 'zh-CN') {
+            $issues[] = $this->issue('article.locale', 'locale_mismatch', 'Article 55 must remain zh-CN.');
+        }
+        if ($actualCanonicalPath !== $expectedCanonicalPath) {
+            $issues[] = $this->issue(
+                'seo_meta.canonical_url',
+                'canonical_path_mismatch',
+                'SEO meta canonical must match the locked Gaokao article route.',
+                [
+                    'expected_canonical_path' => $expectedCanonicalPath,
+                    'actual_canonical_path' => $actualCanonicalPath,
+                ],
+            );
+        }
+        if ((string) $article->status !== 'published') {
+            $issues[] = $this->issue('article.status', 'article_not_published', 'Article must already be published.');
+        }
+        if (! (bool) $article->is_public) {
+            $issues[] = $this->issue('article.is_public', 'article_not_public', 'Article must already be public.');
+        }
+        if (! (bool) $article->is_indexable) {
+            $issues[] = $this->issue('article.is_indexable', 'article_not_indexable', 'Article must already be indexable.');
+        }
+        if ((string) $article->lifecycle_state !== '' && in_array((string) $article->lifecycle_state, [
+            Article::LIFECYCLE_ARCHIVED,
+            Article::LIFECYCLE_SOFT_DELETED,
+        ], true)) {
+            $issues[] = $this->issue('article.lifecycle_state', 'article_lifecycle_not_eligible', 'Archived or soft-deleted articles cannot be made URL Truth eligible.');
+        }
+        if (method_exists($article, 'trashed') && $article->trashed()) {
+            $issues[] = $this->issue('article.deleted_at', 'article_soft_deleted', 'Soft-deleted articles cannot be made URL Truth eligible.');
+        }
+
+        $revision = $article->publishedRevision;
+        if (! $revision instanceof ArticleTranslationRevision) {
+            $issues[] = $this->issue('article.published_revision_id', 'published_revision_missing', 'Article must have a published revision.');
+        } elseif ((string) $revision->revision_status !== ArticleTranslationRevision::STATUS_PUBLISHED) {
+            $issues[] = $this->issue('published_revision.revision_status', 'published_revision_status_invalid', 'Published revision must have published status.');
+        }
+
+        $seoMeta = $article->seoMeta;
+        if (! $seoMeta instanceof ArticleSeoMeta) {
+            $issues[] = $this->issue('seo_meta', 'seo_meta_missing', 'Article SEO meta must exist before URL Truth eligibility.');
+        } else {
+            if (! (bool) $seoMeta->is_indexable) {
+                $issues[] = $this->issue('seo_meta.is_indexable', 'seo_meta_not_indexable', 'SEO meta must already be indexable.');
+            }
+            if ((string) $seoMeta->robots !== 'index,follow') {
+                $issues[] = $this->issue('seo_meta.robots', 'seo_meta_robots_not_index_follow', 'SEO meta robots must be index,follow.');
+            }
+        }
+
+        return [
+            'article_id' => $articleId,
+            'canonical_path' => $actualCanonicalPath,
+            'already_eligible' => (bool) $article->sitemap_eligible && (bool) $article->llms_eligible,
+            'would_make_url_truth_candidate' => $issues === [],
+            'before' => $before,
+            'after' => $after,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(Article $article): array
+    {
+        $revision = $article->publishedRevision;
+        $seoMeta = $article->seoMeta;
+
+        return [
+            'article_id' => (int) $article->id,
+            'slug_hash' => hash('sha256', (string) $article->slug),
+            'locale' => (string) $article->locale,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'published_revision_id' => $article->published_revision_id === null ? null : (int) $article->published_revision_id,
+            'published_revision_status' => $revision instanceof ArticleTranslationRevision ? (string) $revision->revision_status : null,
+            'content_md_sha256' => hash('sha256', (string) $article->content_md),
+            'content_html_sha256' => hash('sha256', (string) $article->content_html),
+            'seo_meta_exists' => $seoMeta instanceof ArticleSeoMeta,
+            'seo_robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
+            'seo_is_indexable' => $seoMeta instanceof ArticleSeoMeta ? (bool) $seoMeta->is_indexable : null,
+            'canonical_path' => $this->canonicalPathFromSeoMeta($article),
+            'schema_json_sha256' => $seoMeta instanceof ArticleSeoMeta
+                ? hash('sha256', (string) json_encode($seoMeta->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE))
+                : null,
+        ];
+    }
+
+    private function canonicalPathFromSeoMeta(Article $article): string
+    {
+        $seoMeta = $article->seoMeta;
+        if (! $seoMeta instanceof ArticleSeoMeta) {
+            return '';
+        }
+
+        return $this->normalizePath((string) $seoMeta->canonical_url);
+    }
+
+    private function normalizePath(string $canonical): string
+    {
+        $trimmed = trim($canonical);
+        $path = parse_url($trimmed, PHP_URL_PATH);
+        $normalized = is_string($path) && $path !== '' ? $path : $trimmed;
+
+        return str_starts_with($normalized, '/') ? $normalized : '/'.$normalized;
+    }
+
+    private function expectedConfirmation(int $articleId, string $expectedCanonicalPath): string
+    {
+        return "I explicitly approve SEO-OPS-GAOKAO-V5-URL-TRUTH-ELIGIBILITY-GATE-01 to enable sitemap/llms eligibility for article {$articleId} canonical {$expectedCanonicalPath}; no content change, no publish, no URL Truth write, no schema/hreflang, no Search Channel, no IndexNow/Baidu/GSC, no deploy/revalidation.";
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $plan
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function summary(bool $ok, string $status, bool $execute, string $action, int $articleId, string $expectedCanonicalPath, string $expectedConfirmation, ?array $plan, array $issues): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $status,
+            'dry_run' => ! $execute,
+            'execute' => $execute,
+            'action' => $action,
+            'article_id' => $articleId,
+            'expected_canonical_path' => $expectedCanonicalPath,
+            'required_confirmation_phrase' => $expectedConfirmation,
+            'planned_write_scope' => ['articles.sitemap_eligible', 'articles.llms_eligible'],
+            'url_truth_candidate_expected_after_execute' => $ok,
+            'plan' => $plan,
+            'issues' => $issues,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'content_write' => false,
+            'cms_publish' => false,
+            'url_truth_write' => false,
+            'schema_hreflang_write' => false,
+            'search_channel_enqueue' => false,
+            'indexnow_submit' => false,
+            'baidu_submit' => false,
+            'gsc_request_indexing' => false,
+            'scheduler_activation' => false,
+            'queue_worker_start' => false,
+            'deploy' => false,
+            'revalidation' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $extra = []): array
+    {
+        return array_merge([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ], $extra);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        $articleId = (int) $this->option('article');
+        $canonical = $this->normalizePath((string) $this->option('expected-canonical-path'));
+
+        return $this->summary(
+            ok: false,
+            status: 'blocked',
+            execute: (bool) $this->option('execute'),
+            action: 'will_skip',
+            articleId: $articleId,
+            expectedCanonicalPath: $canonical,
+            expectedConfirmation: $this->expectedConfirmation($articleId, $canonical),
+            plan: null,
+            issues: [$this->issue('command', $code, $message)],
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @return array<string,mixed>|null
+     */
+    private function writeEvidence(array $summary): ?array
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '') {
+            return null;
+        }
+
+        File::ensureDirectoryExists($dir);
+        if (! is_dir($dir) || ! is_writable($dir)) {
+            $summary['issues'][] = $this->issue('artifact_dir', 'artifact_dir_unwritable', 'Artifact directory is not writable.');
+            $dir = storage_path('app/seo-ops/gaokao-v5-url-truth-eligibility-gate');
+            File::ensureDirectoryExists($dir);
+        }
+
+        $path = rtrim($dir, '/').'/seo-ops-gaokao-v5-url-truth-eligibility-gate-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json';
+        File::put($path, json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
+
+        return [
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? ''));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('execute='.(($summary['execute'] ?? false) ? '1' : '0'));
+        $this->line('article_id='.(string) ($summary['article_id'] ?? ''));
+        $this->line('expected_canonical_path='.(string) ($summary['expected_canonical_path'] ?? ''));
+        $this->line('issues_count='.(string) count((array) ($summary['issues'] ?? [])));
+        $this->line('required_confirmation_phrase='.(string) ($summary['required_confirmation_phrase'] ?? ''));
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -228,6 +228,7 @@ use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
 use App\Console\Commands\SeoOpsGaokaoV5CmsDraftGateCommand;
 use App\Console\Commands\SeoOpsGaokaoV5PropagationGateReadinessCommand;
 use App\Console\Commands\SeoOpsGaokaoV5PublishGateRepairCommand;
+use App\Console\Commands\SeoOpsGaokaoV5UrlTruthEligibilityGateCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityControlledWriterCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityRepairDryRunCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityReadbackCommand;
@@ -481,6 +482,7 @@ class Kernel extends ConsoleKernel
         SeoOpsP0CtrArticleCmsUpdateWriterCommand::class,
         SeoOpsGaokaoV5CmsDraftGateCommand::class,
         SeoOpsGaokaoV5PublishGateRepairCommand::class,
+        SeoOpsGaokaoV5UrlTruthEligibilityGateCommand::class,
         SeoOpsGaokaoV5PropagationGateReadinessCommand::class,
         SeoOpsZhArticleQualityControlledWriterCommand::class,
         SeoOpsZhArticleQualityRepairDryRunCommand::class,

--- a/backend/docs/seo/generated/seo-ops-gaokao-v5-url-truth-eligibility-gate.v1.json
+++ b/backend/docs/seo/generated/seo-ops-gaokao-v5-url-truth-eligibility-gate.v1.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "seo-ops-gaokao-v5-url-truth-eligibility-gate.v1",
+  "command": "php artisan seo-ops:gaokao-v5-url-truth-eligibility-gate",
+  "purpose": "Enable the minimum article discoverability eligibility required for article 55 to enter the article URL Truth handoff candidate pool.",
+  "supported_target": {
+    "article_id": 55,
+    "canonical_path": "/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist",
+    "page_entity_type": "article"
+  },
+  "inputs": {
+    "article": "Exact article id. Only 55 is supported.",
+    "expected_canonical_path": "Must equal /zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist.",
+    "artifact_dir": "Directory for dry-run or execute evidence.",
+    "execute": "Optional. Defaults to dry-run.",
+    "confirm_eligibility": "Exact phrase required only with --execute.",
+    "json": "Emit machine-readable JSON."
+  },
+  "write_scope": [
+    "articles.sitemap_eligible",
+    "articles.llms_eligible"
+  ],
+  "preflight_requires": [
+    "article id is exactly 55",
+    "canonical path is exact",
+    "article is published",
+    "article is public",
+    "article is indexable",
+    "published revision exists and is published",
+    "article SEO meta exists",
+    "SEO meta is indexable",
+    "robots is index,follow"
+  ],
+  "negative_guarantees": {
+    "content_write": false,
+    "cms_publish": false,
+    "url_truth_write": false,
+    "schema_hreflang_write": false,
+    "search_channel_enqueue": false,
+    "indexnow_submit": false,
+    "baidu_submit": false,
+    "gsc_request_indexing": false,
+    "scheduler_activation": false,
+    "queue_worker_start": false,
+    "deploy": false,
+    "revalidation": false
+  },
+  "post_execute_expected_next_step": "Rerun seo-intel:url-truth-handoff export/import dry-run for page-type=article and the exact article 55 canonical path; expected planned_url_count=1.",
+  "separate_gates_required_after_this_command": [
+    "URL Truth bounded import write",
+    "Search Channel enqueue",
+    "queue approval",
+    "IndexNow live submit"
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5UrlTruthEligibilityGateCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoOpsGaokaoV5UrlTruthEligibilityGateCommandTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Console\Commands\SeoOpsGaokaoV5UrlTruthEligibilityGateCommand;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\AuditLog;
+use App\Services\SeoIntel\Sources\BackendAuthorityUrlTruthSource;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+final class SeoOpsGaokaoV5UrlTruthEligibilityGateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const CANONICAL_PATH = '/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist';
+
+    private const CONFIRMATION = 'I explicitly approve SEO-OPS-GAOKAO-V5-URL-TRUTH-ELIGIBILITY-GATE-01 to enable sitemap/llms eligibility for article 55 canonical /zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist; no content change, no publish, no URL Truth write, no schema/hreflang, no Search Channel, no IndexNow/Baidu/GSC, no deploy/revalidation.';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app
+            ->make(ConsoleKernel::class)
+            ->registerCommand($this->app->make(SeoOpsGaokaoV5UrlTruthEligibilityGateCommand::class));
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('seo-ops:gaokao-v5-url-truth-eligibility-gate', Artisan::all());
+    }
+
+    public function test_dry_run_plans_article55_eligibility_without_writes(): void
+    {
+        $this->createPublishedArticle55();
+        Storage::fake('local');
+        $artifactDir = storage_path('framework/testing/gaokao-url-truth-eligibility-dryrun');
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-url-truth-eligibility-gate', [
+            '--article' => '55',
+            '--expected-canonical-path' => self::CANONICAL_PATH,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('planned', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['execute']);
+        $this->assertSame(['articles.sitemap_eligible', 'articles.llms_eligible'], $payload['planned_write_scope']);
+        $this->assertFalse(data_get($payload, 'plan.before.sitemap_eligible'));
+        $this->assertFalse(data_get($payload, 'plan.before.llms_eligible'));
+        $this->assertTrue(data_get($payload, 'plan.after.sitemap_eligible'));
+        $this->assertTrue(data_get($payload, 'plan.after.llms_eligible'));
+        $this->assertFalse(data_get($payload, 'negative_guarantees.url_truth_write'));
+        $this->assertFalse(data_get($payload, 'negative_guarantees.search_channel_enqueue'));
+        $this->assertIsString(data_get($payload, 'artifact.path'));
+        $this->assertFileExists((string) data_get($payload, 'artifact.path'));
+
+        $fresh = Article::query()->withoutGlobalScopes()->findOrFail(55);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+        $this->assertSame(0, AuditLog::query()->withoutGlobalScopes()->where('action', 'seo_ops_gaokao_v5_url_truth_eligibility_gate')->count());
+    }
+
+    public function test_execute_only_enables_sitemap_and_llms_and_makes_url_truth_candidate(): void
+    {
+        $article = $this->createPublishedArticle55();
+        $contentHash = hash('sha256', (string) $article->content_md);
+        $schemaHash = hash('sha256', (string) json_encode($article->seoMeta?->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+        $publishedRevisionId = (int) $article->published_revision_id;
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-url-truth-eligibility-gate', [
+            '--article' => '55',
+            '--expected-canonical-path' => self::CANONICAL_PATH,
+            '--execute' => true,
+            '--confirm-eligibility' => self::CONFIRMATION,
+            '--artifact-dir' => storage_path('framework/testing/gaokao-url-truth-eligibility-execute'),
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('success', $payload['status']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['execute']);
+
+        $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail(55);
+        $this->assertSame('published', (string) $fresh->status);
+        $this->assertTrue((bool) $fresh->is_public);
+        $this->assertTrue((bool) $fresh->is_indexable);
+        $this->assertTrue((bool) $fresh->sitemap_eligible);
+        $this->assertTrue((bool) $fresh->llms_eligible);
+        $this->assertSame($publishedRevisionId, (int) $fresh->published_revision_id);
+        $this->assertSame($contentHash, hash('sha256', (string) $fresh->content_md));
+        $this->assertSame($schemaHash, hash('sha256', (string) json_encode($fresh->seoMeta?->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)));
+
+        $records = (new BackendAuthorityUrlTruthSource)->candidates();
+        $articleRecords = array_values(array_filter(
+            $records,
+            static fn ($record): bool => $record->pageEntityType === 'article'
+                && $record->entityIdOrSlug === '55'
+                && str_ends_with($record->canonicalUrl, self::CANONICAL_PATH),
+        ));
+        $this->assertCount(1, $articleRecords);
+
+        $audit = AuditLog::query()->withoutGlobalScopes()->where('action', 'seo_ops_gaokao_v5_url_truth_eligibility_gate')->first();
+        $this->assertInstanceOf(AuditLog::class, $audit);
+        $this->assertSame('article', (string) $audit->target_type);
+        $this->assertSame('55', (string) $audit->target_id);
+        $this->assertSame(['articles.sitemap_eligible', 'articles.llms_eligible'], data_get($audit->meta_json, 'updates_scope'));
+        $this->assertTrue((bool) data_get($audit->meta_json, 'no_search'));
+        $this->assertTrue((bool) data_get($audit->meta_json, 'no_url_truth_write'));
+    }
+
+    public function test_execute_blocks_wrong_article_or_canonical_without_write(): void
+    {
+        $this->createPublishedArticle55();
+
+        $exitCode = Artisan::call('seo-ops:gaokao-v5-url-truth-eligibility-gate', [
+            '--article' => '56',
+            '--expected-canonical-path' => '/zh/articles/wrong',
+            '--execute' => true,
+            '--confirm-eligibility' => self::CONFIRMATION,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertIssueCode($payload, 'unsupported_article_id');
+        $this->assertIssueCode($payload, 'unsupported_canonical_path');
+
+        $fresh = Article::query()->withoutGlobalScopes()->findOrFail(55);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+    }
+
+    private function createPublishedArticle55(): Article
+    {
+        /** @var Article $article */
+        $article = Model::unguarded(fn (): Article => Article::query()->withoutGlobalScopes()->create([
+            'id' => 55,
+            'org_id' => 0,
+            'category_id' => null,
+            'author_name' => 'Fermat Institute',
+            'reading_minutes' => 15,
+            'slug' => 'gaokao-major-choice-parent-conflict-riasec-course-checklist',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'tg_article_gaokao_parent_conflict_riasec_course_checklist_2026v1',
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => '选专业父母不同意怎么办？高考志愿里用位次、兴趣和课程清单沟通',
+            'excerpt' => '高考志愿选专业时父母不同意，先别争谁对。',
+            'content_md' => '# 选专业父母不同意怎么办？'."\n\n正文。",
+            'content_html' => '<h1>选专业父母不同意怎么办？</h1>',
+            'cover_image_url' => 'https://ops.fermatmind.com/storage/media-library/variants/article/hero.jpg',
+            'cover_image_alt' => '高考志愿沟通清单',
+            'cover_image_width' => 1600,
+            'cover_image_height' => 900,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'published_at' => Carbon::create(2026, 6, 26, 2, 43, 10, 'UTC'),
+        ]));
+
+        /** @var ArticleTranslationRevision $revision */
+        $revision = Model::unguarded(fn (): ArticleTranslationRevision => ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'id' => 75,
+            'org_id' => 0,
+            'article_id' => 55,
+            'source_article_id' => 55,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => '选专业父母不同意怎么办？高考志愿三张清单 | FermatMind',
+            'seo_description' => (string) $article->excerpt,
+            'published_at' => $article->published_at,
+        ]));
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => 55,
+            'locale' => 'zh-CN',
+            'seo_title' => '选专业父母不同意怎么办？高考志愿三张清单 | FermatMind',
+            'seo_description' => (string) $article->excerpt,
+            'canonical_url' => self::CANONICAL_PATH,
+            'og_title' => '选专业父母不同意怎么办？高考志愿三张清单 | FermatMind',
+            'og_description' => (string) $article->excerpt,
+            'og_image_url' => 'https://ops.fermatmind.com/storage/media-library/variants/article/og.jpg',
+            'robots' => 'index,follow',
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'schema_hold' => true,
+                    'hreflang_hold' => true,
+                    'search_submission_allowed' => false,
+                ],
+            ],
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh(['publishedRevision', 'seoMeta']) ?? $article;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertIssueCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $issue): string => (string) ($issue['code'] ?? ''),
+            (array) ($payload['issues'] ?? []),
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -4817,6 +4817,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoOpsGaokaoV5UrlTruthEligibilityGateFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleReleaseCloseoutFile($file)) {
                 continue;
             }
@@ -6347,6 +6351,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isArticleDiscoverabilityReleaseFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/ArticleDiscoverabilityRelease.php';
+    }
+
+    private function isSeoOpsGaokaoV5UrlTruthEligibilityGateFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/SeoOpsGaokaoV5UrlTruthEligibilityGateCommand.php';
     }
 
     private function isArticleReleaseCloseoutFile(string $file): bool
@@ -8737,7 +8746,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(ArticleDiscoverabilityRelease|ArticleEnsureSeoMetaBaseline|ArticleTaxonomyHygiene|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
+            if (preg_match('/\b(ArticleDiscoverabilityRelease|ArticleEnsureSeoMetaBaseline|ArticleTaxonomyHygiene|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand|SeoOpsGaokaoV5UrlTruthEligibilityGateCommand)\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-ops:gaokao-v5-url-truth-eligibility-gate` for the post-publish Gaokao article 55 URL Truth eligibility step.
- The command is locked to article 55 and `/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist`, dry-run by default, and execute only enables `articles.sitemap_eligible` and `articles.llms_eligible` after an exact confirmation phrase.
- Added generated command contract docs and focused feature coverage, including proof that the backend URL Truth source sees article 55 after the marker update.
- Updated the Big Five runtime freeze classifier to treat the new scoped SEO ops command as non-runtime-impacting.

## Why
Article 55 is already published and indexable, but URL Truth export currently plans zero URLs because backend authority requires article sitemap/llms eligibility. This PR adds a narrow gate for that minimum marker update before rerunning the existing URL Truth export/import dry-run.

## Validation
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsGaokaoV5UrlTruthEligibilityGateCommandTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleDiscoverabilityReleaseCommandTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='test_runtime_paths_have_no_uncommitted_diff'`
- `vendor/bin/pint --test app/Console/Commands/SeoOpsGaokaoV5UrlTruthEligibilityGateCommand.php tests/Feature/SeoIntel/SeoOpsGaokaoV5UrlTruthEligibilityGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-ops-gaokao-v5-url-truth-eligibility-gate.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No production deploy in this PR.
- No production execute of the eligibility gate.
- No URL Truth import write.
- No CMS content write, publish, schema/hreflang, sitemap/llms release beyond the two explicit eligibility columns, Search Channel enqueue, IndexNow/Baidu/GSC submission, scheduler, queue worker, deploy, or revalidation.