### PR TITLE
PERSONALITY-AGENT-APPROVAL-QUEUE-APPROVE-CONTRACT-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php
+++ b/backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php
@@ -13,15 +13,21 @@ use Throwable;
 final class PersonalityAgentApprovalQueueCommand extends Command
 {
     private const OPERATOR_APPROVAL = 'PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01';
+    private const APPROVE_OPERATOR_APPROVAL = 'PERSONALITY-AGENT-APPROVAL-QUEUE-APPROVE-CONTRACT-01';
 
     protected $signature = 'personality:agent-approval-queue
         {--package= : Path to a personality agent recommendation package JSON artifact}
         {--qa= : Path to a personality agent QA JSON artifact}
         {--dry-run : Validate and plan approval queue rows without database writes}
         {--write : Create pending human approval queue rows}
+        {--approve : Approve existing pending human approval queue item IDs without CMS writes}
+        {--item-ids= : Comma-separated explicit personality_agent_approval_items IDs for --approve}
+        {--framework= : Required framework lock for --approve}
+        {--source-package-sha256= : Required source package SHA256 lock for --approve}
+        {--qa-sha256= : Required QA artifact SHA256 lock for --approve}
         {--json : Emit the full JSON summary}
         {--output= : Optional path to write the JSON summary}
-        {--operator-approved= : Required exact approval token for --write}';
+        {--operator-approved= : Required exact approval token for --write or --approve}';
 
     protected $description = 'Queue QA-passed personality agent recommendations for human approval without CMS, publish, index, or search side effects.';
 
@@ -48,13 +54,28 @@ final class PersonalityAgentApprovalQueueCommand extends Command
     {
         $write = (bool) $this->option('write');
         $dryRun = (bool) $this->option('dry-run');
+        $approve = (bool) $this->option('approve');
 
-        if ($write && $dryRun) {
-            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        if (($write ? 1 : 0) + ($dryRun ? 1 : 0) + ($approve ? 1 : 0) !== 1) {
+            throw new RuntimeException('Exactly one of --dry-run, --write, or --approve is required.');
         }
 
-        if (! $write && ! $dryRun) {
-            throw new RuntimeException('Either --dry-run or --write is required.');
+        if ($approve) {
+            if ((string) $this->option('operator-approved') !== self::APPROVE_OPERATOR_APPROVAL) {
+                throw new RuntimeException('--operator-approved='.self::APPROVE_OPERATOR_APPROVAL.' is required with --approve.');
+            }
+
+            return array_merge($writer->approveItems(
+                $this->parseItemIds((string) $this->option('item-ids')),
+                trim((string) $this->option('framework')),
+                trim((string) $this->option('source-package-sha256')),
+                trim((string) $this->option('qa-sha256')),
+                [
+                    'item_ids' => (string) $this->option('item-ids'),
+                ],
+            ), [
+                'command' => 'personality:agent-approval-queue',
+            ]);
         }
 
         if ($write && (string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
@@ -127,6 +148,8 @@ final class PersonalityAgentApprovalQueueCommand extends Command
         $this->line('planned_item_count='.(string) ($summary['planned_item_count'] ?? 0));
         $this->line('created_item_count='.(string) ($summary['created_item_count'] ?? 0));
         $this->line('skipped_existing_item_count='.(string) ($summary['skipped_existing_item_count'] ?? 0));
+        $this->line('approved_item_count='.(string) ($summary['approved_item_count'] ?? 0));
+        $this->line('skipped_existing_approved_item_count='.(string) ($summary['skipped_existing_approved_item_count'] ?? 0));
         $this->line('blocked_item_count='.(string) ($summary['blocked_item_count'] ?? 0));
     }
 
@@ -161,8 +184,10 @@ final class PersonalityAgentApprovalQueueCommand extends Command
             'ok' => false,
             'dry_run' => (bool) $this->option('dry-run'),
             'write' => (bool) $this->option('write'),
+            'approve' => (bool) $this->option('approve'),
             'writes_attempted' => false,
             'writes_committed' => false,
+            'approval_state_mutation_attempted' => false,
             'cms_write_attempted' => false,
             'cms_mutation_attempted' => false,
             'publish_attempted' => false,
@@ -178,5 +203,33 @@ final class PersonalityAgentApprovalQueueCommand extends Command
             ]],
             'warnings' => [],
         ];
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function parseItemIds(string $value): array
+    {
+        $parts = array_values(array_filter(array_map('trim', explode(',', $value)), static fn (string $part): bool => $part !== ''));
+        if ($parts === []) {
+            throw new RuntimeException('--item-ids is required with --approve.');
+        }
+
+        $ids = [];
+        foreach ($parts as $part) {
+            if (! ctype_digit($part) || (int) $part <= 0) {
+                throw new RuntimeException('--item-ids must contain positive integer IDs only.');
+            }
+            $ids[] = (int) $part;
+        }
+
+        $unique = array_values(array_unique($ids));
+        sort($unique);
+
+        if (count($unique) !== count($ids)) {
+            throw new RuntimeException('--item-ids must not contain duplicate IDs.');
+        }
+
+        return $unique;
     }
 }

--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
@@ -45,6 +45,18 @@ final class PersonalityAgentApprovalQueueWriter
     }
 
     /**
+     * @param  list<int>  $itemIds
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    public function approveItems(array $itemIds, string $framework, string $sourceSha256, string $qaSha256, array $metadata = []): array
+    {
+        return DB::transaction(function () use ($itemIds, $framework, $sourceSha256, $qaSha256, $metadata): array {
+            return $this->approveItemsInTransaction($itemIds, $framework, $sourceSha256, $qaSha256, $metadata);
+        });
+    }
+
+    /**
      * @param  array<string,mixed>  $package
      * @param  array<string,mixed>  $qa
      * @param  array<string,mixed>  $metadata
@@ -143,6 +155,168 @@ final class PersonalityAgentApprovalQueueWriter
     }
 
     /**
+     * @param  list<int>  $itemIds
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    private function approveItemsInTransaction(array $itemIds, string $framework, string $sourceSha256, string $qaSha256, array $metadata): array
+    {
+        $summary = $this->approvalBaseSummary($itemIds, $framework, $sourceSha256, $qaSha256, $metadata);
+        $errors = $this->approvalValidationErrors($itemIds, $framework, $sourceSha256, $qaSha256);
+
+        if ($errors !== []) {
+            return array_merge($summary, [
+                'ok' => false,
+                'status' => 'fail',
+                'matched_item_count' => 0,
+                'approved_item_count' => 0,
+                'skipped_existing_approved_item_count' => 0,
+                'items' => [],
+                'errors' => $errors,
+                'warnings' => [],
+            ]);
+        }
+
+        $rows = DB::table('personality_agent_approval_items as items')
+            ->join('personality_agent_approval_batches as batches', 'batches.id', '=', 'items.batch_id')
+            ->whereIn('items.id', $itemIds)
+            ->lockForUpdate()
+            ->orderBy('items.id')
+            ->get([
+                'items.id',
+                'items.batch_id',
+                'items.framework',
+                'items.target_url',
+                'items.approval_state',
+                'items.approved_at',
+                'items.rejected_at',
+                'items.blocked_reason',
+                'items.qa_decision',
+                'items.recommendation_sha256',
+                'batches.source_package_sha256',
+                'batches.qa_sha256',
+            ]);
+
+        $foundIds = $rows->pluck('id')->map(static fn (mixed $id): int => (int) $id)->all();
+        sort($foundIds);
+        if ($foundIds !== $itemIds) {
+            return array_merge($summary, [
+                'ok' => false,
+                'status' => 'fail',
+                'matched_item_count' => count($foundIds),
+                'approved_item_count' => 0,
+                'skipped_existing_approved_item_count' => 0,
+                'items' => $this->approvalRows($rows),
+                'errors' => [[
+                    'field' => 'item_ids',
+                    'code' => 'approval_item_ids_missing',
+                    'message' => 'Every explicitly requested approval item ID must exist.',
+                ]],
+                'warnings' => [],
+            ]);
+        }
+
+        $rowErrors = [];
+        foreach ($rows as $row) {
+            $rowErrors = array_merge($rowErrors, $this->approvalRowErrors($row, $framework, $sourceSha256, $qaSha256));
+        }
+
+        if ($rowErrors !== []) {
+            return array_merge($summary, [
+                'ok' => false,
+                'status' => 'fail',
+                'matched_item_count' => $rows->count(),
+                'approved_item_count' => 0,
+                'skipped_existing_approved_item_count' => 0,
+                'items' => $this->approvalRows($rows),
+                'errors' => $rowErrors,
+                'warnings' => [],
+            ]);
+        }
+
+        $states = array_values(array_unique($rows->map(static fn (object $row): string => (string) $row->approval_state)->all()));
+        sort($states);
+
+        if ($states === ['approved']) {
+            return array_merge($summary, [
+                'ok' => true,
+                'status' => 'pass',
+                'matched_item_count' => $rows->count(),
+                'approved_item_count' => 0,
+                'skipped_existing_approved_item_count' => $rows->count(),
+                'writes_committed' => false,
+                'items' => $this->approvalRows($rows),
+                'errors' => [],
+                'warnings' => [],
+            ]);
+        }
+
+        if ($states !== ['pending']) {
+            return array_merge($summary, [
+                'ok' => false,
+                'status' => 'fail',
+                'matched_item_count' => $rows->count(),
+                'approved_item_count' => 0,
+                'skipped_existing_approved_item_count' => 0,
+                'items' => $this->approvalRows($rows),
+                'errors' => [[
+                    'field' => 'approval_state',
+                    'code' => 'approval_items_must_be_all_pending_or_all_approved',
+                    'message' => 'Approval requests must not mix pending, approved, rejected, or blocked states.',
+                ]],
+                'warnings' => [],
+            ]);
+        }
+
+        $now = now();
+        $updated = DB::table('personality_agent_approval_items')
+            ->whereIn('id', $itemIds)
+            ->where('approval_state', 'pending')
+            ->whereNull('approved_at')
+            ->whereNull('rejected_at')
+            ->update([
+                'approval_state' => 'approved',
+                'approved_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+        $approvedRows = DB::table('personality_agent_approval_items as items')
+            ->join('personality_agent_approval_batches as batches', 'batches.id', '=', 'items.batch_id')
+            ->whereIn('items.id', $itemIds)
+            ->orderBy('items.id')
+            ->get([
+                'items.id',
+                'items.batch_id',
+                'items.framework',
+                'items.target_url',
+                'items.approval_state',
+                'items.approved_at',
+                'items.rejected_at',
+                'items.blocked_reason',
+                'items.qa_decision',
+                'items.recommendation_sha256',
+                'batches.source_package_sha256',
+                'batches.qa_sha256',
+            ]);
+
+        return array_merge($summary, [
+            'ok' => $updated === count($itemIds),
+            'status' => $updated === count($itemIds) ? 'pass' : 'fail',
+            'matched_item_count' => $approvedRows->count(),
+            'approved_item_count' => $updated,
+            'skipped_existing_approved_item_count' => 0,
+            'writes_committed' => $updated > 0,
+            'items' => $this->approvalRows($approvedRows),
+            'errors' => $updated === count($itemIds) ? [] : [[
+                'field' => 'approval_items',
+                'code' => 'approval_update_count_mismatch',
+                'message' => 'Approval update count did not match the requested item count.',
+            ]],
+            'warnings' => [],
+        ]);
+    }
+
+    /**
      * @param  array<string,mixed>  $package
      * @return list<array<string,mixed>>
      */
@@ -152,6 +326,186 @@ final class PersonalityAgentApprovalQueueWriter
             is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
             static fn (mixed $item): bool => is_array($item)
         ));
+    }
+
+    /**
+     * @param  list<int>  $itemIds
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    private function approvalBaseSummary(array $itemIds, string $framework, string $sourceSha256, string $qaSha256, array $metadata): array
+    {
+        return [
+            'artifact' => 'PERSONALITY-AGENT-APPROVAL-QUEUE-APPROVE-CONTRACT-01',
+            'status' => 'fail',
+            'ok' => false,
+            'framework' => $framework,
+            'item_ids' => $itemIds,
+            'source_package_sha256' => $sourceSha256,
+            'qa_sha256' => $qaSha256,
+            'metadata' => $metadata,
+            'dry_run' => false,
+            'write' => false,
+            'approve' => true,
+            'writes_attempted' => true,
+            'writes_committed' => false,
+            'approval_state_mutation_attempted' => true,
+            'cms_write_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'cms_live_promotion_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'live_content_updated' => false,
+            'approval_state_written_only' => true,
+            'safety_holds' => $this->safetyHolds(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $itemIds
+     * @return list<array<string,string>>
+     */
+    private function approvalValidationErrors(array $itemIds, string $framework, string $sourceSha256, string $qaSha256): array
+    {
+        $errors = [];
+        if ($itemIds === []) {
+            $errors[] = [
+                'field' => 'item_ids',
+                'code' => 'approval_item_ids_required',
+                'message' => 'Explicit approval item IDs are required.',
+            ];
+        }
+        if (! in_array($framework, self::ALLOWED_FRAMEWORKS, true)) {
+            $errors[] = [
+                'field' => 'framework',
+                'code' => 'unsupported_framework',
+                'message' => 'A supported framework lock is required.',
+            ];
+        }
+        if (! $this->isSha256($sourceSha256)) {
+            $errors[] = [
+                'field' => 'source_package_sha256',
+                'code' => 'source_package_sha256_required',
+                'message' => 'A valid source package SHA256 lock is required.',
+            ];
+        }
+        if (! $this->isSha256($qaSha256)) {
+            $errors[] = [
+                'field' => 'qa_sha256',
+                'code' => 'qa_sha256_required',
+                'message' => 'A valid QA SHA256 lock is required.',
+            ];
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function approvalRowErrors(object $row, string $framework, string $sourceSha256, string $qaSha256): array
+    {
+        $errors = [];
+        $id = (string) $row->id;
+        if ((string) $row->framework !== $framework) {
+            $errors[] = [
+                'field' => 'framework',
+                'code' => 'approval_item_framework_mismatch',
+                'message' => 'Approval item '.$id.' framework does not match the requested framework lock.',
+            ];
+        }
+        if ((string) $row->source_package_sha256 !== $sourceSha256) {
+            $errors[] = [
+                'field' => 'source_package_sha256',
+                'code' => 'approval_item_source_sha256_mismatch',
+                'message' => 'Approval item '.$id.' source package hash does not match.',
+            ];
+        }
+        if ((string) $row->qa_sha256 !== $qaSha256) {
+            $errors[] = [
+                'field' => 'qa_sha256',
+                'code' => 'approval_item_qa_sha256_mismatch',
+                'message' => 'Approval item '.$id.' QA hash does not match.',
+            ];
+        }
+        if ((string) $row->blocked_reason !== '') {
+            $errors[] = [
+                'field' => 'blocked_reason',
+                'code' => 'approval_item_blocked',
+                'message' => 'Approval item '.$id.' has a blocked reason and cannot be approved.',
+            ];
+        }
+        if (! $this->qaDecisionPasses((string) $row->qa_decision)) {
+            $errors[] = [
+                'field' => 'qa_decision',
+                'code' => 'approval_item_qa_not_pass',
+                'message' => 'Approval item '.$id.' QA decision is not pass-ready.',
+            ];
+        }
+        if ((string) $row->recommendation_sha256 === '') {
+            $errors[] = [
+                'field' => 'recommendation_sha256',
+                'code' => 'approval_item_recommendation_sha_missing',
+                'message' => 'Approval item '.$id.' recommendation hash is missing.',
+            ];
+        }
+        if ((string) $row->approval_state === 'rejected' || $row->rejected_at !== null) {
+            $errors[] = [
+                'field' => 'approval_state',
+                'code' => 'approval_item_rejected',
+                'message' => 'Approval item '.$id.' is rejected and cannot be approved.',
+            ];
+        }
+        if ((string) $row->approval_state === 'approved' && $row->approved_at === null) {
+            $errors[] = [
+                'field' => 'approved_at',
+                'code' => 'approval_item_approved_timestamp_missing',
+                'message' => 'Approval item '.$id.' is approved but approved_at is missing.',
+            ];
+        }
+        if (! in_array((string) $row->approval_state, ['pending', 'approved'], true)) {
+            $errors[] = [
+                'field' => 'approval_state',
+                'code' => 'approval_item_state_not_approvable',
+                'message' => 'Approval item '.$id.' must be pending or already approved.',
+            ];
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection<int,object>  $rows
+     * @return list<array<string,mixed>>
+     */
+    private function approvalRows($rows): array
+    {
+        return $rows
+            ->map(static fn (object $row): array => [
+                'id' => (int) $row->id,
+                'batch_id' => (int) $row->batch_id,
+                'framework' => (string) $row->framework,
+                'target_url' => (string) $row->target_url,
+                'approval_state' => (string) $row->approval_state,
+                'approved_at' => $row->approved_at === null ? null : (string) $row->approved_at,
+                'rejected_at' => $row->rejected_at === null ? null : (string) $row->rejected_at,
+                'blocked_reason' => $row->blocked_reason === null ? null : (string) $row->blocked_reason,
+                'qa_decision' => (string) $row->qa_decision,
+                'recommendation_sha256' => (string) $row->recommendation_sha256,
+                'source_package_sha256' => (string) $row->source_package_sha256,
+                'qa_sha256' => (string) $row->qa_sha256,
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function isSha256(string $value): bool
+    {
+        return preg_match('/^[a-f0-9]{64}$/', $value) === 1;
     }
 
     /**

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
@@ -130,6 +130,177 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
         $this->assertSame(0, DB::table('personality_agent_approval_items')->whereNotNull('rejected_at')->count());
     }
 
+    public function test_approve_action_approves_explicit_pending_items_only_without_cms_side_effects(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->assertSame(0, Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath)));
+
+        $ids = DB::table('personality_agent_approval_items')->orderBy('id')->pluck('id')->map(fn ($id): int => (int) $id)->all();
+        $hashes = $this->approvalHashes();
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->approveOptions($ids, $hashes));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['approve']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertTrue($payload['writes_attempted']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertTrue($payload['approval_state_mutation_attempted']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['cms_live_promotion_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['enqueue_attempted']);
+        $this->assertFalse($payload['external_calls_attempted']);
+        $this->assertSame(2, $payload['matched_item_count']);
+        $this->assertSame(2, $payload['approved_item_count']);
+        $this->assertSame(0, $payload['skipped_existing_approved_item_count']);
+        $this->assertSame([], $payload['errors']);
+        $this->assertSame(
+            ['approved'],
+            DB::table('personality_agent_approval_items')->distinct()->pluck('approval_state')->all()
+        );
+        $this->assertSame(2, DB::table('personality_agent_approval_items')->whereNotNull('approved_at')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->whereNotNull('rejected_at')->count());
+    }
+
+    public function test_approve_action_is_idempotent_when_all_requested_items_are_already_approved(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->assertSame(0, Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath)));
+
+        $ids = DB::table('personality_agent_approval_items')->orderBy('id')->pluck('id')->map(fn ($id): int => (int) $id)->all();
+        $hashes = $this->approvalHashes();
+
+        $this->assertSame(0, Artisan::call('personality:agent-approval-queue', $this->approveOptions($ids, $hashes)));
+        $secondExit = Artisan::call('personality:agent-approval-queue', $this->approveOptions($ids, $hashes));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['approved_item_count']);
+        $this->assertSame(2, $payload['skipped_existing_approved_item_count']);
+        $this->assertSame(2, DB::table('personality_agent_approval_items')->where('approval_state', 'approved')->count());
+    }
+
+    public function test_approve_action_fails_closed_for_missing_items_without_partial_updates(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->assertSame(0, Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath)));
+
+        $ids = DB::table('personality_agent_approval_items')->orderBy('id')->pluck('id')->map(fn ($id): int => (int) $id)->all();
+        $ids[] = 999999;
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->approveOptions($ids, $this->approvalHashes()));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame('approval_item_ids_missing', $payload['errors'][0]['code']);
+        $this->assertSame(2, DB::table('personality_agent_approval_items')->where('approval_state', 'pending')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->where('approval_state', 'approved')->count());
+    }
+
+    public function test_approve_action_fails_closed_for_rejected_items_without_partial_updates(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->assertSame(0, Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath)));
+
+        $ids = DB::table('personality_agent_approval_items')->orderBy('id')->pluck('id')->map(fn ($id): int => (int) $id)->all();
+        DB::table('personality_agent_approval_items')->where('id', $ids[0])->update([
+            'approval_state' => 'rejected',
+            'rejected_at' => now(),
+        ]);
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->approveOptions($ids, $this->approvalHashes()));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertContains('approval_item_rejected', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->where('approval_state', 'approved')->count());
+        $this->assertSame(1, DB::table('personality_agent_approval_items')->where('approval_state', 'pending')->count());
+    }
+
+    public function test_approve_action_fails_closed_for_hash_or_framework_mismatch(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->assertSame(0, Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath)));
+
+        $ids = DB::table('personality_agent_approval_items')->orderBy('id')->pluck('id')->map(fn ($id): int => (int) $id)->all();
+        $hashes = $this->approvalHashes();
+        $hashes['source_package_sha256'] = str_repeat('a', 64);
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->approveOptions($ids, $hashes));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertContains('approval_item_source_sha256_mismatch', array_column($payload['errors'], 'code'));
+        $this->assertSame(2, DB::table('personality_agent_approval_items')->where('approval_state', 'pending')->count());
+
+        $hashes = $this->approvalHashes();
+        $hashes['framework'] = 'big_five';
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->approveOptions($ids, $hashes));
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('approval_item_framework_mismatch', array_column($payload['errors'], 'code'));
+        $this->assertSame(2, DB::table('personality_agent_approval_items')->where('approval_state', 'pending')->count());
+    }
+
+    public function test_approve_action_fails_closed_for_mixed_pending_and_approved_items(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->assertSame(0, Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath)));
+
+        $ids = DB::table('personality_agent_approval_items')->orderBy('id')->pluck('id')->map(fn ($id): int => (int) $id)->all();
+        DB::table('personality_agent_approval_items')->where('id', $ids[0])->update([
+            'approval_state' => 'approved',
+            'approved_at' => now(),
+        ]);
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->approveOptions($ids, $this->approvalHashes()));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame('approval_items_must_be_all_pending_or_all_approved', $payload['errors'][0]['code']);
+        $this->assertSame(1, DB::table('personality_agent_approval_items')->where('approval_state', 'pending')->count());
+        $this->assertSame(1, DB::table('personality_agent_approval_items')->where('approval_state', 'approved')->count());
+    }
+
+    public function test_approve_action_requires_exact_operator_token(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->assertSame(0, Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath)));
+
+        $ids = DB::table('personality_agent_approval_items')->orderBy('id')->pluck('id')->map(fn ($id): int => (int) $id)->all();
+        $options = $this->approveOptions($ids, $this->approvalHashes());
+        $options['--operator-approved'] = 'WRONG';
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['approval_state_mutation_attempted']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString('PERSONALITY-AGENT-APPROVAL-QUEUE-APPROVE-CONTRACT-01', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(2, DB::table('personality_agent_approval_items')->where('approval_state', 'pending')->count());
+    }
+
     public function test_second_write_is_idempotent_for_same_package_and_qa_hashes(): void
     {
         [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
@@ -782,6 +953,39 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
             '--qa' => $qaPath,
             '--write' => true,
             '--operator-approved' => 'PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01',
+            '--json' => true,
+        ];
+    }
+
+    /**
+     * @return array{framework:string,source_package_sha256:string,qa_sha256:string}
+     */
+    private function approvalHashes(): array
+    {
+        $batch = DB::table('personality_agent_approval_batches')->orderByDesc('id')->first();
+        $this->assertNotNull($batch);
+
+        return [
+            'framework' => (string) $batch->framework,
+            'source_package_sha256' => (string) $batch->source_package_sha256,
+            'qa_sha256' => (string) $batch->qa_sha256,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @param  array{framework:string,source_package_sha256:string,qa_sha256:string}  $hashes
+     * @return array<string,mixed>
+     */
+    private function approveOptions(array $ids, array $hashes): array
+    {
+        return [
+            '--approve' => true,
+            '--item-ids' => implode(',', $ids),
+            '--framework' => $hashes['framework'],
+            '--source-package-sha256' => $hashes['source_package_sha256'],
+            '--qa-sha256' => $hashes['qa_sha256'],
+            '--operator-approved' => 'PERSONALITY-AGENT-APPROVAL-QUEUE-APPROVE-CONTRACT-01',
             '--json' => true,
         ];
     }


### PR DESCRIPTION
## What changed
- Added a controlled `--approve` action to `personality:agent-approval-queue`.
- Requires explicit item IDs, framework lock, source package SHA, QA SHA, and operator token `PERSONALITY-AGENT-APPROVAL-QUEUE-APPROVE-CONTRACT-01`.
- Approves only valid queue items by moving all requested rows from `pending` to `approved` and setting `approved_at`.
- Keeps already-approved all-ID requests idempotent and fails closed for mixed pending/approved states.

## Why
The next-batch personality agent flow needs a safe human approval step before any CMS draft writer can consume recommendations. Production approval was authorized, but the backend command did not yet expose a bounded approval action.

## Safety boundary
- No CMS draft writes.
- No live promotion.
- No publish, index/search, sitemap/llms, queue enqueue/submit, frontend, or external API calls.
- Partial approval, missing IDs, rejected rows, unsupported framework, stale source/QA hash, and recommendation hash issues fail closed with zero updates.

## Validation
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php tests/Feature/Console/PersonalityAgentApprovalQueueReviewCommandTest.php --display-warnings`
- `php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred
- Production approval execution for queue items 1-6 remains a separate runtime gate after deploy.
- CMS draft write, live promotion, publish/index/search, sitemap/llms, and external search submission remain separate gates.
