### PR TITLE
Support Gaokao publish evidence in search bridge

### DIFF
--- a/backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php
+++ b/backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php
@@ -19,6 +19,8 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
 
     private const ARTICLE_PUBLISH_SCHEMA_VERSION = 'seo-agent-article-cms-publish-canary.v1';
 
+    private const ARTICLES_PUBLISH_CONTROLLED_EVIDENCE_KIND = 'articles_publish_controlled';
+
     private const FORBIDDEN_STRINGS = [
         'raw_url',
         'raw_query',
@@ -71,17 +73,18 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
             return $this->finish($this->failureSummary('publish_evidence_json_invalid'));
         }
 
-        $evidenceIssue = $this->validatePublishEvidence($evidence);
+        $evidenceKind = $this->publishEvidenceKind($evidence);
+        $evidenceIssue = $this->validatePublishEvidence($evidence, $evidenceKind);
         if ($evidenceIssue !== null) {
             return $this->finish($this->failureSummary($evidenceIssue));
         }
 
-        $affected = $this->firstAffectedRef($evidence);
+        $affected = $this->firstAffectedRef($evidence, $evidenceKind);
         if ($affected === null) {
             return $this->finish($this->failureSummary('published_ref_missing'));
         }
 
-        $target = $this->publishedTarget($affected, (string) ($evidence['schema_version'] ?? ''));
+        $target = $this->publishedTarget($affected, $evidenceKind);
         if ($target['issue'] !== null) {
             return $this->finish($this->failureSummary((string) $target['issue']));
         }
@@ -200,14 +203,35 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
     /**
      * @param  array<string, mixed>  $evidence
      */
-    private function validatePublishEvidence(array $evidence): ?string
+    private function publishEvidenceKind(array $evidence): string
     {
-        if (! in_array(($evidence['schema_version'] ?? null), [
+        $schemaVersion = (string) ($evidence['schema_version'] ?? '');
+        if (in_array($schemaVersion, [
             self::PUBLISH_SCHEMA_VERSION,
             self::ARTICLE_PUBLISH_SCHEMA_VERSION,
         ], true)) {
+            return $schemaVersion;
+        }
+
+        if ($this->isArticlesPublishControlledEvidence($evidence)) {
+            return self::ARTICLES_PUBLISH_CONTROLLED_EVIDENCE_KIND;
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function validatePublishEvidence(array $evidence, string $evidenceKind): ?string
+    {
+        if ($evidenceKind === '') {
             return 'publish_evidence_schema_invalid';
         }
+        if ($evidenceKind === self::ARTICLES_PUBLISH_CONTROLLED_EVIDENCE_KIND) {
+            return $this->validateArticlesPublishControlledEvidence($evidence);
+        }
+
         if (($evidence['status'] ?? null) !== 'success' || (bool) ($evidence['execute'] ?? false) !== true) {
             return 'publish_evidence_not_success_execute';
         }
@@ -230,8 +254,26 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
      * @param  array<string, mixed>  $evidence
      * @return array<string, mixed>|null
      */
-    private function firstAffectedRef(array $evidence): ?array
+    private function firstAffectedRef(array $evidence, string $evidenceKind): ?array
     {
+        if ($evidenceKind === self::ARTICLES_PUBLISH_CONTROLLED_EVIDENCE_KIND) {
+            $article = $this->firstArticlesPublishControlledArticle($evidence);
+            if ($article === null) {
+                return null;
+            }
+
+            $articleId = (int) ($article['article_id'] ?? 0);
+            $locale = (string) ($article['locale'] ?? '');
+
+            return [
+                'status' => 'published',
+                'target_model' => 'article',
+                'subject_ref' => 'article:'.$articleId.':'.$locale,
+                'revision_id' => (int) ($article['working_revision_id'] ?? 0),
+                'article_translation_revision_id' => (int) ($article['working_revision_id'] ?? 0),
+            ];
+        }
+
         foreach ((array) ($evidence['affected_refs'] ?? []) as $ref) {
             if (is_array($ref) && ($ref['status'] ?? null) === 'published') {
                 return $ref;
@@ -245,13 +287,16 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
      * @param  array<string, mixed>  $affected
      * @return array{issue: string|null, target_model?: string, page_entity_type?: string, safe_path?: string}
      */
-    private function publishedTarget(array $affected, string $schemaVersion): array
+    private function publishedTarget(array $affected, string $evidenceKind): array
     {
         return match ((string) ($affected['target_model'] ?? '')) {
-            'content_page' => $schemaVersion === self::PUBLISH_SCHEMA_VERSION
+            'content_page' => $evidenceKind === self::PUBLISH_SCHEMA_VERSION
                 ? $this->publishedContentPageTarget($affected)
                 : ['issue' => 'publish_evidence_schema_target_mismatch'],
-            'article' => $schemaVersion === self::ARTICLE_PUBLISH_SCHEMA_VERSION
+            'article' => in_array($evidenceKind, [
+                self::ARTICLE_PUBLISH_SCHEMA_VERSION,
+                self::ARTICLES_PUBLISH_CONTROLLED_EVIDENCE_KIND,
+            ], true)
                 ? $this->publishedArticleTarget($affected)
                 : ['issue' => 'publish_evidence_schema_target_mismatch'],
             default => ['issue' => 'target_model_not_supported'],
@@ -330,6 +375,72 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
         }
 
         return (int) $parts[1];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function isArticlesPublishControlledEvidence(array $evidence): bool
+    {
+        return array_key_exists('article_ids', $evidence)
+            && array_key_exists('articles', $evidence)
+            && array_key_exists('make_indexable', $evidence)
+            && ! array_key_exists('affected_refs', $evidence);
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function validateArticlesPublishControlledEvidence(array $evidence): ?string
+    {
+        if (($evidence['ok'] ?? null) !== true || (bool) ($evidence['dry_run'] ?? true) !== false) {
+            return 'publish_evidence_not_success_execute';
+        }
+
+        $articleIds = array_values(array_filter(
+            array_map(static fn (mixed $id): int => is_numeric($id) ? (int) $id : 0, (array) ($evidence['article_ids'] ?? [])),
+            static fn (int $id): bool => $id > 0,
+        ));
+        if (count($articleIds) !== 1) {
+            return 'publish_evidence_missing_one_committed_publish';
+        }
+
+        $article = $this->firstArticlesPublishControlledArticle($evidence);
+        if ($article === null || (int) ($article['article_id'] ?? 0) !== $articleIds[0]) {
+            return 'published_ref_missing';
+        }
+        if (($article['ok'] ?? null) !== true || (array) ($article['errors'] ?? []) !== []) {
+            return 'publish_evidence_not_success_execute';
+        }
+        if ((bool) ($article['make_indexable'] ?? false) !== true || (int) ($article['working_revision_id'] ?? 0) < 1) {
+            return 'publish_evidence_missing_one_committed_publish';
+        }
+        if ((string) ($article['locale'] ?? '') === '' || (string) ($article['slug'] ?? '') === '') {
+            return 'published_ref_missing';
+        }
+        if ((array) ($evidence['errors'] ?? []) !== []) {
+            return 'publish_evidence_not_success_execute';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>|null
+     */
+    private function firstArticlesPublishControlledArticle(array $evidence): ?array
+    {
+        $articles = array_values(array_filter(
+            (array) ($evidence['articles'] ?? []),
+            static fn (mixed $article): bool => is_array($article),
+        ));
+
+        if (count($articles) !== 1) {
+            return null;
+        }
+
+        return $articles[0];
     }
 
     private function canonicalUrl(string $safePath): ?string

--- a/backend/docs/seo/generated/seo-agent-post-publish-search-submit.v1.json
+++ b/backend/docs/seo/generated/seo-agent-post-publish-search-submit.v1.json
@@ -5,7 +5,8 @@
   "command": "php artisan seo-agent:post-publish-search-submit",
   "input_schema": [
     "seo-agent-cms-publish-canary.v1",
-    "seo-agent-article-cms-publish-canary.v1"
+    "seo-agent-article-cms-publish-canary.v1",
+    "articles:publish-controlled evidence for one article"
   ],
   "output_schema": "seo-agent-post-publish-search-submit.v1",
   "default_mode": "dry_run_plan",
@@ -34,6 +35,7 @@
   },
   "article_support": {
     "input_schema": "seo-agent-article-cms-publish-canary.v1",
+    "compatible_input_schema": "articles:publish-controlled one-article evidence",
     "safe_path_source": "article slug and locale",
     "requires_article_public_indexable_published": true,
     "live_submit": false

--- a/backend/tests/Feature/SeoIntel/SeoAgentPostPublishSearchSubmitTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentPostPublishSearchSubmitTest.php
@@ -140,6 +140,38 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
     }
 
     #[Test]
+    public function dry_run_plans_articles_publish_controlled_gaokao_evidence_without_writing(): void
+    {
+        $article = $this->createPublishedArticle([
+            'slug' => 'gaokao-major-choice-parent-conflict-riasec-course-checklist',
+            'locale' => 'zh-CN',
+        ]);
+        $canonicalUrl = 'https://www.fermatmind.com/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist';
+        $this->seedSeoUrl($canonicalUrl, (string) $article->id, 'article', 'zh-CN');
+        $evidencePath = $this->writeArticlesPublishControlledEvidence($article);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $evidencePath,
+            '--channels' => 'indexnow',
+            '--limit' => 1,
+            '--base-url' => 'https://www.fermatmind.com',
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame('/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist', $summary['safe_path'] ?? null);
+        $this->assertSame('article', $summary['target_model'] ?? null);
+        $this->assertSame('article', $summary['page_entity_type'] ?? null);
+        $this->assertSame(1, $summary['planned_queue_count'] ?? null);
+        $this->assertSame(1, data_get($summary, 'plans.indexnow.planned_queue_count'));
+        $this->assertFalse((bool) ($summary['search_channel_enqueue_attempted'] ?? true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.search_channel_enqueue', true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+    }
+
+    #[Test]
     public function execute_enqueues_article_publish_evidence_without_live_submission(): void
     {
         $article = $this->createPublishedArticle();
@@ -219,6 +251,22 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
         $summary = json_decode(trim(Artisan::output()), true);
         $this->assertSame(1, $exitCode);
         $this->assertContains('publish_evidence_schema_target_mismatch', $summary['issues'] ?? []);
+
+        $gaokaoArticle = $this->createPublishedArticle([
+            'slug' => 'gaokao-major-choice-parent-conflict-riasec-course-checklist',
+            'locale' => 'zh-CN',
+        ]);
+        $multiArticlePath = $this->writeArticlesPublishControlledEvidence($gaokaoArticle, [
+            'article_ids' => [(int) $gaokaoArticle->id, 999],
+        ]);
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $multiArticlePath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('publish_evidence_missing_one_committed_publish', $summary['issues'] ?? []);
     }
 
     #[Test]
@@ -265,9 +313,9 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
         ]);
     }
 
-    private function createPublishedArticle(): Article
+    private function createPublishedArticle(array $overrides = []): Article
     {
-        $article = Article::query()->create([
+        $attributes = array_replace([
             'org_id' => 0,
             'slug' => 'article-candidate',
             'locale' => 'en',
@@ -283,7 +331,9 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
             'sitemap_eligible' => true,
             'llms_eligible' => true,
             'published_at' => now()->subDay(),
-        ]);
+        ], $overrides);
+
+        $article = Article::query()->create($attributes);
         $publishedRevision = ArticleTranslationRevision::query()->create([
             'org_id' => 0,
             'article_id' => (int) $article->id,
@@ -369,6 +419,38 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
                 'scheduler_activation' => false,
                 'queue_worker_start' => false,
             ],
+        ], $overrides));
+    }
+
+    private function writeArticlesPublishControlledEvidence(Article $article, array $overrides = []): string
+    {
+        return $this->writeJson('articles-publish-controlled-', array_replace_recursive([
+            'ok' => true,
+            'dry_run' => false,
+            'expected_confirmation' => 'I explicitly approve Codex to publish article id '.(int) $article->id.' after preflight passes.',
+            'make_indexable' => true,
+            'article_ids' => [(int) $article->id],
+            'articles' => [[
+                'article_id' => (int) $article->id,
+                'slug' => (string) $article->slug,
+                'locale' => (string) $article->locale,
+                'title' => (string) $article->title,
+                'status' => 'draft',
+                'working_revision_id' => (int) $article->published_revision_id,
+                'working_revision_status' => 'approved',
+                'import_status' => 'imported',
+                'claim_status' => 'passed',
+                'body_hash' => hash('sha256', (string) $article->content_md),
+                'references_count' => 3,
+                'media_status' => 'complete',
+                'graph_status' => 'complete',
+                'cta_count' => 2,
+                'faq_count' => 8,
+                'make_indexable' => true,
+                'ok' => true,
+                'errors' => [],
+            ]],
+            'errors' => [],
         ], $overrides));
     }
 


### PR DESCRIPTION
## What changed
- Extended `seo-agent:post-publish-search-submit` to accept one-article `articles:publish-controlled` evidence, such as the Gaokao article 55 publish output.
- Normalizes that evidence into the existing article target path, so URL Truth/Search Channel planning still uses the existing article + URL Truth planner.
- Keeps dry-run as the default and keeps `--execute` gated by the existing publish evidence sha256 confirmation.
- Updated the generated command contract and focused tests.

## Why
Gaokao article 55 was published through `articles:publish-controlled`, not the SEO Agent article publish canary. The Search bridge was therefore failing closed with `publish_evidence_schema_invalid` even after URL Truth had a valid article row.

## Validation
- `php artisan list | rg 'seo-agent:post-publish-search-submit'`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentPostPublishSearchSubmitTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='test_runtime_paths_have_no_uncommitted_diff'`
- `vendor/bin/pint --test app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php tests/Feature/SeoIntel/SeoAgentPostPublishSearchSubmitTest.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-agent-post-publish-search-submit.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No production deploy in this PR.
- No Search Channel enqueue.
- No IndexNow/Baidu/GSC live submit.
- No CMS write, publish, URL Truth write, schema/hreflang, sitemap/llms, scheduler, queue worker start, or revalidation.