### PR TITLE
PERSONALITY-AGENT-CMS-DRAFT-NEXT-BATCH-6-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -22,6 +22,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
     private const AGENT_BATCH_OPERATOR_APPROVAL = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
 
+    private const NEXT_BATCH_6_OPERATOR_APPROVAL = 'PERSONALITY-AGENT-CMS-DRAFT-NEXT-BATCH-6-WRITE-01';
+
     private const WRITE_SAFETY_FLAGS = [
         'draft-only',
         'no-publish',
@@ -39,6 +41,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         {--visible-query-backed-3 : Restrict planning/write to the approved 3 query-backed visible MBTI64 URLs}
         {--fresh-query-backed-3 : Restrict planning/write to the fresh 3 query-backed MBTI64 URLs}
         {--fresh-query-backed-5 : Restrict planning/write to the fresh 5 query-backed MBTI64 URLs}
+        {--next-batch-6 : Restrict planning/write to the approved 6 next-batch MBTI64 URLs}
         {--agent-batch-size= : Restrict planning/write to an artifact-order batch; only 5 or 10 are allowed}
         {--agent-batch-offset= : Zero-based artifact-order offset for --agent-batch-size; defaults to 0}
         {--json : Emit the full JSON summary}
@@ -135,6 +138,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             (bool) $this->option('visible-query-backed-3') => self::VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL,
             (bool) $this->option('fresh-query-backed-3') => self::FRESH_QUERY_BACKED_3_OPERATOR_APPROVAL,
             (bool) $this->option('fresh-query-backed-5') => self::FRESH_QUERY_BACKED_5_OPERATOR_APPROVAL,
+            (bool) $this->option('next-batch-6') => self::NEXT_BATCH_6_OPERATOR_APPROVAL,
             $this->agentBatchRequested() => self::AGENT_BATCH_OPERATOR_APPROVAL,
             default => self::OPERATOR_APPROVAL,
         };
@@ -168,6 +172,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             'visible_query_backed_3' => (bool) $this->option('visible-query-backed-3'),
             'fresh_query_backed_3' => (bool) $this->option('fresh-query-backed-3'),
             'fresh_query_backed_5' => (bool) $this->option('fresh-query-backed-5'),
+            'next_batch_6' => (bool) $this->option('next-batch-6'),
             'agent_batch_size' => trim((string) $this->option('agent-batch-size')),
             'agent_batch_offset' => trim((string) $this->option('agent-batch-offset')),
             'draft_only' => (bool) $this->option('draft-only'),

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -18,6 +18,10 @@ final class Mbti64CmsProjectionDraftWriter
 
     private const QA_ARTIFACT = 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-QA-01';
 
+    private const NEXT_BATCH_6_PACKAGE_ARTIFACT = 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-6-HANDOFF-01';
+
+    private const NEXT_BATCH_6_QA_ARTIFACT = 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-6-HANDOFF-QA-01';
+
     private const VISIBLE_QUERY_BACKED_3_URLS = [
         'https://fermatmind.com/en/personality/enfj-a',
         'https://fermatmind.com/zh/personality/intp-a',
@@ -36,6 +40,15 @@ final class Mbti64CmsProjectionDraftWriter
         'https://fermatmind.com/en/personality/esfj-a',
         'https://fermatmind.com/zh/personality/esfj-a',
         'https://fermatmind.com/en/personality/intp-a',
+    ];
+
+    private const NEXT_BATCH_6_URLS = [
+        'https://fermatmind.com/zh/personality/intp-a',
+        'https://fermatmind.com/en/personality/intp-a',
+        'https://fermatmind.com/zh/personality/esfp-a',
+        'https://fermatmind.com/en/personality/esfp-a',
+        'https://fermatmind.com/en/personality/enfj-a',
+        'https://fermatmind.com/zh/personality/enfj-a',
     ];
 
     private const AGENT_BATCH_ALLOWED_SIZES = [5, 10];
@@ -88,7 +101,7 @@ final class Mbti64CmsProjectionDraftWriter
         bool $write,
         array $options,
     ): array {
-        $errors = $this->validatePackageAndQa($package, $qa);
+        $errors = $this->validatePackageAndQa($package, $qa, $options);
         $warnings = array_values(array_filter((array) ($qa['warnings'] ?? []), static fn (mixed $warning): bool => is_string($warning)));
         $qaResultsByUrl = $this->qaResultsByUrl($qa);
         $recommendations = $this->recommendationsForOptions($package, $options, $write, $errors);
@@ -265,8 +278,12 @@ final class Mbti64CmsProjectionDraftWriter
      * @param  array<string,mixed>  $qa
      * @return list<array<string,string>>
      */
-    private function validatePackageAndQa(array $package, array $qa): array
+    private function validatePackageAndQa(array $package, array $qa, array $options): array
     {
+        if ($this->nextBatch6Requested($options)) {
+            return $this->validateNextBatch6PackageAndQa($package, $qa);
+        }
+
         $errors = [];
         $summary = is_array($package['summary'] ?? null) ? $package['summary'] : [];
         $qaSummary = is_array($qa['summary'] ?? null) ? $qa['summary'] : [];
@@ -326,6 +343,76 @@ final class Mbti64CmsProjectionDraftWriter
 
     /**
      * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return list<array<string,string>>
+     */
+    private function validateNextBatch6PackageAndQa(array $package, array $qa): array
+    {
+        $errors = [];
+        $summary = is_array($package['summary'] ?? null) ? $package['summary'] : [];
+        $qaSummary = is_array($qa['summary'] ?? null) ? $qa['summary'] : [];
+        $recommendationUrls = array_map(
+            static fn (array $item): string => (string) ($item['target_url'] ?? ''),
+            $this->recommendations($package)
+        );
+        $expectedUrls = self::NEXT_BATCH_6_URLS;
+        sort($recommendationUrls);
+        sort($expectedUrls);
+
+        if ((string) ($package['artifact'] ?? '') !== self::NEXT_BATCH_6_PACKAGE_ARTIFACT) {
+            $errors[] = ['field' => 'artifact', 'code' => 'unsupported_package_artifact', 'message' => 'Unexpected next-batch-6 package artifact.'];
+        }
+        if ((string) ($package['status'] ?? '') !== 'pass') {
+            $errors[] = ['field' => 'status', 'code' => 'package_status_not_ready_for_approval_handoff', 'message' => 'Next-batch-6 package must have pass status.'];
+        }
+        if (count($this->recommendations($package)) !== 6 || (int) ($summary['recommendation_count'] ?? -1) !== 6) {
+            $errors[] = ['field' => 'recommendations', 'code' => 'unexpected_recommendation_count', 'message' => 'Expected exactly 6 next-batch recommendations.'];
+        }
+        if ((int) ($summary['variant_pages'] ?? -1) !== 6 || (int) ($summary['comparison_pages'] ?? -1) !== 0) {
+            $errors[] = ['field' => 'summary', 'code' => 'unexpected_page_type_counts', 'message' => 'Expected 6 variant and 0 comparison recommendations.'];
+        }
+        if ($recommendationUrls !== $expectedUrls) {
+            $errors[] = ['field' => 'recommendations', 'code' => 'next_batch_6_url_set_mismatch', 'message' => 'Next-batch-6 package must contain exactly the fixed approved URL set.'];
+        }
+
+        if ((string) ($qa['artifact'] ?? '') !== self::NEXT_BATCH_6_QA_ARTIFACT) {
+            $errors[] = ['field' => 'qa.artifact', 'code' => 'unsupported_qa_artifact', 'message' => 'Unexpected next-batch-6 QA artifact.'];
+        }
+        if ((string) ($qa['final_decision'] ?? '') !== 'PASS_READY_FOR_APPROVAL_REVIEW') {
+            $errors[] = ['field' => 'qa.final_decision', 'code' => 'qa_not_ready_for_approval_review', 'message' => 'Next-batch-6 QA must be ready for approval review.'];
+        }
+        if ((int) ($qaSummary['checked_recommendation_count'] ?? -1) !== 6
+            || (int) ($qaSummary['pass_ready_for_approval_review_count'] ?? -1) !== 6
+            || (int) ($qaSummary['blocked_count'] ?? -1) !== 0) {
+            $errors[] = ['field' => 'qa.summary', 'code' => 'qa_summary_not_all_pass', 'message' => 'Next-batch-6 QA summary must show 6 pass and 0 blocked.'];
+        }
+        if ((array) ($qa['blockers'] ?? []) !== []) {
+            $errors[] = ['field' => 'qa.blockers', 'code' => 'qa_blockers_present', 'message' => 'QA blockers must be empty.'];
+        }
+
+        $qaUrls = array_map(
+            static fn (array $item): string => (string) ($item['target_url'] ?? ''),
+            array_values(array_filter(
+                is_array($qa['page_results'] ?? null) ? $qa['page_results'] : [],
+                static fn (mixed $item): bool => is_array($item)
+            ))
+        );
+        sort($qaUrls);
+        if ($recommendationUrls !== $qaUrls) {
+            $errors[] = ['field' => 'qa.page_results', 'code' => 'qa_url_set_mismatch', 'message' => 'QA page result URLs must match recommendation URLs.'];
+        }
+
+        foreach ($this->qaResultsByUrl($qa) as $url => $result) {
+            if ((string) ($result['decision'] ?? '') !== 'PASS_READY_FOR_APPROVAL_REVIEW' || (array) ($result['blockers'] ?? []) !== []) {
+                $errors[] = ['field' => 'qa.page_results.'.$url, 'code' => 'qa_page_not_pass', 'message' => 'Every next-batch-6 QA page result must pass approval review with no blockers.'];
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
      * @return list<array<string,mixed>>
      */
     private function recommendations(array $package): array
@@ -348,22 +435,24 @@ final class Mbti64CmsProjectionDraftWriter
         $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
         $freshQueryBacked3 = (bool) ($options['fresh_query_backed_3'] ?? false);
         $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
+        $nextBatch6 = $this->nextBatch6Requested($options);
         $agentBatchRequested = $this->agentBatchRequested($options);
 
         if (($visibleQueryBacked3 ? 1 : 0)
             + ($freshQueryBacked3 ? 1 : 0)
             + ($freshQueryBacked5 ? 1 : 0)
+            + ($nextBatch6 ? 1 : 0)
             + ($agentBatchRequested ? 1 : 0) > 1) {
             $errors[] = [
                 'field' => 'options',
                 'code' => 'exclusive_subset_modes_required',
-                'message' => 'Only one subset mode can be used: --visible-query-backed-3, --fresh-query-backed-3, --fresh-query-backed-5, or agent batch options.',
+                'message' => 'Only one subset mode can be used: --visible-query-backed-3, --fresh-query-backed-3, --fresh-query-backed-5, --next-batch-6, or agent batch options.',
             ];
 
             return [];
         }
 
-        if (! $visibleQueryBacked3 && ! $freshQueryBacked3 && ! $freshQueryBacked5 && ! $agentBatchRequested) {
+        if (! $visibleQueryBacked3 && ! $freshQueryBacked3 && ! $freshQueryBacked5 && ! $nextBatch6 && ! $agentBatchRequested) {
             return $recommendations;
         }
 
@@ -377,6 +466,11 @@ final class Mbti64CmsProjectionDraftWriter
         }
 
         [$expectedUrls, $subsetCode, $subsetLabel] = match (true) {
+            $nextBatch6 => [
+                self::NEXT_BATCH_6_URLS,
+                'next_batch_6_subset_required_urls_missing',
+                'next batch 6',
+            ],
             $freshQueryBacked5 => [
                 self::FRESH_QUERY_BACKED_5_URLS,
                 'fresh_query_backed_5_subset_required_urls_missing',
@@ -420,6 +514,14 @@ final class Mbti64CmsProjectionDraftWriter
     {
         return trim((string) ($options['agent_batch_size'] ?? '')) !== ''
             || trim((string) ($options['agent_batch_offset'] ?? '')) !== '';
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function nextBatch6Requested(array $options): bool
+    {
+        return (bool) ($options['next_batch_6'] ?? false);
     }
 
     /**
@@ -621,7 +723,7 @@ final class Mbti64CmsProjectionDraftWriter
      */
     private function agentBatchApprovalGate(array $preparedRows, string $sourceSha256, string $qaSha256, array $options): array
     {
-        if (! $this->agentBatchRequested($options)) {
+        if (! $this->agentBatchRequested($options) && ! $this->nextBatch6Requested($options)) {
             return [
                 'required_for_write' => false,
                 'ready_for_write' => true,
@@ -737,6 +839,7 @@ final class Mbti64CmsProjectionDraftWriter
             'pass',
             'PASS',
             'PASS_READY_FOR_CMS_DRAFT',
+            'PASS_READY_FOR_APPROVAL_REVIEW',
             'READY_QUERY_BACKED_LOW_RISK_DRAFT_REVIEW',
         ], true);
     }
@@ -896,6 +999,7 @@ final class Mbti64CmsProjectionDraftWriter
         $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
         $freshQueryBacked3 = (bool) ($options['fresh_query_backed_3'] ?? false);
         $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
+        $nextBatch6 = $this->nextBatch6Requested($options);
         $agentBatchRequested = $this->agentBatchRequested($options);
         $selectedUrls = array_values(array_map(
             static fn (array $row): string => (string) ($row['url'] ?? ''),
@@ -937,6 +1041,19 @@ final class Mbti64CmsProjectionDraftWriter
                 'write_allowed_with_strict_approval' => true,
                 'allowed_urls' => self::FRESH_QUERY_BACKED_5_URLS,
                 'selected_urls' => $selectedUrls,
+            ];
+        }
+
+        if ($nextBatch6) {
+            return [
+                'mode' => 'next_batch_6',
+                'enabled' => true,
+                'dry_run_only' => false,
+                'write_allowed_with_strict_approval' => true,
+                'approval_queue_required' => true,
+                'allowed_urls' => self::NEXT_BATCH_6_URLS,
+                'selected_urls' => $selectedUrls,
+                'arbitrary_url_subset_allowed' => false,
             ];
         }
 

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -53,6 +53,15 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         'https://fermatmind.com/en/personality/intp-a',
     ];
 
+    private const NEXT_BATCH_6_URLS = [
+        'https://fermatmind.com/zh/personality/intp-a',
+        'https://fermatmind.com/en/personality/intp-a',
+        'https://fermatmind.com/zh/personality/esfp-a',
+        'https://fermatmind.com/en/personality/esfp-a',
+        'https://fermatmind.com/en/personality/enfj-a',
+        'https://fermatmind.com/zh/personality/enfj-a',
+    ];
+
     public function test_dry_run_plans_eighty_eight_projection_drafts_without_writes(): void
     {
         $this->seedAllTargets();
@@ -517,6 +526,228 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(1, $exitCode);
         $this->assertFalse($payload['ok']);
         $this->assertContains('fresh_query_backed_5_subset_required_urls_missing', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_next_batch_six_dry_run_accepts_handoff_artifact_and_requires_approval_queue_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->nextBatchSixPackage(), $this->nextBatchSixQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--next-batch-6' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(6, $payload['row_count']);
+        $this->assertSame(6, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(6, $payload['would_create_revision_count']);
+        $this->assertSame('next_batch_6', $payload['subset']['mode']);
+        $this->assertTrue($payload['subset']['approval_queue_required']);
+        $this->assertFalse($payload['subset']['arbitrary_url_subset_allowed']);
+        $this->assertTrue($payload['approval_queue']['required_for_write']);
+        $this->assertFalse($payload['approval_queue']['ready_for_write']);
+        $this->assertSame(0, $payload['approval_queue']['approved_count']);
+        $this->assertSame(6, $payload['approval_queue']['missing_count']);
+
+        $plannedUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($plannedUrls);
+        $expectedUrls = self::NEXT_BATCH_6_URLS;
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $plannedUrls);
+        $this->assertSame($expectedUrls, array_values($this->sortedStrings((array) $payload['subset']['allowed_urls'])));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_next_batch_six_handoff_artifact_is_rejected_without_explicit_subset_flag(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->nextBatchSixPackage(), $this->nextBatchSixQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('unsupported_package_artifact', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_next_batch_six_write_requires_next_batch_approval_token(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->nextBatchSixPackage(), $this->nextBatchSixQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--next-batch-6'] = true;
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString(
+            '--operator-approved=PERSONALITY-AGENT-CMS-DRAFT-NEXT-BATCH-6-WRITE-01 is required',
+            (string) ($payload['errors'][0]['message'] ?? '')
+        );
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_next_batch_six_write_without_approved_queue_rows_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->nextBatchSixPackage(), $this->nextBatchSixQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--next-batch-6'] = true;
+        $options['--operator-approved'] = 'PERSONALITY-AGENT-CMS-DRAFT-NEXT-BATCH-6-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(6, $payload['row_count']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['approval_queue']['approved_count']);
+        $this->assertSame(6, $payload['approval_queue']['missing_count']);
+        $this->assertContains('agent_batch_approval_required', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_next_batch_six_write_creates_only_approved_variant_draft_revisions(): void
+    {
+        $targets = $this->seedAllTargets();
+        $package = $this->nextBatchSixPackage();
+        $qa = $this->nextBatchSixQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 6, 0);
+        $profileBefore = $this->profileLiveState($targets['zh-CN|INTP']);
+        $variantBefore = $this->variantLiveState($targets['zh-CN|INTP-A']);
+        $surfaceCountsBefore = $this->liveSurfaceCounts();
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--next-batch-6'] = true;
+        $options['--operator-approved'] = 'PERSONALITY-AGENT-CMS-DRAFT-NEXT-BATCH-6-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(6, $payload['row_count']);
+        $this->assertSame(6, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(6, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame('next_batch_6', $payload['subset']['mode']);
+        $this->assertTrue($payload['approval_queue']['ready_for_write']);
+        $this->assertSame(6, $payload['approval_queue']['approved_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(6, PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['zh-CN|INTP']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['zh-CN|INTP-A']));
+        $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        $createdUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($createdUrls);
+        $expectedUrls = self::NEXT_BATCH_6_URLS;
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $createdUrls);
+
+        foreach (PersonalityProfileVariantRevision::query()->get() as $revision) {
+            $this->assertProjectionSnapshot($revision->snapshot_json, 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-6-HANDOFF-01', 'PASS_READY_FOR_APPROVAL_REVIEW');
+        }
+    }
+
+    public function test_next_batch_six_write_with_partial_approval_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->nextBatchSixPackage();
+        $qa = $this->nextBatchSixQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 5, 0);
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--next-batch-6'] = true;
+        $options['--operator-approved'] = 'PERSONALITY-AGENT-CMS-DRAFT-NEXT-BATCH-6-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(5, $payload['approval_queue']['approved_count']);
+        $this->assertSame(1, $payload['approval_queue']['missing_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_next_batch_six_fails_closed_when_handoff_contains_arbitrary_url(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->nextBatchSixPackage();
+        $package['recommendations'][0] = $this->recommendation('/en/personality/entp-a');
+        $qa = $this->nextBatchSixQa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--next-batch-6' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('next_batch_6_url_set_mismatch', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertContains('next_batch_6_subset_required_urls_missing', array_map(
             static fn (array $error): string => (string) ($error['code'] ?? ''),
             $payload['errors'] ?? []
         ));
@@ -1188,12 +1419,15 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
     /**
      * @param  array<string,mixed>  $snapshot
      */
-    private function assertProjectionSnapshot(array $snapshot): void
-    {
+    private function assertProjectionSnapshot(
+        array $snapshot,
+        string $expectedArtifact = 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01',
+        string $expectedQaDecision = 'PASS_READY_FOR_CMS_DRAFT',
+    ): void {
         $this->assertArrayHasKey('mbti64_agent_projection_draft_v1', $snapshot);
         $payload = $snapshot['mbti64_agent_projection_draft_v1'];
-        $this->assertSame('MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01', $payload['source']['artifact']);
-        $this->assertSame('PASS_READY_FOR_CMS_DRAFT', $payload['source']['qa_final_decision']);
+        $this->assertSame($expectedArtifact, $payload['source']['artifact']);
+        $this->assertSame($expectedQaDecision, $payload['source']['qa_final_decision']);
         $this->assertNotSame('', $payload['first_class_draft_fields']['seo']['title']);
         $this->assertNotSame('', $payload['first_class_draft_fields']['seo']['description']);
         $this->assertNotSame('', $payload['first_class_draft_fields']['seo']['h1']);
@@ -1280,6 +1514,89 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
             'warnings' => ['GSC_EVIDENCE_PENDING'],
             'final_decision' => 'PASS_READY_FOR_CMS_DRAFT',
             'recommended_next_task' => 'MBTI64-CMS-PROJECTION-DRAFT-88-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function nextBatchSixPackage(): array
+    {
+        $recommendations = [];
+        foreach (self::NEXT_BATCH_6_URLS as $url) {
+            $path = (string) (parse_url($url, PHP_URL_PATH) ?: '');
+            $recommendations[] = $this->recommendation($path);
+        }
+
+        return [
+            'artifact' => 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-6-HANDOFF-01',
+            'generated_at' => '2026-06-25T00:00:00Z',
+            'status' => 'pass',
+            'summary' => [
+                'recommendation_count' => 6,
+                'query_backed_count' => 3,
+                'bilingual_paired_counterpart_count' => 3,
+                'variant_pages' => 6,
+                'comparison_pages' => 0,
+                'source_qa_pass_count' => 6,
+            ],
+            'recommendations' => $recommendations,
+            'blockers' => [],
+            'warnings' => [],
+            'recommended_next_task' => 'PERSONALITY-AGENT-APPROVAL-QUEUE-NEXT-BATCH-6-DRY-RUN-01',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $package
+     * @return array<string,mixed>
+     */
+    private function nextBatchSixQa(?array $package = null): array
+    {
+        $package ??= $this->nextBatchSixPackage();
+        $pageResults = [];
+        foreach ((array) ($package['recommendations'] ?? []) as $recommendation) {
+            if (! is_array($recommendation)) {
+                continue;
+            }
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            $path = (string) (parse_url($targetUrl, PHP_URL_PATH) ?: '');
+            $pageResults[] = [
+                'target_url' => $targetUrl,
+                'locale' => str_starts_with($path, '/zh/') ? 'zh-CN' : 'en',
+                'page_type' => 'variant',
+                'gates' => [
+                    'schema_validation' => 'pass',
+                    'trademark_claim_gate' => 'pass',
+                    'claim_risk_gate' => 'pass',
+                    'duplicate_template_gate' => 'pass',
+                    'private_route_gate' => 'pass',
+                    'result_page_leakage_gate' => 'pass',
+                    'seo_projection_gate' => 'pass',
+                    'bilingual_consistency_gate' => 'pass',
+                ],
+                'blockers' => [],
+                'warnings' => [],
+                'decision' => 'PASS_READY_FOR_APPROVAL_REVIEW',
+            ];
+        }
+
+        return [
+            'artifact' => 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-6-HANDOFF-QA-01',
+            'generated_at' => '2026-06-25T00:00:00Z',
+            'status' => 'pass',
+            'summary' => [
+                'checked_recommendation_count' => 6,
+                'pass_ready_for_approval_review_count' => 6,
+                'query_backed_count' => 3,
+                'bilingual_paired_counterpart_count' => 3,
+                'blocked_count' => 0,
+            ],
+            'page_results' => $pageResults,
+            'blockers' => [],
+            'warnings' => [],
+            'final_decision' => 'PASS_READY_FOR_APPROVAL_REVIEW',
+            'recommended_next_task' => 'PERSONALITY-AGENT-APPROVAL-QUEUE-NEXT-BATCH-6-WRITE-01',
         ];
     }
 
@@ -1515,7 +1832,7 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
                 'page_type' => str_contains($path, '-a-vs-') ? 'personality_profile_comparison' : 'personality_profile_variant',
                 'recommendation_id' => (string) ($recommendation['recommendation_id'] ?? ''),
                 'recommendation_sha256' => hash('sha256', $this->jsonString($recommendation)),
-                'qa_decision' => 'PASS_READY_FOR_CMS_DRAFT',
+                'qa_decision' => (string) ($qaResult['decision'] ?? 'PASS_READY_FOR_CMS_DRAFT'),
                 'approval_state' => 'approved',
                 'approved_at' => now(),
                 'rejected_at' => null,


### PR DESCRIPTION
## What changed
- Added a fail-closed `--next-batch-6` mode to `personality:mbti64-cms-projection-draft`.
- Accepted only the `PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-6-HANDOFF-*` package/QA artifacts in that mode.
- Locked the mode to the six approved MBTI64 URLs and required matching approved approval-queue rows before write.
- Added focused coverage for dry-run, strict write token, missing/partial approvals, approved write, and arbitrary URL rejection.

## Why
This lets the already-approved next-batch-6 handoff move into the CMS draft writer safely without reopening arbitrary subsets or bypassing the human approval queue.

## Validation
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Deferred
- No production deploy.
- No production CMS write.
- No live promotion, publish, index/search, sitemap/llms, queue enqueue/approve/submit, frontend, or external API action.