### PR TITLE
[codex] Fix MBTI Chinese PDF rendering

### DIFF
--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -7,6 +7,8 @@ namespace App\Services\Report\Pdf;
 use App\Models\Attempt;
 use App\Models\ReportSnapshot;
 use App\Models\Result;
+use Mpdf\Mpdf;
+use Mpdf\Output\Destination;
 
 final class ReportPdfDocumentService
 {
@@ -448,7 +450,7 @@ final class ReportPdfDocumentService
             ?? now()->format('Y-m-d');
 
         if ($isChinese) {
-            return $this->buildFormalPdfDocument(
+            return $this->buildMpdfHtmlDocument(
                 '费马测试 MBTI 完整报告',
                 [
                     '人格类型' => $typeCode,
@@ -459,7 +461,7 @@ final class ReportPdfDocumentService
                     [
                         'heading' => '核心画像',
                         'body' => [
-                            sprintf('你的人格类型是 %s。报告基于本次 MBTI 作答结果，帮助你理解能量来源、信息处理、决策方式、生活节奏和压力反应。', $typeCode),
+                            sprintf('你的人格类型是 %s. 这份报告基于本次 MBTI 作答结果，帮助你理解能量来源、信息处理、决策方式、生活节奏和压力反应。', $typeCode),
                         ],
                     ],
                     [
@@ -748,6 +750,87 @@ final class ReportPdfDocumentService
     }
 
     /**
+     * @param  array<string,string>  $summary
+     * @param  list<array{heading:string,body:list<string>}>  $sections
+     */
+    private function buildMpdfHtmlDocument(
+        string $title,
+        array $summary,
+        array $sections,
+        string $footer,
+        bool $isChinese
+    ): string {
+        $tempDir = storage_path('framework/cache/mpdf');
+        if (! is_dir($tempDir)) {
+            mkdir($tempDir, 0775, true);
+        }
+
+        $mpdf = new Mpdf([
+            'mode' => 'utf-8',
+            'format' => 'A4',
+            'autoScriptToLang' => true,
+            'autoLangToFont' => true,
+            'tempDir' => $tempDir,
+            'margin_left' => 18,
+            'margin_right' => 18,
+            'margin_top' => 18,
+            'margin_bottom' => 16,
+            'margin_footer' => 8,
+        ]);
+        $mpdf->SetTitle($title);
+        $mpdf->SetAuthor('FermatMind');
+        $mpdf->SetCreator('FermatMind Report PDF');
+        $mpdf->SetHTMLFooter(
+            '<table width="100%" style="border-top:1px solid #d9eadf;color:#64748b;font-size:9pt;padding-top:6px;">'
+            .'<tr><td width="50%" align="left">'.$this->escapeHtml($footer).'</td>'
+            .'<td width="50%" align="right">{PAGENO}</td></tr></table>'
+        );
+        $mpdf->WriteHTML($this->mbtiReportHtml($title, $summary, $sections, $isChinese));
+
+        return $mpdf->Output('', Destination::STRING_RETURN);
+    }
+
+    /**
+     * @param  array<string,string>  $summary
+     * @param  list<array{heading:string,body:list<string>}>  $sections
+     */
+    private function mbtiReportHtml(string $title, array $summary, array $sections, bool $isChinese): string
+    {
+        $fontStack = $isChinese
+            ? 'sans-serif'
+            : 'DejaVu Sans, Arial, sans-serif';
+        $html = '<html><head><meta charset="utf-8"><style>'
+            .'body{font-family:'.$fontStack.';color:#172033;font-size:12pt;line-height:1.55;}'
+            .'.cover{border-top:5px solid #1b7f5c;padding-top:18px;margin-bottom:22px;}'
+            .'h1{font-size:26pt;margin:0 0 14px 0;color:#0f172a;}'
+            .'h2{font-size:15pt;margin:20px 0 8px 0;color:#123d34;border-bottom:1px solid #d9eadf;padding-bottom:5px;}'
+            .'.summary{background:#edf8f2;border:1px solid #bfe9d0;border-radius:8px;padding:12px 14px;margin:12px 0 18px 0;}'
+            .'.summary-row{margin:4px 0;}'
+            .'.label{font-weight:bold;color:#315047;}'
+            .'p{margin:0 0 8px 0;}'
+            .'ul{margin:0 0 0 18px;padding:0;}'
+            .'li{margin:4px 0;}'
+            .'</style></head><body>';
+        $html .= '<div class="cover"><h1>'.$this->escapeHtml($title).'</h1></div>';
+        $html .= '<div class="summary">';
+        foreach ($summary as $label => $value) {
+            $html .= '<div class="summary-row"><span class="label">'.$this->escapeHtml($label).':</span> '.$this->escapeHtml($value).'</div>';
+        }
+        $html .= '</div>';
+
+        foreach ($sections as $section) {
+            $html .= '<h2>'.$this->escapeHtml((string) $section['heading']).'</h2>';
+            $html .= '<ul>';
+            foreach ($section['body'] as $paragraph) {
+                $html .= '<li>'.$this->escapeHtml($paragraph).'</li>';
+            }
+            $html .= '</ul>';
+        }
+
+        return $html.'</body></html>';
+    }
+
+    /**
      * @param  list<string>  $operations
      */
     private function appendPdfText(array &$operations, int $x, int $y, string $text, int $size, bool $useCjkFont): void
@@ -866,6 +949,11 @@ final class ReportPdfDocumentService
     private function textSlice(string $value, int $start, ?int $length = null): string
     {
         return mb_substr($value, $start, $length, 'UTF-8');
+    }
+
+    private function escapeHtml(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 
     private function sanitizePdfText(string $value): string

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -16,6 +16,7 @@
     "laravel/framework": "^12.0",
     "laravel/tinker": "^2.10.1",
     "league/flysystem-aws-s3-v3": "^3.0",
+    "mpdf/mpdf": "^8.3",
     "sentry/sentry-laravel": "^4.16",
     "yansongda/pay": "^3.7"
   },

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b7f0d20095f8996b1c0844d5ac0ac97",
+    "content-hash": "8250666f06e2939089a193db709ef10d",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -3598,6 +3598,180 @@
             "time": "2026-01-02T08:56:05+00:00"
         },
         {
+            "name": "mpdf/mpdf",
+            "version": "v8.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mpdf/mpdf.git",
+                "reference": "2a454ec334109911fdb323a284c19dbf3f049810"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mpdf/mpdf/zipball/2a454ec334109911fdb323a284c19dbf3f049810",
+                "reference": "2a454ec334109911fdb323a284c19dbf3f049810",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "ext-mbstring": "*",
+                "mpdf/psr-http-message-shim": "^1.0 || ^2.0",
+                "mpdf/psr-log-aware-trait": "^2.0 || ^3.0",
+                "myclabs/deep-copy": "^1.7",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": "^5.6 || ^7.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "setasign/fpdi": "^2.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.0",
+                "mpdf/qrcode": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.5.0",
+                "tracy/tracy": "~2.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Needed for generation of some types of barcodes",
+                "ext-imagick": "Needed if developing the Mpdf library",
+                "ext-xml": "Needed mainly for SVG manipulation",
+                "ext-zlib": "Needed for compression of embedded resources, such as fonts"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Mpdf\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Matěj Humpál",
+                    "role": "Developer, maintainer"
+                },
+                {
+                    "name": "Ian Back",
+                    "role": "Developer (retired)"
+                }
+            ],
+            "description": "PHP library generating PDF files from UTF-8 encoded HTML",
+            "homepage": "https://mpdf.github.io",
+            "keywords": [
+                "pdf",
+                "php",
+                "utf-8"
+            ],
+            "support": {
+                "docs": "https://mpdf.github.io",
+                "issues": "https://github.com/mpdf/mpdf/issues",
+                "source": "https://github.com/mpdf/mpdf"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/mpdf",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-03-11T10:58:44+00:00"
+        },
+        {
+            "name": "mpdf/psr-http-message-shim",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mpdf/psr-http-message-shim.git",
+                "reference": "f25a0153d645e234f9db42e5433b16d9b113920f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mpdf/psr-http-message-shim/zipball/f25a0153d645e234f9db42e5433b16d9b113920f",
+                "reference": "f25a0153d645e234f9db42e5433b16d9b113920f",
+                "shasum": ""
+            },
+            "require": {
+                "psr/http-message": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Mpdf\\PsrHttpMessageShim\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Dorison",
+                    "email": "mark@chromatichq.com"
+                },
+                {
+                    "name": "Kristofer Widholm",
+                    "email": "kristofer@chromatichq.com"
+                },
+                {
+                    "name": "Nigel Cunningham",
+                    "email": "nigel.cunningham@technocrat.com.au"
+                }
+            ],
+            "description": "Shim to allow support of different psr/message versions.",
+            "support": {
+                "issues": "https://github.com/mpdf/psr-http-message-shim/issues",
+                "source": "https://github.com/mpdf/psr-http-message-shim/tree/v2.0.1"
+            },
+            "time": "2023-10-02T14:34:03+00:00"
+        },
+        {
+            "name": "mpdf/psr-log-aware-trait",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mpdf/psr-log-aware-trait.git",
+                "reference": "a633da6065e946cc491e1c962850344bb0bf3e78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mpdf/psr-log-aware-trait/zipball/a633da6065e946cc491e1c962850344bb0bf3e78",
+                "reference": "a633da6065e946cc491e1c962850344bb0bf3e78",
+                "shasum": ""
+            },
+            "require": {
+                "psr/log": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Mpdf\\PsrLogAwareTrait\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Dorison",
+                    "email": "mark@chromatichq.com"
+                },
+                {
+                    "name": "Kristofer Widholm",
+                    "email": "kristofer@chromatichq.com"
+                }
+            ],
+            "description": "Trait to allow support of different psr/log versions.",
+            "support": {
+                "issues": "https://github.com/mpdf/psr-log-aware-trait/issues",
+                "source": "https://github.com/mpdf/psr-log-aware-trait/tree/v3.0.0"
+            },
+            "time": "2023-05-03T06:19:36+00:00"
+        },
+        {
             "name": "mtdowling/jmespath.php",
             "version": "2.9.1",
             "source": {
@@ -3662,6 +3836,66 @@
                 "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
             },
             "time": "2026-06-11T10:43:56+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -4241,6 +4475,56 @@
                 }
             ],
             "time": "2025-09-03T16:03:54+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -5310,6 +5594,78 @@
                 }
             ],
             "time": "2026-01-07T08:53:19+00:00"
+        },
+        {
+            "name": "setasign/fpdi",
+            "version": "v2.6.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDI.git",
+                "reference": "881945be29a4996ad3d008eb18ddc01fa3df890c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/881945be29a4996ad3d008eb18ddc01fa3df890c",
+                "reference": "881945be29a4996ad3d008eb18ddc01fa3df890c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zlib": "*",
+                "php": ">=7.2 <=8.5.99999"
+            },
+            "conflict": {
+                "setasign/tfpdf": "<1.31"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.52",
+                "setasign/fpdf": "^1.9.0",
+                "setasign/tfpdf": "~1.33",
+                "squizlabs/php_codesniffer": "^3.5",
+                "tecnickcom/tcpdf": "^6.8"
+            },
+            "suggest": {
+                "setasign/fpdf": "FPDI will extend this class but as it is also possible to use TCPDF or tFPDF as an alternative. There's no fixed dependency configured."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "setasign\\Fpdi\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Slabon",
+                    "email": "jan.slabon@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                },
+                {
+                    "name": "Maximilian Kresse",
+                    "email": "maximilian.kresse@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                }
+            ],
+            "description": "FPDI is a collection of PHP classes facilitating developers to read pages from existing PDF documents and use them as templates in FPDF. Because it is also possible to use FPDI with TCPDF, there are no fixed dependencies defined. Please see suggestions for packages which evaluates the dependencies automatically.",
+            "homepage": "https://www.setasign.com/fpdi",
+            "keywords": [
+                "fpdf",
+                "fpdi",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/Setasign/FPDI/issues",
+                "source": "https://github.com/Setasign/FPDI/tree/v2.6.8"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/setasign/fpdi",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-11T10:37:24+00:00"
         },
         {
             "name": "spatie/color",
@@ -9191,66 +9547,6 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.13.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.6.8",
-                "doctrine/common": "^2.13.3 || ^3.2.2",
-                "phpspec/prophecy": "^1.10",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ],
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nunomaduro/collision",

--- a/backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
@@ -224,8 +224,10 @@ final class MbtiReadPathParityContractTest extends TestCase
             $result
         );
 
-        $this->assertStringContainsString($this->utf16Hex('INTJ-A'), $pdf['binary']);
-        $this->assertStringContainsString($this->utf16Hex('费马测试 MBTI 完整报告'), $pdf['binary']);
+        $this->assertStringStartsWith('%PDF-1.4', $pdf['binary']);
+        $this->assertStringContainsString('MPDFAA+', $pdf['binary']);
+        $this->assertStringNotContainsString('STSong-Light', $pdf['binary']);
+        $this->assertStringNotContainsString('UniGB-UCS2-H', $pdf['binary']);
         $this->assertStringNotContainsString('Attempt ID:', $pdf['binary']);
         $this->assertStringNotContainsString('Quality Level:', $pdf['binary']);
         $this->assertStringNotContainsString('Scale:', $pdf['binary']);
@@ -509,10 +511,5 @@ final class MbtiReadPathParityContractTest extends TestCase
                 'updated_at' => now(),
             ],
         ]);
-    }
-
-    private function utf16Hex(string $value): string
-    {
-        return strtoupper(bin2hex(mb_convert_encoding($value, 'UTF-16BE', 'UTF-8')));
     }
 }


### PR DESCRIPTION
## What changed

- Switched the Chinese MBTI PDF path from the hand-written CID font PDF surface to mPDF HTML rendering.
- Added `mpdf/mpdf` as a backend dependency for reliable Unicode/CJK font embedding.
- Kept the existing lightweight English MBTI PDF path unchanged.
- Added assertions that the Chinese MBTI PDF no longer uses `STSong-Light` / `UniGB-UCS2-H`, which rendered as a blank page in viewers without Adobe-GB1 mappings.

## Why

The previous MBTI PDF PR removed the internal debug fields and generated a formal Chinese report, but it referenced a non-embedded CJK CID font. Chrome/Poppler-style PDF viewers can lack the Adobe-GB1 mapping and then render the document as a blank page. The downloaded production sample confirmed this failure mode: the PDF was valid and contained the new content, but `pdftoppm` reported missing Adobe-GB1 mappings and produced a white page.

## Validation

- `php artisan test --filter=MbtiReadPathParityContractTest --no-ansi`
- `vendor/bin/pint app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php`
- `composer validate --strict --no-check-publish`
- `git diff --check`
- Rendered the generated Chinese MBTI PDF with Poppler `pdftoppm`; the PNG shows readable Chinese report content, not a blank page.

## Intentionally deferred

- No frontend changes.
- No production deploy.
- No server mutation.
- No paid-report content expansion beyond the current MBTI PDF surface.
