### PR TITLE
MBTI-PDF-PRODUCT-01: add MBTI PDF payload authority

### DIFF
--- a/backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php
+++ b/backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Report\Pdf\Mbti;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Legacy\Mbti\Content\LegacyMbtiPackRepository;
+use App\Services\Legacy\Mbti\Report\V2\LegacyMbtiReportPayloadBuilderV2Facade;
+
+final class MbtiPdfPayloadBuilder
+{
+    public const PAYLOAD_KEY = 'mbti_pdf_payload';
+
+    public const SCHEMA_VERSION = 'fap.mbti.report_pdf.payload.v0_1';
+
+    /**
+     * These fields are either internal, raw scoring material, or unsafe to carry into
+     * a user-facing PDF projection.
+     */
+    private const FORBIDDEN_KEYS = [
+        'attempt_id',
+        'attemptId',
+        'raw_answer',
+        'raw_answers',
+        'answers',
+        'answers_json',
+        'raw_score',
+        'raw_scores',
+        'scores_json',
+        'raw_mean',
+        'z',
+        't',
+        'debug',
+        'debug_info',
+        'qa_notes',
+        'editor_notes',
+        'internal_metadata',
+        'internal_path',
+        'storage_path',
+        'source_trace',
+        'source_reference',
+        'quality',
+        'quality_level',
+    ];
+
+    public function __construct(
+        private readonly LegacyMbtiPackRepository $packRepository,
+        private readonly LegacyMbtiReportPayloadBuilderV2Facade $legacyComposer,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function build(Attempt $attempt, ?Result $result = null): array
+    {
+        $locale = trim((string) ($attempt->locale ?? 'zh-CN'));
+        $region = trim((string) ($attempt->region ?? 'CN_MAINLAND'));
+        $dirVersion = trim((string) ($attempt->dir_version ?? $result?->dir_version ?? ''));
+        $typeCode = $this->resolveTypeCode($result);
+        $scoresPct = $this->resolveScoresPct($result);
+        $axisStates = $this->resolveAxisStates($result);
+        $contentDir = $this->packRepository->resolveContentDir(
+            is_string($attempt->pack_id ?? null) ? (string) $attempt->pack_id : null,
+            $dirVersion !== '' ? $dirVersion : null,
+            $region !== '' ? $region : null,
+            $locale !== '' ? $locale : null,
+        );
+        $typeProfile = $this->resolveTypeProfile($contentDir, $typeCode);
+        $legacyPayload = $this->legacyComposer->build([
+            'contentDir' => $contentDir,
+            'scores_pct' => $scoresPct,
+            'axis_states' => $axisStates,
+            'type_profile' => $typeProfile,
+            'opts' => [
+                'type_code' => $typeCode,
+                'recommended_reads_max' => 4,
+            ],
+        ]);
+
+        return [
+            self::PAYLOAD_KEY => [
+                'schema_version' => self::SCHEMA_VERSION,
+                'surface_key' => 'pdf',
+                'source_payload_key' => 'legacy_mbti_report_payload_v2',
+                'scale_code' => 'MBTI',
+                'locale' => $locale !== '' ? $locale : 'zh-CN',
+                'region' => $region !== '' ? $region : 'CN_MAINLAND',
+                'dir_version' => $dirVersion,
+                'type' => $this->publicTypeProfile($typeCode, $typeProfile, $legacyPayload),
+                'axis_scores' => $this->publicAxisScores($scoresPct, $axisStates),
+                'highlights' => $this->publicHighlights((array) ($legacyPayload['highlights'] ?? [])),
+                'sections' => $this->publicSections((array) ($legacyPayload['cards'] ?? [])),
+                'recommended_reads' => $this->publicRecommendedReads((array) ($legacyPayload['recommended_reads'] ?? [])),
+                'adapter_policy' => [
+                    'source' => 'backend_mbti_content_package_and_result_projection',
+                    'frontend_authored_body_allowed' => false,
+                    'metadata_filter_required' => true,
+                    'internal_fields_allowed' => false,
+                    'production_enablement_allowed' => false,
+                ],
+            ],
+        ];
+    }
+
+    private function resolveTypeCode(?Result $result): string
+    {
+        $payload = is_array($result?->result_json ?? null) ? $result->result_json : [];
+        $typeCode = strtoupper(trim((string) (
+            $result?->type_code
+            ?? data_get($payload, 'type_code')
+            ?? data_get($payload, 'result.type_code')
+            ?? ''
+        )));
+
+        return $typeCode !== '' ? $typeCode : 'UNKNOWN';
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    private function resolveScoresPct(?Result $result): array
+    {
+        $payload = is_array($result?->result_json ?? null) ? $result->result_json : [];
+        $scores = is_array($result?->scores_pct ?? null) ? $result->scores_pct : [];
+        if ($scores === []) {
+            $candidate = data_get($payload, 'axis_scores_json.scores_pct');
+            $scores = is_array($candidate) ? $candidate : [];
+        }
+
+        $out = [];
+        foreach (['EI', 'SN', 'TF', 'JP', 'AT'] as $axis) {
+            $value = $scores[$axis] ?? null;
+            if (is_numeric($value)) {
+                $out[$axis] = max(0, min(100, (int) round((float) $value)));
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function resolveAxisStates(?Result $result): array
+    {
+        $payload = is_array($result?->result_json ?? null) ? $result->result_json : [];
+        $states = is_array($result?->axis_states ?? null) ? $result->axis_states : [];
+        if ($states === []) {
+            $candidate = data_get($payload, 'axis_scores_json.axis_states');
+            $states = is_array($candidate) ? $candidate : [];
+        }
+
+        $out = [];
+        foreach (['EI', 'SN', 'TF', 'JP', 'AT'] as $axis) {
+            $state = trim((string) ($states[$axis] ?? ''));
+            if ($state !== '') {
+                $out[$axis] = $state;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolveTypeProfile(string $contentDir, string $typeCode): array
+    {
+        if ($typeCode === 'UNKNOWN') {
+            return [];
+        }
+
+        $profiles = $this->packRepository->loadJsonFromPack($contentDir, 'type_profiles.json');
+        $items = is_array($profiles['items'] ?? null) ? $profiles['items'] : [];
+        $profile = $items[$typeCode] ?? null;
+
+        return is_array($profile) ? $profile : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $typeProfile
+     * @param  array<string,mixed>  $legacyPayload
+     * @return array<string,mixed>
+     */
+    private function publicTypeProfile(string $typeCode, array $typeProfile, array $legacyPayload): array
+    {
+        $identity = is_array($legacyPayload['identity_layer'] ?? null) ? $legacyPayload['identity_layer'] : [];
+        $profile = [
+            'type_code' => $typeCode,
+            'type_name' => $this->stringOrNull($typeProfile['type_name'] ?? null),
+            'tagline' => $this->stringOrNull($typeProfile['tagline'] ?? null),
+            'rarity' => $this->stringOrNull($typeProfile['rarity'] ?? null),
+            'keywords' => $this->stringList($typeProfile['keywords'] ?? []),
+            'short_summary' => $this->stringOrNull($typeProfile['short_summary'] ?? null),
+            'identity_layer' => $this->filterPublicContent($identity),
+        ];
+
+        return $this->dropNulls($profile);
+    }
+
+    /**
+     * @param  array<string,int>  $scoresPct
+     * @param  array<string,string>  $axisStates
+     * @return list<array<string,mixed>>
+     */
+    private function publicAxisScores(array $scoresPct, array $axisStates): array
+    {
+        $out = [];
+        foreach (['EI', 'SN', 'TF', 'JP', 'AT'] as $axis) {
+            if (! array_key_exists($axis, $scoresPct)) {
+                continue;
+            }
+
+            $out[] = $this->dropNulls([
+                'axis' => $axis,
+                'percent' => $scoresPct[$axis],
+                'state' => $axisStates[$axis] ?? null,
+            ]);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function publicHighlights(array $highlights): array
+    {
+        $out = [];
+        foreach ($highlights as $highlight) {
+            if (! is_array($highlight)) {
+                continue;
+            }
+
+            $out[] = $this->filterPublicContent([
+                'id' => $highlight['id'] ?? null,
+                'kind' => $highlight['kind'] ?? null,
+                'title' => $highlight['title'] ?? null,
+                'text' => $highlight['text'] ?? $highlight['desc'] ?? null,
+                'tips' => $highlight['tips'] ?? [],
+                'tags' => $highlight['tags'] ?? [],
+            ]);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string,mixed>  $cardsBySection
+     * @return list<array<string,mixed>>
+     */
+    private function publicSections(array $cardsBySection): array
+    {
+        $sections = [];
+        foreach (['traits', 'career', 'growth', 'relationships'] as $sectionKey) {
+            $cards = is_array($cardsBySection[$sectionKey] ?? null) ? $cardsBySection[$sectionKey] : [];
+            $publicCards = [];
+            foreach ($cards as $card) {
+                if (! is_array($card)) {
+                    continue;
+                }
+
+                $publicCards[] = $this->filterPublicContent([
+                    'id' => $card['id'] ?? null,
+                    'title' => $card['title'] ?? null,
+                    'description' => $card['desc'] ?? $card['description'] ?? null,
+                    'bullets' => $card['bullets'] ?? [],
+                    'tips' => $card['tips'] ?? [],
+                    'tags' => $card['tags'] ?? [],
+                ]);
+            }
+
+            if ($publicCards !== []) {
+                $sections[] = [
+                    'section_key' => $sectionKey,
+                    'cards' => $publicCards,
+                ];
+            }
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function publicRecommendedReads(array $reads): array
+    {
+        $out = [];
+        foreach ($reads as $read) {
+            if (! is_array($read)) {
+                continue;
+            }
+
+            $out[] = $this->filterPublicContent([
+                'title' => $read['title'] ?? null,
+                'description' => $read['desc'] ?? $read['description'] ?? null,
+                'category' => $read['category'] ?? null,
+            ]);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $content
+     * @return array<int|string,mixed>
+     */
+    private function filterPublicContent(array $content): array
+    {
+        $filtered = [];
+        foreach ($content as $key => $value) {
+            if (in_array((string) $key, self::FORBIDDEN_KEYS, true)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $value = $this->filterPublicContent($value);
+            }
+
+            if ($value === null || $value === '' || $value === []) {
+                continue;
+            }
+
+            $filtered[$key] = $value;
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(static fn (mixed $item): string => trim((string) $item), $value),
+            static fn (string $item): bool => $item !== '',
+        ));
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $value
+     * @return array<string,mixed>
+     */
+    private function dropNulls(array $value): array
+    {
+        return array_filter($value, static fn (mixed $item): bool => $item !== null && $item !== [] && $item !== '');
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -501,6 +501,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_pdf_payload_authority_files(): void
+    {
+        $changed = [
+            'backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_eq_cross_assessment_context_guard_changes(): void
     {
         $changed = [
@@ -4695,6 +4704,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiPdfPayloadAuthorityFile($file)) {
+                continue;
+            }
+
             if ($this->isPublicContentReleaseGuardCommandFile($file)) {
                 continue;
             }
@@ -6122,6 +6135,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php',
             'backend/app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php',
         ], true);
+    }
+
+    private function isMbtiPdfPayloadAuthorityFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php';
     }
 
     private function isPublicContentReleaseGuardCommandFile(string $file): bool

--- a/backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Report\Pdf\Mbti;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Report\Pdf\Mbti\MbtiPdfPayloadBuilder;
+use Tests\TestCase;
+
+final class MbtiPdfPayloadBuilderTest extends TestCase
+{
+    public function test_builds_reader_safe_payload_from_mbti_content_authority(): void
+    {
+        $attempt = new Attempt([
+            'id' => 'attempt-should-not-appear',
+            'scale_code' => 'MBTI',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'pack_id' => 'default',
+            'dir_version' => 'MBTI-CN-v0.3',
+        ]);
+        $result = new Result([
+            'type_code' => 'ISFP-T',
+            'scores_pct' => [
+                'EI' => 82,
+                'SN' => 65,
+                'TF' => 41,
+                'JP' => 37,
+                'AT' => 29,
+            ],
+            'axis_states' => [
+                'EI' => 'strong',
+                'SN' => 'clear',
+                'TF' => 'moderate',
+                'JP' => 'clear',
+                'AT' => 'strong',
+            ],
+            'result_json' => [
+                'type_code' => 'ISFP-T',
+                'raw_score' => 999,
+                'debug' => ['unsafe' => true],
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 82,
+                        'SN' => 65,
+                        'TF' => 41,
+                        'JP' => 37,
+                        'AT' => 29,
+                    ],
+                ],
+            ],
+        ]);
+
+        /** @var MbtiPdfPayloadBuilder $builder */
+        $builder = app(MbtiPdfPayloadBuilder::class);
+        $envelope = $builder->build($attempt, $result);
+        $payload = $envelope[MbtiPdfPayloadBuilder::PAYLOAD_KEY] ?? null;
+
+        $this->assertIsArray($payload);
+        $this->assertSame(MbtiPdfPayloadBuilder::SCHEMA_VERSION, $payload['schema_version'] ?? null);
+        $this->assertSame('pdf', $payload['surface_key'] ?? null);
+        $this->assertSame('backend_mbti_content_package_and_result_projection', data_get($payload, 'adapter_policy.source'));
+        $this->assertSame(false, data_get($payload, 'adapter_policy.frontend_authored_body_allowed'));
+        $this->assertSame('ISFP-T', data_get($payload, 'type.type_code'));
+        $this->assertNotEmpty(data_get($payload, 'type.short_summary'));
+        $this->assertCount(5, $payload['axis_scores'] ?? []);
+        $this->assertNotEmpty($payload['highlights'] ?? []);
+        $this->assertNotEmpty($payload['sections'] ?? []);
+    }
+
+    public function test_payload_filters_internal_and_raw_fields_recursively(): void
+    {
+        $attempt = new Attempt([
+            'id' => 'attempt-should-not-appear',
+            'scale_code' => 'MBTI',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'pack_id' => 'default',
+            'dir_version' => 'MBTI-CN-v0.3',
+        ]);
+        $result = new Result([
+            'type_code' => 'INTJ-A',
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'result_json' => [
+                'attempt_id' => 'attempt-should-not-appear',
+                'raw_scores' => ['unsafe' => true],
+                'quality' => ['level' => 'internal'],
+                'source_trace' => ['/private/internal/path'],
+            ],
+        ]);
+
+        /** @var MbtiPdfPayloadBuilder $builder */
+        $builder = app(MbtiPdfPayloadBuilder::class);
+        $encoded = json_encode($builder->build($attempt, $result), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $this->assertIsString($encoded);
+        foreach ([
+            'attempt-should-not-appear',
+            'raw_score',
+            'raw_scores',
+            'source_trace',
+            'quality_level',
+            '/private/internal/path',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded);
+        }
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62837,7 +62837,7 @@
     "repo": "fap-api",
     "branch": "codex/mbti-pdf-product-01-payload-authority",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "mbti_pdf_product",
     "title": "MBTI-PDF-PRODUCT-01: add MBTI PDF payload authority",
     "depends_on": [],
@@ -62865,12 +62865,12 @@
         "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-01 scope: backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php, backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php, the required BigFive runtime freeze harness allowance for this backend-only MBTI PDF payload authority file, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, staging deploy, production deploy, PDF layout, or expanded PDF prose change."
       },
       "github": {
-        "status": "pending",
-        "evidence": "GitHub verify-bigfive initially failed because BigFiveResultPageV2CoreBodyPreviewTest runtime path guard treated backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php as Big Five runtime drift. A narrow classifier allowance and focused test were added in current PR scope; retry pending after push."
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2448 head 8c833239a1c14fc79aebaf5a09be8e004f9aa537 after the scoped runtime freeze fix: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all succeeded. mergeStateStatus was CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "6eeb4bb97f0b8b928fff9dceda75c31eabd7afdb",
+    "commit_sha": "8c833239a1c14fc79aebaf5a09be8e004f9aa537",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2448",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -62900,6 +62900,11 @@
         "at": "2026-06-26T20:37:28+08:00",
         "status": "github_checks_failed_fix_prepared",
         "note": "Required verify-bigfive failed because the Big Five runtime freeze guard did not yet allow the backend-only MBTI PDF payload authority file. Added a narrow classifier allowance and focused test, updated PR manifest validation, and re-ran focused BigFive freeze, MBTI PDF payload, MBTI read-path parity, public report PDF parity, scoped Pint, YAML/JSON parse, and git diff checks successfully."
+      },
+      {
+        "at": "2026-06-26T20:45:24+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2448 head 8c833239a1c14fc79aebaf5a09be8e004f9aa537 and mergeStateStatus was CLEAN. Ready for squash merge; no staging deploy wait, production deploy, CMS write, search, sitemap, llms, canonical, noindex, JSON-LD, queue, or scheduler change included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62852,20 +62852,21 @@
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi",
-          "cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_pdf_payload_authority_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
           "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
           "git diff --check"
         ],
-        "evidence": "PASS: syntax check for MbtiPdfPayloadBuilder.php and MbtiPdfPayloadBuilderTest.php; focused payload test passed (2 tests, 17 assertions); MbtiReadPathParityContractTest passed after composer install restored locked mpdf/mpdf local dependency (3 tests, 174 assertions); AttemptPublicReportPdfParityTest passed (2 tests, 14 assertions); scoped Pint --test passed; docs/codex state JSON parse passed; pr-train YAML parse passed; git diff --check passed."
+        "evidence": "PASS: syntax check for MbtiPdfPayloadBuilder.php and MbtiPdfPayloadBuilderTest.php; focused payload test passed (2 tests, 17 assertions); MbtiReadPathParityContractTest passed after composer install restored locked mpdf/mpdf local dependency (3 tests, 174 assertions); AttemptPublicReportPdfParityTest passed (2 tests, 14 assertions); focused BigFive runtime freeze retry passed for MBTI PDF payload authority and runtime path diff guard (2 tests, 4 assertions); scoped Pint --test passed; docs/codex state JSON parse passed; pr-train YAML parse passed; git diff --check passed."
       },
       "scope_validation": {
         "status": "pass",
-        "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-01 scope: backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php, backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, staging deploy, production deploy, PDF layout, or expanded PDF prose change."
+        "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-01 scope: backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php, backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php, the required BigFive runtime freeze harness allowance for this backend-only MBTI PDF payload authority file, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, staging deploy, production deploy, PDF layout, or expanded PDF prose change."
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "GitHub verify-bigfive initially failed because BigFiveResultPageV2CoreBodyPreviewTest runtime path guard treated backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php as Big Five runtime drift. A narrow classifier allowance and focused test were added in current PR scope; retry pending after push."
       }
     },
     "failure_reason": null,
@@ -62894,6 +62895,11 @@
         "at": "2026-06-26T20:17:06+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2448 at https://github.com/fermatmind/fap-api/pull/2448. Waiting for required GitHub checks; no staging deploy wait, server verification, manual deploy, or production deploy included."
+      },
+      {
+        "at": "2026-06-26T20:37:28+08:00",
+        "status": "github_checks_failed_fix_prepared",
+        "note": "Required verify-bigfive failed because the Big Five runtime freeze guard did not yet allow the backend-only MBTI PDF payload authority file. Added a narrow classifier allowance and focused test, updated PR manifest validation, and re-ran focused BigFive freeze, MBTI PDF payload, MBTI read-path parity, public report PDF parity, scoped Pint, YAML/JSON parse, and git diff checks successfully."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62837,7 +62837,7 @@
     "repo": "fap-api",
     "branch": "codex/mbti-pdf-product-01-payload-authority",
     "base": "main",
-    "status": "committed",
+    "status": "github_checks_pending",
     "train_scope": "mbti_pdf_product",
     "title": "MBTI-PDF-PRODUCT-01: add MBTI PDF payload authority",
     "depends_on": [],
@@ -62869,8 +62869,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "550506b535e1c2c4f4a02694e8f391ba0d4969d3",
-    "pr_url": null,
+    "commit_sha": "6eeb4bb97f0b8b928fff9dceda75c31eabd7afdb",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2448",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62889,6 +62889,11 @@
         "at": "2026-06-26T20:17:06+08:00",
         "status": "committed",
         "note": "Prepared scoped commit 550506b535e1c2c4f4a02694e8f391ba0d4969d3 for MBTI PDF payload authority. No frontend, CMS, SEO runtime, search, queue, scheduler, staging deploy, or production deploy included."
+      },
+      {
+        "at": "2026-06-26T20:17:06+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2448 at https://github.com/fermatmind/fap-api/pull/2448. Waiting for required GitHub checks; no staging deploy wait, server verification, manual deploy, or production deploy included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62832,4 +62832,64 @@
       }
     ]
   }
+  ,
+  "MBTI-PDF-PRODUCT-01": {
+    "repo": "fap-api",
+    "branch": "codex/mbti-pdf-product-01-payload-authority",
+    "base": "main",
+    "status": "committed",
+    "train_scope": "mbti_pdf_product",
+    "title": "MBTI-PDF-PRODUCT-01: add MBTI PDF payload authority",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided /goal MBTI-PDF-PRODUCT-PR-TRAIN-01 with MBTI-PDF-PRODUCT-01 scope and requested continuous backend-only PR train execution."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: syntax check for MbtiPdfPayloadBuilder.php and MbtiPdfPayloadBuilderTest.php; focused payload test passed (2 tests, 17 assertions); MbtiReadPathParityContractTest passed after composer install restored locked mpdf/mpdf local dependency (3 tests, 174 assertions); AttemptPublicReportPdfParityTest passed (2 tests, 14 assertions); scoped Pint --test passed; docs/codex state JSON parse passed; pr-train YAML parse passed; git diff --check passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-01 scope: backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php, backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, staging deploy, production deploy, PDF layout, or expanded PDF prose change."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": "550506b535e1c2c4f4a02694e8f391ba0d4969d3",
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-26T20:17:06+08:00",
+        "status": "in_progress",
+        "note": "Started MBTI PDF payload authority PR from latest origin/main in a clean fap-api worktree. Scope is backend-only payload adapter/builder, focused tests, and authorized docs/codex train metadata. No frontend, CMS write, SEO runtime, search, queue, scheduler, staging deploy, or production deploy."
+      },
+      {
+        "at": "2026-06-26T20:17:06+08:00",
+        "status": "local_validated",
+        "note": "Added MBTI PDF payload builder that projects reader-safe payload from backend MBTI content package and legacy composer authority. Local focused tests, existing MBTI PDF/read-path contracts, scoped Pint, JSON/YAML parse, git diff --check, and scope validation passed."
+      },
+      {
+        "at": "2026-06-26T20:17:06+08:00",
+        "status": "committed",
+        "note": "Prepared scoped commit 550506b535e1c2c4f4a02694e8f391ba0d4969d3 for MBTI PDF payload authority. No frontend, CMS, SEO runtime, search, queue, scheduler, staging deploy, or production deploy included."
+      }
+    ]
+  }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -54,6 +54,44 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: MBTI-PDF-PRODUCT-01
+    repo: fap-api
+    branch: codex/mbti-pdf-product-01-payload-authority
+    title: "MBTI-PDF-PRODUCT-01: add MBTI PDF payload authority"
+    train_scope: mbti_pdf_product
+    status: user_authorized
+    scope:
+      - Add an MBTI PDF dedicated payload adapter/builder.
+      - Extract user-readable PDF payload from existing MBTI result, content package, and legacy composer authority.
+      - Filter attempt ids, raw answers, raw scores, debug fields, quality/internal state, internal paths, and source traces that are not meant for users.
+      - Follow the safety pattern of the Big Five PDF payload adapter without changing PDF visual layout or expanding prose depth.
+    allowed_paths:
+      - backend/app/Services/Report/Pdf/Mbti/**
+      - backend/tests/Unit/Services/Report/Pdf/Mbti/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Change public API route paths, frontend download behavior, CMS, sitemap, llms, canonical, noindex, JSON-LD, search submission, scheduler, queue, secrets, staging deploy, or production deploy.
+      - Write CMS, run production import, run production smoke, or expand MBTI PDF prose/pagination beyond the payload authority contract.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-ASSET-02
     repo: fap-api
     depends_on: [PR-EQ-ASSET-01]

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -68,6 +68,7 @@ prs:
     allowed_paths:
       - backend/app/Services/Report/Pdf/Mbti/**
       - backend/tests/Unit/Services/Report/Pdf/Mbti/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
       - generated/pr-train-sidecar-issues/**
@@ -79,7 +80,8 @@ prs:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi
-      - cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_pdf_payload_authority_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
       - git diff --check


### PR DESCRIPTION
## What changed
- Added backend `MbtiPdfPayloadBuilder` for MBTI PDF payload authority.
- Projects reader-safe PDF payload from existing MBTI content package, result data, and legacy composer authority.
- Filters attempt ids, raw answers/scores, debug/internal fields, quality/internal state, internal paths, and source traces from the PDF payload.
- Added focused PHPUnit coverage and authorized PR train manifest/state entries for this scope.

## Why
This creates the safe backend payload contract needed before expanding MBTI PDF content depth or pagination. It follows the Big Five PDF adapter safety pattern while avoiding frontend/CMS/public-route changes.

## Validation
- `php -l backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php`
- `php -l backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

Note: local worktree initially lacked the locked `mpdf/mpdf` vendor package; `composer install --no-interaction --prefer-dist` restored the lockfile dependency before existing PDF contract tests were rerun.

## Intentionally deferred
- MBTI-PDF-PRODUCT-02 content depth.
- MBTI-PDF-PRODUCT-03 pagination and brand styling.
- MBTI-PDF-PRODUCT-04 surface version/cache invalidation QA.
- No fap-web changes.
- No CMS write, production import, search submission, scheduler/queue change, staging deploy, or production deploy.

## Repository rule impact
Backend authority only. This PR introduces a PDF payload authority projection; it does not move content authority to frontend or CMS fallback logic.