### PR TITLE
PERSONALITY-URL-TRUTH-FRESHNESS-AFTER-PROMOTION-01

### DIFF
--- a/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
+++ b/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
@@ -188,13 +188,14 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
                 ->with(['variants' => static function ($query): void {
                     $query
                         ->withoutGlobalScopes()
+                        ->with(['seoMeta', 'sections'])
                         ->where('is_published', true)
                         ->where(static function ($builder): void {
                             $builder->whereNull('published_at')
                                 ->orWhere('published_at', '<=', now());
                         })
                         ->orderBy('variant_code');
-                }])
+                }, 'seoMeta', 'sections'])
                 ->where('org_id', 0)
                 ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
                 ->whereIn('type_code', PersonalityProfile::BASE_TYPE_CODES)
@@ -230,6 +231,7 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
                 if ($path === null) {
                     continue;
                 }
+                $freshness = $this->personalityVariantFreshness($profile, $variant, $path);
 
                 $records[] = $this->personalityRecord(
                     canonicalPath: $path,
@@ -237,43 +239,49 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
                     pageEntityType: 'personality_profile_variant',
                     entityIdOrSlug: (string) $variant->id,
                     entitySource: 'personality_profile_variants',
-                    lastmodSource: 'personality_profile_variants.updated_at',
-                    sourceUpdatedAt: $variant->updated_at instanceof Carbon ? $variant->updated_at : null,
-                    lastmodAt: $variant->updated_at instanceof Carbon ? $variant->updated_at : null,
+                    lastmodSource: (string) $freshness['lastmod_source'],
+                    sourceUpdatedAt: $freshness['source_updated_at'],
+                    lastmodAt: $freshness['lastmod_at'],
                     extraMetadata: [
                         'profile_id_hash' => hash('sha256', (string) $profile->id),
                         'variant_id_hash' => hash('sha256', (string) $variant->id),
                         'runtime_type_code_hash' => hash('sha256', (string) $variant->runtime_type_code),
                         'canonical_type_code_hash' => hash('sha256', (string) $variant->canonical_type_code),
+                        'content_hash' => (string) $freshness['content_hash'],
+                        'content_hash_source' => (string) $freshness['content_hash_source'],
                     ],
                     extraAttributes: [
                         'profile_id_hash' => hash('sha256', (string) $profile->id),
                         'variant_id_hash' => hash('sha256', (string) $variant->id),
                         'runtime_type_code_hash' => hash('sha256', (string) $variant->runtime_type_code),
+                        'content_hash' => (string) $freshness['content_hash'],
                     ],
                 );
             }
 
             $comparisonPath = $this->personalityComparisonCanonicalPath($profile, $variants);
             if ($comparisonPath !== null) {
-                $updatedAt = $profile->updated_at instanceof Carbon ? $profile->updated_at : null;
+                $freshness = $this->personalityComparisonFreshness($profile, $comparisonPath);
                 $records[] = $this->personalityRecord(
                     canonicalPath: $comparisonPath,
                     locale: (string) $profile->locale,
                     pageEntityType: 'personality_profile_comparison',
                     entityIdOrSlug: (string) $profile->id,
                     entitySource: 'personality_profiles',
-                    lastmodSource: 'personality_profiles.updated_at',
-                    sourceUpdatedAt: $updatedAt,
-                    lastmodAt: $updatedAt,
+                    lastmodSource: (string) $freshness['lastmod_source'],
+                    sourceUpdatedAt: $freshness['source_updated_at'],
+                    lastmodAt: $freshness['lastmod_at'],
                     extraMetadata: [
                         'profile_id_hash' => hash('sha256', (string) $profile->id),
                         'canonical_type_code_hash' => hash('sha256', (string) $profile->canonical_type_code),
                         'comparison_kind' => 'a_vs_t',
+                        'content_hash' => (string) $freshness['content_hash'],
+                        'content_hash_source' => (string) $freshness['content_hash_source'],
                     ],
                     extraAttributes: [
                         'profile_id_hash' => hash('sha256', (string) $profile->id),
                         'canonical_type_code_hash' => hash('sha256', (string) $profile->canonical_type_code),
+                        'content_hash' => (string) $freshness['content_hash'],
                     ],
                 );
             }
@@ -719,6 +727,164 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
             && (string) $profile->status === 'published'
             && (bool) $profile->is_public
             && (bool) $profile->is_indexable;
+    }
+
+    /**
+     * @return array{lastmod_at:?Carbon,source_updated_at:?Carbon,lastmod_source:string,content_hash:string,content_hash_source:string}
+     */
+    private function personalityVariantFreshness(PersonalityProfile $profile, PersonalityProfileVariant $variant, string $canonicalPath): array
+    {
+        $seoMeta = $variant->seoMeta;
+        $sections = $variant->sections;
+
+        $lastmodAt = $this->latestCarbon([
+            $variant->updated_at instanceof Carbon ? $variant->updated_at : null,
+            $seoMeta?->updated_at instanceof Carbon ? $seoMeta->updated_at : null,
+            ...$sections
+                ->filter(static fn ($section): bool => (bool) ($section->is_enabled ?? false))
+                ->map(static fn ($section): ?Carbon => $section->updated_at instanceof Carbon ? $section->updated_at : null)
+                ->all(),
+        ]);
+
+        return [
+            'lastmod_at' => $lastmodAt,
+            'source_updated_at' => $lastmodAt,
+            'lastmod_source' => $seoMeta !== null || $sections->isNotEmpty()
+                ? 'personality_profile_variant_live_content.updated_at'
+                : 'personality_profile_variants.updated_at',
+            'content_hash' => $this->stableContentHash([
+                'canonical_path' => $canonicalPath,
+                'profile' => [
+                    'locale' => (string) $profile->locale,
+                    'canonical_type_code' => (string) $profile->canonical_type_code,
+                    'title' => (string) $profile->title,
+                    'subtitle' => (string) ($profile->subtitle ?? ''),
+                    'excerpt' => (string) ($profile->excerpt ?? ''),
+                ],
+                'variant' => [
+                    'runtime_type_code' => (string) $variant->runtime_type_code,
+                    'type_name' => (string) $variant->type_name,
+                    'nickname' => (string) ($variant->nickname ?? ''),
+                    'hero_summary_md' => (string) ($variant->hero_summary_md ?? ''),
+                    'hero_summary_html' => (string) ($variant->hero_summary_html ?? ''),
+                ],
+                'seo' => $seoMeta === null ? null : [
+                    'seo_title' => (string) ($seoMeta->seo_title ?? ''),
+                    'seo_description' => (string) ($seoMeta->seo_description ?? ''),
+                    'canonical_url' => (string) ($seoMeta->canonical_url ?? ''),
+                    'robots' => (string) ($seoMeta->robots ?? ''),
+                ],
+                'sections' => $sections
+                    ->filter(static fn ($section): bool => (bool) ($section->is_enabled ?? false))
+                    ->map(static fn ($section): array => [
+                        'section_key' => (string) ($section->section_key ?? ''),
+                        'render_variant' => (string) ($section->render_variant ?? ''),
+                        'body_md' => (string) ($section->body_md ?? ''),
+                        'body_html' => (string) ($section->body_html ?? ''),
+                        'payload_json' => $section->payload_json ?? null,
+                        'sort_order' => (int) ($section->sort_order ?? 0),
+                    ])
+                    ->values()
+                    ->all(),
+            ]),
+            'content_hash_source' => 'personality_profile_variant_live_content_v1',
+        ];
+    }
+
+    /**
+     * @return array{lastmod_at:?Carbon,source_updated_at:?Carbon,lastmod_source:string,content_hash:string,content_hash_source:string}
+     */
+    private function personalityComparisonFreshness(PersonalityProfile $profile, string $canonicalPath): array
+    {
+        $seoMeta = $profile->seoMeta;
+        $comparisonSection = $profile->sections
+            ->first(static fn ($section): bool => (string) ($section->section_key ?? '') === 'mbti64_comparison_a_vs_t'
+                && (bool) ($section->is_enabled ?? false));
+
+        $lastmodAt = $this->latestCarbon([
+            $profile->updated_at instanceof Carbon ? $profile->updated_at : null,
+            $seoMeta?->updated_at instanceof Carbon ? $seoMeta->updated_at : null,
+            $comparisonSection?->updated_at instanceof Carbon ? $comparisonSection->updated_at : null,
+        ]);
+
+        return [
+            'lastmod_at' => $lastmodAt,
+            'source_updated_at' => $lastmodAt,
+            'lastmod_source' => $comparisonSection !== null
+                ? 'personality_profile_sections.mbti64_comparison_a_vs_t.updated_at'
+                : 'personality_profiles.updated_at',
+            'content_hash' => $this->stableContentHash([
+                'canonical_path' => $canonicalPath,
+                'profile' => [
+                    'locale' => (string) $profile->locale,
+                    'canonical_type_code' => (string) $profile->canonical_type_code,
+                    'title' => (string) $profile->title,
+                    'subtitle' => (string) ($profile->subtitle ?? ''),
+                    'excerpt' => (string) ($profile->excerpt ?? ''),
+                ],
+                'seo' => $seoMeta === null ? null : [
+                    'seo_title' => (string) ($seoMeta->seo_title ?? ''),
+                    'seo_description' => (string) ($seoMeta->seo_description ?? ''),
+                    'canonical_url' => (string) ($seoMeta->canonical_url ?? ''),
+                    'robots' => (string) ($seoMeta->robots ?? ''),
+                ],
+                'comparison_section' => $comparisonSection === null ? null : [
+                    'title' => (string) ($comparisonSection->title ?? ''),
+                    'render_variant' => (string) ($comparisonSection->render_variant ?? ''),
+                    'body_md' => (string) ($comparisonSection->body_md ?? ''),
+                    'body_html' => (string) ($comparisonSection->body_html ?? ''),
+                    'payload_json' => $comparisonSection->payload_json ?? null,
+                    'sort_order' => (int) ($comparisonSection->sort_order ?? 0),
+                ],
+            ]),
+            'content_hash_source' => 'personality_profile_comparison_live_content_v1',
+        ];
+    }
+
+    /**
+     * @param  list<?Carbon>  $values
+     */
+    private function latestCarbon(array $values): ?Carbon
+    {
+        $latest = null;
+        foreach ($values as $value) {
+            if (! $value instanceof Carbon) {
+                continue;
+            }
+
+            if (! $latest instanceof Carbon || $value->greaterThan($latest)) {
+                $latest = $value;
+            }
+        }
+
+        return $latest;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function stableContentHash(array $payload): string
+    {
+        $normalized = $this->sortForStableHash($payload);
+
+        return hash('sha256', json_encode($normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+    }
+
+    private function sortForStableHash(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if (! array_is_list($value)) {
+            ksort($value);
+        }
+
+        foreach ($value as $key => $item) {
+            $value[$key] = $this->sortForStableHash($item);
+        }
+
+        return $value;
     }
 
     private function personalityVariantCanonicalPath(

--- a/backend/tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Tests\Feature\SeoIntel;
 
 use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
 use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
 use App\Services\SeoIntel\Sources\BackendAuthorityUrlTruthSource;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
@@ -65,6 +69,8 @@ final class SeoIntelMbti64PersonalityUrlTruthInventoryTest extends TestCase
         $this->assertFalse($sampleVariant->isPrivateFlow);
         $this->assertSame('published', $sampleVariant->metadata['publication_state'] ?? null);
         $this->assertTrue((bool) ($sampleVariant->metadata['claim_safe'] ?? false));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($sampleVariant->metadata['content_hash'] ?? ''));
+        $this->assertSame('personality_profile_variant_live_content_v1', $sampleVariant->metadata['content_hash_source'] ?? null);
         $this->assertFalse((bool) ($sampleVariant->metadata['frontend_fallback'] ?? true));
         $this->assertFalse((bool) ($sampleVariant->metadata['static_sitemap_fallback'] ?? true));
         $this->assertFalse((bool) ($sampleVariant->metadata['static_llms_fallback'] ?? true));
@@ -74,6 +80,8 @@ final class SeoIntelMbti64PersonalityUrlTruthInventoryTest extends TestCase
         $this->assertSame('backend_cms', $sampleComparison->sourceAuthority);
         $this->assertSame('indexable', $sampleComparison->indexabilityState);
         $this->assertSame('a_vs_t', $sampleComparison->metadata['comparison_kind'] ?? null);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($sampleComparison->metadata['content_hash'] ?? ''));
+        $this->assertSame('personality_profile_comparison_live_content_v1', $sampleComparison->metadata['content_hash_source'] ?? null);
 
         $metadata = $source->metadata();
         $this->assertTrue((bool) ($metadata['personality_profiles_attempted'] ?? false));
@@ -123,6 +131,99 @@ final class SeoIntelMbti64PersonalityUrlTruthInventoryTest extends TestCase
         $this->assertNotContains('https://fermatmind.com/en/personality/entj-a-vs-entj-t', $canonicalUrls);
     }
 
+    #[Test]
+    public function backend_authority_source_uses_variant_live_content_for_url_truth_freshness(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+
+        $now = now()->startOfSecond();
+        $profile = $this->createProfile('ENFJ', 'en');
+        PersonalityProfile::withoutTimestamps(fn () => $profile->forceFill(['updated_at' => $now->copy()->subDays(12)])->save());
+        $variant = $this->createVariant($profile, 'A');
+        PersonalityProfileVariant::withoutTimestamps(fn () => $variant->forceFill(['updated_at' => $now->copy()->subDays(11)])->save());
+        $this->createVariant($profile, 'T', ['is_published' => true]);
+
+        $seoMeta = PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'seo_title' => 'ENFJ-A old title',
+            'seo_description' => 'Old description',
+            'canonical_url' => 'https://fermatmind.com/en/personality/enfj-a',
+            'robots' => 'index,follow',
+        ]);
+        PersonalityProfileVariantSeoMeta::withoutTimestamps(fn () => $seoMeta->forceFill(['updated_at' => $now->copy()->subDays(3)])->save());
+        $section = PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => 'quick_answer',
+            'render_variant' => 'callout',
+            'body_md' => 'Old quick answer.',
+            'payload_json' => ['summary' => 'old'],
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileVariantSection::withoutTimestamps(fn () => $section->forceFill(['updated_at' => $now->copy()->subDays(2)])->save());
+
+        $before = $this->recordFor('https://fermatmind.com/en/personality/enfj-a');
+        $this->assertSame('personality_profile_variant_live_content.updated_at', $before->lastmodSource);
+        $this->assertSame($now->copy()->subDays(2)->toDateTimeString(), $before->lastmodAt?->toDateTimeString());
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($before->metadata['content_hash'] ?? ''));
+
+        PersonalityProfileVariantSection::withoutTimestamps(fn () => $section->forceFill([
+            'body_md' => 'Promoted quick answer.',
+            'payload_json' => ['summary' => 'promoted'],
+            'updated_at' => $now,
+        ])->save());
+
+        $after = $this->recordFor('https://fermatmind.com/en/personality/enfj-a');
+        $this->assertNotSame($before->metadata['content_hash'], $after->metadata['content_hash']);
+        $this->assertSame($now->toDateTimeString(), $after->lastmodAt?->toDateTimeString());
+    }
+
+    #[Test]
+    public function backend_authority_source_uses_comparison_live_overlay_for_url_truth_freshness(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+
+        $now = now()->startOfSecond();
+        $profile = $this->createProfile('INTP', 'zh-CN');
+        PersonalityProfile::withoutTimestamps(fn () => $profile->forceFill(['updated_at' => $now->copy()->subDays(8)])->save());
+        $this->createVariant($profile, 'A', ['is_published' => true]);
+        $this->createVariant($profile, 'T', ['is_published' => true]);
+        $seoMeta = PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => 'INTP A/T old comparison',
+            'seo_description' => 'Old comparison description',
+            'canonical_url' => 'https://fermatmind.com/zh/personality/intp-a-vs-intp-t',
+            'robots' => 'index,follow',
+        ]);
+        PersonalityProfileSeoMeta::withoutTimestamps(fn () => $seoMeta->forceFill(['updated_at' => $now->copy()->subDays(4)])->save());
+        $section = PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'mbti64_comparison_a_vs_t',
+            'title' => 'Old comparison',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Old comparison quick answer.',
+            'payload_json' => ['content' => ['quick_answer' => 'old']],
+            'sort_order' => 920,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileSection::withoutTimestamps(fn () => $section->forceFill(['updated_at' => $now->copy()->subDay()])->save());
+
+        $before = $this->recordFor('https://fermatmind.com/zh/personality/intp-a-vs-intp-t');
+        $this->assertSame('personality_profile_sections.mbti64_comparison_a_vs_t.updated_at', $before->lastmodSource);
+        $this->assertSame($now->copy()->subDay()->toDateTimeString(), $before->lastmodAt?->toDateTimeString());
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($before->metadata['content_hash'] ?? ''));
+
+        PersonalityProfileSection::withoutTimestamps(fn () => $section->forceFill([
+            'body_md' => 'Promoted comparison quick answer.',
+            'payload_json' => ['content' => ['quick_answer' => 'promoted']],
+            'updated_at' => $now,
+        ])->save());
+
+        $after = $this->recordFor('https://fermatmind.com/zh/personality/intp-a-vs-intp-t');
+        $this->assertNotSame($before->metadata['content_hash'], $after->metadata['content_hash']);
+        $this->assertSame($now->toDateTimeString(), $after->lastmodAt?->toDateTimeString());
+    }
+
     private function seedPublishedMbti64Profiles(): void
     {
         foreach (PersonalityProfile::SUPPORTED_LOCALES as $locale) {
@@ -136,6 +237,16 @@ final class SeoIntelMbti64PersonalityUrlTruthInventoryTest extends TestCase
                 $this->createVariant($profile, 'T', ['is_published' => true]);
             }
         }
+    }
+
+    private function recordFor(string $canonicalUrl): object
+    {
+        $record = collect((new BackendAuthorityUrlTruthSource)->candidates())
+            ->firstWhere('canonicalUrl', $canonicalUrl);
+
+        $this->assertNotNull($record);
+
+        return $record;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Updates MBTI64 personality URL Truth candidates to derive `lastmod_at` and `metadata_json.content_hash` from live CMS personality content surfaces after promotion.
- Variant pages now hash live variant SEO meta + enabled variant sections + public identity fields.
- Comparison pages now hash the live `personality_profile_sections.mbti64_comparison_a_vs_t` overlay + profile SEO/public identity fields.

## Why
After personality agent promotion, Search Queue planning still saw old submitted IndexNow items as active duplicates because URL Truth rows had stale `lastmod_at` and empty source content hashes. This PR gives URL Truth a stable source version for promoted personality pages without writing production URL Truth or touching queue/search behavior.

## Validation
- `php artisan test tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php --display-warnings` ✅
- `php -l backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php` ✅
- `php -l backend/tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php` ✅
- `git diff --check` ✅

## Full CI Note
- `bash backend/scripts/ci_verify_mbti.sh` was run and failed outside this PR scope in existing Big Five pack tests:
  - `Tests\Feature\Content\PacksPublishBig5Test::packs publish creates release and target pack dir`
  - `Tests\Feature\Content\PacksRollbackBig5Test::packs rollback restores previous release with to release id`
- Both failures assert missing generated `compiled` target directories in Big Five pack publish/rollback tests. This PR changes only:
  - `backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php`
  - `backend/tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php`
- Draft state is intentional: this PR should not be merged until required CI is green or the unrelated Big Five failure is resolved.

## Deferred
- No production deploy.
- No URL Truth import/write.
- No Search Queue enqueue/approve/submit.
- No sitemap/llms mutation.
- Follow-up PRs remain separate:
  - `PERSONALITY-SEARCH-QUEUE-REQUEUE-POLICY-01`
  - `PERSONALITY-AGENT-POST-PROMOTION-SEARCH-GATE-01`
