### PR TITLE
PERSONALITY-SEARCH-QUEUE-REQUEUE-POLICY-01

### DIFF
--- a/backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
+++ b/backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
@@ -148,6 +148,8 @@ final class SeoIntelSearchChannelQueueCommand extends Command
             'eligible_count' => $plan['eligible_count'],
             'blocked_count' => $plan['blocked_count'],
             'planned_queue_count' => $plan['planned_queue_count'],
+            'stale_submitted_queue_item_count' => $plan['stale_submitted_queue_item_count'] ?? 0,
+            'stale_submitted_queue_items' => $plan['stale_submitted_queue_items'] ?? [],
             'channel_breakdown' => $plan['channel_breakdown'],
             'page_type_breakdown' => $plan['page_type_breakdown'],
             'reason_code_breakdown' => $plan['reason_code_breakdown'],

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php
@@ -24,16 +24,24 @@ final class SearchChannelQueueIdempotency
         return hash('sha256', implode('|', $parts));
     }
 
-    /**
-     * @return array{id:int, approval_state:string, execution_state:string}|null
-     */
     public function existingQueueItem(string $canonicalUrl, string $locale, string $channel, mixed $sourceLastmod = null, ?string $sourceContentHash = null): ?array
+    {
+        return $this->duplicateStatus($canonicalUrl, $locale, $channel, $sourceLastmod, $sourceContentHash)['blocking_item'];
+    }
+
+    /**
+     * @return array{
+     *     blocking_item:array{id:int, approval_state:string, execution_state:string}|null,
+     *     stale_submitted_items:list<array{id:int, approval_state:string, execution_state:string, stale_reason:string}>
+     * }
+     */
+    public function duplicateStatus(string $canonicalUrl, string $locale, string $channel, mixed $sourceLastmod = null, ?string $sourceContentHash = null): array
     {
         $connectionName = (string) config('seo_intel.connection', 'seo_intel');
 
         try {
             if (! Schema::connection($connectionName)->hasTable('seo_search_channel_queue_items')) {
-                return null;
+                return $this->emptyStatus();
             }
 
             $rows = DB::connection($connectionName)
@@ -46,43 +54,60 @@ final class SearchChannelQueueIdempotency
 
             $sourceTimestamp = $this->timestamp($sourceLastmod);
             $normalizedSourceContentHash = $this->normalizedContentHash($sourceContentHash);
+            $staleSubmittedItems = [];
 
             foreach ($rows as $row) {
-                if ($this->submittedItemIsOlderThanSource($row, $sourceTimestamp, $normalizedSourceContentHash)) {
+                $staleReason = $this->submittedItemStaleReason($row, $sourceTimestamp, $normalizedSourceContentHash);
+                if ($staleReason !== null) {
+                    $staleSubmittedItems[] = [
+                        'id' => (int) $row->id,
+                        'approval_state' => (string) $row->approval_state,
+                        'execution_state' => (string) $row->execution_state,
+                        'stale_reason' => $staleReason,
+                    ];
+
                     continue;
                 }
 
                 return [
-                    'id' => (int) $row->id,
-                    'approval_state' => (string) $row->approval_state,
-                    'execution_state' => (string) $row->execution_state,
+                    'blocking_item' => [
+                        'id' => (int) $row->id,
+                        'approval_state' => (string) $row->approval_state,
+                        'execution_state' => (string) $row->execution_state,
+                    ],
+                    'stale_submitted_items' => $staleSubmittedItems,
                 ];
             }
 
-            return null;
+            return [
+                'blocking_item' => null,
+                'stale_submitted_items' => $staleSubmittedItems,
+            ];
         } catch (\Throwable) {
-            return null;
+            return $this->emptyStatus();
         }
     }
 
-    private function submittedItemIsOlderThanSource(object $row, ?int $sourceTimestamp, ?string $sourceContentHash): bool
+    private function submittedItemStaleReason(object $row, ?int $sourceTimestamp, ?string $sourceContentHash): ?string
     {
         if ((string) $row->execution_state !== 'submitted') {
-            return false;
+            return null;
         }
 
         $itemContentHash = $this->normalizedContentHash($row->content_hash ?? null);
-        if ($sourceContentHash !== null && $itemContentHash !== null && ! hash_equals($itemContentHash, $sourceContentHash)) {
-            return true;
+        if ($sourceContentHash !== null && ($itemContentHash === null || ! hash_equals($itemContentHash, $sourceContentHash))) {
+            return 'existing_submitted_item_stale_by_content_hash';
         }
 
         if ($sourceTimestamp === null) {
-            return false;
+            return null;
         }
 
         $itemTimestamp = $this->timestamp($row->lastmod ?? null) ?? $this->timestamp($row->updated_at ?? null);
 
-        return $itemTimestamp === null || $sourceTimestamp > $itemTimestamp;
+        return $itemTimestamp === null || $sourceTimestamp > $itemTimestamp
+            ? 'existing_submitted_item_stale_by_lastmod'
+            : null;
     }
 
     private function timestamp(mixed $value): ?int
@@ -101,5 +126,19 @@ final class SearchChannelQueueIdempotency
         $hash = strtolower(trim((string) $value));
 
         return $hash === '' ? null : $hash;
+    }
+
+    /**
+     * @return array{
+     *     blocking_item:null,
+     *     stale_submitted_items:list<array{id:int, approval_state:string, execution_state:string, stale_reason:string}>
+     * }
+     */
+    private function emptyStatus(): array
+    {
+        return [
+            'blocking_item' => null,
+            'stale_submitted_items' => [],
+        ];
     }
 }

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php
@@ -61,6 +61,7 @@ final class SearchChannelQueuePlanner
         $selectedChannels = $this->channels->channels($channel);
         $matchedCandidates = [];
         $duplicateDetected = false;
+        $staleSubmittedQueueItems = [];
 
         if ($selectedChannels === [] && $channel !== null && $channel !== '') {
             $reasonCodeBreakdown['channel_not_allowed'] = 1;
@@ -91,13 +92,29 @@ final class SearchChannelQueuePlanner
             $eligibleUrlCount++;
 
             foreach ($selectedChannels as $selectedChannel) {
-                $duplicate = $this->idempotency->existingQueueItem(
+                $duplicateStatus = $this->idempotency->duplicateStatus(
                     canonicalUrl: (string) ($row['canonical_url'] ?? ''),
                     locale: (string) ($row['locale'] ?? ''),
                     channel: $selectedChannel,
                     sourceLastmod: $row['lastmod_at'] ?? null,
                     sourceContentHash: $this->contentHash($row),
                 );
+                $duplicate = $duplicateStatus['blocking_item'];
+
+                foreach ($duplicateStatus['stale_submitted_items'] as $staleItem) {
+                    $staleReason = (string) $staleItem['stale_reason'];
+                    $staleSubmittedQueueItems[] = [
+                        'canonical_url_hash' => hash('sha256', (string) ($row['canonical_url'] ?? '')),
+                        'locale' => (string) ($row['locale'] ?? ''),
+                        'page_entity_type' => $pageEntityType,
+                        'channel' => $selectedChannel,
+                        'stale_reason' => $staleReason,
+                        'stale_queue_item_id' => $staleItem['id'],
+                        'stale_approval_state' => $staleItem['approval_state'],
+                        'stale_execution_state' => $staleItem['execution_state'],
+                    ];
+                    $reasonCodeBreakdown[$staleReason] = ($reasonCodeBreakdown[$staleReason] ?? 0) + 1;
+                }
 
                 if ($duplicate !== null) {
                     $duplicateDetected = true;
@@ -134,6 +151,8 @@ final class SearchChannelQueuePlanner
             'planned_queue_count' => count($planned),
             'planned_items' => $planned,
             'blocked_items' => $blocked,
+            'stale_submitted_queue_item_count' => count($staleSubmittedQueueItems),
+            'stale_submitted_queue_items' => $staleSubmittedQueueItems,
             'channel_breakdown' => $channelBreakdown,
             'page_type_breakdown' => $pageTypeBreakdown,
             'reason_code_breakdown' => $reasonCodeBreakdown,

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
@@ -563,6 +563,9 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
         $this->assertSame(1, $dryRun['planned_queue_count'] ?? null);
         $this->assertSame(0, $dryRun['blocked_count'] ?? null);
         $this->assertFalse((bool) ($dryRun['duplicate_detected'] ?? true));
+        $this->assertSame(1, $dryRun['stale_submitted_queue_item_count'] ?? null);
+        $this->assertSame(1, data_get($dryRun, 'reason_code_breakdown.existing_submitted_item_stale_by_lastmod'));
+        $this->assertSame('existing_submitted_item_stale_by_lastmod', data_get($dryRun, 'stale_submitted_queue_items.0.stale_reason'));
 
         $write = $this->runQueueCommand([
             '--enqueue' => true,
@@ -587,6 +590,62 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
         $this->assertSame('pending', $newItem->approval_state);
         $this->assertSame('dry_run_ready', $newItem->execution_state);
         $this->assertSame($newLastmod->toDateTimeString(), $newItem->lastmod);
+    }
+
+    #[Test]
+    public function submitted_queue_item_with_changed_content_hash_allows_personality_requeue(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/en/personality/enfj-a';
+        $lastmod = now()->subHour();
+        $oldHash = hash('sha256', 'old-live-personality-content');
+        $newHash = hash('sha256', 'new-live-personality-content');
+
+        $this->seedSeoUrl([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'en',
+            'page_entity_type' => 'personality_profile_variant',
+            'entity_id_or_slug' => '301',
+            'cluster' => 'personality',
+            'source_authority' => 'backend_cms',
+            'lastmod_at' => $lastmod,
+            'lastmod_source' => 'personality_profile_variants.live_content_updated_at',
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'personality_profile_variants',
+                'content_hash' => $newHash,
+            ],
+        ]);
+        $this->seedQueueItem($canonicalUrl, [
+            'locale' => 'en',
+            'page_entity_type' => 'personality_profile_variant',
+            'entity_id' => '301',
+            'source_table' => 'personality_profile_variants',
+            'approval_state' => 'approved',
+            'execution_state' => 'submitted',
+            'lastmod' => $lastmod,
+            'content_hash' => $oldHash,
+            'updated_at' => $lastmod,
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--canonical-url' => $canonicalUrl,
+            '--channel' => 'indexnow',
+            '--page-type' => 'personality_profile_variant',
+            '--limit' => 1,
+        ]);
+
+        $this->assertSame('success', $output['status'] ?? null);
+        $this->assertSame(1, $output['planned_queue_count'] ?? null);
+        $this->assertSame(0, $output['blocked_count'] ?? null);
+        $this->assertFalse((bool) ($output['duplicate_detected'] ?? true));
+        $this->assertSame(1, $output['stale_submitted_queue_item_count'] ?? null);
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.existing_submitted_item_stale_by_content_hash'));
+        $this->assertSame('existing_submitted_item_stale_by_content_hash', data_get($output, 'stale_submitted_queue_items.0.stale_reason'));
     }
 
     #[Test]
@@ -634,6 +693,54 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
             $this->assertTrue((bool) ($output['duplicate_detected'] ?? false));
             $this->assertSame(1, data_get($output, 'reason_code_breakdown.existing_active_queue_item'));
         }
+    }
+
+    #[Test]
+    public function submitted_queue_item_without_source_hash_or_lastmod_still_dedupes(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/requeue-no-source-freshness';
+
+        $this->seedSeoUrl([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id_or_slug' => 'no-source-freshness',
+            'cluster' => 'article',
+            'source_authority' => 'backend_cms',
+            'lastmod_at' => null,
+            'lastmod_source' => null,
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'articles',
+            ],
+        ]);
+        $this->seedQueueItem($canonicalUrl, [
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id' => 'no-source-freshness',
+            'approval_state' => 'approved',
+            'execution_state' => 'submitted',
+            'lastmod' => now()->subDays(9),
+            'updated_at' => now()->subDays(9),
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--canonical-url' => $canonicalUrl,
+            '--channel' => 'indexnow',
+            '--page-type' => 'article',
+            '--limit' => 1,
+        ], expectSuccess: false);
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertSame(0, $output['planned_queue_count'] ?? null);
+        $this->assertTrue((bool) ($output['duplicate_detected'] ?? false));
+        $this->assertSame(0, $output['stale_submitted_queue_item_count'] ?? null);
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.existing_active_queue_item'));
     }
 
     #[Test]
@@ -785,8 +892,8 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
             'cluster' => $overrides['cluster'] ?? 'research',
             'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
             'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
-            'lastmod_at' => $overrides['lastmod_at'] ?? now()->subHour(),
-            'lastmod_source' => $overrides['lastmod_source'] ?? 'research_reports.updated_at',
+            'lastmod_at' => array_key_exists('lastmod_at', $overrides) ? $overrides['lastmod_at'] : now()->subHour(),
+            'lastmod_source' => array_key_exists('lastmod_source', $overrides) ? $overrides['lastmod_source'] : 'research_reports.updated_at',
             'is_private_flow' => (bool) ($overrides['is_private_flow'] ?? false),
             'first_seen_at' => now()->subDay(),
             'last_seen_at' => now(),


### PR DESCRIPTION
## Summary
- expose Search Queue duplicate status so submitted items stale by content hash or lastmod can be replanned
- keep active non-submitted queue items blocking duplicate enqueue
- surface stale submitted queue item details in dry-run JSON output
- add focused runtime coverage for stale-by-lastmod, stale-by-content-hash, active duplicate blocking, and fail-closed missing freshness

## Validation
- php -l backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php
- php -l backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php
- php -l backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
- php artisan test tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php --display-warnings
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh (fails on pre-existing Big Five legacy pack publish/rollback compiled-dir assertions)
- verified the Big Five failure reproduces on clean origin/main at 73bb8116bad1ad21f0c651072cd2b5bb548e1c00 with: php artisan test tests/Feature/Content/PacksPublishBig5Test.php tests/Feature/Content/PacksRollbackBig5Test.php --display-warnings

## Deferred
- no enqueue/write gate changes
- no production deploy
- no URL Truth import/write
- no search submit or external API calls
- Big Five legacy pack publish/rollback test failure remains an external follow-up, not part of this Search Queue policy scope