### PR TITLE
MBTI-PDF-PRODUCT-02: expand MBTI PDF content depth

### DIFF
--- a/backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php
+++ b/backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php
@@ -92,6 +92,15 @@ final class MbtiPdfPayloadBuilder
                 'axis_scores' => $this->publicAxisScores($scoresPct, $axisStates),
                 'highlights' => $this->publicHighlights((array) ($legacyPayload['highlights'] ?? [])),
                 'sections' => $this->publicSections((array) ($legacyPayload['cards'] ?? [])),
+                'document' => $this->publicDocument(
+                    $locale !== '' ? $locale : 'zh-CN',
+                    $typeCode,
+                    $typeProfile,
+                    $scoresPct,
+                    $axisStates,
+                    (array) ($legacyPayload['highlights'] ?? []),
+                    (array) ($legacyPayload['cards'] ?? [])
+                ),
                 'recommended_reads' => $this->publicRecommendedReads((array) ($legacyPayload['recommended_reads'] ?? [])),
                 'adapter_policy' => [
                     'source' => 'backend_mbti_content_package_and_result_projection',
@@ -281,6 +290,245 @@ final class MbtiPdfPayloadBuilder
         }
 
         return $sections;
+    }
+
+    /**
+     * @param  array<string,mixed>  $typeProfile
+     * @param  array<string,int>  $scoresPct
+     * @param  array<string,string>  $axisStates
+     * @param  array<int|string,mixed>  $highlights
+     * @param  array<string,mixed>  $cardsBySection
+     * @return array<string,mixed>
+     */
+    private function publicDocument(
+        string $locale,
+        string $typeCode,
+        array $typeProfile,
+        array $scoresPct,
+        array $axisStates,
+        array $highlights,
+        array $cardsBySection
+    ): array {
+        $isChinese = str_starts_with(strtolower($locale), 'zh');
+        $typeName = $this->stringOrNull($typeProfile['type_name'] ?? null);
+        $tagline = $this->stringOrNull($typeProfile['tagline'] ?? null);
+        $summary = $this->stringOrNull($typeProfile['short_summary'] ?? null);
+        $keywords = $this->stringList($typeProfile['keywords'] ?? []);
+        $displayName = trim(implode(' · ', array_filter([$typeCode !== 'UNKNOWN' ? $typeCode : null, $typeName, $tagline])));
+
+        return [
+            'title' => $isChinese ? 'MBTI 完整人格报告' : 'MBTI Full Personality Report',
+            'subtitle' => $isChinese
+                ? '用于自我理解、职业探索、成长复盘与关系沟通的结构化报告。'
+                : 'A structured report for self-understanding, career reflection, growth planning, and communication.',
+            'language' => $isChinese ? 'zh-CN' : 'en',
+            'chapters' => [
+                $this->documentChapter(
+                    'type_portrait',
+                    $isChinese ? '类型画像' : 'Type portrait',
+                    $isChinese
+                        ? array_values(array_filter([
+                            $displayName !== '' ? "当前结果显示为 {$displayName}。" : '当前结果已经形成可阅读的人格画像。',
+                            $summary,
+                            '这一章用来建立对能量来源、信息处理、决策习惯和行动节奏的整体理解，而不是给你贴上固定标签。',
+                        ]))
+                        : array_values(array_filter([
+                            $displayName !== '' ? "Your current result is {$displayName}." : 'Your result is ready as a reader-facing personality portrait.',
+                            $summary,
+                            'Use this chapter as a working map of energy, information processing, decision style, and operating rhythm, not as a fixed label.',
+                        ])),
+                    $keywords !== [] ? array_slice($keywords, 0, 6) : [],
+                    ['type_profile', 'identity_layer']
+                ),
+                $this->documentChapter(
+                    'core_traits',
+                    $isChinese ? '核心特质' : 'Core traits',
+                    $this->chapterLinesFromHighlights($highlights, $isChinese),
+                    [],
+                    ['highlights', 'traits']
+                ),
+                $this->documentChapter(
+                    'dimension_explanation',
+                    $isChinese ? '维度解释' : 'Dimension explanation',
+                    $this->dimensionChapterLines($scoresPct, $axisStates, $isChinese),
+                    [],
+                    ['axis_scores']
+                ),
+                $this->documentChapter(
+                    'career_direction',
+                    $isChinese ? '职业方向' : 'Career direction',
+                    $this->chapterLinesFromCards($cardsBySection, 'career', $isChinese, [
+                        '先比较任务类型、协作节奏、决策环境和反馈周期，再判断一个方向是否适合长期投入。',
+                        '把 MBTI 作为职业探索的辅助语言，而不是录用、薪资或成功率预测工具。',
+                    ], [
+                        'Compare the problem type, collaboration rhythm, decision environment, and feedback cycle before judging long-term role fit.',
+                        'Treat MBTI as a supporting language for career reflection, not as a hiring, salary, or success predictor.',
+                    ]),
+                    [],
+                    ['career']
+                ),
+                $this->documentChapter(
+                    'growth_plan',
+                    $isChinese ? '成长建议' : 'Growth plan',
+                    $this->chapterLinesFromCards($cardsBySection, 'growth', $isChinese, [
+                        '把抽象目标拆成可以观察的下一步，并定期用事实、反馈和身体状态复盘。',
+                        '压力上升时，先澄清真实限制，再决定是调整计划、求助还是重新安排沟通。',
+                    ], [
+                        'Turn broad goals into observable next steps, then review them against evidence, feedback, and your own capacity.',
+                        'When pressure rises, clarify the real constraints before changing the plan, asking for help, or resetting communication.',
+                    ]),
+                    [],
+                    ['growth']
+                ),
+                $this->documentChapter(
+                    'relationships_communication',
+                    $isChinese ? '关系与沟通' : 'Relationships and communication',
+                    $this->chapterLinesFromCards($cardsBySection, 'relationships', $isChinese, [
+                        '重要沟通中先说明你看重的事实、感受和边界，再邀请对方补充他们看到的信息。',
+                        '协作时提前写清期望、时间线和验收标准，可以减少误读和重复消耗。',
+                    ], [
+                        'In important conversations, name the facts, feelings, and boundaries you are working from, then invite the other person to add what they see.',
+                        'In collaboration, written expectations, timelines, and acceptance criteria reduce avoidable misunderstanding.',
+                    ]),
+                    [],
+                    ['relationships']
+                ),
+                $this->documentChapter(
+                    'use_boundaries',
+                    $isChinese ? '使用边界' : 'How to use this report',
+                    $isChinese
+                        ? [
+                            '本报告适合用于自我观察、复盘和讨论，不用于医疗诊断、录用筛选、升学录取或人生结果保证。',
+                            '当结果与你的真实体验不一致时，应优先回到具体情境、近期压力和作答状态，而不是强行套用类型描述。',
+                        ]
+                        : [
+                            'This report is designed for reflection and discussion. It is not a medical diagnosis, hiring screen, admission predictor, or guarantee of life outcomes.',
+                            'If a section does not match your lived experience, return to the concrete situation, recent stressors, and the way you answered instead of forcing the type description to fit.',
+                        ],
+                    [],
+                    ['safety_policy']
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $body
+     * @param  list<string>  $bullets
+     * @param  list<string>  $sourceKeys
+     * @return array<string,mixed>
+     */
+    private function documentChapter(string $key, string $title, array $body, array $bullets, array $sourceKeys): array
+    {
+        return $this->dropNulls([
+            'chapter_key' => $key,
+            'title' => $title,
+            'body' => array_values(array_slice(array_filter(
+                array_map(static fn (mixed $line): string => trim((string) $line), $body),
+                static fn (string $line): bool => $line !== ''
+            ), 0, 6)),
+            'bullets' => array_values(array_slice(array_filter(
+                array_map(static fn (mixed $line): string => trim((string) $line), $bullets),
+                static fn (string $line): bool => $line !== ''
+            ), 0, 8)),
+            'source_section_keys' => $sourceKeys,
+        ]);
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $highlights
+     * @return list<string>
+     */
+    private function chapterLinesFromHighlights(array $highlights, bool $isChinese): array
+    {
+        $lines = [];
+        foreach ($this->publicHighlights($highlights) as $highlight) {
+            $title = trim((string) ($highlight['title'] ?? ''));
+            $text = trim((string) ($highlight['text'] ?? ''));
+            if ($title !== '' && $text !== '') {
+                $lines[] = $title.': '.$text;
+            } elseif ($text !== '') {
+                $lines[] = $text;
+            }
+        }
+
+        return $lines !== []
+            ? array_slice($lines, 0, 4)
+            : ($isChinese
+                ? ['这部分汇总你在本次作答中最稳定、最容易被他人观察到的行为倾向。']
+                : ['This section summarizes the most stable and observable patterns in your current response profile.']);
+    }
+
+    /**
+     * @param  array<string,mixed>  $cardsBySection
+     * @param  list<string>  $zhFallback
+     * @param  list<string>  $enFallback
+     * @return list<string>
+     */
+    private function chapterLinesFromCards(array $cardsBySection, string $sectionKey, bool $isChinese, array $zhFallback, array $enFallback): array
+    {
+        $cards = is_array($cardsBySection[$sectionKey] ?? null) ? $cardsBySection[$sectionKey] : [];
+        $lines = [];
+        foreach ($cards as $card) {
+            if (! is_array($card)) {
+                continue;
+            }
+
+            $title = trim((string) ($card['title'] ?? ''));
+            $description = trim((string) ($card['desc'] ?? $card['description'] ?? ''));
+            if ($title !== '' && $description !== '') {
+                $lines[] = $title.': '.$description;
+            } elseif ($description !== '') {
+                $lines[] = $description;
+            }
+
+            foreach ($this->stringList($card['bullets'] ?? []) as $bullet) {
+                $lines[] = $bullet;
+            }
+        }
+
+        return $lines !== [] ? array_slice($lines, 0, 5) : ($isChinese ? $zhFallback : $enFallback);
+    }
+
+    /**
+     * @param  array<string,int>  $scoresPct
+     * @param  array<string,string>  $axisStates
+     * @return list<string>
+     */
+    private function dimensionChapterLines(array $scoresPct, array $axisStates, bool $isChinese): array
+    {
+        $labels = $isChinese
+            ? [
+                'EI' => '能量来源',
+                'SN' => '信息处理',
+                'TF' => '决策依据',
+                'JP' => '生活节奏',
+                'AT' => '稳定感',
+            ]
+            : [
+                'EI' => 'Energy orientation',
+                'SN' => 'Information style',
+                'TF' => 'Decision lens',
+                'JP' => 'Operating rhythm',
+                'AT' => 'Stability under pressure',
+            ];
+        $lines = [];
+        foreach ($labels as $axis => $label) {
+            if (! array_key_exists($axis, $scoresPct)) {
+                continue;
+            }
+
+            $state = trim((string) ($axisStates[$axis] ?? ''));
+            $lines[] = $isChinese
+                ? sprintf('%s：%d%%。这个维度用于描述当前倾向强弱%s。', $label, $scoresPct[$axis], $state !== '' ? "（{$state}）" : '')
+                : sprintf('%s: %d%%. This dimension describes the current strength of the preference%s.', $label, $scoresPct[$axis], $state !== '' ? " ({$state})" : '');
+        }
+
+        return $lines !== []
+            ? $lines
+            : ($isChinese
+                ? ['维度数据已保存在完整结果中，可在结果页继续查看。']
+                : ['Dimension data is available in the full result and can be reviewed on the result page.']);
     }
 
     /**

--- a/backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php
@@ -68,6 +68,62 @@ final class MbtiPdfPayloadBuilderTest extends TestCase
         $this->assertCount(5, $payload['axis_scores'] ?? []);
         $this->assertNotEmpty($payload['highlights'] ?? []);
         $this->assertNotEmpty($payload['sections'] ?? []);
+        $this->assertSame('zh-CN', data_get($payload, 'document.language'));
+        $this->assertSame([
+            'type_portrait',
+            'core_traits',
+            'dimension_explanation',
+            'career_direction',
+            'growth_plan',
+            'relationships_communication',
+            'use_boundaries',
+        ], array_column((array) data_get($payload, 'document.chapters', []), 'chapter_key'));
+        $this->assertStringContainsString('职业探索', (string) data_get($payload, 'document.subtitle'));
+        $this->assertStringContainsString('医疗诊断', json_encode(data_get($payload, 'document.chapters'), JSON_UNESCAPED_UNICODE));
+    }
+
+    public function test_builds_english_document_depth_without_chinese_machine_copy(): void
+    {
+        $attempt = new Attempt([
+            'id' => 'attempt-should-not-appear',
+            'scale_code' => 'MBTI',
+            'locale' => 'en',
+            'region' => 'GLOBAL',
+            'pack_id' => 'default',
+            'dir_version' => 'MBTI-CN-v0.3',
+        ]);
+        $result = new Result([
+            'type_code' => 'ENTJ-A',
+            'scores_pct' => [
+                'EI' => 74,
+                'SN' => 58,
+                'TF' => 63,
+                'JP' => 79,
+                'AT' => 66,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'moderate',
+                'TF' => 'clear',
+                'JP' => 'strong',
+                'AT' => 'moderate',
+            ],
+        ]);
+
+        /** @var MbtiPdfPayloadBuilder $builder */
+        $builder = app(MbtiPdfPayloadBuilder::class);
+        $payload = $builder->build($attempt, $result)[MbtiPdfPayloadBuilder::PAYLOAD_KEY] ?? [];
+        $document = is_array($payload) ? (array) ($payload['document'] ?? []) : [];
+        $encoded = json_encode($document, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $this->assertSame('en', $document['language'] ?? null);
+        $this->assertSame('MBTI Full Personality Report', $document['title'] ?? null);
+        $this->assertStringContainsString('Career direction', $encoded);
+        $this->assertStringContainsString('Growth plan', $encoded);
+        $this->assertStringContainsString('Relationships and communication', $encoded);
+        $this->assertStringContainsString('not a medical diagnosis', $encoded);
+        $this->assertStringNotContainsString('职业方向', $encoded);
+        $this->assertStringNotContainsString('医疗诊断', $encoded);
     }
 
     public function test_payload_filters_internal_and_raw_fields_recursively(): void
@@ -112,5 +168,48 @@ final class MbtiPdfPayloadBuilderTest extends TestCase
         ] as $forbidden) {
             $this->assertStringNotContainsString($forbidden, $encoded);
         }
+    }
+
+    public function test_document_depth_keeps_required_pdf_chapters(): void
+    {
+        $attempt = new Attempt([
+            'id' => 'attempt-should-not-appear',
+            'scale_code' => 'MBTI',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'pack_id' => 'default',
+            'dir_version' => 'MBTI-CN-v0.3',
+        ]);
+        $result = new Result([
+            'type_code' => 'INFJ-T',
+            'scores_pct' => [
+                'EI' => 88,
+                'SN' => 72,
+                'TF' => 61,
+                'JP' => 69,
+                'AT' => 45,
+            ],
+        ]);
+
+        /** @var MbtiPdfPayloadBuilder $builder */
+        $builder = app(MbtiPdfPayloadBuilder::class);
+        $chapters = data_get($builder->build($attempt, $result), 'mbti_pdf_payload.document.chapters');
+        $this->assertIsArray($chapters);
+
+        foreach ($chapters as $chapter) {
+            $this->assertIsArray($chapter);
+            $this->assertNotEmpty($chapter['title'] ?? null);
+            $this->assertNotEmpty($chapter['body'] ?? null);
+            $this->assertNotEmpty($chapter['source_section_keys'] ?? null);
+        }
+
+        $encoded = json_encode($chapters, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertStringContainsString('类型画像', $encoded);
+        $this->assertStringContainsString('核心特质', $encoded);
+        $this->assertStringContainsString('维度解释', $encoded);
+        $this->assertStringContainsString('职业方向', $encoded);
+        $this->assertStringContainsString('成长建议', $encoded);
+        $this->assertStringContainsString('关系与沟通', $encoded);
+        $this->assertStringContainsString('使用边界', $encoded);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62917,7 +62917,7 @@
     "repo": "fap-api",
     "branch": "codex/mbti-pdf-product-02-content-depth",
     "base": "main",
-    "status": "in_progress",
+    "status": "github_checks_pending",
     "train_scope": "mbti_pdf_product",
     "title": "MBTI-PDF-PRODUCT-02: expand MBTI PDF content depth",
     "depends_on": [
@@ -62953,8 +62953,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "681f04121e44777e8df379d622038e3c87f5585e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2451",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62968,6 +62968,11 @@
         "at": "2026-06-26T21:02:28+08:00",
         "status": "local_validated",
         "note": "Added formal MBTI PDF document chapters to the backend payload authority and focused tests for required chapters, English/Chinese language boundaries, and internal-field filtering. Local scoped checks and changed-file scope validation passed."
+      },
+      {
+        "at": "2026-06-26T21:04:49+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2451 at https://github.com/fermatmind/fap-api/pull/2451. Waiting for required GitHub checks; no staging deploy wait, server verification, manual deploy, or production deploy included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -62917,7 +62917,7 @@
     "repo": "fap-api",
     "branch": "codex/mbti-pdf-product-02-content-depth",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "mbti_pdf_product",
     "title": "MBTI-PDF-PRODUCT-02: expand MBTI PDF content depth",
     "depends_on": [
@@ -62948,12 +62948,12 @@
         "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-02 scope: backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php, backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, cache-version, PDF renderer pagination/style, staging deploy, or production deploy change."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2451 head 0ec6c619d05539a19ff159f844e0b737db82290e: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all succeeded. mergeStateStatus was CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "681f04121e44777e8df379d622038e3c87f5585e",
+    "commit_sha": "0ec6c619d05539a19ff159f844e0b737db82290e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2451",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -62973,6 +62973,11 @@
         "at": "2026-06-26T21:04:49+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2451 at https://github.com/fermatmind/fap-api/pull/2451. Waiting for required GitHub checks; no staging deploy wait, server verification, manual deploy, or production deploy included."
+      },
+      {
+        "at": "2026-06-26T21:11:58+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2451 head 0ec6c619d05539a19ff159f844e0b737db82290e and mergeStateStatus was CLEAN. Ready for squash merge; no staging deploy wait, production deploy, CMS write, search, sitemap, llms, canonical, noindex, JSON-LD, queue, cache-version, or PDF renderer styling change included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48768,7 +48768,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-redacted-public-proof-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): gate DailyGiving redacted public proof",
     "depends_on": [
@@ -62870,11 +62870,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "8c833239a1c14fc79aebaf5a09be8e004f9aa537",
+    "commit_sha": "614af7ed2aa38dfa2201cb723f48e0f49de471a8",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2448",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-26T12:53:08Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-26T20:17:06+08:00",
@@ -62905,6 +62905,69 @@
         "at": "2026-06-26T20:45:24+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #2448 head 8c833239a1c14fc79aebaf5a09be8e004f9aa537 and mergeStateStatus was CLEAN. Ready for squash merge; no staging deploy wait, production deploy, CMS write, search, sitemap, llms, canonical, noindex, JSON-LD, queue, or scheduler change included."
+      },
+      {
+        "at": "2026-06-26T20:54:00+08:00",
+        "status": "merged",
+        "note": "PR #2448 was squash merged with merge commit 614af7ed2aa38dfa2201cb723f48e0f49de471a8. origin/main contains the merge commit, local main was synced to origin/main, the worktree was clean, and the local and remote task branches were deleted."
+      }
+    ]
+  },
+  "MBTI-PDF-PRODUCT-02": {
+    "repo": "fap-api",
+    "branch": "codex/mbti-pdf-product-02-content-depth",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "mbti_pdf_product",
+    "title": "MBTI-PDF-PRODUCT-02: expand MBTI PDF content depth",
+    "depends_on": [
+      "MBTI-PDF-PRODUCT-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided /goal MBTI-PDF-PRODUCT-PR-TRAIN-01 with MBTI-PDF-PRODUCT-02 scope and requested continuous backend-only PR train execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "MBTI-PDF-PRODUCT-01 is merged in PR #2448 with merge commit 614af7ed2aa38dfa2201cb723f48e0f49de471a8, and origin/main contains that merge commit."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: MbtiPdfPayloadBuilderTest passed (4 tests, 65 assertions); scoped Pint --test passed for app/Services/Report/Pdf/Mbti and tests/Unit/Services/Report/Pdf/Mbti; docs/codex state JSON parse passed; pr-train YAML parse passed; git diff --check passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-02 scope: backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php, backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, cache-version, PDF renderer pagination/style, staging deploy, or production deploy change."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-26T20:54:00+08:00",
+        "status": "in_progress",
+        "note": "Started MBTI PDF content-depth PR from latest origin/main after MBTI-PDF-PRODUCT-01 merge cleanup. Scope is backend-only PDF payload document chapters and focused tests. No frontend, public route, CMS write, sitemap, llms, search, cache-version, renderer pagination/style, staging deploy, or production deploy."
+      },
+      {
+        "at": "2026-06-26T21:02:28+08:00",
+        "status": "local_validated",
+        "note": "Added formal MBTI PDF document chapters to the backend payload authority and focused tests for required chapters, English/Chinese language boundaries, and internal-field filtering. Local scoped checks and changed-file scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -94,6 +94,43 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: MBTI-PDF-PRODUCT-02
+    repo: fap-api
+    depends_on: [MBTI-PDF-PRODUCT-01]
+    branch: codex/mbti-pdf-product-02-content-depth
+    title: "MBTI-PDF-PRODUCT-02: expand MBTI PDF content depth"
+    train_scope: mbti_pdf_product
+    status: user_authorized
+    scope:
+      - Use the MBTI PDF payload authority from MBTI-PDF-PRODUCT-01 to expose formal reader-facing PDF chapters.
+      - Cover type portrait, core traits, dimension explanation, career direction, growth plan, relationships and communication, and report use boundaries.
+      - Keep Chinese and English chapter copy intentionally authored for each locale without mixing user-facing languages.
+      - Keep the work backend-only and do not change public routes, frontend behavior, PDF pagination/brand styling, cache surface version, CMS, search, sitemap, llms, or deployment.
+    allowed_paths:
+      - backend/app/Services/Report/Pdf/Mbti/**
+      - backend/tests/Unit/Services/Report/Pdf/Mbti/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Change public API route paths, frontend download behavior, CMS, sitemap, llms, canonical, noindex, JSON-LD, search submission, scheduler, queue, secrets, staging deploy, or production deploy.
+      - Change PDF surface version, artifact cache key, renderer pagination, mPDF styling, page headers/footers, or public filename behavior; those belong to later MBTI-PDF-PRODUCT PRs.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-ASSET-02
     repo: fap-api
     depends_on: [PR-EQ-ASSET-01]


### PR DESCRIPTION
## What changed
- Added formal MBTI PDF document chapters to the backend MBTI PDF payload authority.
- Covered type portrait, core traits, dimension explanation, career direction, growth plan, relationships/communication, and report use boundaries.
- Added focused tests for required chapters, locale-specific Chinese/English copy boundaries, and internal-field filtering.
- Reconciled MBTI-PDF-PRODUCT-01 post-merge facts in the fap-api PR-train ledger.

## Why
This prepares product-grade PDF content depth behind the backend authority layer before the later renderer/pagination/cache-version PRs.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti tests/Unit/Services/Report/Pdf/Mbti`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`\n- `git diff --check`\n\n## Intentionally deferred\n- No frontend changes.\n- No public route/API path changes.\n- No CMS writes/imports.\n- No sitemap/llms/canonical/noindex/JSON-LD/search work.\n- No PDF renderer pagination/brand styling or surface-version/cache invalidation; those remain for later MBTI-PDF-PRODUCT PRs.\n- No staging or production deploy.\n