### PR TITLE
MBTI-PDF-PRODUCT-04: version MBTI PDF surface and cache QA

### DIFF
--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -13,6 +13,8 @@ use Mpdf\Output\Destination;
 
 final class ReportPdfDocumentService
 {
+    private const MBTI_PDF_SURFACE_VERSION = 'mbti.pdf_surface.v2';
+
     public function __construct(
         private readonly ReportPdfArtifactStore $artifactStore,
         private readonly MbtiPdfPayloadBuilder $mbtiPdfPayloadBuilder,
@@ -57,7 +59,7 @@ final class ReportPdfDocumentService
                 ?? now()->format('Y-m-d');
 
             return [
-                'pdf_surface_version' => 'mbti.pdf_surface.v1',
+                'pdf_surface_version' => self::MBTI_PDF_SURFACE_VERSION,
                 'scale_code' => 'MBTI',
                 'form_code' => null,
                 'form_label' => null,
@@ -338,7 +340,13 @@ final class ReportPdfDocumentService
             ?? ''
         ));
 
-        return $hash !== '' ? $hash : 'nohash';
+        $hash = $hash !== '' ? $hash : 'nohash';
+
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI') {
+            return $hash.'-'.self::MBTI_PDF_SURFACE_VERSION;
+        }
+
+        return $hash;
     }
 
     /**

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -147,11 +147,29 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $json->assertJsonPath('ok', true);
         $json->assertJsonPath('locked', true);
 
+        Storage::disk('local')->put(
+            "artifacts/pdf/MBTI/{$attemptId}/nohash/report_free.pdf",
+            'OLD_ONE_PAGE_MBTI_PDF_CACHE'
+        );
+
         $pdf = $this->withHeaders($headers)->get("/api/v0.3/attempts/{$attemptId}/report.pdf");
         $pdf->assertStatus(200);
         $pdf->assertHeader('Content-Type', 'application/pdf');
         $pdf->assertHeader('X-Report-Scale', 'MBTI');
         $pdf->assertHeader('X-Report-Locked', 'true');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.pdf_surface.v2');
+
+        $pdfBinary = (string) $pdf->getContent();
+        $this->assertStringStartsWith('%PDF-1.4', $pdfBinary);
+        $this->assertStringNotContainsString('OLD_ONE_PAGE_MBTI_PDF_CACHE', $pdfBinary);
+        $this->assertStringStartsWith(
+            'attachment; filename="fermatmind-mbti-report-',
+            (string) $pdf->headers->get('Content-Disposition')
+        );
+        $this->assertStringEndsWith('.pdf"', (string) $pdf->headers->get('Content-Disposition'));
+        Storage::disk('local')->assertExists(
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.pdf_surface.v2/report_free.pdf"
+        );
     }
 
     public function test_public_mbti_report_pdf_still_requires_matching_attempt_subject(): void

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -85,7 +85,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-02-report-payload-fixtures-v16",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "eq_v16_content_asset_productization",
     "title": "PR-EQ-ASSET-02 Backend EQ v1.6 report payload and canonical fixtures",
     "depends_on": [
@@ -63028,11 +63028,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "20f8db92c3f8d0e5ea1729b25e0f31999dedd987",
+    "commit_sha": "aa213ad5eb3ec0f815e098bcd3b5bbf2f59e8084",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2452",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-26T13:54:57Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-26T21:35:00+08:00",
@@ -63053,6 +63053,67 @@
         "at": "2026-06-26T22:00:00+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #2452 head 20f8db92c3f8d0e5ea1729b25e0f31999dedd987 and mergeStateStatus was CLEAN. Ready for squash merge; no staging deploy wait, production deploy, CMS write, search, sitemap, llms, canonical, noindex, JSON-LD, queue, cache-version, artifact key, or public route change included."
+      },
+      {
+        "at": "2026-06-26T22:08:00+08:00",
+        "status": "merged",
+        "note": "Reconciled during MBTI-PDF-PRODUCT-04 start: PR #2452 is merged with merge commit aa213ad5eb3ec0f815e098bcd3b5bbf2f59e8084, origin/main contains the merge commit, local main equals origin/main, and the task branch was cleaned locally/remotely."
+      }
+    ]
+  },
+  "MBTI-PDF-PRODUCT-04": {
+    "repo": "fap-api",
+    "branch": "codex/mbti-pdf-product-04-version-cache-qa",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "mbti_pdf_product",
+    "title": "MBTI-PDF-PRODUCT-04: version MBTI PDF surface and cache QA",
+    "depends_on": [
+      "MBTI-PDF-PRODUCT-03"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided /goal MBTI-PDF-PRODUCT-PR-TRAIN-01 with MBTI-PDF-PRODUCT-04 scope and requested continuous backend-only PR train execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "MBTI-PDF-PRODUCT-03 is merged in PR #2452 with merge commit aa213ad5eb3ec0f815e098bcd3b5bbf2f59e8084, and origin/main contains that merge commit."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptReportAccessReadTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: AttemptPublicReportPdfParityTest passed (2 tests, 21 assertions); AttemptReportAccessReadTest passed (13 tests, 162 assertions); MbtiReadPathParityContractTest passed (3 tests, 186 assertions); scoped Pint --test passed for ReportPdfDocumentService and report PDF/access tests; docs/codex state JSON parse passed; pr-train YAML parse passed; git diff --check passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-04 scope: backend/app/Services/Report/Pdf/ReportPdfDocumentService.php, backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, staging deploy, production deploy, or report-access URL shape change."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-26T22:08:00+08:00",
+        "status": "in_progress",
+        "note": "Started MBTI PDF version/cache QA PR from latest origin/main after MBTI-PDF-PRODUCT-03 merge cleanup. Scope is backend-only MBTI PDF surface version, artifact cache key, and focused /report.pdf regression QA. No frontend, public route, CMS write, sitemap, llms, search, staging deploy, or production deploy."
+      },
+      {
+        "at": "2026-06-26T22:18:00+08:00",
+        "status": "local_validated",
+        "note": "Bumped MBTI PDF surface to v2, included the surface version in the MBTI PDF artifact cache key, and added regression coverage proving /report.pdf does not reuse the old one-page nohash cache. Local scoped checks and changed-file scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -63065,7 +63065,7 @@
     "repo": "fap-api",
     "branch": "codex/mbti-pdf-product-04-version-cache-qa",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_open",
     "train_scope": "mbti_pdf_product",
     "title": "MBTI-PDF-PRODUCT-04: version MBTI PDF surface and cache QA",
     "depends_on": [
@@ -63099,8 +63099,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "d9069723888658f8b6fb63b568b66a9a2ea96d0f",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2453",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -63114,6 +63114,11 @@
         "at": "2026-06-26T22:18:00+08:00",
         "status": "local_validated",
         "note": "Bumped MBTI PDF surface to v2, included the surface version in the MBTI PDF artifact cache key, and added regression coverage proving /report.pdf does not reuse the old one-page nohash cache. Local scoped checks and changed-file scope validation passed."
+      },
+      {
+        "at": "2026-06-26T22:24:00+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2453 at https://github.com/fermatmind/fap-api/pull/2453. Waiting for required GitHub checks; no staging deploy wait, server verification, manual deploy, or production deploy included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -63065,7 +63065,7 @@
     "repo": "fap-api",
     "branch": "codex/mbti-pdf-product-04-version-cache-qa",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "mbti_pdf_product",
     "title": "MBTI-PDF-PRODUCT-04: version MBTI PDF surface and cache QA",
     "depends_on": [
@@ -63096,10 +63096,14 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-04 scope: backend/app/Services/Report/Pdf/ReportPdfDocumentService.php, backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, staging deploy, production deploy, or report-access URL shape change."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2453 head f4c358c9a210091f5602be848c2c924049002169: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all succeeded. mergeStateStatus was CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "d9069723888658f8b6fb63b568b66a9a2ea96d0f",
+    "commit_sha": "f4c358c9a210091f5602be848c2c924049002169",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2453",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -63119,6 +63123,11 @@
         "at": "2026-06-26T22:24:00+08:00",
         "status": "pr_open",
         "note": "Opened PR #2453 at https://github.com/fermatmind/fap-api/pull/2453. Waiting for required GitHub checks; no staging deploy wait, server verification, manual deploy, or production deploy included."
+      },
+      {
+        "at": "2026-06-26T22:31:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2453 head f4c358c9a210091f5602be848c2c924049002169 and mergeStateStatus was CLEAN. Ready for squash merge; no staging deploy wait, production deploy, CMS write, search, sitemap, llms, canonical, noindex, JSON-LD, queue, or public route change included."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -175,6 +175,46 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: MBTI-PDF-PRODUCT-04
+    repo: fap-api
+    depends_on: [MBTI-PDF-PRODUCT-03]
+    branch: codex/mbti-pdf-product-04-version-cache-qa
+    title: "MBTI-PDF-PRODUCT-04: version MBTI PDF surface and cache QA"
+    train_scope: mbti_pdf_product
+    status: user_authorized
+    scope:
+      - Bump the MBTI PDF surface version so production can distinguish the productized PDF renderer from the old one-page artifact.
+      - Include the MBTI PDF surface version in the MBTI PDF artifact cache key so existing one-page cached PDFs do not keep serving after deploy.
+      - Add regression QA for /report.pdf response headers, attachment filename, generated PDF body, and new v2 artifact path while preserving /report-access PDF href contract.
+      - Keep public route paths, frontend behavior, CMS, search, sitemap, llms, canonical, noindex, JSON-LD, queue, scheduler, staging deploy, and production deploy unchanged.
+    allowed_paths:
+      - backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+      - backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+      - backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Change public API route paths, frontend download behavior, CMS, sitemap, llms, canonical, noindex, JSON-LD, search submission, scheduler, queue, secrets, staging deploy, or production deploy.
+      - Write CMS, run production import, run production smoke, change report-access action URL shape, or purge production artifacts.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptReportAccessReadTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-ASSET-02
     repo: fap-api
     depends_on: [PR-EQ-ASSET-01]


### PR DESCRIPTION
## What changed
- Bumped MBTI PDF surface metadata to `mbti.pdf_surface.v2`.
- Included the MBTI PDF surface version in the MBTI artifact cache key so old one-page cached PDFs under the previous `nohash` path are not reused.
- Added `/report.pdf` regression coverage for PDF body generation, attachment filename, `X-Pdf-Surface-Version`, and v2 artifact path creation while preserving report-access PDF href behavior.
- Added the authorized PR-train manifest/state entry for MBTI-PDF-PRODUCT-04 and reconciled MBTI-PDF-PRODUCT-03 merge facts.

## Why
PR3 introduced the productized MBTI PDF renderer. This PR makes the new surface deployable without stale v1 artifacts continuing to serve after production rollout.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptReportAccessReadTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No frontend change.
- No production deploy, staging deploy, production smoke, CMS write, search, sitemap, llms, canonical, noindex, JSON-LD, scheduler, queue, or artifact purge.
- No public route path or report-access action URL shape change.

Repository rule impact: backend PDF artifact versioning only; MBTI PDF remains backend-authoritative and no content ownership boundary changes are introduced.
