### PR TITLE
PERSONALITY-AGENT-POST-PROMOTION-SEARCH-GATE-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php
+++ b/backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php
@@ -1,0 +1,559 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueuePlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+
+final class PersonalityAgentPostPromotionSearchGateCommand extends Command
+{
+    private const SCHEMA_VERSION = 'personality-agent-post-promotion-search-gate.v1';
+
+    private const SURFACE_PATHS = [
+        'sitemap' => '/sitemap.xml',
+        'llms' => '/llms.txt',
+        'llms_full' => '/llms-full.txt',
+    ];
+
+    private const PRIVATE_PATTERNS = [
+        '/results',
+        '/orders',
+        '/pay',
+        '/payment',
+        '/history',
+        '/private',
+        '/account',
+        'token=',
+        'session=',
+        'result_id=',
+        'report_id=',
+        'order_no=',
+    ];
+
+    protected $signature = 'personality:agent-post-promotion-search-gate
+        {--dry-run : Required. Run read-only planning only}
+        {--json : Emit JSON summary}
+        {--output= : Optional output JSON path}
+        {--channel=indexnow : Search Channel to dry-run; v1 supports indexnow}
+        {--urls= : Comma-separated canonical URLs/paths or path to JSON list}
+        {--package= : Optional agent/promotion package JSON containing target URLs}
+        {--base-url= : Public site base URL; defaults to seo_intel.public_canonical_host}
+        {--timeout=10 : Public HTTP timeout seconds}';
+
+    protected $description = 'Read-only post-promotion search gate for personality agent batches; no enqueue, approve, submit, CMS, sitemap, or llms mutation.';
+
+    public function handle(SearchChannelQueuePlanner $planner): int
+    {
+        if (! (bool) $this->option('dry-run')) {
+            return $this->finish($this->payload('NO_GO_SAFETY_VIOLATION', ['dry_run_required']));
+        }
+
+        $channel = strtolower(trim((string) $this->option('channel')));
+        if ($channel !== 'indexnow') {
+            return $this->finish($this->payload('NO_GO_SAFETY_VIOLATION', ['channel_not_allowed']));
+        }
+
+        $baseUrl = $this->baseUrl();
+        $targets = $this->targets($baseUrl);
+        if ($targets === []) {
+            return $this->finish($this->payload('NO_GO_SURFACE_OR_SAFETY', ['target_urls_missing']));
+        }
+
+        $surfaceTexts = $this->fetchSurfaceTexts($baseUrl);
+        $results = [];
+        $issues = [];
+        foreach ($targets as $target) {
+            $surface = $this->liveSurfaceObservation($target);
+            $membership = $this->surfaceMembership($target, $surfaceTexts);
+            $truth = $this->urlTruthObservation($target['canonical_url']);
+            $plan = $truth['found']
+                ? $this->planSummary($planner->plan($channel, (string) $truth['page_entity_type'], 1, $target['canonical_url']))
+                : $this->emptyPlanSummary('url_truth_missing');
+
+            $resultIssues = array_values(array_unique([
+                ...$surface['issues'],
+                ...$membership['issues'],
+                ...$truth['issues'],
+                ...$plan['issues'],
+            ]));
+            $issues = [...$issues, ...$resultIssues];
+
+            $results[] = [
+                'canonical_url' => $target['canonical_url'],
+                'path' => $target['path'],
+                'live_surface' => $surface,
+                'sitemap_llms_membership' => $membership,
+                'url_truth' => $truth,
+                'search_queue_plan' => $plan,
+                'issues' => $resultIssues,
+            ];
+        }
+
+        $decision = $this->decision($results);
+        $payload = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $decision,
+            'final_decision' => $decision,
+            'ok' => $decision === 'GO_FOR_INDEXNOW_DRY_RUN',
+            'dry_run' => true,
+            'write' => false,
+            'generated_at' => Carbon::now('UTC')->toIso8601String(),
+            'channel' => $channel,
+            'base_url' => $baseUrl,
+            'target_count' => count($targets),
+            'targets' => $results,
+            'counts' => [
+                'surface_ok' => $this->countPassing($results, 'live_surface.ok'),
+                'sitemap_llms_ok' => $this->countPassing($results, 'sitemap_llms_membership.ok'),
+                'url_truth_ready' => $this->countPassing($results, 'url_truth.ready'),
+                'planned_or_duplicate_safe' => $this->countPassing($results, 'search_queue_plan.ready'),
+            ],
+            'issues' => array_values(array_unique($issues)),
+            'recommended_next_task' => $decision === 'GO_FOR_INDEXNOW_DRY_RUN'
+                ? 'PERSONALITY-AGENT-POST-PROMOTION-INDEXNOW-DRY-RUN-01'
+                : $this->recommendedNextTask($decision),
+            'safety_flags' => $this->safetyFlags(),
+        ];
+
+        $this->writeOutput($payload);
+
+        return $this->finish($payload);
+    }
+
+    /**
+     * @return list<array{canonical_url:string, path:string}>
+     */
+    private function targets(string $baseUrl): array
+    {
+        $values = [];
+        $urlsOption = trim((string) $this->option('urls'));
+        if ($urlsOption !== '') {
+            $values = array_merge($values, $this->valuesFromOption($urlsOption));
+        }
+
+        $packagePath = trim((string) $this->option('package'));
+        if ($packagePath !== '') {
+            $path = $this->safePath($packagePath);
+            if ($path !== null) {
+                $decoded = json_decode((string) file_get_contents($path), true);
+                if (is_array($decoded)) {
+                    $values = array_merge($values, $this->collectTargetValues($decoded));
+                }
+            }
+        }
+
+        $targets = [];
+        foreach ($values as $value) {
+            $target = $this->normalizeTarget($value, $baseUrl);
+            if ($target === null) {
+                continue;
+            }
+            $targets[$target['canonical_url']] = $target;
+        }
+
+        return array_values($targets);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function valuesFromOption(string $raw): array
+    {
+        $path = $this->safePath($raw);
+        if ($path !== null) {
+            $decoded = json_decode((string) file_get_contents($path), true);
+
+            return is_array($decoded) ? $this->collectTargetValues($decoded) : [];
+        }
+
+        return array_values(array_filter(array_map('trim', explode(',', $raw))));
+    }
+
+    /**
+     * @param  array<mixed>  $payload
+     * @return list<string>
+     */
+    private function collectTargetValues(array $payload): array
+    {
+        $values = [];
+        foreach ($payload as $key => $value) {
+            if (is_array($value)) {
+                $values = array_merge($values, $this->collectTargetValues($value));
+                continue;
+            }
+            if (! is_string($value)) {
+                continue;
+            }
+            if (in_array((string) $key, ['target_url', 'canonical_url', 'canonicalUrl', 'path'], true)) {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array{canonical_url:string, path:string}|null
+     */
+    private function normalizeTarget(string $value, string $baseUrl): ?array
+    {
+        $value = trim($value);
+        if ($value === '' || str_contains($value, "\0")) {
+            return null;
+        }
+
+        $parts = parse_url($value);
+        $path = is_array($parts) && isset($parts['host'])
+            ? (string) ($parts['path'] ?? '')
+            : $value;
+        $host = is_array($parts) ? strtolower((string) ($parts['host'] ?? '')) : '';
+
+        if ($host !== '' && ! in_array($host, ['fermatmind.com', 'www.fermatmind.com'], true)) {
+            return null;
+        }
+        if (! str_starts_with($path, '/en/personality/') && ! str_starts_with($path, '/zh/personality/')) {
+            return null;
+        }
+        if ($this->containsPrivatePattern($path)) {
+            return null;
+        }
+
+        return [
+            'canonical_url' => $baseUrl.$path,
+            'path' => $path,
+        ];
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function fetchSurfaceTexts(string $baseUrl): array
+    {
+        $texts = [];
+        foreach (self::SURFACE_PATHS as $key => $path) {
+            try {
+                $response = Http::timeout($this->timeout())->get($baseUrl.$path);
+                $texts[$key] = $response->ok() ? (string) $response->body() : null;
+            } catch (\Throwable) {
+                $texts[$key] = null;
+            }
+        }
+
+        return $texts;
+    }
+
+    /**
+     * @param  array{canonical_url:string, path:string}  $target
+     * @return array<string, mixed>
+     */
+    private function liveSurfaceObservation(array $target): array
+    {
+        $issues = [];
+        $status = null;
+        $canonical = null;
+        $robots = null;
+        $privateMatches = [];
+
+        try {
+            $response = Http::timeout($this->timeout())->withOptions(['allow_redirects' => true])->get($target['canonical_url']);
+            $status = $response->status();
+            $html = (string) $response->body();
+            $canonical = $this->firstMatch('/<link[^>]+rel=["\']canonical["\'][^>]+href=["\']([^"\']+)["\']/i', $html)
+                ?? $this->firstMatch('/<link[^>]+href=["\']([^"\']+)["\'][^>]+rel=["\']canonical["\']/i', $html);
+            $robots = $this->firstMatch('/<meta[^>]+name=["\']robots["\'][^>]+content=["\']([^"\']+)["\']/i', $html);
+            $privateMatches = $this->privateMatches($html);
+
+            if (! $response->ok()) {
+                $issues[] = 'live_surface_non_200';
+            }
+            if ($canonical !== $target['canonical_url']) {
+                $issues[] = 'canonical_mismatch';
+            }
+            if (is_string($robots) && str_contains(strtolower($robots), 'noindex')) {
+                $issues[] = 'noindex_present';
+            }
+            if ($privateMatches !== []) {
+                $issues[] = 'private_route_or_sensitive_pattern_present';
+            }
+        } catch (\Throwable) {
+            $issues[] = 'live_surface_request_failed';
+        }
+
+        return [
+            'ok' => $issues === [],
+            'status' => $status,
+            'canonical_ok' => $canonical === $target['canonical_url'],
+            'robots_indexable' => ! (is_string($robots) && str_contains(strtolower($robots), 'noindex')),
+            'private_match_count' => count($privateMatches),
+            'private_matches' => $privateMatches,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @param  array{canonical_url:string, path:string}  $target
+     * @param  array<string, string|null>  $surfaceTexts
+     * @return array<string, mixed>
+     */
+    private function surfaceMembership(array $target, array $surfaceTexts): array
+    {
+        $membership = [];
+        $issues = [];
+        foreach (self::SURFACE_PATHS as $key => $_path) {
+            $text = $surfaceTexts[$key] ?? null;
+            $present = is_string($text) && str_contains($text, $target['canonical_url']);
+            $membership[$key] = $present;
+            if (! $present) {
+                $issues[] = $key.'_membership_missing';
+            }
+            if (is_string($text) && $this->containsPrivatePattern($text)) {
+                $issues[] = $key.'_private_pattern_present';
+            }
+        }
+
+        return [
+            'ok' => $issues === [],
+            'membership' => $membership,
+            'issues' => array_values(array_unique($issues)),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function urlTruthObservation(string $canonicalUrl): array
+    {
+        $connection = (string) config('seo_intel.connection', 'seo_intel');
+        if (! Schema::connection($connection)->hasTable('seo_urls')) {
+            return [
+                'found' => false,
+                'ready' => false,
+                'issues' => ['seo_urls_table_missing'],
+            ];
+        }
+
+        $row = DB::connection($connection)
+            ->table('seo_urls')
+            ->where('canonical_url', $canonicalUrl)
+            ->first();
+
+        if ($row === null) {
+            return [
+                'found' => false,
+                'ready' => false,
+                'issues' => ['canonical_url_not_found'],
+            ];
+        }
+
+        $metadata = json_decode((string) ($row->metadata_json ?? ''), true);
+        $metadata = is_array($metadata) ? $metadata : [];
+        $contentHash = strtolower(trim((string) ($metadata['content_hash'] ?? '')));
+        $lastmod = trim((string) ($row->lastmod_at ?? ''));
+        $issues = [];
+        if ($contentHash === '') {
+            $issues[] = 'url_truth_content_hash_missing';
+        }
+        if ($lastmod === '') {
+            $issues[] = 'url_truth_lastmod_missing';
+        }
+
+        return [
+            'found' => true,
+            'ready' => $issues === [],
+            'page_entity_type' => (string) $row->page_entity_type,
+            'locale' => (string) $row->locale,
+            'content_hash_present' => $contentHash !== '',
+            'lastmod_present' => $lastmod !== '',
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @return array<string, mixed>
+     */
+    private function planSummary(array $plan): array
+    {
+        $planned = (int) ($plan['planned_queue_count'] ?? 0);
+        $duplicate = (bool) ($plan['duplicate_detected'] ?? false);
+        $issues = [];
+        if ($planned < 1 && $duplicate) {
+            $issues[] = 'duplicate_active_queue_item';
+        } elseif ($planned < 1) {
+            $issues[] = (string) (($plan['source_unavailable_reason'] ?? null) ?: 'no_planned_queue_item');
+        }
+
+        return [
+            'ready' => $planned > 0,
+            'planned_queue_count' => $planned,
+            'duplicate_detected' => $duplicate,
+            'stale_submitted_queue_item_count' => (int) ($plan['stale_submitted_queue_item_count'] ?? 0),
+            'reason_code_breakdown' => $plan['reason_code_breakdown'] ?? [],
+            'issues' => array_values(array_unique($issues)),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function emptyPlanSummary(string $issue): array
+    {
+        return [
+            'ready' => false,
+            'planned_queue_count' => 0,
+            'duplicate_detected' => false,
+            'stale_submitted_queue_item_count' => 0,
+            'reason_code_breakdown' => [],
+            'issues' => [$issue],
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $results
+     */
+    private function decision(array $results): string
+    {
+        if ($this->countPassing($results, 'live_surface.ok') < count($results)
+            || $this->countPassing($results, 'sitemap_llms_membership.ok') < count($results)) {
+            return 'NO_GO_SURFACE_OR_SAFETY';
+        }
+        if ($this->countPassing($results, 'url_truth.ready') < count($results)) {
+            return 'CONDITIONAL_URL_TRUTH_REFRESH_REQUIRED';
+        }
+        if ($this->countPassing($results, 'search_queue_plan.ready') < count($results)) {
+            return 'CONDITIONAL_DUPLICATE_OR_POLICY_REVIEW';
+        }
+
+        return 'GO_FOR_INDEXNOW_DRY_RUN';
+    }
+
+    private function recommendedNextTask(string $decision): string
+    {
+        return match ($decision) {
+            'CONDITIONAL_URL_TRUTH_REFRESH_REQUIRED' => 'PERSONALITY-URL-TRUTH-HANDOFF-REFRESH-01',
+            'CONDITIONAL_DUPLICATE_OR_POLICY_REVIEW' => 'PERSONALITY-SEARCH-QUEUE-DUPLICATE-STATE-REVIEW-01',
+            default => 'PERSONALITY-POST-PROMOTION-SURFACE-SAFETY-REPAIR-01',
+        };
+    }
+
+    private function firstMatch(string $pattern, string $text): ?string
+    {
+        return preg_match($pattern, $text, $matches) === 1 ? (string) $matches[1] : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function privateMatches(string $text): array
+    {
+        return array_values(array_filter(
+            self::PRIVATE_PATTERNS,
+            fn (string $pattern): bool => str_contains(strtolower($text), strtolower($pattern)),
+        ));
+    }
+
+    private function containsPrivatePattern(string $text): bool
+    {
+        return $this->privateMatches($text) !== [];
+    }
+
+    private function baseUrl(): string
+    {
+        $option = trim((string) $this->option('base-url'));
+        $base = $option !== '' ? $option : (string) config('seo_intel.public_canonical_host', 'https://fermatmind.com');
+        $base = rtrim($base, '/');
+
+        return $base === '' ? 'https://fermatmind.com' : $base;
+    }
+
+    private function timeout(): int
+    {
+        return max(1, min(30, (int) $this->option('timeout')));
+    }
+
+    private function safePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function writeOutput(array $payload): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '' || str_contains($output, "\0")) {
+            return;
+        }
+
+        $path = str_starts_with($output, '/') ? $output : base_path($output);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    private function countPassing(array $rows, string $key): int
+    {
+        return collect($rows)
+            ->filter(fn (array $row): bool => (bool) data_get($row, $key, false))
+            ->count();
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function safetyFlags(): array
+    {
+        return [
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'enqueue_attempted' => false,
+            'enqueue_committed' => false,
+            'approval_attempted' => false,
+            'search_submission_attempted' => false,
+            'live_submission_attempted' => false,
+            'external_search_api_calls_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'url_truth_write_attempted' => false,
+        ];
+    }
+
+    private function payload(string $decision, array $issues): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => $decision,
+            'final_decision' => $decision,
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => false,
+            'issues' => $issues,
+            'safety_flags' => $this->safetyFlags(),
+        ];
+    }
+
+    private function finish(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+        }
+
+        return ($payload['final_decision'] ?? $payload['status'] ?? null) === 'NO_GO_SAFETY_VIOLATION'
+            ? self::FAILURE
+            : self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -176,6 +176,7 @@ use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityAgentApprovalQueueCommand;
 use App\Console\Commands\PersonalityAgentApprovalQueueReviewCommand;
+use App\Console\Commands\PersonalityAgentPostPromotionSearchGateCommand;
 use App\Console\Commands\PersonalityBigFivePublicProfileAgentDraft;
 use App\Console\Commands\PersonalityEnneagramCmsDraft;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
@@ -262,6 +263,7 @@ class Kernel extends ConsoleKernel
         FapWeeklyReport::class,
         PersonalityAgentApprovalQueueCommand::class,
         PersonalityAgentApprovalQueueReviewCommand::class,
+        PersonalityAgentPostPromotionSearchGateCommand::class,
         PersonalityBigFivePublicProfileAgentDraft::class,
         PersonalityEnneagramCmsPromote::class,
         PersonalityEnneagramCmsDraft::class,

--- a/backend/tests/Feature/SeoIntel/PersonalityAgentPostPromotionSearchGateCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/PersonalityAgentPostPromotionSearchGateCommandTest.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Console\Commands\PersonalityAgentPostPromotionSearchGateCommand;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PersonalityAgentPostPromotionSearchGateCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(PersonalityAgentPostPromotionSearchGateCommand::class)
+        );
+
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+            'seo_intel.public_canonical_host' => 'https://fermatmind.com',
+            'seo_intel.search_channel_queue.write_enabled' => false,
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function dry_run_outputs_go_for_indexnow_when_surface_url_truth_and_planner_are_ready(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/en/personality/enfj-a';
+        $this->seedSeoUrl($canonicalUrl);
+        $this->fakeHttp([$canonicalUrl]);
+
+        $countsBefore = $this->rowCounts();
+        $output = $this->runGate([
+            '--dry-run' => true,
+            '--json' => true,
+            '--urls' => $canonicalUrl,
+        ]);
+
+        $this->assertSame('GO_FOR_INDEXNOW_DRY_RUN', $output['final_decision'] ?? null);
+        $this->assertTrue((bool) ($output['ok'] ?? false));
+        $this->assertSame(1, $output['target_count'] ?? null);
+        $this->assertSame(1, data_get($output, 'counts.surface_ok'));
+        $this->assertSame(1, data_get($output, 'counts.sitemap_llms_ok'));
+        $this->assertSame(1, data_get($output, 'counts.url_truth_ready'));
+        $this->assertSame(1, data_get($output, 'counts.planned_or_duplicate_safe'));
+        $this->assertSame(1, data_get($output, 'targets.0.search_queue_plan.planned_queue_count'));
+        $this->assertFalse((bool) data_get($output, 'safety_flags.enqueue_attempted', true));
+        $this->assertFalse((bool) data_get($output, 'safety_flags.live_submission_attempted', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+    }
+
+    #[Test]
+    public function dry_run_reports_url_truth_refresh_required_when_hash_or_lastmod_is_missing(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/zh/personality/intp-a';
+        $this->seedSeoUrl($canonicalUrl, [
+            'locale' => 'zh-CN',
+            'lastmod_at' => null,
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'personality_profile_variants',
+            ],
+        ]);
+        $this->fakeHttp([$canonicalUrl]);
+
+        $output = $this->runGate([
+            '--dry-run' => true,
+            '--json' => true,
+            '--urls' => $canonicalUrl,
+        ]);
+
+        $this->assertSame('CONDITIONAL_URL_TRUTH_REFRESH_REQUIRED', $output['final_decision'] ?? null);
+        $this->assertContains('url_truth_content_hash_missing', $output['issues'] ?? []);
+        $this->assertContains('url_truth_lastmod_missing', $output['issues'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+    }
+
+    #[Test]
+    public function dry_run_reports_duplicate_policy_review_when_active_queue_item_blocks_replan(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/zh/personality/esfp-a';
+        $this->seedSeoUrl($canonicalUrl, ['locale' => 'zh-CN']);
+        $this->seedQueueItem($canonicalUrl, [
+            'locale' => 'zh-CN',
+            'execution_state' => 'dry_run_ready',
+        ]);
+        $this->fakeHttp([$canonicalUrl]);
+
+        $output = $this->runGate([
+            '--dry-run' => true,
+            '--json' => true,
+            '--urls' => $canonicalUrl,
+        ]);
+
+        $this->assertSame('CONDITIONAL_DUPLICATE_OR_POLICY_REVIEW', $output['final_decision'] ?? null);
+        $this->assertContains('duplicate_active_queue_item', $output['issues'] ?? []);
+        $this->assertTrue((bool) data_get($output, 'targets.0.search_queue_plan.duplicate_detected'));
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+    }
+
+    #[Test]
+    public function dry_run_reports_no_go_for_noindex_or_private_route_surface(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/en/personality/enfj-a';
+        $this->seedSeoUrl($canonicalUrl);
+        $this->fakeHttp([$canonicalUrl], targetHtml: $this->html($canonicalUrl, robots: 'noindex, nofollow', body: '<a href="/results/lookup">lookup</a>'));
+
+        $output = $this->runGate([
+            '--dry-run' => true,
+            '--json' => true,
+            '--urls' => $canonicalUrl,
+        ]);
+
+        $this->assertSame('NO_GO_SURFACE_OR_SAFETY', $output['final_decision'] ?? null);
+        $this->assertContains('noindex_present', $output['issues'] ?? []);
+        $this->assertContains('private_route_or_sensitive_pattern_present', $output['issues'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+    }
+
+    #[Test]
+    public function command_requires_explicit_dry_run_and_never_calls_external_search_api(): void
+    {
+        Http::fake();
+
+        $exitCode = Artisan::call('personality:agent-post-promotion-search-gate', [
+            '--json' => true,
+            '--urls' => 'https://fermatmind.com/en/personality/enfj-a',
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('NO_GO_SAFETY_VIOLATION', $output['final_decision'] ?? null);
+        $this->assertContains('dry_run_required', $output['issues'] ?? []);
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    private function runGate(array $arguments): array
+    {
+        $exitCode = Artisan::call('personality:agent-post-promotion-search-gate', $arguments);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($output);
+
+        return $output;
+    }
+
+    /**
+     * @param  list<string>  $canonicalUrls
+     */
+    private function fakeHttp(array $canonicalUrls, ?string $targetHtml = null): void
+    {
+        $surfaceBody = implode("\n", $canonicalUrls);
+        $fakes = [
+            'https://fermatmind.com/sitemap.xml' => Http::response($surfaceBody, 200),
+            'https://fermatmind.com/llms.txt' => Http::response($surfaceBody, 200),
+            'https://fermatmind.com/llms-full.txt' => Http::response($surfaceBody, 200),
+        ];
+
+        foreach ($canonicalUrls as $canonicalUrl) {
+            $fakes[$canonicalUrl] = Http::response($targetHtml ?? $this->html($canonicalUrl), 200);
+        }
+
+        Http::fake($fakes);
+    }
+
+    private function html(string $canonicalUrl, string $robots = 'index, follow', string $body = '<main>Promoted public personality content</main>'): string
+    {
+        return '<!doctype html><html><head><link rel="canonical" href="'.$canonicalUrl.'"><meta name="robots" content="'.$robots.'"></head><body>'.$body.'</body></html>';
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedSeoUrl(string $canonicalUrl, array $overrides = []): void
+    {
+        $metadata = $overrides['metadata_json'] ?? [
+            'claim_safe' => true,
+            'claim_boundary_state' => 'approved',
+            'publication_state' => 'published',
+            'source_table' => 'personality_profile_variants',
+            'content_hash' => hash('sha256', 'promoted-content-'.$canonicalUrl),
+        ];
+
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'canonical_url' => $canonicalUrl,
+            'locale' => $overrides['locale'] ?? 'en',
+            'page_entity_type' => $overrides['page_entity_type'] ?? 'personality_profile_variant',
+            'entity_id_or_slug' => $overrides['entity_id_or_slug'] ?? '301',
+            'cluster' => $overrides['cluster'] ?? 'personality',
+            'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
+            'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
+            'lastmod_at' => array_key_exists('lastmod_at', $overrides) ? $overrides['lastmod_at'] : now()->subMinute(),
+            'lastmod_source' => $overrides['lastmod_source'] ?? 'personality_profile_variants.live_content_updated_at',
+            'is_private_flow' => (bool) ($overrides['is_private_flow'] ?? false),
+            'first_seen_at' => now()->subDay(),
+            'last_seen_at' => now(),
+            'metadata_json' => json_encode($metadata, JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedQueueItem(string $canonicalUrl, array $overrides = []): void
+    {
+        DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insert([
+            'batch_id' => null,
+            'canonical_url' => $canonicalUrl,
+            'locale' => $overrides['locale'] ?? 'en',
+            'page_entity_type' => $overrides['page_entity_type'] ?? 'personality_profile_variant',
+            'entity_type' => $overrides['entity_type'] ?? ($overrides['page_entity_type'] ?? 'personality_profile_variant'),
+            'entity_id' => $overrides['entity_id'] ?? '301',
+            'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
+            'source_table' => $overrides['source_table'] ?? 'personality_profile_variants',
+            'channel' => $overrides['channel'] ?? 'indexnow',
+            'eligibility_state' => 'eligible',
+            'approval_state' => $overrides['approval_state'] ?? 'pending',
+            'execution_state' => $overrides['execution_state'] ?? 'dry_run_ready',
+            'indexability_state' => 'indexable',
+            'claim_boundary_state' => 'claim_safe',
+            'private_flow' => false,
+            'reason_codes' => json_encode([], JSON_THROW_ON_ERROR),
+            'lastmod' => $overrides['lastmod'] ?? now()->subHour(),
+            'content_hash' => $overrides['content_hash'] ?? null,
+            'url_hash' => hash('sha256', $canonicalUrl),
+            'idempotency_key' => hash('sha256', implode('|', [
+                strtolower($canonicalUrl),
+                strtolower((string) ($overrides['locale'] ?? 'en')),
+                strtolower((string) ($overrides['channel'] ?? 'indexnow')),
+            ])),
+            'created_at' => now()->subHour(),
+            'updated_at' => now()->subHour(),
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 128)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'queue_items' => DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count(),
+            'seo_urls' => DB::connection('seo_intel')->table('seo_urls')->count(),
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -411,6 +411,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_personality_post_promotion_search_gate_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityAgentPostPromotionSearchGateCommand;',
+            '+        PersonalityAgentPostPromotionSearchGateCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_cms_draft_writer_files(): void
     {
         $changed = [
@@ -4680,6 +4694,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isPersonalityPostPromotionSearchGateFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramCmsDraftFile($file)) {
                 continue;
             }
@@ -5847,6 +5865,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64GscReadonlyExportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsPersonalityAgentApprovalQueueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsPersonalityTdkNextBatchGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsPersonalityPostPromotionSearchGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramCmsDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramCmsPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6086,6 +6105,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityTdkNextBatchApprovalDraftGateCommand.php',
             'backend/app/Console/Commands/PersonalityTdkRuntimePromotionSearchGateReadinessCommand.php',
+        ], true);
+    }
+
+    private function isPersonalityPostPromotionSearchGateFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php',
         ], true);
     }
 
@@ -10087,6 +10113,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityTdk(?:NextBatchApprovalDraftGate|RuntimePromotionSearchGateReadiness)Command\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsPersonalityPostPromotionSearchGateOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityAgentPostPromotionSearchGateCommand\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `personality:agent-post-promotion-search-gate`, a dry-run-only post-promotion search readiness gate for personality agent batches.
- The gate checks live page surface safety, sitemap/llms/llms-full membership, URL Truth freshness, and Search Queue planner readiness for `indexnow`.
- Registered the command and added focused tests for PASS, URL Truth refresh required, duplicate policy review, noindex/private-route blocking, and no-write safety behavior.
- Added a narrow Big Five runtime-freeze classifier exception for this read-only personality post-promotion gate.

## Why
Post-promotion personality pages need a bounded read-only gate before any IndexNow dry-run/enqueue decision. This keeps CMS promotion, URL Truth freshness, Search Queue planning, and live search submission separated.

## Validation
- `php -l backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php`
- `php -l backend/tests/Feature/SeoIntel/PersonalityAgentPostPromotionSearchGateCommandTest.php`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|post_promotion_search_gate' --display-warnings`
- `php artisan test tests/Feature/SeoIntel/PersonalityAgentPostPromotionSearchGateCommandTest.php tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php --display-warnings`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh` ran before the classifier fix with 1070 passed and 2 failing Big Five pack tests: `PacksPublishBig5Test` and `PacksRollbackBig5Test`, both failing on existing `compiled` directory assertions. The same two-test failure was reproduced on clean `origin/main`, so it is treated as an external local baseline issue. GitHub later exposed a current-scope Big Five runtime-freeze classifier failure, which this PR now fixes and validates with the focused classifier test above.

## Deferred
- No production deploy.
- No URL Truth import/write.
- No Search Queue enqueue/approve/submit.
- No external IndexNow/GSC/Baidu call.
- No CMS draft, promotion, publish, sitemap, or llms mutation.
