### PR TITLE
fix(eq): label v1.9 report payload version

### DIFF
--- a/backend/app/Services/Report/Eq60ReportComposer.php
+++ b/backend/app/Services/Report/Eq60ReportComposer.php
@@ -202,7 +202,7 @@ final class Eq60ReportComposer
                 'methodology' => [
                     'norm_status' => strtolower(trim((string) data_get($score, 'norms.status', 'provisional'))) ?: 'provisional',
                     'scoring_version' => (string) data_get($score, 'version_snapshot.engine_version', 'v1.0_normed_validity'),
-                    'report_version' => 'eq_report_v5_assets_commercial_ready_v1_6',
+                    'report_version' => 'eq_report_v5_assets_commercial_ready_v1_9',
                     'content_version' => Eq60PackLoader::PACK_ID.'/'.$version,
                 ],
                 'generated_at' => now()->toISOString(),

--- a/backend/tests/Feature/Report/Eq60ReportPaywallTest.php
+++ b/backend/tests/Feature/Report/Eq60ReportPaywallTest.php
@@ -76,7 +76,7 @@ final class Eq60ReportPaywallTest extends TestCase
         $this->assertSame('planned', (string) data_get($gate, 'report.next_module.status'));
         $this->assertFalse((bool) data_get($gate, 'report.next_module.available', true));
         $this->assertSame('provisional', (string) data_get($gate, 'report.methodology.norm_status'));
-        $this->assertSame('eq_report_v5_assets_commercial_ready_v1_6', (string) data_get($gate, 'report.methodology.report_version'));
+        $this->assertSame('eq_report_v5_assets_commercial_ready_v1_9', (string) data_get($gate, 'report.methodology.report_version'));
         $this->assertNotSame('', (string) data_get($gate, 'report.asset_refs.core_formulation_id'));
         $this->assertNotSame('', (string) data_get($gate, 'report.asset_refs.action_prescription_id'));
         $this->assertNotSame('', (string) data_get($gate, 'report.asset_refs.result_snapshot_id'));

--- a/backend/tests/Feature/Report/Eq60V5ReportContractTest.php
+++ b/backend/tests/Feature/Report/Eq60V5ReportContractTest.php
@@ -348,7 +348,7 @@ final class Eq60V5ReportContractTest extends TestCase
         $this->assertNotEmpty((array) data_get($fixture, 'report.assets'));
         $this->assertFalse((bool) data_get($fixture, 'report.next_module.available', true));
         $this->assertSame('planned', (string) data_get($fixture, 'report.next_module.status'));
-        $this->assertSame('eq_report_v5_assets_commercial_ready_v1_6', (string) data_get($fixture, 'report.methodology.report_version'));
+        $this->assertSame('eq_report_v5_assets_commercial_ready_v1_9', (string) data_get($fixture, 'report.methodology.report_version'));
         $this->assertNotSame('', (string) data_get($fixture, 'report.asset_refs.result_snapshot_id'));
         $this->assertCount(7, (array) data_get($fixture, 'report.asset_refs.commercial_conversion_ids'));
         $this->assertNotSame('', (string) data_get($fixture, 'report.asset_refs.quality_confidence_id'));

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_en.json
@@ -1169,7 +1169,7 @@
         "methodology": {
             "content_version": "EQ_60/v1",
             "norm_status": "provisional",
-            "report_version": "eq_report_v5_assets_commercial_ready_v1_6",
+            "report_version": "eq_report_v5_assets_commercial_ready_v1_9",
             "scoring_version": "v1.0_normed_validity"
         },
         "next_module": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_zh.json
@@ -1169,7 +1169,7 @@
         "methodology": {
             "content_version": "EQ_60/v1",
             "norm_status": "provisional",
-            "report_version": "eq_report_v5_assets_commercial_ready_v1_6",
+            "report_version": "eq_report_v5_assets_commercial_ready_v1_9",
             "scoring_version": "v1.0_normed_validity"
         },
         "next_module": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_en.json
@@ -1169,7 +1169,7 @@
         "methodology": {
             "content_version": "EQ_60/v1",
             "norm_status": "provisional",
-            "report_version": "eq_report_v5_assets_commercial_ready_v1_6",
+            "report_version": "eq_report_v5_assets_commercial_ready_v1_9",
             "scoring_version": "v1.0_normed_validity"
         },
         "next_module": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_zh.json
@@ -1169,7 +1169,7 @@
         "methodology": {
             "content_version": "EQ_60/v1",
             "norm_status": "provisional",
-            "report_version": "eq_report_v5_assets_commercial_ready_v1_6",
+            "report_version": "eq_report_v5_assets_commercial_ready_v1_9",
             "scoring_version": "v1.0_normed_validity"
         },
         "next_module": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_en.json
@@ -1129,7 +1129,7 @@
         "methodology": {
             "content_version": "EQ_60/v1",
             "norm_status": "provisional",
-            "report_version": "eq_report_v5_assets_commercial_ready_v1_6",
+            "report_version": "eq_report_v5_assets_commercial_ready_v1_9",
             "scoring_version": "v1.0_normed_validity"
         },
         "next_module": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_zh.json
@@ -1129,7 +1129,7 @@
         "methodology": {
             "content_version": "EQ_60/v1",
             "norm_status": "provisional",
-            "report_version": "eq_report_v5_assets_commercial_ready_v1_6",
+            "report_version": "eq_report_v5_assets_commercial_ready_v1_9",
             "scoring_version": "v1.0_normed_validity"
         },
         "next_module": {

--- a/docs/audits/eq/eq_technical_state_2026-06-25.md
+++ b/docs/audits/eq/eq_technical_state_2026-06-25.md
@@ -12,11 +12,11 @@ This document consolidates the previous EQ scan, productization, acceptance, Age
 - The active dimensions are `SA`, `ER`, `EM`, and `RM`: self-awareness, emotion regulation, empathy, and relationship management.
 - The 50/60 question-count mismatch was fixed; registry and runtime now expect 60 items.
 - EQ report access is all-free: no user-facing locked sections, blur, paywall, paid offers, or SKU path.
-- The active report payload version is `eq_report_v5_assets_commercial_ready_v1_6`.
+- The active report payload version is `eq_report_v5_assets_commercial_ready_v1_9`.
 - EQ v1.6 is frozen as the first commercial-ready EQ-60 content baseline.
 - Backend content pack and `Eq60ReportComposer` are the authority layer for report interpretation.
 - Frontend uses the EQ-specific `EQResultV5` renderer instead of generic `RichResultReport` fallback.
-- Production smoke verified 60 questions, report delivery, v1.6 resolved assets, localized `en` and `zh-CN` assets, and no paywall/SKU leakage.
+- Production smoke verified 60 questions, report delivery, v1.9 resolved assets, localized `en` and `zh-CN` assets, and no paywall/SKU leakage.
 - Agent-ready context is production accepted: the Agent may read EQ report context and assets, but cannot mutate scores, formulations, report sections, SJT state, or commerce state.
 - Deterministic read-only Agent runtime shell exists and is the accepted runtime direction for now.
 - LLM/provider work is deferred. `EQ_AGENT_LLM_ENABLED` should remain `false`; do not pursue live LLM smoke until a separate future decision reopens that lane.
@@ -219,13 +219,13 @@ Renderer rules:
 
 ## 9. Production Acceptance Summary
 
-Production EQ v1.6 acceptance confirmed:
+Production EQ v1.9 acceptance confirmed:
 
 - `/api/v0.3/scales/EQ_60/questions?locale=en` returns 60 items.
 - `/api/v0.3/scales/EQ_60/questions?locale=zh-CN` returns 60 items.
 - Anonymous EQ submit works.
 - `/report-access` converges to ready/full/all-free.
-- `/report` returns `eq_report_v5_assets_commercial_ready_v1_6`.
+- `/report` returns `eq_report_v5_assets_commercial_ready_v1_9`.
 - `/report?locale=en` returns English resolved assets.
 - `/report?locale=zh-CN` returns Chinese resolved assets.
 - Frontend result pages use `EQResultV5`.


### PR DESCRIPTION
## What changed
- Updates `Eq60ReportComposer` so EQ reports now emit `methodology.report_version=eq_report_v5_assets_commercial_ready_v1_9`.
- Updates EQ v5 contract/paywall assertions and canonical fixtures to expect the v1.9 report version label.
- Updates the consolidated EQ technical state document so the current active payload and production acceptance wording match v1.9.

## Why
Production smoke confirmed the live EQ page is rendering v1.9 assets, but the report payload still advertised the older v1.6 report version. This PR removes that audit/operations ambiguity without changing scoring, questions, content assets, SJT state, commerce, or frontend behavior.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest` (passes; existing warnings only)
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest` (passes; existing warnings only)
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=attempts`
- `git diff --check`
- `git diff --cached --check`
- JSON fixture parse check for changed EQ canonical fixtures

## Intentionally deferred
- No production deploy in this PR.
- No frontend change.
- No EQ scoring/question/norm/SJT/commercial logic change.
- Historical PR-train ledger entries and older acceptance source records remain unchanged.

## Repository rule impact
EQ report content remains backend-authoritative via the content pack and `Eq60ReportComposer`; this PR only updates the current runtime report version label and matching contract expectations.
