### PR TITLE
fix(cms): preserve utf8 seo package frontmatter

### DIFF
--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
@@ -774,8 +774,8 @@ final class SeoContentPackageDraftImporter
      */
     private function readMarkdownPage(string $path): array
     {
-        $contents = (string) file_get_contents($path);
-        if (preg_match('/\A---\R(.*?)\R---\R(.*)\z/s', $contents, $matches) !== 1) {
+        $contents = $this->normalizeLineEndings((string) file_get_contents($path));
+        if (preg_match('/\A---\n(.*?)\n---\n(.*)\z/s', $contents, $matches) !== 1) {
             return ['frontmatter' => [], 'body' => trim($contents)];
         }
 
@@ -791,10 +791,10 @@ final class SeoContentPackageDraftImporter
     private function parseSimpleFrontmatter(string $yaml): array
     {
         $data = [];
-        $lines = preg_split('/\R/', $yaml) ?: [];
+        $lines = explode("\n", $this->normalizeLineEndings($yaml));
         $currentKey = null;
         foreach ($lines as $line) {
-            if (preg_match('/^([A-Za-z0-9_-]+):\s*(.*)$/', $line, $matches) === 1) {
+            if (preg_match('/^([A-Za-z0-9_-]+):\s*(.*)$/u', $line, $matches) === 1) {
                 $currentKey = (string) $matches[1];
                 $value = trim((string) $matches[2]);
                 $data[$currentKey] = $value === '' ? [] : $this->parseScalar($value);
@@ -802,7 +802,7 @@ final class SeoContentPackageDraftImporter
                 continue;
             }
 
-            if ($currentKey !== null && preg_match('/^\s*-\s*(.+)$/', $line, $matches) === 1) {
+            if ($currentKey !== null && preg_match('/^\s*-\s*(.+)$/u', $line, $matches) === 1) {
                 if (! is_array($data[$currentKey] ?? null)) {
                     $data[$currentKey] = [];
                 }
@@ -811,6 +811,11 @@ final class SeoContentPackageDraftImporter
         }
 
         return $data;
+    }
+
+    private function normalizeLineEndings(string $value): string
+    {
+        return str_replace(["\r\n", "\r"], "\n", $value);
     }
 
     private function parseScalar(string $value): mixed
@@ -921,6 +926,7 @@ final class SeoContentPackageDraftImporter
                 $errors[] = $this->issue($locale.'.'.$field, 'missing_required_field', $field.' is required.');
             }
         }
+        $this->validateUtf8ScalarFields($item, $errors);
 
         if (! is_string($item['primary_keyword'] ?? null)) {
             $errors[] = $this->issue($locale.'.primary_keyword', 'primary_keyword_not_string', 'primary_keyword must be a string.');
@@ -967,6 +973,25 @@ final class SeoContentPackageDraftImporter
 
         if (trim((string) $item['twitter_image_url']) === '') {
             $warnings[] = $this->issue($locale.'.twitter_image_url', 'twitter_image_reuses_og', 'Twitter image is missing and should reuse OG if needed.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateUtf8ScalarFields(array $item, array &$errors): void
+    {
+        $locale = (string) ($item['locale'] ?? 'unknown');
+        foreach (['title', 'meta_title', 'meta_description', 'excerpt', 'body_markdown'] as $field) {
+            $value = $item[$field] ?? null;
+            if (is_string($value) && ! mb_check_encoding($value, 'UTF-8')) {
+                $errors[] = $this->issue(
+                    $locale.'.'.$field,
+                    'invalid_utf8_scalar',
+                    $field.' must be valid UTF-8 before it can be written to article draft fields.'
+                );
+            }
         }
     }
 

--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageExistingArticleUpdater.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageExistingArticleUpdater.php
@@ -618,8 +618,8 @@ final class SeoContentPackageExistingArticleUpdater
      */
     private function readMarkdownPage(string $path): array
     {
-        $contents = (string) file_get_contents($path);
-        if (preg_match('/\A---\R(.*?)\R---\R(.*)\z/s', $contents, $matches) !== 1) {
+        $contents = $this->normalizeLineEndings((string) file_get_contents($path));
+        if (preg_match('/\A---\n(.*?)\n---\n(.*)\z/s', $contents, $matches) !== 1) {
             return ['frontmatter' => [], 'body' => trim($contents)];
         }
 
@@ -635,10 +635,10 @@ final class SeoContentPackageExistingArticleUpdater
     private function parseSimpleFrontmatter(string $yaml): array
     {
         $data = [];
-        $lines = preg_split('/\R/', $yaml) ?: [];
+        $lines = explode("\n", $this->normalizeLineEndings($yaml));
         $currentKey = null;
         foreach ($lines as $line) {
-            if (preg_match('/^([A-Za-z0-9_-]+):\s*(.*)$/', $line, $matches) === 1) {
+            if (preg_match('/^([A-Za-z0-9_-]+):\s*(.*)$/u', $line, $matches) === 1) {
                 $currentKey = (string) $matches[1];
                 $value = trim((string) $matches[2]);
                 $data[$currentKey] = $value === '' ? [] : $this->parseScalar($value);
@@ -646,7 +646,7 @@ final class SeoContentPackageExistingArticleUpdater
                 continue;
             }
 
-            if ($currentKey !== null && preg_match('/^\s*-\s*(.+)$/', $line, $matches) === 1) {
+            if ($currentKey !== null && preg_match('/^\s*-\s*(.+)$/u', $line, $matches) === 1) {
                 if (! is_array($data[$currentKey] ?? null)) {
                     $data[$currentKey] = [];
                 }
@@ -655,6 +655,11 @@ final class SeoContentPackageExistingArticleUpdater
         }
 
         return $data;
+    }
+
+    private function normalizeLineEndings(string $value): string
+    {
+        return str_replace(["\r\n", "\r"], "\n", $value);
     }
 
     private function parseScalar(string $value): mixed
@@ -695,6 +700,7 @@ final class SeoContentPackageExistingArticleUpdater
                 $errors[] = $this->issue($locale.'.'.$field, 'missing_required_field', $field.' is required.');
             }
         }
+        $this->validateUtf8ScalarFields($item, $errors);
 
         if ((bool) $item['schema_hold'] !== true) {
             $errors[] = $this->issue($locale.'.schema_hold', 'schema_hold_not_satisfied', 'schema_hold must remain true.');
@@ -719,6 +725,25 @@ final class SeoContentPackageExistingArticleUpdater
         }
 
         $this->articleBodyHeadingGuard->assertNoBodyH1((string) $item['body_markdown']);
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateUtf8ScalarFields(array $item, array &$errors): void
+    {
+        $locale = (string) ($item['locale'] ?? 'unknown');
+        foreach (['title', 'meta_title', 'meta_description', 'excerpt', 'body_markdown'] as $field) {
+            $value = $item[$field] ?? null;
+            if (is_string($value) && ! mb_check_encoding($value, 'UTF-8')) {
+                $errors[] = $this->issue(
+                    $locale.'.'.$field,
+                    'invalid_utf8_scalar',
+                    $field.' must be valid UTF-8 before it can be written to article draft fields.'
+                );
+            }
+        }
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
@@ -450,6 +450,52 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         Http::assertNothingSent();
     }
 
+    public function test_import_preserves_zh_utf8_frontmatter_meta_draft_fallback_without_corruption(): void
+    {
+        $metaTitle = '高考志愿要不要服从调剂？先看不能接受专业 | FermatMind';
+        $metaDescription = '填院校专业组前，别先争服从调剂。先把全部专业分成不能接受、待验证、可接受。';
+        $package = $this->writeModeCPackage(static function (array &$files) use ($metaTitle, $metaDescription): void {
+            foreach ([
+                'manifest.json',
+                'cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json',
+                'cms/CMS_IMPORT_DRAFT_zh-CN_career-interest-vs-personality-test-differences.json',
+            ] as $path) {
+                unset(
+                    $files[$path]['meta_title'],
+                    $files[$path]['meta_title_draft'],
+                    $files[$path]['meta_description'],
+                    $files[$path]['meta_description_draft']
+                );
+            }
+
+            $files['pages/zh-CN-career-interest-vs-personality-test-differences.md'] = str_replace(
+                "canonical_url_draft: /zh/articles/career-interest-vs-personality-test-differences\n",
+                "canonical_url_draft: /zh/articles/career-interest-vs-personality-test-differences\nmeta_title_draft: {$metaTitle}\nmeta_description_draft: {$metaDescription}\n",
+                $files['pages/zh-CN-career-interest-vs-personality-test-differences.md']
+            );
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--locales' => 'zh-CN',
+            '--expected-en-slug' => '',
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+
+        $revision = ArticleTranslationRevision::query()
+            ->withoutGlobalScopes()
+            ->where('locale', 'zh-CN')
+            ->firstOrFail();
+
+        $this->assertSame($metaTitle, (string) $revision->seo_title);
+        $this->assertSame($metaDescription, (string) $revision->seo_description);
+        $this->assertTrue(mb_check_encoding((string) $revision->seo_title, 'UTF-8'));
+        $this->assertTrue(mb_check_encoding((string) $revision->seo_description, 'UTF-8'));
+    }
+
     public function test_import_serializes_multilingual_heading_sequence_with_smart_and_fullwidth_punctuation(): void
     {
         $package = $this->writeModeCPackage(static function (array &$files): void {
@@ -479,7 +525,7 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         );
     }
 
-    public function test_import_normalizes_malformed_utf8_heading_sequence_with_sanitized_warning(): void
+    public function test_dry_run_rejects_malformed_utf8_body_scalar_before_database_write(): void
     {
         $malformed = (string) hex2bin('c328');
         $package = $this->writeModeCPackage(static function (array &$files) use ($malformed): void {
@@ -491,20 +537,16 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         });
 
         $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
             '--json' => true,
         ]));
 
         $payload = $this->jsonOutput();
-        $this->assertSame(0, $exitCode);
-        $this->assertTrue($payload['ok']);
-        $this->assertWarningCode($payload, 'json_string_utf8_normalized');
-
-        $importLog = ArticleEditorialPackageImport::query()
-            ->withoutGlobalScopes()
-            ->where('locale', 'en')
-            ->firstOrFail();
-
-        $this->assertContains('2:Broken �( heading', $importLog->heading_sequence_json);
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertErrorCode($payload, 'invalid_utf8_scalar');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
     }
 
     public function test_malformed_utf8_in_review_context_does_not_crash_import_audit_json(): void

--- a/backend/tests/Feature/Console/ArticleUpdateExistingSeoContentPackageCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleUpdateExistingSeoContentPackageCommandTest.php
@@ -112,6 +112,73 @@ final class ArticleUpdateExistingSeoContentPackageCommandTest extends TestCase
         $this->assertSame(0, (int) $import->references_count);
     }
 
+    public function test_execute_preserves_zh_utf8_frontmatter_meta_draft_fallback_without_corruption(): void
+    {
+        $this->createExistingPublishedArticle40();
+        $metaTitle = '高考志愿要不要服从调剂？先看不能接受专业 | FermatMind';
+        $metaDescription = '填院校专业组前，别先争服从调剂。先把全部专业分成不能接受、待验证、可接受。';
+        $package = $this->writeExistingUpdatePackage(static function (array &$files) use ($metaTitle, $metaDescription): void {
+            foreach ([
+                'cms/CMS_IMPORT_UPDATE_DRAFT_zh-CN_article-40_riasec-holland-career-interest-test-explained.json',
+                'cms/CMS_FIELDS_UPDATE_zh-CN_article-40_riasec-holland-career-interest-test-explained.json',
+            ] as $path) {
+                unset(
+                    $files[$path]['meta_title'],
+                    $files[$path]['meta_description']
+                );
+            }
+
+            $files['pages/zh-CN-riasec-holland-career-interest-test-explained.md'] = str_replace(
+                "canonical_url_draft: {self::CANONICAL}\n",
+                "canonical_url_draft: {self::CANONICAL}\nmeta_title_draft: {$metaTitle}\nmeta_description_draft: {$metaDescription}\n",
+                $files['pages/zh-CN-riasec-holland-career-interest-test-explained.md']
+            );
+        });
+
+        $exitCode = Artisan::call('articles:update-existing-seo-content-package', $this->commandOptions($package, [
+            '--execute' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with('workingRevision')
+            ->findOrFail(self::ARTICLE_ID);
+
+        $this->assertSame($metaTitle, (string) $article->workingRevision?->seo_title);
+        $this->assertSame($metaDescription, (string) $article->workingRevision?->seo_description);
+        $this->assertTrue(mb_check_encoding((string) $article->workingRevision?->seo_title, 'UTF-8'));
+        $this->assertTrue(mb_check_encoding((string) $article->workingRevision?->seo_description, 'UTF-8'));
+    }
+
+    public function test_dry_run_rejects_malformed_utf8_update_body_scalar_before_database_write(): void
+    {
+        $this->createExistingPublishedArticle40();
+        $malformed = (string) hex2bin('c328');
+        $package = $this->writeExistingUpdatePackage(static function (array &$files) use ($malformed): void {
+            $files['pages/zh-CN-riasec-holland-career-interest-test-explained.md'] = str_replace(
+                "## 霍兰德职业兴趣测试是什么\n",
+                "## Broken {$malformed} heading\n\n## 霍兰德职业兴趣测试是什么\n",
+                $files['pages/zh-CN-riasec-holland-career-interest-test-explained.md']
+            );
+        });
+
+        $exitCode = Artisan::call('articles:update-existing-seo-content-package', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertErrorCode($payload, 'invalid_utf8_scalar');
+        $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
+    }
+
     public function test_dry_run_rejects_identity_lock_article_id_mismatch(): void
     {
         $this->createExistingPublishedArticle40();


### PR DESCRIPTION
## Summary
- Make SEO content package Markdown frontmatter parsing Unicode-safe for draft creation and existing article update flows.
- Replace PCRE \R line splitting with explicit CRLF/CR normalization plus LF splitting, and use Unicode-aware frontmatter line matching.
- Add DB-bound UTF-8 scalar validation for article draft fields before dry-run/write plans can pass.
- Add regression coverage for zh-CN frontmatter meta fallback containing characters such as 先, plus malformed UTF-8 dry-run rejection.

## Why
A production draft import failed when frontmatter fallback meta fields were parsed with byte-oriented PCRE behavior. Chinese UTF-8 continuation byte 0x85 could be treated like a newline boundary, corrupting seo_title/seo_description before the DB write path.

## Validation
- php -l backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
- php -l backend/app/Services/Cms/SeoContentPackage/SeoContentPackageExistingArticleUpdater.php
- php -l backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
- php -l backend/tests/Feature/Console/ArticleUpdateExistingSeoContentPackageCommandTest.php
- ./vendor/bin/pint --test app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php app/Services/Cms/SeoContentPackage/SeoContentPackageExistingArticleUpdater.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php tests/Feature/Console/ArticleUpdateExistingSeoContentPackageCommandTest.php
- php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest
- php artisan test --filter=ArticleUpdateExistingSeoContentPackageCommandTest

## Intentionally deferred
- No production CMS draft retry.
- No DB schema change.
- No publish, URL Truth, sitemap/llms, schema/hreflang, search submission, revalidation, deploy, or PR-train metadata changes.

## Repository rule impact
Backend CMS Article resources remain the authority for article content and SEO metadata. This PR only hardens package import parsing/validation; it does not introduce frontend content fallback or change publishing authority.