### PR TITLE
PERSONALITY-POST-PROMOTION-SURFACE-SAFETY-REPAIR-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php
+++ b/backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php
@@ -22,19 +22,23 @@ final class PersonalityAgentPostPromotionSearchGateCommand extends Command
         'llms_full' => '/llms-full.txt',
     ];
 
-    private const PRIVATE_PATTERNS = [
-        '/results',
-        '/orders',
-        '/pay',
-        '/payment',
-        '/history',
-        '/private',
-        '/account',
-        'token=',
-        'session=',
-        'result_id=',
-        'report_id=',
-        'order_no=',
+    private const PRIVATE_ROUTE_FAMILIES = [
+        'result',
+        'results',
+        'orders',
+        'pay',
+        'payment',
+        'history',
+        'private',
+        'account',
+    ];
+
+    private const SENSITIVE_QUERY_KEYS = [
+        'token',
+        'session',
+        'result_id',
+        'report_id',
+        'order_no',
     ];
 
     protected $signature = 'personality:agent-post-promotion-search-gate
@@ -453,15 +457,80 @@ final class PersonalityAgentPostPromotionSearchGateCommand extends Command
      */
     private function privateMatches(string $text): array
     {
-        return array_values(array_filter(
-            self::PRIVATE_PATTERNS,
-            fn (string $pattern): bool => str_contains(strtolower($text), strtolower($pattern)),
-        ));
+        $matches = [];
+        $lower = strtolower($text);
+        foreach (self::SENSITIVE_QUERY_KEYS as $key) {
+            if (preg_match('/(?:[?&]|&amp;)'.preg_quote($key, '/').'=|(?:^|[\s"\'])'.preg_quote($key, '/').'=/i', $text) === 1) {
+                $matches[] = $key.'=';
+            }
+        }
+
+        if (preg_match_all('/https?:\/\/[^\s<>"\')]+/i', $text, $urlMatches) > 0) {
+            foreach ($urlMatches[0] as $url) {
+                $parts = parse_url($url);
+                if (! is_array($parts)) {
+                    continue;
+                }
+
+                $host = strtolower((string) ($parts['host'] ?? ''));
+                if (! in_array($host, ['fermatmind.com', 'www.fermatmind.com'], true)) {
+                    continue;
+                }
+
+                $path = $this->stripLocalePrefix($this->normalizePath((string) ($parts['path'] ?? '/')));
+                if ($this->isPrivateRoutePath($path)) {
+                    $matches[] = $url;
+                }
+
+                $query = (string) ($parts['query'] ?? '');
+                if ($query !== '') {
+                    parse_str($query, $queryParams);
+                    foreach (self::SENSITIVE_QUERY_KEYS as $key) {
+                        if (array_key_exists($key, $queryParams)) {
+                            $matches[] = $key.'=';
+                        }
+                    }
+                }
+            }
+        }
+
+        if (preg_match_all('/(?<![A-Za-z0-9_-])\/(?:(?:en|zh)\/)?(?:result|results|orders|pay|payment|history|private|account)(?:[\/?#\s<>"\')]|$)/i', $lower, $pathMatches) > 0) {
+            foreach ($pathMatches[0] as $match) {
+                $matches[] = trim($match);
+            }
+        }
+
+        return array_values(array_unique(array_filter($matches)));
     }
 
     private function containsPrivatePattern(string $text): bool
     {
         return $this->privateMatches($text) !== [];
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return '/';
+        }
+        $path = str_starts_with($path, '/') ? $path : '/'.$path;
+
+        return rtrim(preg_replace('/\/+/', '/', $path) ?: '/', '/') ?: '/';
+    }
+
+    private function stripLocalePrefix(string $path): string
+    {
+        $stripped = preg_replace('/^\/(?:en|zh)(?=\/|$)/i', '', $path) ?: $path;
+
+        return $stripped === '' ? '/' : $stripped;
+    }
+
+    private function isPrivateRoutePath(string $path): bool
+    {
+        $firstSegment = strtolower(explode('/', trim($path, '/'))[0] ?? '');
+
+        return in_array($firstSegment, self::PRIVATE_ROUTE_FAMILIES, true);
     }
 
     private function baseUrl(): string

--- a/backend/tests/Feature/SeoIntel/PersonalityAgentPostPromotionSearchGateCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/PersonalityAgentPostPromotionSearchGateCommandTest.php
@@ -67,6 +67,52 @@ final class PersonalityAgentPostPromotionSearchGateCommandTest extends TestCase
     }
 
     #[Test]
+    public function dry_run_does_not_treat_public_results_article_slugs_as_private_surface_leakage(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/en/personality/enfj-a';
+        $this->seedSeoUrl($canonicalUrl);
+        $this->fakeHttp(
+            [$canonicalUrl],
+            surfaceExtra: "\nhttps://fermatmind.com/en/articles/results-interpretation-guide\nResults summary text for public reading."
+        );
+
+        $output = $this->runGate([
+            '--dry-run' => true,
+            '--json' => true,
+            '--urls' => $canonicalUrl,
+        ]);
+
+        $this->assertSame('GO_FOR_INDEXNOW_DRY_RUN', $output['final_decision'] ?? null);
+        $this->assertSame([], data_get($output, 'targets.0.sitemap_llms_membership.issues'));
+        $this->assertNotContains('sitemap_private_pattern_present', $output['issues'] ?? []);
+        $this->assertNotContains('llms_private_pattern_present', $output['issues'] ?? []);
+        $this->assertNotContains('llms_full_private_pattern_present', $output['issues'] ?? []);
+    }
+
+    #[Test]
+    public function dry_run_blocks_same_origin_private_routes_and_sensitive_query_keys_in_discoverability_surfaces(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/en/personality/enfj-a';
+        $this->seedSeoUrl($canonicalUrl);
+        $this->fakeHttp(
+            [$canonicalUrl],
+            surfaceExtra: "\nhttps://fermatmind.com/en/results/lookup\nhttps://fermatmind.com/en/personality/enfj-a?token=private"
+        );
+
+        $output = $this->runGate([
+            '--dry-run' => true,
+            '--json' => true,
+            '--urls' => $canonicalUrl,
+        ]);
+
+        $this->assertSame('NO_GO_SURFACE_OR_SAFETY', $output['final_decision'] ?? null);
+        $this->assertContains('sitemap_private_pattern_present', $output['issues'] ?? []);
+        $this->assertContains('llms_private_pattern_present', $output['issues'] ?? []);
+        $this->assertContains('llms_full_private_pattern_present', $output['issues'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+    }
+
+    #[Test]
     public function dry_run_reports_url_truth_refresh_required_when_hash_or_lastmod_is_missing(): void
     {
         $canonicalUrl = 'https://fermatmind.com/zh/personality/intp-a';
@@ -171,9 +217,9 @@ final class PersonalityAgentPostPromotionSearchGateCommandTest extends TestCase
     /**
      * @param  list<string>  $canonicalUrls
      */
-    private function fakeHttp(array $canonicalUrls, ?string $targetHtml = null): void
+    private function fakeHttp(array $canonicalUrls, ?string $targetHtml = null, string $surfaceExtra = ''): void
     {
-        $surfaceBody = implode("\n", $canonicalUrls);
+        $surfaceBody = implode("\n", $canonicalUrls).$surfaceExtra;
         $fakes = [
             'https://fermatmind.com/sitemap.xml' => Http::response($surfaceBody, 200),
             'https://fermatmind.com/llms.txt' => Http::response($surfaceBody, 200),


### PR DESCRIPTION
## What changed
- Tightened the personality post-promotion search gate private surface scanner to detect same-origin private route segments instead of raw substring matches.
- Preserved blocking for actual same-origin private routes like /results, /orders, /pay, /payment, /history, /private, /account and sensitive query keys.
- Added focused tests for public slugs containing results text and for real private-route/query-key leakage.

## Why
The live sitemap, llms.txt, and llms-full.txt surfaces already contain the next-batch 6 URLs and do not expose same-origin private routes. The production gate was failing on private-pattern false positives, blocking the IndexNow dry-run decision.

## Validation
- php artisan test tests/Feature/SeoIntel/PersonalityAgentPostPromotionSearchGateCommandTest.php --display-warnings
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

## Deferred
- No production deploy in this PR.
- No CMS write, live promotion, URL Truth write, Search Queue enqueue/approve/submit, external search API call, sitemap mutation, or llms mutation.
- Runtime follow-up after deploy: rerun PERSONALITY-AGENT-POST-PROMOTION-SEARCH-GATE-01.