### PR TITLE
fix(eq): isolate legacy report payload

### DIFF
--- a/backend/app/Services/Report/Eq60ReportComposer.php
+++ b/backend/app/Services/Report/Eq60ReportComposer.php
@@ -148,6 +148,7 @@ final class Eq60ReportComposer
         $crossAssessmentContext = $this->crossAssessmentContextGuard->build($attempt, $result);
         $assetRefs = $this->buildV5AssetRefs($interpretation, $quality, $crossAssessmentContext);
         $resolvedAssets = $this->resolveV5Assets($reportAssets, $locale, $interpretation, $quality, $crossAssessmentContext);
+        $legacyCompat = $this->buildLegacyCompat($sections, $compatFree, $compatPaid, $score);
 
         return [
             'ok' => true,
@@ -164,24 +165,20 @@ final class Eq60ReportComposer
                     'blur' => false,
                     'paywall' => false,
                 ],
-                'sections' => $sections,
-                'compat' => [
-                    'free_blocks' => $compatFree,
-                    'paid_blocks' => $compatPaid,
+                'display_contract' => [
+                    'schema_version' => 'eq_60.display_contract.v1',
+                    'authority' => 'v5_resolved_assets',
+                    'user_visible_roots' => ['scores', 'dimension_summary', 'quality', 'interpretation', 'asset_refs', 'assets', 'next_module', 'methodology'],
+                    'legacy_compat_user_visible' => false,
                 ],
                 'quality' => $quality,
                 'scores' => $v5Scores,
                 'dimension_summary' => $dimensionSummary,
-                'legacy_scores' => is_array($score['scores'] ?? null) ? $score['scores'] : [],
-                'report' => is_array($score['report'] ?? null) ? $score['report'] : [],
-                'report_tags' => array_values(array_filter(
-                    array_map('strval', (array) ($score['report_tags'] ?? [])),
-                    static fn (string $tag): bool => $tag !== ''
-                )),
                 'interpretation' => $interpretation,
                 'cross_assessment_context' => $crossAssessmentContext,
                 'asset_refs' => $assetRefs,
                 'assets' => $resolvedAssets,
+                'legacy_compat' => $legacyCompat,
                 'next_module' => [
                     'available' => false,
                     'module_code' => 'EQ_SJT_16',
@@ -207,6 +204,33 @@ final class Eq60ReportComposer
                 ],
                 'generated_at' => now()->toISOString(),
             ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $sections
+     * @param  list<array<string,mixed>>  $compatFree
+     * @param  list<array<string,mixed>>  $compatPaid
+     * @param  array<string,mixed>  $score
+     * @return array<string,mixed>
+     */
+    private function buildLegacyCompat(array $sections, array $compatFree, array $compatPaid, array $score): array
+    {
+        return [
+            'schema_version' => 'eq_60.legacy_compat.v1',
+            'user_visible' => false,
+            'purpose' => 'legacy_renderer_compatibility_only',
+            'sections' => $sections,
+            'compat' => [
+                'free_blocks' => $compatFree,
+                'paid_blocks' => $compatPaid,
+            ],
+            'legacy_scores' => is_array($score['scores'] ?? null) ? $score['scores'] : [],
+            'scorer_report' => is_array($score['report'] ?? null) ? $score['report'] : [],
+            'report_tags' => array_values(array_filter(
+                array_map('strval', (array) ($score['report_tags'] ?? [])),
+                static fn (string $tag): bool => $tag !== ''
+            )),
         ];
     }
 

--- a/backend/tests/Feature/Report/Eq60ReportPaywallTest.php
+++ b/backend/tests/Feature/Report/Eq60ReportPaywallTest.php
@@ -45,7 +45,17 @@ final class Eq60ReportPaywallTest extends TestCase
         $this->assertSame(ReportAccess::eq60FreeSectionKeys(), array_values((array) data_get($gate, 'view_policy.free_sections', [])));
         $this->assertFalse((bool) data_get($gate, 'view_policy.blur_others', true));
 
-        $sections = (array) data_get($gate, 'report.sections', []);
+        $this->assertNull(data_get($gate, 'report.sections'));
+        $this->assertNull(data_get($gate, 'report.compat'));
+        $this->assertNull(data_get($gate, 'report.report_tags'));
+        $this->assertNull(data_get($gate, 'report.report'));
+        $this->assertNull(data_get($gate, 'report.legacy_scores'));
+        $this->assertSame('v5_resolved_assets', (string) data_get($gate, 'report.display_contract.authority'));
+        $this->assertFalse((bool) data_get($gate, 'report.display_contract.legacy_compat_user_visible', true));
+        $this->assertFalse((bool) data_get($gate, 'report.legacy_compat.user_visible', true));
+        $this->assertSame('legacy_renderer_compatibility_only', (string) data_get($gate, 'report.legacy_compat.purpose'));
+
+        $sections = (array) data_get($gate, 'report.legacy_compat.sections', []);
         $this->assertNotEmpty($sections);
         $keys = array_map(
             static fn (array $section): string => (string) ($section['key'] ?? ''),
@@ -58,8 +68,8 @@ final class Eq60ReportPaywallTest extends TestCase
         foreach ($sections as $section) {
             $this->assertSame('free', (string) ($section['access_level'] ?? ''));
         }
-        $this->assertNotEmpty((array) data_get($gate, 'report.compat.free_blocks', []));
-        $this->assertSame([], (array) data_get($gate, 'report.compat.paid_blocks', []));
+        $this->assertNotEmpty((array) data_get($gate, 'report.legacy_compat.compat.free_blocks', []));
+        $this->assertSame([], (array) data_get($gate, 'report.legacy_compat.compat.paid_blocks', []));
 
         $this->assertSame('self_report', (string) data_get($gate, 'report.eq_report_mode'));
         $this->assertSame('self_report_trait_mixed_ei', (string) data_get($gate, 'report.measurement_type'));
@@ -135,11 +145,14 @@ final class Eq60ReportPaywallTest extends TestCase
         $this->assertSame([], (array) ($gate['offers'] ?? []));
         $this->assertSame([], (array) ($gate['modules_preview'] ?? []));
 
-        $sections = (array) data_get($gate, 'report.sections', []);
+        $sections = (array) data_get($gate, 'report.legacy_compat.sections', []);
         foreach ($sections as $section) {
             $this->assertSame('free', (string) ($section['access_level'] ?? ''));
         }
-        $this->assertSame([], (array) data_get($gate, 'report.compat.paid_blocks', []));
+        $this->assertSame([], (array) data_get($gate, 'report.legacy_compat.compat.paid_blocks', []));
+        $this->assertFalse((bool) data_get($gate, 'report.legacy_compat.user_visible', true));
+        $this->assertNull(data_get($gate, 'report.sections'));
+        $this->assertNull(data_get($gate, 'report.compat'));
     }
 
     public function test_eq60_report_access_fallback_is_ready_full_all_free(): void

--- a/backend/tests/Feature/Report/Eq60V5ReportContractTest.php
+++ b/backend/tests/Feature/Report/Eq60V5ReportContractTest.php
@@ -334,6 +334,30 @@ final class Eq60V5ReportContractTest extends TestCase
         $this->assertFalse((bool) data_get($fixture, 'report.access.locked', true));
         $this->assertFalse((bool) data_get($fixture, 'report.access.blur', true));
         $this->assertFalse((bool) data_get($fixture, 'report.access.paywall', true));
+        $this->assertSame('eq_60.display_contract.v1', (string) data_get($fixture, 'report.display_contract.schema_version'));
+        $this->assertSame('v5_resolved_assets', (string) data_get($fixture, 'report.display_contract.authority'));
+        $this->assertFalse((bool) data_get($fixture, 'report.display_contract.legacy_compat_user_visible', true));
+        $this->assertSame([
+            'scores',
+            'dimension_summary',
+            'quality',
+            'interpretation',
+            'asset_refs',
+            'assets',
+            'next_module',
+            'methodology',
+        ], (array) data_get($fixture, 'report.display_contract.user_visible_roots'));
+        $this->assertNull(data_get($fixture, 'report.sections'));
+        $this->assertNull(data_get($fixture, 'report.compat'));
+        $this->assertNull(data_get($fixture, 'report.report_tags'));
+        $this->assertNull(data_get($fixture, 'report.report'));
+        $this->assertNull(data_get($fixture, 'report.legacy_scores'));
+        $this->assertSame('eq_60.legacy_compat.v1', (string) data_get($fixture, 'report.legacy_compat.schema_version'));
+        $this->assertFalse((bool) data_get($fixture, 'report.legacy_compat.user_visible', true));
+        $this->assertSame('legacy_renderer_compatibility_only', (string) data_get($fixture, 'report.legacy_compat.purpose'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.legacy_compat.sections'));
+        $this->assertNotEmpty((array) data_get($fixture, 'report.legacy_compat.compat.free_blocks'));
+        $this->assertSame([], (array) data_get($fixture, 'report.legacy_compat.compat.paid_blocks'));
         $this->assertIsArray(data_get($fixture, 'report.scores.global'));
         foreach (['SA', 'ER', 'EM', 'RM'] as $code) {
             $this->assertIsArray(data_get($fixture, 'report.scores.dimensions.'.$code));
@@ -439,7 +463,7 @@ final class Eq60V5ReportContractTest extends TestCase
             }
         };
 
-        foreach (['sections', 'assets'] as $key) {
+        foreach (['assets'] as $key) {
             $walk($payload[$key] ?? []);
         }
 

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_en.json
@@ -813,77 +813,6 @@
                 "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment."
             }
         },
-        "compat": {
-            "free_blocks": [
-                {
-                    "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
-                    "id": "eq60_disclaimer_top_en",
-                    "section_key": "disclaimer_top",
-                    "title": "Important Notice"
-                },
-                {
-                    "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
-                    "id": "eq60_quality_level_A_en",
-                    "section_key": "quality_notice",
-                    "title": "Response Quality"
-                },
-                {
-                    "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
-                    "id": "eq60_global_overview_en",
-                    "section_key": "global_overview",
-                    "title": "Overview"
-                },
-                {
-                    "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
-                    "id": "eq60_sa_proficient_en",
-                    "section_key": "self_awareness",
-                    "title": "Self‑Awareness · Proficient"
-                },
-                {
-                    "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
-                    "id": "eq60_er_proficient_en",
-                    "section_key": "emotion_regulation",
-                    "title": "Emotion Regulation · Proficient"
-                },
-                {
-                    "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
-                    "id": "eq60_em_proficient_en",
-                    "section_key": "empathy",
-                    "title": "Social Awareness & Empathy · Proficient"
-                },
-                {
-                    "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
-                    "id": "eq60_rm_proficient_en",
-                    "section_key": "relationship_management",
-                    "title": "Relationship Management · Proficient"
-                },
-                {
-                    "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nThis free report breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What this free report gives you**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
-                    "id": "eq60_profile_balanced_high_en",
-                    "section_key": "cross_quadrant_insight",
-                    "title": "Balanced High EQ"
-                },
-                {
-                    "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
-                    "id": "eq60_plan_maintenance_en",
-                    "section_key": "action_plan_14d",
-                    "title": "High‑Level Consolidation"
-                },
-                {
-                    "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
-                    "id": "eq60_methodology_en",
-                    "section_key": "methodology",
-                    "title": "Methodology"
-                },
-                {
-                    "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
-                    "id": "eq60_disclaimer_bottom_en",
-                    "section_key": "disclaimer_bottom",
-                    "title": "Closing Notes"
-                }
-            ],
-            "paid_blocks": []
-        },
         "cross_assessment_context": {
             "available": true,
             "boundary_asset_id": "eq.cross_context.boundary.default",
@@ -963,6 +892,21 @@
                 "standard_score": 113
             }
         ],
+        "display_contract": {
+            "authority": "v5_resolved_assets",
+            "legacy_compat_user_visible": false,
+            "schema_version": "eq_60.display_contract.v1",
+            "user_visible_roots": [
+                "scores",
+                "dimension_summary",
+                "quality",
+                "interpretation",
+                "asset_refs",
+                "assets",
+                "next_module",
+                "methodology"
+            ]
+        },
         "eq_report_mode": "self_report",
         "generated_at": "2026-05-21T00:00:00.000000Z",
         "interpretation": {
@@ -1081,88 +1025,331 @@
             ],
             "version": "eq_journey_state.v1"
         },
-        "legacy_scores": {
-            "EM": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+        "legacy_compat": {
+            "compat": {
+                "free_blocks": [
+                    {
+                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                        "id": "eq60_disclaimer_top_en",
+                        "section_key": "disclaimer_top",
+                        "title": "Important Notice"
+                    },
+                    {
+                        "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
+                        "id": "eq60_quality_level_A_en",
+                        "section_key": "quality_notice",
+                        "title": "Response Quality"
+                    },
+                    {
+                        "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
+                        "id": "eq60_global_overview_en",
+                        "section_key": "global_overview",
+                        "title": "Overview"
+                    },
+                    {
+                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
+                        "id": "eq60_sa_proficient_en",
+                        "section_key": "self_awareness",
+                        "title": "Self‑Awareness · Proficient"
+                    },
+                    {
+                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
+                        "id": "eq60_er_proficient_en",
+                        "section_key": "emotion_regulation",
+                        "title": "Emotion Regulation · Proficient"
+                    },
+                    {
+                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
+                        "id": "eq60_em_proficient_en",
+                        "section_key": "empathy",
+                        "title": "Social Awareness & Empathy · Proficient"
+                    },
+                    {
+                        "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
+                        "id": "eq60_rm_proficient_en",
+                        "section_key": "relationship_management",
+                        "title": "Relationship Management · Proficient"
+                    },
+                    {
+                        "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nThis free report breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What this free report gives you**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
+                        "id": "eq60_profile_balanced_high_en",
+                        "section_key": "cross_quadrant_insight",
+                        "title": "Balanced High EQ"
+                    },
+                    {
+                        "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
+                        "id": "eq60_plan_maintenance_en",
+                        "section_key": "action_plan_14d",
+                        "title": "High‑Level Consolidation"
+                    },
+                    {
+                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                        "id": "eq60_methodology_en",
+                        "section_key": "methodology",
+                        "title": "Methodology"
+                    },
+                    {
+                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                        "id": "eq60_disclaimer_bottom_en",
+                        "section_key": "disclaimer_bottom",
+                        "title": "Closing Notes"
+                    }
+                ],
+                "paid_blocks": []
             },
-            "ER": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+            "legacy_scores": {
+                "EM": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "ER": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "RM": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "SA": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "emotion_regulation": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "empathy": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "global": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 240,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "relationship_management": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "self_awareness": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                }
             },
-            "RM": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+            "purpose": "legacy_renderer_compatibility_only",
+            "report_tags": [
+                "quality_level:A",
+                "profile:balanced_high_eq"
+            ],
+            "schema_version": "eq_60.legacy_compat.v1",
+            "scorer_report": {
+                "primary_profile": "profile:balanced_high_eq",
+                "tags": [
+                    "quality_level:A",
+                    "profile:balanced_high_eq"
+                ]
             },
-            "SA": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "emotion_regulation": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "empathy": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "global": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 240,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "relationship_management": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "self_awareness": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            }
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                            "id": "eq60_disclaimer_top_en",
+                            "title": "Important Notice",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "eq_core",
+                    "title": "Important Notice"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
+                            "id": "eq60_quality_level_A_en",
+                            "title": "Response Quality",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "quality_notice",
+                    "module_code": "eq_core",
+                    "title": "Response Quality"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
+                            "id": "eq60_global_overview_en",
+                            "title": "Overview",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "global_overview",
+                    "module_code": "eq_core",
+                    "title": "Overview"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
+                            "id": "eq60_sa_proficient_en",
+                            "title": "Self‑Awareness · Proficient",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "self_awareness",
+                    "module_code": "eq_core",
+                    "title": "Self‑Awareness"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
+                            "id": "eq60_er_proficient_en",
+                            "title": "Emotion Regulation · Proficient",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "emotion_regulation",
+                    "module_code": "eq_core",
+                    "title": "Emotion Regulation"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
+                            "id": "eq60_em_proficient_en",
+                            "title": "Social Awareness & Empathy · Proficient",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "empathy",
+                    "module_code": "eq_core",
+                    "title": "Social Awareness & Empathy"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
+                            "id": "eq60_rm_proficient_en",
+                            "title": "Relationship Management · Proficient",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "relationship_management",
+                    "module_code": "eq_core",
+                    "title": "Relationship Management"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nThis free report breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What this free report gives you**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
+                            "id": "eq60_profile_balanced_high_en",
+                            "title": "Balanced High EQ",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "cross_quadrant_insight",
+                    "module_code": "eq_cross_insights",
+                    "title": "Cross‑Quadrant Insight"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
+                            "id": "eq60_plan_maintenance_en",
+                            "title": "High‑Level Consolidation",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "action_plan_14d",
+                    "module_code": "eq_growth_plan",
+                    "title": "14‑Day Plan"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                            "id": "eq60_methodology_en",
+                            "title": "Methodology",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "methodology",
+                    "module_code": "eq_core",
+                    "title": "Methodology"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                            "id": "eq60_disclaimer_bottom_en",
+                            "title": "Closing Notes",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_bottom",
+                    "module_code": "eq_core",
+                    "title": "Closing Notes"
+                }
+            ],
+            "user_visible": false
         },
         "locale": "en",
         "measurement_type": "self_report_trait_mixed_ei",
@@ -1196,17 +1383,6 @@
             },
             "neutral_rate": 0
         },
-        "report": {
-            "primary_profile": "profile:balanced_high_eq",
-            "tags": [
-                "quality_level:A",
-                "profile:balanced_high_eq"
-            ]
-        },
-        "report_tags": [
-            "quality_level:A",
-            "profile:balanced_high_eq"
-        ],
         "scale_code": "EQ_60",
         "schema_version": "eq_60.report.v2",
         "scores": {
@@ -1252,162 +1428,6 @@
                 "standard_score": 113
             }
         },
-        "sections": [
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
-                        "id": "eq60_disclaimer_top_en",
-                        "title": "Important Notice",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_top",
-                "module_code": "eq_core",
-                "title": "Important Notice"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
-                        "id": "eq60_quality_level_A_en",
-                        "title": "Response Quality",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "quality_notice",
-                "module_code": "eq_core",
-                "title": "Response Quality"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
-                        "id": "eq60_global_overview_en",
-                        "title": "Overview",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "global_overview",
-                "module_code": "eq_core",
-                "title": "Overview"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
-                        "id": "eq60_sa_proficient_en",
-                        "title": "Self‑Awareness · Proficient",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "self_awareness",
-                "module_code": "eq_core",
-                "title": "Self‑Awareness"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
-                        "id": "eq60_er_proficient_en",
-                        "title": "Emotion Regulation · Proficient",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "emotion_regulation",
-                "module_code": "eq_core",
-                "title": "Emotion Regulation"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
-                        "id": "eq60_em_proficient_en",
-                        "title": "Social Awareness & Empathy · Proficient",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "empathy",
-                "module_code": "eq_core",
-                "title": "Social Awareness & Empathy"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
-                        "id": "eq60_rm_proficient_en",
-                        "title": "Relationship Management · Proficient",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "relationship_management",
-                "module_code": "eq_core",
-                "title": "Relationship Management"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nThis free report breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What this free report gives you**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
-                        "id": "eq60_profile_balanced_high_en",
-                        "title": "Balanced High EQ",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "cross_quadrant_insight",
-                "module_code": "eq_cross_insights",
-                "title": "Cross‑Quadrant Insight"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
-                        "id": "eq60_plan_maintenance_en",
-                        "title": "High‑Level Consolidation",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "action_plan_14d",
-                "module_code": "eq_growth_plan",
-                "title": "14‑Day Plan"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
-                        "id": "eq60_methodology_en",
-                        "title": "Methodology",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "methodology",
-                "module_code": "eq_core",
-                "title": "Methodology"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
-                        "id": "eq60_disclaimer_bottom_en",
-                        "title": "Closing Notes",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_bottom",
-                "module_code": "eq_core",
-                "title": "Closing Notes"
-            }
-        ],
         "variant": "full"
     },
     "report_access": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_balanced_integrated_zh.json
@@ -813,77 +813,6 @@
                 "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。"
             }
         },
-        "compat": {
-            "free_blocks": [
-                {
-                    "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
-                    "id": "eq60_disclaimer_top_zh",
-                    "section_key": "disclaimer_top",
-                    "title": "重要声明"
-                },
-                {
-                    "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
-                    "id": "eq60_quality_level_A_zh",
-                    "section_key": "quality_notice",
-                    "title": "作答质量提示"
-                },
-                {
-                    "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
-                    "id": "eq60_global_overview_zh",
-                    "section_key": "global_overview",
-                    "title": "综合概览"
-                },
-                {
-                    "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
-                    "id": "eq60_sa_proficient_zh",
-                    "section_key": "self_awareness",
-                    "title": "自我情绪认知 · 成熟（Proficient）"
-                },
-                {
-                    "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
-                    "id": "eq60_er_proficient_zh",
-                    "section_key": "emotion_regulation",
-                    "title": "情绪调节与控制 · 成熟（Proficient）"
-                },
-                {
-                    "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
-                    "id": "eq60_em_proficient_zh",
-                    "section_key": "empathy",
-                    "title": "同理心与社会感知 · 成熟（Proficient）"
-                },
-                {
-                    "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
-                    "id": "eq60_rm_proficient_zh",
-                    "section_key": "relationship_management",
-                    "title": "社交技能与人际管理 · 成熟（Proficient）"
-                },
-                {
-                    "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n这份免费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在这份免费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
-                    "id": "eq60_profile_balanced_high_zh",
-                    "section_key": "cross_quadrant_insight",
-                    "title": "四维均衡高"
-                },
-                {
-                    "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
-                    "id": "eq60_plan_maintenance_zh",
-                    "section_key": "action_plan_14d",
-                    "title": "高水平巩固"
-                },
-                {
-                    "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
-                    "id": "eq60_methodology_zh",
-                    "section_key": "methodology",
-                    "title": "方法说明"
-                },
-                {
-                    "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
-                    "id": "eq60_disclaimer_bottom_zh",
-                    "section_key": "disclaimer_bottom",
-                    "title": "结尾提示"
-                }
-            ],
-            "paid_blocks": []
-        },
         "cross_assessment_context": {
             "available": true,
             "boundary_asset_id": "eq.cross_context.boundary.default",
@@ -963,6 +892,21 @@
                 "standard_score": 113
             }
         ],
+        "display_contract": {
+            "authority": "v5_resolved_assets",
+            "legacy_compat_user_visible": false,
+            "schema_version": "eq_60.display_contract.v1",
+            "user_visible_roots": [
+                "scores",
+                "dimension_summary",
+                "quality",
+                "interpretation",
+                "asset_refs",
+                "assets",
+                "next_module",
+                "methodology"
+            ]
+        },
         "eq_report_mode": "self_report",
         "generated_at": "2026-05-21T00:00:00.000000Z",
         "interpretation": {
@@ -1081,88 +1025,331 @@
             ],
             "version": "eq_journey_state.v1"
         },
-        "legacy_scores": {
-            "EM": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+        "legacy_compat": {
+            "compat": {
+                "free_blocks": [
+                    {
+                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                        "id": "eq60_disclaimer_top_zh",
+                        "section_key": "disclaimer_top",
+                        "title": "重要声明"
+                    },
+                    {
+                        "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
+                        "id": "eq60_quality_level_A_zh",
+                        "section_key": "quality_notice",
+                        "title": "作答质量提示"
+                    },
+                    {
+                        "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
+                        "id": "eq60_global_overview_zh",
+                        "section_key": "global_overview",
+                        "title": "综合概览"
+                    },
+                    {
+                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
+                        "id": "eq60_sa_proficient_zh",
+                        "section_key": "self_awareness",
+                        "title": "自我情绪认知 · 成熟（Proficient）"
+                    },
+                    {
+                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
+                        "id": "eq60_er_proficient_zh",
+                        "section_key": "emotion_regulation",
+                        "title": "情绪调节与控制 · 成熟（Proficient）"
+                    },
+                    {
+                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
+                        "id": "eq60_em_proficient_zh",
+                        "section_key": "empathy",
+                        "title": "同理心与社会感知 · 成熟（Proficient）"
+                    },
+                    {
+                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
+                        "id": "eq60_rm_proficient_zh",
+                        "section_key": "relationship_management",
+                        "title": "社交技能与人际管理 · 成熟（Proficient）"
+                    },
+                    {
+                        "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n这份免费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在这份免费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
+                        "id": "eq60_profile_balanced_high_zh",
+                        "section_key": "cross_quadrant_insight",
+                        "title": "四维均衡高"
+                    },
+                    {
+                        "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
+                        "id": "eq60_plan_maintenance_zh",
+                        "section_key": "action_plan_14d",
+                        "title": "高水平巩固"
+                    },
+                    {
+                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                        "id": "eq60_methodology_zh",
+                        "section_key": "methodology",
+                        "title": "方法说明"
+                    },
+                    {
+                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                        "id": "eq60_disclaimer_bottom_zh",
+                        "section_key": "disclaimer_bottom",
+                        "title": "结尾提示"
+                    }
+                ],
+                "paid_blocks": []
             },
-            "ER": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+            "legacy_scores": {
+                "EM": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "ER": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "RM": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "SA": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "emotion_regulation": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "empathy": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "global": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 240,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "relationship_management": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "self_awareness": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                }
             },
-            "RM": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+            "purpose": "legacy_renderer_compatibility_only",
+            "report_tags": [
+                "quality_level:A",
+                "profile:balanced_high_eq"
+            ],
+            "schema_version": "eq_60.legacy_compat.v1",
+            "scorer_report": {
+                "primary_profile": "profile:balanced_high_eq",
+                "tags": [
+                    "quality_level:A",
+                    "profile:balanced_high_eq"
+                ]
             },
-            "SA": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "emotion_regulation": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "empathy": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "global": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 240,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "relationship_management": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "self_awareness": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            }
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                            "id": "eq60_disclaimer_top_zh",
+                            "title": "重要声明",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "eq_core",
+                    "title": "重要声明"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
+                            "id": "eq60_quality_level_A_zh",
+                            "title": "作答质量提示",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "quality_notice",
+                    "module_code": "eq_core",
+                    "title": "作答质量提示"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
+                            "id": "eq60_global_overview_zh",
+                            "title": "综合概览",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "global_overview",
+                    "module_code": "eq_core",
+                    "title": "综合概览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
+                            "id": "eq60_sa_proficient_zh",
+                            "title": "自我情绪认知 · 成熟（Proficient）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "self_awareness",
+                    "module_code": "eq_core",
+                    "title": "自我情绪认知"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
+                            "id": "eq60_er_proficient_zh",
+                            "title": "情绪调节与控制 · 成熟（Proficient）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "emotion_regulation",
+                    "module_code": "eq_core",
+                    "title": "情绪调节与控制"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
+                            "id": "eq60_em_proficient_zh",
+                            "title": "同理心与社会感知 · 成熟（Proficient）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "empathy",
+                    "module_code": "eq_core",
+                    "title": "同理心与社会感知"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
+                            "id": "eq60_rm_proficient_zh",
+                            "title": "社交技能与人际管理 · 成熟（Proficient）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "relationship_management",
+                    "module_code": "eq_core",
+                    "title": "社交技能与人际管理"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n这份免费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在这份免费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
+                            "id": "eq60_profile_balanced_high_zh",
+                            "title": "四维均衡高",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "cross_quadrant_insight",
+                    "module_code": "eq_cross_insights",
+                    "title": "交叉洞察长文"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
+                            "id": "eq60_plan_maintenance_zh",
+                            "title": "高水平巩固",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "action_plan_14d",
+                    "module_code": "eq_growth_plan",
+                    "title": "14 天游程"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                            "id": "eq60_methodology_zh",
+                            "title": "方法说明",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "methodology",
+                    "module_code": "eq_core",
+                    "title": "方法说明"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                            "id": "eq60_disclaimer_bottom_zh",
+                            "title": "结尾提示",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_bottom",
+                    "module_code": "eq_core",
+                    "title": "结尾提示"
+                }
+            ],
+            "user_visible": false
         },
         "locale": "zh-CN",
         "measurement_type": "self_report_trait_mixed_ei",
@@ -1196,17 +1383,6 @@
             },
             "neutral_rate": 0
         },
-        "report": {
-            "primary_profile": "profile:balanced_high_eq",
-            "tags": [
-                "quality_level:A",
-                "profile:balanced_high_eq"
-            ]
-        },
-        "report_tags": [
-            "quality_level:A",
-            "profile:balanced_high_eq"
-        ],
         "scale_code": "EQ_60",
         "schema_version": "eq_60.report.v2",
         "scores": {
@@ -1252,162 +1428,6 @@
                 "standard_score": 113
             }
         },
-        "sections": [
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
-                        "id": "eq60_disclaimer_top_zh",
-                        "title": "重要声明",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_top",
-                "module_code": "eq_core",
-                "title": "重要声明"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
-                        "id": "eq60_quality_level_A_zh",
-                        "title": "作答质量提示",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "quality_notice",
-                "module_code": "eq_core",
-                "title": "作答质量提示"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
-                        "id": "eq60_global_overview_zh",
-                        "title": "综合概览",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "global_overview",
-                "module_code": "eq_core",
-                "title": "综合概览"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
-                        "id": "eq60_sa_proficient_zh",
-                        "title": "自我情绪认知 · 成熟（Proficient）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "self_awareness",
-                "module_code": "eq_core",
-                "title": "自我情绪认知"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
-                        "id": "eq60_er_proficient_zh",
-                        "title": "情绪调节与控制 · 成熟（Proficient）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "emotion_regulation",
-                "module_code": "eq_core",
-                "title": "情绪调节与控制"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
-                        "id": "eq60_em_proficient_zh",
-                        "title": "同理心与社会感知 · 成熟（Proficient）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "empathy",
-                "module_code": "eq_core",
-                "title": "同理心与社会感知"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
-                        "id": "eq60_rm_proficient_zh",
-                        "title": "社交技能与人际管理 · 成熟（Proficient）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "relationship_management",
-                "module_code": "eq_core",
-                "title": "社交技能与人际管理"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n这份免费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在这份免费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
-                        "id": "eq60_profile_balanced_high_zh",
-                        "title": "四维均衡高",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "cross_quadrant_insight",
-                "module_code": "eq_cross_insights",
-                "title": "交叉洞察长文"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
-                        "id": "eq60_plan_maintenance_zh",
-                        "title": "高水平巩固",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "action_plan_14d",
-                "module_code": "eq_growth_plan",
-                "title": "14 天游程"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
-                        "id": "eq60_methodology_zh",
-                        "title": "方法说明",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "methodology",
-                "module_code": "eq_core",
-                "title": "方法说明"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
-                        "id": "eq60_disclaimer_bottom_zh",
-                        "title": "结尾提示",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_bottom",
-                "module_code": "eq_core",
-                "title": "结尾提示"
-            }
-        ],
         "variant": "full"
     },
     "report_access": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_en.json
@@ -813,77 +813,6 @@
                 "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment."
             }
         },
-        "compat": {
-            "free_blocks": [
-                {
-                    "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
-                    "id": "eq60_disclaimer_top_en",
-                    "section_key": "disclaimer_top",
-                    "title": "Important Notice"
-                },
-                {
-                    "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
-                    "id": "eq60_quality_level_A_en",
-                    "section_key": "quality_notice",
-                    "title": "Response Quality"
-                },
-                {
-                    "content": "Your overall EQ standard score is **99.5** (population mean 100, SD 15), at the **48.67** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
-                    "id": "eq60_global_overview_en",
-                    "section_key": "global_overview",
-                    "title": "Overview"
-                },
-                {
-                    "content": "**Dimension: Self‑Awareness**\n\nStandard score: **97** (42.07 percentile), band: **Competent**.\n\nYou usually identify emotions and connect them to triggers and needs. In many situations you can say things like “I’m tense,” “I need a moment,” or “I felt overlooked.” This reduces misunderstanding and rumination, keeping conversations closer to the real issue.\n\n**Practice**: Before a key conversation, write one sentence: “What matters most to me here?”",
-                    "id": "eq60_sa_competent_en",
-                    "section_key": "self_awareness",
-                    "title": "Self‑Awareness · Competent"
-                },
-                {
-                    "content": "**Dimension: Emotion Regulation**\n\nStandard score: **83** (12.85 percentile), band: **Baseline**.\n\nUnder pressure or triggers, emotions can take over the action system—impulses, rumination, sleep disruption, or prolonged tension. This is not a “willpower” label; it reflects a toolbox that isn’t automatic yet. Regulation aims to bring intensity and duration back into a manageable range, not to erase emotions.\n\n**90‑second reset**: Pause → slow exhale 6 times → feel your feet on the ground to create space before reacting.",
-                    "id": "eq60_er_baseline_en",
-                    "section_key": "emotion_regulation",
-                    "title": "Emotion Regulation · Baseline"
-                },
-                {
-                    "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **119** (89.74 percentile), band: **Exceptional**.\n\nYour empathy is exceptionally strong. Even in noisy environments you read emotions and motives accurately and respond with warmth. This is a foundation of influence. Keep boundaries to prevent emotional overload.\n\n**Practice**: Use: “I see this is hard for you. I can stay with you for a bit,” while keeping your limits.",
-                    "id": "eq60_em_exceptional_en",
-                    "section_key": "empathy",
-                    "title": "Social Awareness & Empathy · Exceptional"
-                },
-                {
-                    "content": "**Dimension: Relationship Management**\n\nStandard score: **99** (47.34 percentile), band: **Competent**.\n\nYou communicate and collaborate well, maintain trust, and manage disagreements without breaking the relationship. You tend to balance authenticity with relationship care.\n\n**Practice**: In conflict, align on the shared goal first, then discuss options.",
-                    "id": "eq60_rm_competent_en",
-                    "section_key": "relationship_management",
-                    "title": "Relationship Management · Competent"
-                },
-                {
-                    "content": "**Primary profile: Compassion Overload (High Empathy + Low Regulation)**\n\nYour results show Empathy **119** very high and Emotion Regulation **83** lower. You feel others’ pain and stress strongly, and group climate can affect you quickly. The gift is warmth and attunement; the cost is overload and blurry boundaries.\n\n**Typical strengths**\n- High resonance: people open up to you easily.\n- Strong ‘room reading’: you sense shifts and hidden tension.\n- Care motive: a real drive to help.\n\n**Typical costs**\n- Emotional contagion: others’ feelings enter your body and drain sleep/energy.\n- Rescue reflex: urgency to fix, leading to over‑involvement.\n- Boundary loss: ‘empathy’ turns into ‘carrying,’ then burnout.\n\n**Key shift: bounded care**\nHigh empathy doesn’t require self‑sacrifice. Training focuses on three boundaries:\n1) **Emotional boundary**: “This is theirs” vs “this is mine.”\n2) **Time boundary**: define how long you can be available.\n3) **Action boundary**: move from ‘fixing’ to ‘helping them see choices.’\n\n**Support scripts**\n- “I hear this is hard. I can stay with you for 10 minutes to sort it out.”\n- “What I can offer is … The deeper choice is yours.”\n- “I care about you, and I also need to protect my energy.”\n\n**What this free report gives you**\n- Boundary training to turn empathy into a resource.\n- Regulation tools to prevent overload spillover.\n- 14‑day plan for sustainable helping.",
-                    "id": "eq60_profile_compassion_overload_en",
-                    "section_key": "cross_quadrant_insight",
-                    "title": "Compassion Overload"
-                },
-                {
-                    "content": "**14‑Day Plan: Boundaried Care (10–15 min/day)**\n\nGoal: keep your warmth and sensitivity while building emotional, time, and action boundaries to prevent overload.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Mine vs yours | Note one contagion moment: whose emotion is it? what can I do? |\n| Day 2 | Emotional boundary | Practice: “I see it’s hard for you. This is your feeling. I’m here with you.” |\n| Day 3 | Time boundary | Set a time cap (10/20 min) and write an ending script. |\n| Day 4 | Action boundary | Shift from fixing to options: write 3 guiding questions. |\n| Day 5 | Back to body | 2‑minute tactile grounding (cup/table texture). |\n| Day 6 | Self‑compassion | Write 3 lines: this is hard; I’m not alone; I’ll be kind to myself. |\n| Day 7 | Support & referral | List 3 resources you can hand off to; don’t carry alone. |\n| Day 8 | Empathize without spiraling | Reflect feeling, then ask: listen or brainstorm? |\n| Day 9 | Energy return | After deep listening: 5 minutes walk/breath to reset. |\n| Day10 | State limits | Use: “I can stay up to here; then I need rest.” once. |\n| Day11 | Load monitoring | Rate emotional load 0–10; above 7, reduce inputs intentionally. |\n| Day12 | One smallest act | Keep helping action to 1 minimal step; avoid over‑involvement. |\n| Day13 | Relationship structure | Pick one draining relationship: what boundary makes it sustainable? |\n| Day14 | Consolidate | 3 boundary principles + 3 care scripts. |\n\nBoundaries aren’t coldness—they make care sustainable.",
-                    "id": "eq60_plan_boundary_en",
-                    "section_key": "action_plan_14d",
-                    "title": "Boundaried Care"
-                },
-                {
-                    "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
-                    "id": "eq60_methodology_en",
-                    "section_key": "methodology",
-                    "title": "Methodology"
-                },
-                {
-                    "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
-                    "id": "eq60_disclaimer_bottom_en",
-                    "section_key": "disclaimer_bottom",
-                    "title": "Closing Notes"
-                }
-            ],
-            "paid_blocks": []
-        },
         "cross_assessment_context": {
             "available": true,
             "boundary_asset_id": "eq.cross_context.boundary.default",
@@ -963,6 +892,21 @@
                 "standard_score": 99
             }
         ],
+        "display_contract": {
+            "authority": "v5_resolved_assets",
+            "legacy_compat_user_visible": false,
+            "schema_version": "eq_60.display_contract.v1",
+            "user_visible_roots": [
+                "scores",
+                "dimension_summary",
+                "quality",
+                "interpretation",
+                "asset_refs",
+                "assets",
+                "next_module",
+                "methodology"
+            ]
+        },
         "eq_report_mode": "self_report",
         "generated_at": "2026-05-21T00:00:00.000000Z",
         "interpretation": {
@@ -1081,88 +1025,333 @@
             ],
             "version": "eq_journey_state.v1"
         },
-        "legacy_scores": {
-            "EM": {
-                "level": "exceptional",
-                "percentile": 89.74,
-                "pomp": 80,
-                "raw_mean": 4.2,
-                "raw_sum": 63,
-                "std_score": 119,
-                "z": 1.266667
+        "legacy_compat": {
+            "compat": {
+                "free_blocks": [
+                    {
+                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                        "id": "eq60_disclaimer_top_en",
+                        "section_key": "disclaimer_top",
+                        "title": "Important Notice"
+                    },
+                    {
+                        "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
+                        "id": "eq60_quality_level_A_en",
+                        "section_key": "quality_notice",
+                        "title": "Response Quality"
+                    },
+                    {
+                        "content": "Your overall EQ standard score is **99.5** (population mean 100, SD 15), at the **48.67** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
+                        "id": "eq60_global_overview_en",
+                        "section_key": "global_overview",
+                        "title": "Overview"
+                    },
+                    {
+                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **97** (42.07 percentile), band: **Competent**.\n\nYou usually identify emotions and connect them to triggers and needs. In many situations you can say things like “I’m tense,” “I need a moment,” or “I felt overlooked.” This reduces misunderstanding and rumination, keeping conversations closer to the real issue.\n\n**Practice**: Before a key conversation, write one sentence: “What matters most to me here?”",
+                        "id": "eq60_sa_competent_en",
+                        "section_key": "self_awareness",
+                        "title": "Self‑Awareness · Competent"
+                    },
+                    {
+                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **83** (12.85 percentile), band: **Baseline**.\n\nUnder pressure or triggers, emotions can take over the action system—impulses, rumination, sleep disruption, or prolonged tension. This is not a “willpower” label; it reflects a toolbox that isn’t automatic yet. Regulation aims to bring intensity and duration back into a manageable range, not to erase emotions.\n\n**90‑second reset**: Pause → slow exhale 6 times → feel your feet on the ground to create space before reacting.",
+                        "id": "eq60_er_baseline_en",
+                        "section_key": "emotion_regulation",
+                        "title": "Emotion Regulation · Baseline"
+                    },
+                    {
+                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **119** (89.74 percentile), band: **Exceptional**.\n\nYour empathy is exceptionally strong. Even in noisy environments you read emotions and motives accurately and respond with warmth. This is a foundation of influence. Keep boundaries to prevent emotional overload.\n\n**Practice**: Use: “I see this is hard for you. I can stay with you for a bit,” while keeping your limits.",
+                        "id": "eq60_em_exceptional_en",
+                        "section_key": "empathy",
+                        "title": "Social Awareness & Empathy · Exceptional"
+                    },
+                    {
+                        "content": "**Dimension: Relationship Management**\n\nStandard score: **99** (47.34 percentile), band: **Competent**.\n\nYou communicate and collaborate well, maintain trust, and manage disagreements without breaking the relationship. You tend to balance authenticity with relationship care.\n\n**Practice**: In conflict, align on the shared goal first, then discuss options.",
+                        "id": "eq60_rm_competent_en",
+                        "section_key": "relationship_management",
+                        "title": "Relationship Management · Competent"
+                    },
+                    {
+                        "content": "**Primary profile: Compassion Overload (High Empathy + Low Regulation)**\n\nYour results show Empathy **119** very high and Emotion Regulation **83** lower. You feel others’ pain and stress strongly, and group climate can affect you quickly. The gift is warmth and attunement; the cost is overload and blurry boundaries.\n\n**Typical strengths**\n- High resonance: people open up to you easily.\n- Strong ‘room reading’: you sense shifts and hidden tension.\n- Care motive: a real drive to help.\n\n**Typical costs**\n- Emotional contagion: others’ feelings enter your body and drain sleep/energy.\n- Rescue reflex: urgency to fix, leading to over‑involvement.\n- Boundary loss: ‘empathy’ turns into ‘carrying,’ then burnout.\n\n**Key shift: bounded care**\nHigh empathy doesn’t require self‑sacrifice. Training focuses on three boundaries:\n1) **Emotional boundary**: “This is theirs” vs “this is mine.”\n2) **Time boundary**: define how long you can be available.\n3) **Action boundary**: move from ‘fixing’ to ‘helping them see choices.’\n\n**Support scripts**\n- “I hear this is hard. I can stay with you for 10 minutes to sort it out.”\n- “What I can offer is … The deeper choice is yours.”\n- “I care about you, and I also need to protect my energy.”\n\n**What this free report gives you**\n- Boundary training to turn empathy into a resource.\n- Regulation tools to prevent overload spillover.\n- 14‑day plan for sustainable helping.",
+                        "id": "eq60_profile_compassion_overload_en",
+                        "section_key": "cross_quadrant_insight",
+                        "title": "Compassion Overload"
+                    },
+                    {
+                        "content": "**14‑Day Plan: Boundaried Care (10–15 min/day)**\n\nGoal: keep your warmth and sensitivity while building emotional, time, and action boundaries to prevent overload.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Mine vs yours | Note one contagion moment: whose emotion is it? what can I do? |\n| Day 2 | Emotional boundary | Practice: “I see it’s hard for you. This is your feeling. I’m here with you.” |\n| Day 3 | Time boundary | Set a time cap (10/20 min) and write an ending script. |\n| Day 4 | Action boundary | Shift from fixing to options: write 3 guiding questions. |\n| Day 5 | Back to body | 2‑minute tactile grounding (cup/table texture). |\n| Day 6 | Self‑compassion | Write 3 lines: this is hard; I’m not alone; I’ll be kind to myself. |\n| Day 7 | Support & referral | List 3 resources you can hand off to; don’t carry alone. |\n| Day 8 | Empathize without spiraling | Reflect feeling, then ask: listen or brainstorm? |\n| Day 9 | Energy return | After deep listening: 5 minutes walk/breath to reset. |\n| Day10 | State limits | Use: “I can stay up to here; then I need rest.” once. |\n| Day11 | Load monitoring | Rate emotional load 0–10; above 7, reduce inputs intentionally. |\n| Day12 | One smallest act | Keep helping action to 1 minimal step; avoid over‑involvement. |\n| Day13 | Relationship structure | Pick one draining relationship: what boundary makes it sustainable? |\n| Day14 | Consolidate | 3 boundary principles + 3 care scripts. |\n\nBoundaries aren’t coldness—they make care sustainable.",
+                        "id": "eq60_plan_boundary_en",
+                        "section_key": "action_plan_14d",
+                        "title": "Boundaried Care"
+                    },
+                    {
+                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                        "id": "eq60_methodology_en",
+                        "section_key": "methodology",
+                        "title": "Methodology"
+                    },
+                    {
+                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                        "id": "eq60_disclaimer_bottom_en",
+                        "section_key": "disclaimer_bottom",
+                        "title": "Closing Notes"
+                    }
+                ],
+                "paid_blocks": []
             },
-            "ER": {
-                "level": "baseline",
-                "percentile": 12.85,
-                "pomp": 50,
-                "raw_mean": 3,
-                "raw_sum": 45,
-                "std_score": 83,
-                "z": -1.133333
+            "legacy_scores": {
+                "EM": {
+                    "level": "exceptional",
+                    "percentile": 89.74,
+                    "pomp": 80,
+                    "raw_mean": 4.2,
+                    "raw_sum": 63,
+                    "std_score": 119,
+                    "z": 1.266667
+                },
+                "ER": {
+                    "level": "baseline",
+                    "percentile": 12.85,
+                    "pomp": 50,
+                    "raw_mean": 3,
+                    "raw_sum": 45,
+                    "std_score": 83,
+                    "z": -1.133333
+                },
+                "RM": {
+                    "level": "competent",
+                    "percentile": 47.34,
+                    "pomp": 63.33,
+                    "raw_mean": 3.5333,
+                    "raw_sum": 53,
+                    "std_score": 99,
+                    "z": -0.066667
+                },
+                "SA": {
+                    "level": "competent",
+                    "percentile": 42.07,
+                    "pomp": 61.67,
+                    "raw_mean": 3.4667,
+                    "raw_sum": 52,
+                    "std_score": 97,
+                    "z": -0.2
+                },
+                "emotion_regulation": {
+                    "level": "baseline",
+                    "percentile": 12.85,
+                    "pomp": 50,
+                    "raw_mean": 3,
+                    "raw_sum": 45,
+                    "std_score": 83,
+                    "z": -1.133333
+                },
+                "empathy": {
+                    "level": "exceptional",
+                    "percentile": 89.74,
+                    "pomp": 80,
+                    "raw_mean": 4.2,
+                    "raw_sum": 63,
+                    "std_score": 119,
+                    "z": 1.266667
+                },
+                "global": {
+                    "level": "competent",
+                    "percentile": 48.67,
+                    "pomp": 63.75,
+                    "raw_mean": 3.55,
+                    "raw_sum": 213,
+                    "std_score": 99.5,
+                    "z": -0.033333
+                },
+                "relationship_management": {
+                    "level": "competent",
+                    "percentile": 47.34,
+                    "pomp": 63.33,
+                    "raw_mean": 3.5333,
+                    "raw_sum": 53,
+                    "std_score": 99,
+                    "z": -0.066667
+                },
+                "self_awareness": {
+                    "level": "competent",
+                    "percentile": 42.07,
+                    "pomp": 61.67,
+                    "raw_mean": 3.4667,
+                    "raw_sum": 52,
+                    "std_score": 97,
+                    "z": -0.2
+                }
             },
-            "RM": {
-                "level": "competent",
-                "percentile": 47.34,
-                "pomp": 63.33,
-                "raw_mean": 3.5333,
-                "raw_sum": 53,
-                "std_score": 99,
-                "z": -0.066667
+            "purpose": "legacy_renderer_compatibility_only",
+            "report_tags": [
+                "quality_level:A",
+                "profile:compassion_overload",
+                "focus:boundary_setting"
+            ],
+            "schema_version": "eq_60.legacy_compat.v1",
+            "scorer_report": {
+                "primary_profile": "profile:compassion_overload",
+                "tags": [
+                    "quality_level:A",
+                    "profile:compassion_overload",
+                    "focus:boundary_setting"
+                ]
             },
-            "SA": {
-                "level": "competent",
-                "percentile": 42.07,
-                "pomp": 61.67,
-                "raw_mean": 3.4667,
-                "raw_sum": 52,
-                "std_score": 97,
-                "z": -0.2
-            },
-            "emotion_regulation": {
-                "level": "baseline",
-                "percentile": 12.85,
-                "pomp": 50,
-                "raw_mean": 3,
-                "raw_sum": 45,
-                "std_score": 83,
-                "z": -1.133333
-            },
-            "empathy": {
-                "level": "exceptional",
-                "percentile": 89.74,
-                "pomp": 80,
-                "raw_mean": 4.2,
-                "raw_sum": 63,
-                "std_score": 119,
-                "z": 1.266667
-            },
-            "global": {
-                "level": "competent",
-                "percentile": 48.67,
-                "pomp": 63.75,
-                "raw_mean": 3.55,
-                "raw_sum": 213,
-                "std_score": 99.5,
-                "z": -0.033333
-            },
-            "relationship_management": {
-                "level": "competent",
-                "percentile": 47.34,
-                "pomp": 63.33,
-                "raw_mean": 3.5333,
-                "raw_sum": 53,
-                "std_score": 99,
-                "z": -0.066667
-            },
-            "self_awareness": {
-                "level": "competent",
-                "percentile": 42.07,
-                "pomp": 61.67,
-                "raw_mean": 3.4667,
-                "raw_sum": 52,
-                "std_score": 97,
-                "z": -0.2
-            }
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                            "id": "eq60_disclaimer_top_en",
+                            "title": "Important Notice",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "eq_core",
+                    "title": "Important Notice"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
+                            "id": "eq60_quality_level_A_en",
+                            "title": "Response Quality",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "quality_notice",
+                    "module_code": "eq_core",
+                    "title": "Response Quality"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "Your overall EQ standard score is **99.5** (population mean 100, SD 15), at the **48.67** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
+                            "id": "eq60_global_overview_en",
+                            "title": "Overview",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "global_overview",
+                    "module_code": "eq_core",
+                    "title": "Overview"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Self‑Awareness**\n\nStandard score: **97** (42.07 percentile), band: **Competent**.\n\nYou usually identify emotions and connect them to triggers and needs. In many situations you can say things like “I’m tense,” “I need a moment,” or “I felt overlooked.” This reduces misunderstanding and rumination, keeping conversations closer to the real issue.\n\n**Practice**: Before a key conversation, write one sentence: “What matters most to me here?”",
+                            "id": "eq60_sa_competent_en",
+                            "title": "Self‑Awareness · Competent",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "self_awareness",
+                    "module_code": "eq_core",
+                    "title": "Self‑Awareness"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Emotion Regulation**\n\nStandard score: **83** (12.85 percentile), band: **Baseline**.\n\nUnder pressure or triggers, emotions can take over the action system—impulses, rumination, sleep disruption, or prolonged tension. This is not a “willpower” label; it reflects a toolbox that isn’t automatic yet. Regulation aims to bring intensity and duration back into a manageable range, not to erase emotions.\n\n**90‑second reset**: Pause → slow exhale 6 times → feel your feet on the ground to create space before reacting.",
+                            "id": "eq60_er_baseline_en",
+                            "title": "Emotion Regulation · Baseline",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "emotion_regulation",
+                    "module_code": "eq_core",
+                    "title": "Emotion Regulation"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **119** (89.74 percentile), band: **Exceptional**.\n\nYour empathy is exceptionally strong. Even in noisy environments you read emotions and motives accurately and respond with warmth. This is a foundation of influence. Keep boundaries to prevent emotional overload.\n\n**Practice**: Use: “I see this is hard for you. I can stay with you for a bit,” while keeping your limits.",
+                            "id": "eq60_em_exceptional_en",
+                            "title": "Social Awareness & Empathy · Exceptional",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "empathy",
+                    "module_code": "eq_core",
+                    "title": "Social Awareness & Empathy"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Relationship Management**\n\nStandard score: **99** (47.34 percentile), band: **Competent**.\n\nYou communicate and collaborate well, maintain trust, and manage disagreements without breaking the relationship. You tend to balance authenticity with relationship care.\n\n**Practice**: In conflict, align on the shared goal first, then discuss options.",
+                            "id": "eq60_rm_competent_en",
+                            "title": "Relationship Management · Competent",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "relationship_management",
+                    "module_code": "eq_core",
+                    "title": "Relationship Management"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Primary profile: Compassion Overload (High Empathy + Low Regulation)**\n\nYour results show Empathy **119** very high and Emotion Regulation **83** lower. You feel others’ pain and stress strongly, and group climate can affect you quickly. The gift is warmth and attunement; the cost is overload and blurry boundaries.\n\n**Typical strengths**\n- High resonance: people open up to you easily.\n- Strong ‘room reading’: you sense shifts and hidden tension.\n- Care motive: a real drive to help.\n\n**Typical costs**\n- Emotional contagion: others’ feelings enter your body and drain sleep/energy.\n- Rescue reflex: urgency to fix, leading to over‑involvement.\n- Boundary loss: ‘empathy’ turns into ‘carrying,’ then burnout.\n\n**Key shift: bounded care**\nHigh empathy doesn’t require self‑sacrifice. Training focuses on three boundaries:\n1) **Emotional boundary**: “This is theirs” vs “this is mine.”\n2) **Time boundary**: define how long you can be available.\n3) **Action boundary**: move from ‘fixing’ to ‘helping them see choices.’\n\n**Support scripts**\n- “I hear this is hard. I can stay with you for 10 minutes to sort it out.”\n- “What I can offer is … The deeper choice is yours.”\n- “I care about you, and I also need to protect my energy.”\n\n**What this free report gives you**\n- Boundary training to turn empathy into a resource.\n- Regulation tools to prevent overload spillover.\n- 14‑day plan for sustainable helping.",
+                            "id": "eq60_profile_compassion_overload_en",
+                            "title": "Compassion Overload",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "cross_quadrant_insight",
+                    "module_code": "eq_cross_insights",
+                    "title": "Cross‑Quadrant Insight"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**14‑Day Plan: Boundaried Care (10–15 min/day)**\n\nGoal: keep your warmth and sensitivity while building emotional, time, and action boundaries to prevent overload.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Mine vs yours | Note one contagion moment: whose emotion is it? what can I do? |\n| Day 2 | Emotional boundary | Practice: “I see it’s hard for you. This is your feeling. I’m here with you.” |\n| Day 3 | Time boundary | Set a time cap (10/20 min) and write an ending script. |\n| Day 4 | Action boundary | Shift from fixing to options: write 3 guiding questions. |\n| Day 5 | Back to body | 2‑minute tactile grounding (cup/table texture). |\n| Day 6 | Self‑compassion | Write 3 lines: this is hard; I’m not alone; I’ll be kind to myself. |\n| Day 7 | Support & referral | List 3 resources you can hand off to; don’t carry alone. |\n| Day 8 | Empathize without spiraling | Reflect feeling, then ask: listen or brainstorm? |\n| Day 9 | Energy return | After deep listening: 5 minutes walk/breath to reset. |\n| Day10 | State limits | Use: “I can stay up to here; then I need rest.” once. |\n| Day11 | Load monitoring | Rate emotional load 0–10; above 7, reduce inputs intentionally. |\n| Day12 | One smallest act | Keep helping action to 1 minimal step; avoid over‑involvement. |\n| Day13 | Relationship structure | Pick one draining relationship: what boundary makes it sustainable? |\n| Day14 | Consolidate | 3 boundary principles + 3 care scripts. |\n\nBoundaries aren’t coldness—they make care sustainable.",
+                            "id": "eq60_plan_boundary_en",
+                            "title": "Boundaried Care",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "action_plan_14d",
+                    "module_code": "eq_growth_plan",
+                    "title": "14‑Day Plan"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                            "id": "eq60_methodology_en",
+                            "title": "Methodology",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "methodology",
+                    "module_code": "eq_core",
+                    "title": "Methodology"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                            "id": "eq60_disclaimer_bottom_en",
+                            "title": "Closing Notes",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_bottom",
+                    "module_code": "eq_core",
+                    "title": "Closing Notes"
+                }
+            ],
+            "user_visible": false
         },
         "locale": "en",
         "measurement_type": "self_report_trait_mixed_ei",
@@ -1196,19 +1385,6 @@
             },
             "neutral_rate": 0.2667
         },
-        "report": {
-            "primary_profile": "profile:compassion_overload",
-            "tags": [
-                "quality_level:A",
-                "profile:compassion_overload",
-                "focus:boundary_setting"
-            ]
-        },
-        "report_tags": [
-            "quality_level:A",
-            "profile:compassion_overload",
-            "focus:boundary_setting"
-        ],
         "scale_code": "EQ_60",
         "schema_version": "eq_60.report.v2",
         "scores": {
@@ -1259,162 +1435,6 @@
                 "standard_score": 99.5
             }
         },
-        "sections": [
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
-                        "id": "eq60_disclaimer_top_en",
-                        "title": "Important Notice",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_top",
-                "module_code": "eq_core",
-                "title": "Important Notice"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "Response quality is **A**: consistency and pacing are stable; interpretability is high.",
-                        "id": "eq60_quality_level_A_en",
-                        "title": "Response Quality",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "quality_notice",
-                "module_code": "eq_core",
-                "title": "Response Quality"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "Your overall EQ standard score is **99.5** (population mean 100, SD 15), at the **48.67** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **A**.",
-                        "id": "eq60_global_overview_en",
-                        "title": "Overview",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "global_overview",
-                "module_code": "eq_core",
-                "title": "Overview"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **97** (42.07 percentile), band: **Competent**.\n\nYou usually identify emotions and connect them to triggers and needs. In many situations you can say things like “I’m tense,” “I need a moment,” or “I felt overlooked.” This reduces misunderstanding and rumination, keeping conversations closer to the real issue.\n\n**Practice**: Before a key conversation, write one sentence: “What matters most to me here?”",
-                        "id": "eq60_sa_competent_en",
-                        "title": "Self‑Awareness · Competent",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "self_awareness",
-                "module_code": "eq_core",
-                "title": "Self‑Awareness"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **83** (12.85 percentile), band: **Baseline**.\n\nUnder pressure or triggers, emotions can take over the action system—impulses, rumination, sleep disruption, or prolonged tension. This is not a “willpower” label; it reflects a toolbox that isn’t automatic yet. Regulation aims to bring intensity and duration back into a manageable range, not to erase emotions.\n\n**90‑second reset**: Pause → slow exhale 6 times → feel your feet on the ground to create space before reacting.",
-                        "id": "eq60_er_baseline_en",
-                        "title": "Emotion Regulation · Baseline",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "emotion_regulation",
-                "module_code": "eq_core",
-                "title": "Emotion Regulation"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **119** (89.74 percentile), band: **Exceptional**.\n\nYour empathy is exceptionally strong. Even in noisy environments you read emotions and motives accurately and respond with warmth. This is a foundation of influence. Keep boundaries to prevent emotional overload.\n\n**Practice**: Use: “I see this is hard for you. I can stay with you for a bit,” while keeping your limits.",
-                        "id": "eq60_em_exceptional_en",
-                        "title": "Social Awareness & Empathy · Exceptional",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "empathy",
-                "module_code": "eq_core",
-                "title": "Social Awareness & Empathy"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Relationship Management**\n\nStandard score: **99** (47.34 percentile), band: **Competent**.\n\nYou communicate and collaborate well, maintain trust, and manage disagreements without breaking the relationship. You tend to balance authenticity with relationship care.\n\n**Practice**: In conflict, align on the shared goal first, then discuss options.",
-                        "id": "eq60_rm_competent_en",
-                        "title": "Relationship Management · Competent",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "relationship_management",
-                "module_code": "eq_core",
-                "title": "Relationship Management"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Primary profile: Compassion Overload (High Empathy + Low Regulation)**\n\nYour results show Empathy **119** very high and Emotion Regulation **83** lower. You feel others’ pain and stress strongly, and group climate can affect you quickly. The gift is warmth and attunement; the cost is overload and blurry boundaries.\n\n**Typical strengths**\n- High resonance: people open up to you easily.\n- Strong ‘room reading’: you sense shifts and hidden tension.\n- Care motive: a real drive to help.\n\n**Typical costs**\n- Emotional contagion: others’ feelings enter your body and drain sleep/energy.\n- Rescue reflex: urgency to fix, leading to over‑involvement.\n- Boundary loss: ‘empathy’ turns into ‘carrying,’ then burnout.\n\n**Key shift: bounded care**\nHigh empathy doesn’t require self‑sacrifice. Training focuses on three boundaries:\n1) **Emotional boundary**: “This is theirs” vs “this is mine.”\n2) **Time boundary**: define how long you can be available.\n3) **Action boundary**: move from ‘fixing’ to ‘helping them see choices.’\n\n**Support scripts**\n- “I hear this is hard. I can stay with you for 10 minutes to sort it out.”\n- “What I can offer is … The deeper choice is yours.”\n- “I care about you, and I also need to protect my energy.”\n\n**What this free report gives you**\n- Boundary training to turn empathy into a resource.\n- Regulation tools to prevent overload spillover.\n- 14‑day plan for sustainable helping.",
-                        "id": "eq60_profile_compassion_overload_en",
-                        "title": "Compassion Overload",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "cross_quadrant_insight",
-                "module_code": "eq_cross_insights",
-                "title": "Cross‑Quadrant Insight"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**14‑Day Plan: Boundaried Care (10–15 min/day)**\n\nGoal: keep your warmth and sensitivity while building emotional, time, and action boundaries to prevent overload.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Mine vs yours | Note one contagion moment: whose emotion is it? what can I do? |\n| Day 2 | Emotional boundary | Practice: “I see it’s hard for you. This is your feeling. I’m here with you.” |\n| Day 3 | Time boundary | Set a time cap (10/20 min) and write an ending script. |\n| Day 4 | Action boundary | Shift from fixing to options: write 3 guiding questions. |\n| Day 5 | Back to body | 2‑minute tactile grounding (cup/table texture). |\n| Day 6 | Self‑compassion | Write 3 lines: this is hard; I’m not alone; I’ll be kind to myself. |\n| Day 7 | Support & referral | List 3 resources you can hand off to; don’t carry alone. |\n| Day 8 | Empathize without spiraling | Reflect feeling, then ask: listen or brainstorm? |\n| Day 9 | Energy return | After deep listening: 5 minutes walk/breath to reset. |\n| Day10 | State limits | Use: “I can stay up to here; then I need rest.” once. |\n| Day11 | Load monitoring | Rate emotional load 0–10; above 7, reduce inputs intentionally. |\n| Day12 | One smallest act | Keep helping action to 1 minimal step; avoid over‑involvement. |\n| Day13 | Relationship structure | Pick one draining relationship: what boundary makes it sustainable? |\n| Day14 | Consolidate | 3 boundary principles + 3 care scripts. |\n\nBoundaries aren’t coldness—they make care sustainable.",
-                        "id": "eq60_plan_boundary_en",
-                        "title": "Boundaried Care",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "action_plan_14d",
-                "module_code": "eq_growth_plan",
-                "title": "14‑Day Plan"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
-                        "id": "eq60_methodology_en",
-                        "title": "Methodology",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "methodology",
-                "module_code": "eq_core",
-                "title": "Methodology"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
-                        "id": "eq60_disclaimer_bottom_en",
-                        "title": "Closing Notes",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_bottom",
-                "module_code": "eq_core",
-                "title": "Closing Notes"
-            }
-        ],
         "variant": "full"
     },
     "report_access": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_high_empathy_low_recovery_zh.json
@@ -813,77 +813,6 @@
                 "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。"
             }
         },
-        "compat": {
-            "free_blocks": [
-                {
-                    "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
-                    "id": "eq60_disclaimer_top_zh",
-                    "section_key": "disclaimer_top",
-                    "title": "重要声明"
-                },
-                {
-                    "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
-                    "id": "eq60_quality_level_A_zh",
-                    "section_key": "quality_notice",
-                    "title": "作答质量提示"
-                },
-                {
-                    "content": "你的综合 EQ 标准分为 **99.5**（人群平均 100，标准差 15），处于第 **48.67** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
-                    "id": "eq60_global_overview_zh",
-                    "section_key": "global_overview",
-                    "title": "综合概览"
-                },
-                {
-                    "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**97**（第 42.07 百分位），阶段：**稳定可用（Competent）**。\n\n你通常能识别情绪，并把情绪与触发点、需求联系起来。你能在大部分场景下清楚表达“我正在紧张/我需要时间/我被忽视了”。这种能力能明显降低误解与内耗，让沟通更聚焦问题本身，而不是被情绪噪音牵着走。\n\n**练习提示**：在关键对话前，用一句话写清“我在乎什么”，让表达更稳定。",
-                    "id": "eq60_sa_competent_zh",
-                    "section_key": "self_awareness",
-                    "title": "自我情绪认知 · 稳定可用（Competent）"
-                },
-                {
-                    "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**83**（第 12.85 百分位），阶段：**觉察盲区（Baseline）**。\n\n在高压或被触发时，情绪更容易接管行动系统，出现冲动反应、反复纠结、睡眠受影响或持续紧绷。这个分数不代表意志力不足，而是调节工具箱尚未形成稳定的自动化。调节的目标不是“把情绪消灭”，而是把强度与持续时间拉回可管理范围。\n\n**练习提示（90秒）**：停下→缓慢呼气 6 次→把注意力放回脚底触地感，给自己争取“反应前的空隙”。",
-                    "id": "eq60_er_baseline_zh",
-                    "section_key": "emotion_regulation",
-                    "title": "情绪调节与控制 · 觉察盲区（Baseline）"
-                },
-                {
-                    "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**119**（第 89.74 百分位），阶段：**卓越稀缺（Exceptional）**。\n\n你的共情能力极强，能在高噪音环境里仍准确读到他人的情绪与动机，并用温和方式回应。这是影响力的重要底座。需要留意的点是：共情强度越高，越要建立边界，避免把别人的情绪带回自己的生活节奏里。\n\n**练习提示**：把“我也很难受”改成“我看见你很难受，我愿意陪你一会儿”，保留边界感。",
-                    "id": "eq60_em_exceptional_zh",
-                    "section_key": "empathy",
-                    "title": "同理心与社会感知 · 卓越稀缺（Exceptional）"
-                },
-                {
-                    "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**99**（第 47.34 百分位），阶段：**稳定可用（Competent）**。\n\n你具备良好的沟通与协作能力，能建立稳定的人际网络与信任。你能在多数场景里表达观点、处理分歧、维持关系质量。你通常能在“真实表达”和“关系维护”之间找到平衡。\n\n**练习提示**：遇到分歧时先对齐共同目标，再讨论方案。",
-                    "id": "eq60_rm_competent_zh",
-                    "section_key": "relationship_management",
-                    "title": "社交技能与人际管理 · 稳定可用（Competent）"
-                },
-                {
-                    "content": "**你的主要画像：情绪海绵型（高同理心 + 低情绪调节）**\n\n本次测评显示：同理心与社会感知 **119** 很高，情绪调节 **83** 偏低。你对他人的痛苦与压力高度敏感，常常会“替别人难受”，也更容易被群体氛围影响。优势是真诚、温暖、能看见别人；代价是情绪过载与边界模糊。\n\n**你常见的优势**\n- 高共鸣：别人更愿意向你倾诉，信任建立更快。\n- 读空气能力强：能敏锐捕捉情绪变化与隐性冲突。\n- 关怀动机：有强烈的助人倾向与责任感。\n\n**常见代价**\n- 情绪感染：别人的情绪进入你的身体，影响睡眠与精力。\n- 救援反射：看到痛苦就想立刻解决，容易过度卷入。\n- 边界消失：把“同理”误用成“承担”，最后自己被掏空。\n\n**关键转折：把共情变成“有边界的关怀”**\n高共情不需要牺牲自我。训练重点是三层边界：\n1) **情绪边界**：区分“这是对方的感受”与“这是我的感受”。\n2) **时间边界**：明确陪伴时长与可用精力。\n3) **行动边界**：从“替你解决”转成“陪你一起看见选择”。\n\n**适合你的回应句式**\n- “我听见你很难受，我愿意陪你 10 分钟，先把事情捋清。”\n- “我能提供的是……更深入的部分需要你自己决定。”\n- “我很在乎你，我也需要先照顾好自己的精力。”\n\n**你会在这份免费报告里得到什么**\n- 边界训练：把共情从消耗变成资源。\n- 调节工具：让情绪不过载、不回流到生活里。\n- 14 天游程：建立可持续的助人方式。",
-                    "id": "eq60_profile_compassion_overload_zh",
-                    "section_key": "cross_quadrant_insight",
-                    "title": "情绪海绵型"
-                },
-                {
-                    "content": "**14 天游程：共情边界与可持续关怀（每天 10–15 分钟）**\n\n目标：保留你的温暖与敏锐，同时建立情绪、时间与行动边界，避免情绪过载。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 区分“我的/你的” | 写下今天一次情绪感染：这是谁的情绪？我能做的是什么？ |\n| Day 2 | 情绪隔离 | 练习一句话：“我看见你很难受，这是你的感受，我在这里陪你。” |\n| Day 3 | 时间边界 | 设定陪伴时长（10/20 分钟），并写下结束句式。 |\n| Day 4 | 行动边界 | 把“替你解决”改成“我陪你看见选择”，写 3 个提问。 |\n| Day 5 | 身体回到自己 | 2 分钟触感练习：握杯子/触摸桌面，回到身体。 |\n| Day 6 | 自我慈悲 | 写 3 句：这很难；我并不孤单；我愿意善待自己。 |\n| Day 7 | 求助与转介 | 列出 3 个可转介资源（朋友/专业/工具），不独自承担。 |\n| Day 8 | 同理而不内卷 | 对话中先复述感受，再问“你想要倾听还是建议？” |\n| Day 9 | 关怀后回收 | 每次深度倾听后做 5 分钟走动/呼吸，回收能量。 |\n| Day10 | 说出限制 | 练习：“我能陪你到这里，之后我需要休息。”并使用 1 次。 |\n| Day11 | 负荷监测 | 今日给情绪负荷打分 0–10，超过 7 时主动减少输入。 |\n| Day12 | 只做一件事 | 把助人行动缩到 1 个最小动作，避免过度卷入。 |\n| Day13 | 关系结构 | 写下 1 段高消耗关系：我需要怎样的边界才能持续？ |\n| Day14 | 复盘与巩固 | 总结 3 条你的边界原则 + 3 句你的关怀脚本。 |\n\n**使用方式**：边界不是冷漠，是让你的关怀变得可持续。",
-                    "id": "eq60_plan_boundary_zh",
-                    "section_key": "action_plan_14d",
-                    "title": "共情边界"
-                },
-                {
-                    "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
-                    "id": "eq60_methodology_zh",
-                    "section_key": "methodology",
-                    "title": "方法说明"
-                },
-                {
-                    "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
-                    "id": "eq60_disclaimer_bottom_zh",
-                    "section_key": "disclaimer_bottom",
-                    "title": "结尾提示"
-                }
-            ],
-            "paid_blocks": []
-        },
         "cross_assessment_context": {
             "available": true,
             "boundary_asset_id": "eq.cross_context.boundary.default",
@@ -963,6 +892,21 @@
                 "standard_score": 99
             }
         ],
+        "display_contract": {
+            "authority": "v5_resolved_assets",
+            "legacy_compat_user_visible": false,
+            "schema_version": "eq_60.display_contract.v1",
+            "user_visible_roots": [
+                "scores",
+                "dimension_summary",
+                "quality",
+                "interpretation",
+                "asset_refs",
+                "assets",
+                "next_module",
+                "methodology"
+            ]
+        },
         "eq_report_mode": "self_report",
         "generated_at": "2026-05-21T00:00:00.000000Z",
         "interpretation": {
@@ -1081,88 +1025,333 @@
             ],
             "version": "eq_journey_state.v1"
         },
-        "legacy_scores": {
-            "EM": {
-                "level": "exceptional",
-                "percentile": 89.74,
-                "pomp": 80,
-                "raw_mean": 4.2,
-                "raw_sum": 63,
-                "std_score": 119,
-                "z": 1.266667
+        "legacy_compat": {
+            "compat": {
+                "free_blocks": [
+                    {
+                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                        "id": "eq60_disclaimer_top_zh",
+                        "section_key": "disclaimer_top",
+                        "title": "重要声明"
+                    },
+                    {
+                        "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
+                        "id": "eq60_quality_level_A_zh",
+                        "section_key": "quality_notice",
+                        "title": "作答质量提示"
+                    },
+                    {
+                        "content": "你的综合 EQ 标准分为 **99.5**（人群平均 100，标准差 15），处于第 **48.67** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
+                        "id": "eq60_global_overview_zh",
+                        "section_key": "global_overview",
+                        "title": "综合概览"
+                    },
+                    {
+                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**97**（第 42.07 百分位），阶段：**稳定可用（Competent）**。\n\n你通常能识别情绪，并把情绪与触发点、需求联系起来。你能在大部分场景下清楚表达“我正在紧张/我需要时间/我被忽视了”。这种能力能明显降低误解与内耗，让沟通更聚焦问题本身，而不是被情绪噪音牵着走。\n\n**练习提示**：在关键对话前，用一句话写清“我在乎什么”，让表达更稳定。",
+                        "id": "eq60_sa_competent_zh",
+                        "section_key": "self_awareness",
+                        "title": "自我情绪认知 · 稳定可用（Competent）"
+                    },
+                    {
+                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**83**（第 12.85 百分位），阶段：**觉察盲区（Baseline）**。\n\n在高压或被触发时，情绪更容易接管行动系统，出现冲动反应、反复纠结、睡眠受影响或持续紧绷。这个分数不代表意志力不足，而是调节工具箱尚未形成稳定的自动化。调节的目标不是“把情绪消灭”，而是把强度与持续时间拉回可管理范围。\n\n**练习提示（90秒）**：停下→缓慢呼气 6 次→把注意力放回脚底触地感，给自己争取“反应前的空隙”。",
+                        "id": "eq60_er_baseline_zh",
+                        "section_key": "emotion_regulation",
+                        "title": "情绪调节与控制 · 觉察盲区（Baseline）"
+                    },
+                    {
+                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**119**（第 89.74 百分位），阶段：**卓越稀缺（Exceptional）**。\n\n你的共情能力极强，能在高噪音环境里仍准确读到他人的情绪与动机，并用温和方式回应。这是影响力的重要底座。需要留意的点是：共情强度越高，越要建立边界，避免把别人的情绪带回自己的生活节奏里。\n\n**练习提示**：把“我也很难受”改成“我看见你很难受，我愿意陪你一会儿”，保留边界感。",
+                        "id": "eq60_em_exceptional_zh",
+                        "section_key": "empathy",
+                        "title": "同理心与社会感知 · 卓越稀缺（Exceptional）"
+                    },
+                    {
+                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**99**（第 47.34 百分位），阶段：**稳定可用（Competent）**。\n\n你具备良好的沟通与协作能力，能建立稳定的人际网络与信任。你能在多数场景里表达观点、处理分歧、维持关系质量。你通常能在“真实表达”和“关系维护”之间找到平衡。\n\n**练习提示**：遇到分歧时先对齐共同目标，再讨论方案。",
+                        "id": "eq60_rm_competent_zh",
+                        "section_key": "relationship_management",
+                        "title": "社交技能与人际管理 · 稳定可用（Competent）"
+                    },
+                    {
+                        "content": "**你的主要画像：情绪海绵型（高同理心 + 低情绪调节）**\n\n本次测评显示：同理心与社会感知 **119** 很高，情绪调节 **83** 偏低。你对他人的痛苦与压力高度敏感，常常会“替别人难受”，也更容易被群体氛围影响。优势是真诚、温暖、能看见别人；代价是情绪过载与边界模糊。\n\n**你常见的优势**\n- 高共鸣：别人更愿意向你倾诉，信任建立更快。\n- 读空气能力强：能敏锐捕捉情绪变化与隐性冲突。\n- 关怀动机：有强烈的助人倾向与责任感。\n\n**常见代价**\n- 情绪感染：别人的情绪进入你的身体，影响睡眠与精力。\n- 救援反射：看到痛苦就想立刻解决，容易过度卷入。\n- 边界消失：把“同理”误用成“承担”，最后自己被掏空。\n\n**关键转折：把共情变成“有边界的关怀”**\n高共情不需要牺牲自我。训练重点是三层边界：\n1) **情绪边界**：区分“这是对方的感受”与“这是我的感受”。\n2) **时间边界**：明确陪伴时长与可用精力。\n3) **行动边界**：从“替你解决”转成“陪你一起看见选择”。\n\n**适合你的回应句式**\n- “我听见你很难受，我愿意陪你 10 分钟，先把事情捋清。”\n- “我能提供的是……更深入的部分需要你自己决定。”\n- “我很在乎你，我也需要先照顾好自己的精力。”\n\n**你会在这份免费报告里得到什么**\n- 边界训练：把共情从消耗变成资源。\n- 调节工具：让情绪不过载、不回流到生活里。\n- 14 天游程：建立可持续的助人方式。",
+                        "id": "eq60_profile_compassion_overload_zh",
+                        "section_key": "cross_quadrant_insight",
+                        "title": "情绪海绵型"
+                    },
+                    {
+                        "content": "**14 天游程：共情边界与可持续关怀（每天 10–15 分钟）**\n\n目标：保留你的温暖与敏锐，同时建立情绪、时间与行动边界，避免情绪过载。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 区分“我的/你的” | 写下今天一次情绪感染：这是谁的情绪？我能做的是什么？ |\n| Day 2 | 情绪隔离 | 练习一句话：“我看见你很难受，这是你的感受，我在这里陪你。” |\n| Day 3 | 时间边界 | 设定陪伴时长（10/20 分钟），并写下结束句式。 |\n| Day 4 | 行动边界 | 把“替你解决”改成“我陪你看见选择”，写 3 个提问。 |\n| Day 5 | 身体回到自己 | 2 分钟触感练习：握杯子/触摸桌面，回到身体。 |\n| Day 6 | 自我慈悲 | 写 3 句：这很难；我并不孤单；我愿意善待自己。 |\n| Day 7 | 求助与转介 | 列出 3 个可转介资源（朋友/专业/工具），不独自承担。 |\n| Day 8 | 同理而不内卷 | 对话中先复述感受，再问“你想要倾听还是建议？” |\n| Day 9 | 关怀后回收 | 每次深度倾听后做 5 分钟走动/呼吸，回收能量。 |\n| Day10 | 说出限制 | 练习：“我能陪你到这里，之后我需要休息。”并使用 1 次。 |\n| Day11 | 负荷监测 | 今日给情绪负荷打分 0–10，超过 7 时主动减少输入。 |\n| Day12 | 只做一件事 | 把助人行动缩到 1 个最小动作，避免过度卷入。 |\n| Day13 | 关系结构 | 写下 1 段高消耗关系：我需要怎样的边界才能持续？ |\n| Day14 | 复盘与巩固 | 总结 3 条你的边界原则 + 3 句你的关怀脚本。 |\n\n**使用方式**：边界不是冷漠，是让你的关怀变得可持续。",
+                        "id": "eq60_plan_boundary_zh",
+                        "section_key": "action_plan_14d",
+                        "title": "共情边界"
+                    },
+                    {
+                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                        "id": "eq60_methodology_zh",
+                        "section_key": "methodology",
+                        "title": "方法说明"
+                    },
+                    {
+                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                        "id": "eq60_disclaimer_bottom_zh",
+                        "section_key": "disclaimer_bottom",
+                        "title": "结尾提示"
+                    }
+                ],
+                "paid_blocks": []
             },
-            "ER": {
-                "level": "baseline",
-                "percentile": 12.85,
-                "pomp": 50,
-                "raw_mean": 3,
-                "raw_sum": 45,
-                "std_score": 83,
-                "z": -1.133333
+            "legacy_scores": {
+                "EM": {
+                    "level": "exceptional",
+                    "percentile": 89.74,
+                    "pomp": 80,
+                    "raw_mean": 4.2,
+                    "raw_sum": 63,
+                    "std_score": 119,
+                    "z": 1.266667
+                },
+                "ER": {
+                    "level": "baseline",
+                    "percentile": 12.85,
+                    "pomp": 50,
+                    "raw_mean": 3,
+                    "raw_sum": 45,
+                    "std_score": 83,
+                    "z": -1.133333
+                },
+                "RM": {
+                    "level": "competent",
+                    "percentile": 47.34,
+                    "pomp": 63.33,
+                    "raw_mean": 3.5333,
+                    "raw_sum": 53,
+                    "std_score": 99,
+                    "z": -0.066667
+                },
+                "SA": {
+                    "level": "competent",
+                    "percentile": 42.07,
+                    "pomp": 61.67,
+                    "raw_mean": 3.4667,
+                    "raw_sum": 52,
+                    "std_score": 97,
+                    "z": -0.2
+                },
+                "emotion_regulation": {
+                    "level": "baseline",
+                    "percentile": 12.85,
+                    "pomp": 50,
+                    "raw_mean": 3,
+                    "raw_sum": 45,
+                    "std_score": 83,
+                    "z": -1.133333
+                },
+                "empathy": {
+                    "level": "exceptional",
+                    "percentile": 89.74,
+                    "pomp": 80,
+                    "raw_mean": 4.2,
+                    "raw_sum": 63,
+                    "std_score": 119,
+                    "z": 1.266667
+                },
+                "global": {
+                    "level": "competent",
+                    "percentile": 48.67,
+                    "pomp": 63.75,
+                    "raw_mean": 3.55,
+                    "raw_sum": 213,
+                    "std_score": 99.5,
+                    "z": -0.033333
+                },
+                "relationship_management": {
+                    "level": "competent",
+                    "percentile": 47.34,
+                    "pomp": 63.33,
+                    "raw_mean": 3.5333,
+                    "raw_sum": 53,
+                    "std_score": 99,
+                    "z": -0.066667
+                },
+                "self_awareness": {
+                    "level": "competent",
+                    "percentile": 42.07,
+                    "pomp": 61.67,
+                    "raw_mean": 3.4667,
+                    "raw_sum": 52,
+                    "std_score": 97,
+                    "z": -0.2
+                }
             },
-            "RM": {
-                "level": "competent",
-                "percentile": 47.34,
-                "pomp": 63.33,
-                "raw_mean": 3.5333,
-                "raw_sum": 53,
-                "std_score": 99,
-                "z": -0.066667
+            "purpose": "legacy_renderer_compatibility_only",
+            "report_tags": [
+                "quality_level:A",
+                "profile:compassion_overload",
+                "focus:boundary_setting"
+            ],
+            "schema_version": "eq_60.legacy_compat.v1",
+            "scorer_report": {
+                "primary_profile": "profile:compassion_overload",
+                "tags": [
+                    "quality_level:A",
+                    "profile:compassion_overload",
+                    "focus:boundary_setting"
+                ]
             },
-            "SA": {
-                "level": "competent",
-                "percentile": 42.07,
-                "pomp": 61.67,
-                "raw_mean": 3.4667,
-                "raw_sum": 52,
-                "std_score": 97,
-                "z": -0.2
-            },
-            "emotion_regulation": {
-                "level": "baseline",
-                "percentile": 12.85,
-                "pomp": 50,
-                "raw_mean": 3,
-                "raw_sum": 45,
-                "std_score": 83,
-                "z": -1.133333
-            },
-            "empathy": {
-                "level": "exceptional",
-                "percentile": 89.74,
-                "pomp": 80,
-                "raw_mean": 4.2,
-                "raw_sum": 63,
-                "std_score": 119,
-                "z": 1.266667
-            },
-            "global": {
-                "level": "competent",
-                "percentile": 48.67,
-                "pomp": 63.75,
-                "raw_mean": 3.55,
-                "raw_sum": 213,
-                "std_score": 99.5,
-                "z": -0.033333
-            },
-            "relationship_management": {
-                "level": "competent",
-                "percentile": 47.34,
-                "pomp": 63.33,
-                "raw_mean": 3.5333,
-                "raw_sum": 53,
-                "std_score": 99,
-                "z": -0.066667
-            },
-            "self_awareness": {
-                "level": "competent",
-                "percentile": 42.07,
-                "pomp": 61.67,
-                "raw_mean": 3.4667,
-                "raw_sum": 52,
-                "std_score": 97,
-                "z": -0.2
-            }
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                            "id": "eq60_disclaimer_top_zh",
+                            "title": "重要声明",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "eq_core",
+                    "title": "重要声明"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
+                            "id": "eq60_quality_level_A_zh",
+                            "title": "作答质量提示",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "quality_notice",
+                    "module_code": "eq_core",
+                    "title": "作答质量提示"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "你的综合 EQ 标准分为 **99.5**（人群平均 100，标准差 15），处于第 **48.67** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
+                            "id": "eq60_global_overview_zh",
+                            "title": "综合概览",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "global_overview",
+                    "module_code": "eq_core",
+                    "title": "综合概览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**97**（第 42.07 百分位），阶段：**稳定可用（Competent）**。\n\n你通常能识别情绪，并把情绪与触发点、需求联系起来。你能在大部分场景下清楚表达“我正在紧张/我需要时间/我被忽视了”。这种能力能明显降低误解与内耗，让沟通更聚焦问题本身，而不是被情绪噪音牵着走。\n\n**练习提示**：在关键对话前，用一句话写清“我在乎什么”，让表达更稳定。",
+                            "id": "eq60_sa_competent_zh",
+                            "title": "自我情绪认知 · 稳定可用（Competent）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "self_awareness",
+                    "module_code": "eq_core",
+                    "title": "自我情绪认知"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**83**（第 12.85 百分位），阶段：**觉察盲区（Baseline）**。\n\n在高压或被触发时，情绪更容易接管行动系统，出现冲动反应、反复纠结、睡眠受影响或持续紧绷。这个分数不代表意志力不足，而是调节工具箱尚未形成稳定的自动化。调节的目标不是“把情绪消灭”，而是把强度与持续时间拉回可管理范围。\n\n**练习提示（90秒）**：停下→缓慢呼气 6 次→把注意力放回脚底触地感，给自己争取“反应前的空隙”。",
+                            "id": "eq60_er_baseline_zh",
+                            "title": "情绪调节与控制 · 觉察盲区（Baseline）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "emotion_regulation",
+                    "module_code": "eq_core",
+                    "title": "情绪调节与控制"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**119**（第 89.74 百分位），阶段：**卓越稀缺（Exceptional）**。\n\n你的共情能力极强，能在高噪音环境里仍准确读到他人的情绪与动机，并用温和方式回应。这是影响力的重要底座。需要留意的点是：共情强度越高，越要建立边界，避免把别人的情绪带回自己的生活节奏里。\n\n**练习提示**：把“我也很难受”改成“我看见你很难受，我愿意陪你一会儿”，保留边界感。",
+                            "id": "eq60_em_exceptional_zh",
+                            "title": "同理心与社会感知 · 卓越稀缺（Exceptional）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "empathy",
+                    "module_code": "eq_core",
+                    "title": "同理心与社会感知"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**99**（第 47.34 百分位），阶段：**稳定可用（Competent）**。\n\n你具备良好的沟通与协作能力，能建立稳定的人际网络与信任。你能在多数场景里表达观点、处理分歧、维持关系质量。你通常能在“真实表达”和“关系维护”之间找到平衡。\n\n**练习提示**：遇到分歧时先对齐共同目标，再讨论方案。",
+                            "id": "eq60_rm_competent_zh",
+                            "title": "社交技能与人际管理 · 稳定可用（Competent）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "relationship_management",
+                    "module_code": "eq_core",
+                    "title": "社交技能与人际管理"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**你的主要画像：情绪海绵型（高同理心 + 低情绪调节）**\n\n本次测评显示：同理心与社会感知 **119** 很高，情绪调节 **83** 偏低。你对他人的痛苦与压力高度敏感，常常会“替别人难受”，也更容易被群体氛围影响。优势是真诚、温暖、能看见别人；代价是情绪过载与边界模糊。\n\n**你常见的优势**\n- 高共鸣：别人更愿意向你倾诉，信任建立更快。\n- 读空气能力强：能敏锐捕捉情绪变化与隐性冲突。\n- 关怀动机：有强烈的助人倾向与责任感。\n\n**常见代价**\n- 情绪感染：别人的情绪进入你的身体，影响睡眠与精力。\n- 救援反射：看到痛苦就想立刻解决，容易过度卷入。\n- 边界消失：把“同理”误用成“承担”，最后自己被掏空。\n\n**关键转折：把共情变成“有边界的关怀”**\n高共情不需要牺牲自我。训练重点是三层边界：\n1) **情绪边界**：区分“这是对方的感受”与“这是我的感受”。\n2) **时间边界**：明确陪伴时长与可用精力。\n3) **行动边界**：从“替你解决”转成“陪你一起看见选择”。\n\n**适合你的回应句式**\n- “我听见你很难受，我愿意陪你 10 分钟，先把事情捋清。”\n- “我能提供的是……更深入的部分需要你自己决定。”\n- “我很在乎你，我也需要先照顾好自己的精力。”\n\n**你会在这份免费报告里得到什么**\n- 边界训练：把共情从消耗变成资源。\n- 调节工具：让情绪不过载、不回流到生活里。\n- 14 天游程：建立可持续的助人方式。",
+                            "id": "eq60_profile_compassion_overload_zh",
+                            "title": "情绪海绵型",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "cross_quadrant_insight",
+                    "module_code": "eq_cross_insights",
+                    "title": "交叉洞察长文"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**14 天游程：共情边界与可持续关怀（每天 10–15 分钟）**\n\n目标：保留你的温暖与敏锐，同时建立情绪、时间与行动边界，避免情绪过载。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 区分“我的/你的” | 写下今天一次情绪感染：这是谁的情绪？我能做的是什么？ |\n| Day 2 | 情绪隔离 | 练习一句话：“我看见你很难受，这是你的感受，我在这里陪你。” |\n| Day 3 | 时间边界 | 设定陪伴时长（10/20 分钟），并写下结束句式。 |\n| Day 4 | 行动边界 | 把“替你解决”改成“我陪你看见选择”，写 3 个提问。 |\n| Day 5 | 身体回到自己 | 2 分钟触感练习：握杯子/触摸桌面，回到身体。 |\n| Day 6 | 自我慈悲 | 写 3 句：这很难；我并不孤单；我愿意善待自己。 |\n| Day 7 | 求助与转介 | 列出 3 个可转介资源（朋友/专业/工具），不独自承担。 |\n| Day 8 | 同理而不内卷 | 对话中先复述感受，再问“你想要倾听还是建议？” |\n| Day 9 | 关怀后回收 | 每次深度倾听后做 5 分钟走动/呼吸，回收能量。 |\n| Day10 | 说出限制 | 练习：“我能陪你到这里，之后我需要休息。”并使用 1 次。 |\n| Day11 | 负荷监测 | 今日给情绪负荷打分 0–10，超过 7 时主动减少输入。 |\n| Day12 | 只做一件事 | 把助人行动缩到 1 个最小动作，避免过度卷入。 |\n| Day13 | 关系结构 | 写下 1 段高消耗关系：我需要怎样的边界才能持续？ |\n| Day14 | 复盘与巩固 | 总结 3 条你的边界原则 + 3 句你的关怀脚本。 |\n\n**使用方式**：边界不是冷漠，是让你的关怀变得可持续。",
+                            "id": "eq60_plan_boundary_zh",
+                            "title": "共情边界",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "action_plan_14d",
+                    "module_code": "eq_growth_plan",
+                    "title": "14 天游程"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                            "id": "eq60_methodology_zh",
+                            "title": "方法说明",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "methodology",
+                    "module_code": "eq_core",
+                    "title": "方法说明"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                            "id": "eq60_disclaimer_bottom_zh",
+                            "title": "结尾提示",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_bottom",
+                    "module_code": "eq_core",
+                    "title": "结尾提示"
+                }
+            ],
+            "user_visible": false
         },
         "locale": "zh-CN",
         "measurement_type": "self_report_trait_mixed_ei",
@@ -1196,19 +1385,6 @@
             },
             "neutral_rate": 0.2667
         },
-        "report": {
-            "primary_profile": "profile:compassion_overload",
-            "tags": [
-                "quality_level:A",
-                "profile:compassion_overload",
-                "focus:boundary_setting"
-            ]
-        },
-        "report_tags": [
-            "quality_level:A",
-            "profile:compassion_overload",
-            "focus:boundary_setting"
-        ],
         "scale_code": "EQ_60",
         "schema_version": "eq_60.report.v2",
         "scores": {
@@ -1259,162 +1435,6 @@
                 "standard_score": 99.5
             }
         },
-        "sections": [
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
-                        "id": "eq60_disclaimer_top_zh",
-                        "title": "重要声明",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_top",
-                "module_code": "eq_core",
-                "title": "重要声明"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "本次答卷质量等级为 **A**：一致性与作答节奏表现稳定，结果解释可靠度较高。",
-                        "id": "eq60_quality_level_A_zh",
-                        "title": "作答质量提示",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "quality_notice",
-                "module_code": "eq_core",
-                "title": "作答质量提示"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "你的综合 EQ 标准分为 **99.5**（人群平均 100，标准差 15），处于第 **48.67** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**A**。",
-                        "id": "eq60_global_overview_zh",
-                        "title": "综合概览",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "global_overview",
-                "module_code": "eq_core",
-                "title": "综合概览"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**97**（第 42.07 百分位），阶段：**稳定可用（Competent）**。\n\n你通常能识别情绪，并把情绪与触发点、需求联系起来。你能在大部分场景下清楚表达“我正在紧张/我需要时间/我被忽视了”。这种能力能明显降低误解与内耗，让沟通更聚焦问题本身，而不是被情绪噪音牵着走。\n\n**练习提示**：在关键对话前，用一句话写清“我在乎什么”，让表达更稳定。",
-                        "id": "eq60_sa_competent_zh",
-                        "title": "自我情绪认知 · 稳定可用（Competent）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "self_awareness",
-                "module_code": "eq_core",
-                "title": "自我情绪认知"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**83**（第 12.85 百分位），阶段：**觉察盲区（Baseline）**。\n\n在高压或被触发时，情绪更容易接管行动系统，出现冲动反应、反复纠结、睡眠受影响或持续紧绷。这个分数不代表意志力不足，而是调节工具箱尚未形成稳定的自动化。调节的目标不是“把情绪消灭”，而是把强度与持续时间拉回可管理范围。\n\n**练习提示（90秒）**：停下→缓慢呼气 6 次→把注意力放回脚底触地感，给自己争取“反应前的空隙”。",
-                        "id": "eq60_er_baseline_zh",
-                        "title": "情绪调节与控制 · 觉察盲区（Baseline）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "emotion_regulation",
-                "module_code": "eq_core",
-                "title": "情绪调节与控制"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**119**（第 89.74 百分位），阶段：**卓越稀缺（Exceptional）**。\n\n你的共情能力极强，能在高噪音环境里仍准确读到他人的情绪与动机，并用温和方式回应。这是影响力的重要底座。需要留意的点是：共情强度越高，越要建立边界，避免把别人的情绪带回自己的生活节奏里。\n\n**练习提示**：把“我也很难受”改成“我看见你很难受，我愿意陪你一会儿”，保留边界感。",
-                        "id": "eq60_em_exceptional_zh",
-                        "title": "同理心与社会感知 · 卓越稀缺（Exceptional）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "empathy",
-                "module_code": "eq_core",
-                "title": "同理心与社会感知"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**99**（第 47.34 百分位），阶段：**稳定可用（Competent）**。\n\n你具备良好的沟通与协作能力，能建立稳定的人际网络与信任。你能在多数场景里表达观点、处理分歧、维持关系质量。你通常能在“真实表达”和“关系维护”之间找到平衡。\n\n**练习提示**：遇到分歧时先对齐共同目标，再讨论方案。",
-                        "id": "eq60_rm_competent_zh",
-                        "title": "社交技能与人际管理 · 稳定可用（Competent）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "relationship_management",
-                "module_code": "eq_core",
-                "title": "社交技能与人际管理"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**你的主要画像：情绪海绵型（高同理心 + 低情绪调节）**\n\n本次测评显示：同理心与社会感知 **119** 很高，情绪调节 **83** 偏低。你对他人的痛苦与压力高度敏感，常常会“替别人难受”，也更容易被群体氛围影响。优势是真诚、温暖、能看见别人；代价是情绪过载与边界模糊。\n\n**你常见的优势**\n- 高共鸣：别人更愿意向你倾诉，信任建立更快。\n- 读空气能力强：能敏锐捕捉情绪变化与隐性冲突。\n- 关怀动机：有强烈的助人倾向与责任感。\n\n**常见代价**\n- 情绪感染：别人的情绪进入你的身体，影响睡眠与精力。\n- 救援反射：看到痛苦就想立刻解决，容易过度卷入。\n- 边界消失：把“同理”误用成“承担”，最后自己被掏空。\n\n**关键转折：把共情变成“有边界的关怀”**\n高共情不需要牺牲自我。训练重点是三层边界：\n1) **情绪边界**：区分“这是对方的感受”与“这是我的感受”。\n2) **时间边界**：明确陪伴时长与可用精力。\n3) **行动边界**：从“替你解决”转成“陪你一起看见选择”。\n\n**适合你的回应句式**\n- “我听见你很难受，我愿意陪你 10 分钟，先把事情捋清。”\n- “我能提供的是……更深入的部分需要你自己决定。”\n- “我很在乎你，我也需要先照顾好自己的精力。”\n\n**你会在这份免费报告里得到什么**\n- 边界训练：把共情从消耗变成资源。\n- 调节工具：让情绪不过载、不回流到生活里。\n- 14 天游程：建立可持续的助人方式。",
-                        "id": "eq60_profile_compassion_overload_zh",
-                        "title": "情绪海绵型",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "cross_quadrant_insight",
-                "module_code": "eq_cross_insights",
-                "title": "交叉洞察长文"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**14 天游程：共情边界与可持续关怀（每天 10–15 分钟）**\n\n目标：保留你的温暖与敏锐，同时建立情绪、时间与行动边界，避免情绪过载。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 区分“我的/你的” | 写下今天一次情绪感染：这是谁的情绪？我能做的是什么？ |\n| Day 2 | 情绪隔离 | 练习一句话：“我看见你很难受，这是你的感受，我在这里陪你。” |\n| Day 3 | 时间边界 | 设定陪伴时长（10/20 分钟），并写下结束句式。 |\n| Day 4 | 行动边界 | 把“替你解决”改成“我陪你看见选择”，写 3 个提问。 |\n| Day 5 | 身体回到自己 | 2 分钟触感练习：握杯子/触摸桌面，回到身体。 |\n| Day 6 | 自我慈悲 | 写 3 句：这很难；我并不孤单；我愿意善待自己。 |\n| Day 7 | 求助与转介 | 列出 3 个可转介资源（朋友/专业/工具），不独自承担。 |\n| Day 8 | 同理而不内卷 | 对话中先复述感受，再问“你想要倾听还是建议？” |\n| Day 9 | 关怀后回收 | 每次深度倾听后做 5 分钟走动/呼吸，回收能量。 |\n| Day10 | 说出限制 | 练习：“我能陪你到这里，之后我需要休息。”并使用 1 次。 |\n| Day11 | 负荷监测 | 今日给情绪负荷打分 0–10，超过 7 时主动减少输入。 |\n| Day12 | 只做一件事 | 把助人行动缩到 1 个最小动作，避免过度卷入。 |\n| Day13 | 关系结构 | 写下 1 段高消耗关系：我需要怎样的边界才能持续？ |\n| Day14 | 复盘与巩固 | 总结 3 条你的边界原则 + 3 句你的关怀脚本。 |\n\n**使用方式**：边界不是冷漠，是让你的关怀变得可持续。",
-                        "id": "eq60_plan_boundary_zh",
-                        "title": "共情边界",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "action_plan_14d",
-                "module_code": "eq_growth_plan",
-                "title": "14 天游程"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
-                        "id": "eq60_methodology_zh",
-                        "title": "方法说明",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "methodology",
-                "module_code": "eq_core",
-                "title": "方法说明"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
-                        "id": "eq60_disclaimer_bottom_zh",
-                        "title": "结尾提示",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_bottom",
-                "module_code": "eq_core",
-                "title": "结尾提示"
-            }
-        ],
         "variant": "full"
     },
     "report_access": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_en.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_en.json
@@ -773,83 +773,6 @@
                 "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment."
             }
         },
-        "compat": {
-            "free_blocks": [
-                {
-                    "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
-                    "id": "eq60_disclaimer_top_en",
-                    "section_key": "disclaimer_top",
-                    "title": "Important Notice"
-                },
-                {
-                    "content": "Completion time **90s** is notably short. Very fast responses reduce precision—consider retaking.",
-                    "id": "eq60_quality_flag_SPEEDING_en",
-                    "section_key": "quality_notice",
-                    "title": "Quality Detail"
-                },
-                {
-                    "content": "Response quality is **C**: notable response‑style or consistency issues; treat results as a rough reference and consider retaking.",
-                    "id": "eq60_quality_level_C_en",
-                    "section_key": "quality_notice",
-                    "title": "Response Quality"
-                },
-                {
-                    "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **C**.",
-                    "id": "eq60_global_overview_en",
-                    "section_key": "global_overview",
-                    "title": "Overview"
-                },
-                {
-                    "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
-                    "id": "eq60_sa_proficient_en",
-                    "section_key": "self_awareness",
-                    "title": "Self‑Awareness · Proficient"
-                },
-                {
-                    "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
-                    "id": "eq60_er_proficient_en",
-                    "section_key": "emotion_regulation",
-                    "title": "Emotion Regulation · Proficient"
-                },
-                {
-                    "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
-                    "id": "eq60_em_proficient_en",
-                    "section_key": "empathy",
-                    "title": "Social Awareness & Empathy · Proficient"
-                },
-                {
-                    "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
-                    "id": "eq60_rm_proficient_en",
-                    "section_key": "relationship_management",
-                    "title": "Relationship Management · Proficient"
-                },
-                {
-                    "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nThis free report breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What this free report gives you**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
-                    "id": "eq60_profile_balanced_high_en",
-                    "section_key": "cross_quadrant_insight",
-                    "title": "Balanced High EQ"
-                },
-                {
-                    "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
-                    "id": "eq60_plan_maintenance_en",
-                    "section_key": "action_plan_14d",
-                    "title": "High‑Level Consolidation"
-                },
-                {
-                    "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
-                    "id": "eq60_methodology_en",
-                    "section_key": "methodology",
-                    "title": "Methodology"
-                },
-                {
-                    "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
-                    "id": "eq60_disclaimer_bottom_en",
-                    "section_key": "disclaimer_bottom",
-                    "title": "Closing Notes"
-                }
-            ],
-            "paid_blocks": []
-        },
         "cross_assessment_context": {
             "available": true,
             "boundary_asset_id": "eq.cross_context.boundary.default",
@@ -929,6 +852,21 @@
                 "standard_score": 113
             }
         ],
+        "display_contract": {
+            "authority": "v5_resolved_assets",
+            "legacy_compat_user_visible": false,
+            "schema_version": "eq_60.display_contract.v1",
+            "user_visible_roots": [
+                "scores",
+                "dimension_summary",
+                "quality",
+                "interpretation",
+                "asset_refs",
+                "assets",
+                "next_module",
+                "methodology"
+            ]
+        },
         "eq_report_mode": "self_report",
         "generated_at": "2026-05-21T00:00:00.000000Z",
         "interpretation": {
@@ -1041,88 +979,345 @@
             ],
             "version": "eq_journey_state.v1"
         },
-        "legacy_scores": {
-            "EM": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+        "legacy_compat": {
+            "compat": {
+                "free_blocks": [
+                    {
+                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                        "id": "eq60_disclaimer_top_en",
+                        "section_key": "disclaimer_top",
+                        "title": "Important Notice"
+                    },
+                    {
+                        "content": "Completion time **90s** is notably short. Very fast responses reduce precision—consider retaking.",
+                        "id": "eq60_quality_flag_SPEEDING_en",
+                        "section_key": "quality_notice",
+                        "title": "Quality Detail"
+                    },
+                    {
+                        "content": "Response quality is **C**: notable response‑style or consistency issues; treat results as a rough reference and consider retaking.",
+                        "id": "eq60_quality_level_C_en",
+                        "section_key": "quality_notice",
+                        "title": "Response Quality"
+                    },
+                    {
+                        "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **C**.",
+                        "id": "eq60_global_overview_en",
+                        "section_key": "global_overview",
+                        "title": "Overview"
+                    },
+                    {
+                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
+                        "id": "eq60_sa_proficient_en",
+                        "section_key": "self_awareness",
+                        "title": "Self‑Awareness · Proficient"
+                    },
+                    {
+                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
+                        "id": "eq60_er_proficient_en",
+                        "section_key": "emotion_regulation",
+                        "title": "Emotion Regulation · Proficient"
+                    },
+                    {
+                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
+                        "id": "eq60_em_proficient_en",
+                        "section_key": "empathy",
+                        "title": "Social Awareness & Empathy · Proficient"
+                    },
+                    {
+                        "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
+                        "id": "eq60_rm_proficient_en",
+                        "section_key": "relationship_management",
+                        "title": "Relationship Management · Proficient"
+                    },
+                    {
+                        "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nThis free report breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What this free report gives you**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
+                        "id": "eq60_profile_balanced_high_en",
+                        "section_key": "cross_quadrant_insight",
+                        "title": "Balanced High EQ"
+                    },
+                    {
+                        "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
+                        "id": "eq60_plan_maintenance_en",
+                        "section_key": "action_plan_14d",
+                        "title": "High‑Level Consolidation"
+                    },
+                    {
+                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                        "id": "eq60_methodology_en",
+                        "section_key": "methodology",
+                        "title": "Methodology"
+                    },
+                    {
+                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                        "id": "eq60_disclaimer_bottom_en",
+                        "section_key": "disclaimer_bottom",
+                        "title": "Closing Notes"
+                    }
+                ],
+                "paid_blocks": []
             },
-            "ER": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+            "legacy_scores": {
+                "EM": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "ER": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "RM": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "SA": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "emotion_regulation": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "empathy": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "global": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 240,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "relationship_management": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "self_awareness": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                }
             },
-            "RM": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+            "purpose": "legacy_renderer_compatibility_only",
+            "report_tags": [
+                "quality_level:C",
+                "quality_flag:SPEEDING",
+                "profile:balanced_high_eq"
+            ],
+            "schema_version": "eq_60.legacy_compat.v1",
+            "scorer_report": {
+                "primary_profile": "profile:balanced_high_eq",
+                "tags": [
+                    "quality_level:C",
+                    "quality_flag:SPEEDING",
+                    "profile:balanced_high_eq"
+                ]
             },
-            "SA": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "emotion_regulation": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "empathy": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "global": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 240,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "relationship_management": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "self_awareness": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            }
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
+                            "id": "eq60_disclaimer_top_en",
+                            "title": "Important Notice",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "eq_core",
+                    "title": "Important Notice"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "Completion time **90s** is notably short. Very fast responses reduce precision—consider retaking.",
+                            "id": "eq60_quality_flag_SPEEDING_en",
+                            "title": "Quality Detail",
+                            "type": "markdown"
+                        },
+                        {
+                            "content": "Response quality is **C**: notable response‑style or consistency issues; treat results as a rough reference and consider retaking.",
+                            "id": "eq60_quality_level_C_en",
+                            "title": "Response Quality",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "quality_notice",
+                    "module_code": "eq_core",
+                    "title": "Response Quality"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **C**.",
+                            "id": "eq60_global_overview_en",
+                            "title": "Overview",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "global_overview",
+                    "module_code": "eq_core",
+                    "title": "Overview"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
+                            "id": "eq60_sa_proficient_en",
+                            "title": "Self‑Awareness · Proficient",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "self_awareness",
+                    "module_code": "eq_core",
+                    "title": "Self‑Awareness"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
+                            "id": "eq60_er_proficient_en",
+                            "title": "Emotion Regulation · Proficient",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "emotion_regulation",
+                    "module_code": "eq_core",
+                    "title": "Emotion Regulation"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
+                            "id": "eq60_em_proficient_en",
+                            "title": "Social Awareness & Empathy · Proficient",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "empathy",
+                    "module_code": "eq_core",
+                    "title": "Social Awareness & Empathy"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
+                            "id": "eq60_rm_proficient_en",
+                            "title": "Relationship Management · Proficient",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "relationship_management",
+                    "module_code": "eq_core",
+                    "title": "Relationship Management"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nThis free report breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What this free report gives you**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
+                            "id": "eq60_profile_balanced_high_en",
+                            "title": "Balanced High EQ",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "cross_quadrant_insight",
+                    "module_code": "eq_cross_insights",
+                    "title": "Cross‑Quadrant Insight"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
+                            "id": "eq60_plan_maintenance_en",
+                            "title": "High‑Level Consolidation",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "action_plan_14d",
+                    "module_code": "eq_growth_plan",
+                    "title": "14‑Day Plan"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
+                            "id": "eq60_methodology_en",
+                            "title": "Methodology",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "methodology",
+                    "module_code": "eq_core",
+                    "title": "Methodology"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
+                            "id": "eq60_disclaimer_bottom_en",
+                            "title": "Closing Notes",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_bottom",
+                    "module_code": "eq_core",
+                    "title": "Closing Notes"
+                }
+            ],
+            "user_visible": false
         },
         "locale": "en",
         "measurement_type": "self_report_trait_mixed_ei",
@@ -1158,19 +1353,6 @@
             },
             "neutral_rate": 0
         },
-        "report": {
-            "primary_profile": "profile:balanced_high_eq",
-            "tags": [
-                "quality_level:C",
-                "quality_flag:SPEEDING",
-                "profile:balanced_high_eq"
-            ]
-        },
-        "report_tags": [
-            "quality_level:C",
-            "quality_flag:SPEEDING",
-            "profile:balanced_high_eq"
-        ],
         "scale_code": "EQ_60",
         "schema_version": "eq_60.report.v2",
         "scores": {
@@ -1216,168 +1398,6 @@
                 "standard_score": 113
             }
         },
-        "sections": [
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "This assessment is a self‑report questionnaire for self‑reflection and skill development. It is not a medical diagnosis or psychotherapy advice.\nResults depend on your current state, interpretation, and response quality.\nWhen distress persists or daily functioning is significantly impaired, professional support is recommended.",
-                        "id": "eq60_disclaimer_top_en",
-                        "title": "Important Notice",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_top",
-                "module_code": "eq_core",
-                "title": "Important Notice"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "Completion time **90s** is notably short. Very fast responses reduce precision—consider retaking.",
-                        "id": "eq60_quality_flag_SPEEDING_en",
-                        "title": "Quality Detail",
-                        "type": "markdown"
-                    },
-                    {
-                        "content": "Response quality is **C**: notable response‑style or consistency issues; treat results as a rough reference and consider retaking.",
-                        "id": "eq60_quality_level_C_en",
-                        "title": "Response Quality",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "quality_notice",
-                "module_code": "eq_core",
-                "title": "Response Quality"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "Your overall EQ standard score is **113** (population mean 100, SD 15), at the **80.69** percentile.\n\nThis assessment covers four capabilities: Self‑Awareness (SA), Emotion Regulation (ER), Social Awareness & Empathy (EM), and Relationship Management (RM). Each section includes a standard score and a maturity band to locate strengths and training priorities.\n\nResponse quality: **C**.",
-                        "id": "eq60_global_overview_en",
-                        "title": "Overview",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "global_overview",
-                "module_code": "eq_core",
-                "title": "Overview"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Self‑Awareness**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou pick up emotional signals early and name them with specific words. You also see the value/need behind the emotion, which supports steadier choices. You often notice yourself entering a defensive or tense state and adjust how you respond.\n\n**Practice**: Use “Name → Allow → Redirect” when intensity rises (not suppressing, not acting it out).",
-                        "id": "eq60_sa_proficient_en",
-                        "title": "Self‑Awareness · Proficient",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "self_awareness",
-                "module_code": "eq_core",
-                "title": "Self‑Awareness"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Emotion Regulation**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou stay relatively clear under pressure, move on from negative states faster, and respond in more constructive ways. Your decisions carry less emotional noise. You can accept emotions while converting them into action.\n\n**Practice**: Use “Fact → Feeling → Request” to keep communication from escalating.",
-                        "id": "eq60_er_proficient_en",
-                        "title": "Emotion Regulation · Proficient",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "emotion_regulation",
-                "module_code": "eq_core",
-                "title": "Emotion Regulation"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Social Awareness & Empathy**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou’re sensitive to micro‑expressions, tone, and pace shifts, and you sense group climate quickly. You often notice tension before it escalates and can de‑escalate early.\n\n**Practice**: Stabilize emotional temperature first, then discuss facts and solutions.",
-                        "id": "eq60_em_proficient_en",
-                        "title": "Social Awareness & Empathy · Proficient",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "empathy",
-                "module_code": "eq_core",
-                "title": "Social Awareness & Empathy"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Dimension: Relationship Management**\n\nStandard score: **113** (80.69 percentile), band: **Proficient**.\n\nYou create rapport and connection, and you can move conflict toward a win‑win path. People often feel understood and respected around you, which naturally builds influence.\n\n**Practice**: Use a 3‑step: Appreciation → Specific feedback → Invitation.",
-                        "id": "eq60_rm_proficient_en",
-                        "title": "Relationship Management · Proficient",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "relationship_management",
-                "module_code": "eq_core",
-                "title": "Relationship Management"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Primary profile: Balanced High EQ (High across all four quadrants)**\n\nAll four dimensions are in a high range, meaning you can connect the loop: notice emotion → regulate → understand others → manage relationships. You can identify and express feelings, stay stable under pressure, empathize, and move relationships toward cooperation.\n\n**Typical strengths**\n- Self stability under emotional fluctuation.\n- Connection with boundaries.\n- Trust building and conflict‑to‑consensus influence.\n\n**Risks to watch**\n- Over‑carrying others’ emotions as a default duty.\n- High‑standards fatigue.\n- Output exceeding recovery; you need deliberate restoration.\n\n**Upgrade direction: turn strengths into a system**\nThis free report breaks your strengths into reusable modules and provides a 14‑day consolidation plan:\n1) Emotional reflection that transfers across contexts.\n2) Influence scripts for low‑friction collaboration.\n3) Recovery strategy for sustainable high performance.\n\n**What this free report gives you**\n- Your strongest moat capabilities.\n- Risk warnings in high‑intensity environments.\n- 14‑day plan to consolidate, recover, and upgrade leadership.",
-                        "id": "eq60_profile_balanced_high_en",
-                        "title": "Balanced High EQ",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "cross_quadrant_insight",
-                "module_code": "eq_cross_insights",
-                "title": "Cross‑Quadrant Insight"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**14‑Day Plan: High‑Level Consolidation & Recovery (10–15 min/day)**\n\nGoal: consolidate strong capabilities, avoid over‑carrying, and build a steady recovery rhythm.\n\n| Day | Theme | Practice |\n|---|---|---|\n| Day 1 | Strength map | Identify your top 2 dimensions and how they show up behaviorally. |\n| Day 2 | Boundaries | Write 3 boundary principles (time/emotion/action). |\n| Day 3 | High‑pressure plan | 3 scenarios + 1 cool‑down action + 1 support person each. |\n| Day 4 | Relationship investment | Do one high‑quality connection: listen + specific feedback. |\n| Day 5 | Conflict script | Draft your empathize → goal → next step template and rehearse. |\n| Day 6 | Output vs recovery | Track the ratio; schedule 20 minutes restoration. |\n| Day 7 | Emotional reflection | Signal → choice → outcome → better next move. |\n| Day 8 | Influence ethics | Write 3 principles (no manipulation, respect choice, etc.). |\n| Day 9 | Sustainable care | Support one person with clear time/energy boundaries. |\n| Day10 | Authentic request | Share feeling + need + request with warmth and clarity. |\n| Day11 | Hard conversation | Draft 5 lines: open/empathize/boundary/plan/close. |\n| Day12 | Energy management | Rate energy 0–10; below 6, reduce load intentionally. |\n| Day13 | Skill upgrade | Pick one micro skill (questions/feedback/negotiation) and drill 10 minutes. |\n| Day14 | Consolidate & plan | Summarize your best 3 moves and plan the next cycle. |\n\nHigh performance lasts through rhythm and boundaries.",
-                        "id": "eq60_plan_maintenance_en",
-                        "title": "High‑Level Consolidation",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "action_plan_14d",
-                "module_code": "eq_growth_plan",
-                "title": "14‑Day Plan"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**Scoring (Production v1.0)**\n\n1) 60 items use a 5‑point scale; reverse‑keyed items are flipped before aggregation (6 − response).\n2) Each quadrant has 15 items. Raw sums are mapped to standard scores (mean 100, SD 15).\n3) Response‑quality indicators are computed (time, long‑stringing, extreme/neutral bias, internal consistency). Only A/B quality enters the norm pool.\n4) This free report includes cross‑quadrant insights and a 14‑day training plan to convert understanding into practice.",
-                        "id": "eq60_methodology_en",
-                        "title": "Methodology",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "methodology",
-                "module_code": "eq_core",
-                "title": "Methodology"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**How to use this report**: Treat this as guidance for self‑reflection and skill training. A retake interval of at least 14 days improves stability.\nThis platform does not use a single test result for labeling decisions.",
-                        "id": "eq60_disclaimer_bottom_en",
-                        "title": "Closing Notes",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_bottom",
-                "module_code": "eq_core",
-                "title": "Closing Notes"
-            }
-        ],
         "variant": "full"
     },
     "report_access": {

--- a/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_zh.json
+++ b/backend/tests/Fixtures/eq/v5/eq60_v5_low_confidence_zh.json
@@ -773,83 +773,6 @@
                 "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。"
             }
         },
-        "compat": {
-            "free_blocks": [
-                {
-                    "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
-                    "id": "eq60_disclaimer_top_zh",
-                    "section_key": "disclaimer_top",
-                    "title": "重要声明"
-                },
-                {
-                    "content": "完成用时 **90 秒**，明显偏短。快速作答会降低区分度，建议复测以获得更稳的画像。",
-                    "id": "eq60_quality_flag_SPEEDING_zh",
-                    "section_key": "quality_notice",
-                    "title": "作答质量细节"
-                },
-                {
-                    "content": "本次答卷质量等级为 **C**：存在明显作答风格或一致性问题，结果用于自我参考更合适；建议在精力更稳定时复测。",
-                    "id": "eq60_quality_level_C_zh",
-                    "section_key": "quality_notice",
-                    "title": "作答质量提示"
-                },
-                {
-                    "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**C**。",
-                    "id": "eq60_global_overview_zh",
-                    "section_key": "global_overview",
-                    "title": "综合概览"
-                },
-                {
-                    "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
-                    "id": "eq60_sa_proficient_zh",
-                    "section_key": "self_awareness",
-                    "title": "自我情绪认知 · 成熟（Proficient）"
-                },
-                {
-                    "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
-                    "id": "eq60_er_proficient_zh",
-                    "section_key": "emotion_regulation",
-                    "title": "情绪调节与控制 · 成熟（Proficient）"
-                },
-                {
-                    "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
-                    "id": "eq60_em_proficient_zh",
-                    "section_key": "empathy",
-                    "title": "同理心与社会感知 · 成熟（Proficient）"
-                },
-                {
-                    "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
-                    "id": "eq60_rm_proficient_zh",
-                    "section_key": "relationship_management",
-                    "title": "社交技能与人际管理 · 成熟（Proficient）"
-                },
-                {
-                    "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n这份免费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在这份免费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
-                    "id": "eq60_profile_balanced_high_zh",
-                    "section_key": "cross_quadrant_insight",
-                    "title": "四维均衡高"
-                },
-                {
-                    "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
-                    "id": "eq60_plan_maintenance_zh",
-                    "section_key": "action_plan_14d",
-                    "title": "高水平巩固"
-                },
-                {
-                    "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
-                    "id": "eq60_methodology_zh",
-                    "section_key": "methodology",
-                    "title": "方法说明"
-                },
-                {
-                    "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
-                    "id": "eq60_disclaimer_bottom_zh",
-                    "section_key": "disclaimer_bottom",
-                    "title": "结尾提示"
-                }
-            ],
-            "paid_blocks": []
-        },
         "cross_assessment_context": {
             "available": true,
             "boundary_asset_id": "eq.cross_context.boundary.default",
@@ -929,6 +852,21 @@
                 "standard_score": 113
             }
         ],
+        "display_contract": {
+            "authority": "v5_resolved_assets",
+            "legacy_compat_user_visible": false,
+            "schema_version": "eq_60.display_contract.v1",
+            "user_visible_roots": [
+                "scores",
+                "dimension_summary",
+                "quality",
+                "interpretation",
+                "asset_refs",
+                "assets",
+                "next_module",
+                "methodology"
+            ]
+        },
         "eq_report_mode": "self_report",
         "generated_at": "2026-05-21T00:00:00.000000Z",
         "interpretation": {
@@ -1041,88 +979,345 @@
             ],
             "version": "eq_journey_state.v1"
         },
-        "legacy_scores": {
-            "EM": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+        "legacy_compat": {
+            "compat": {
+                "free_blocks": [
+                    {
+                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                        "id": "eq60_disclaimer_top_zh",
+                        "section_key": "disclaimer_top",
+                        "title": "重要声明"
+                    },
+                    {
+                        "content": "完成用时 **90 秒**，明显偏短。快速作答会降低区分度，建议复测以获得更稳的画像。",
+                        "id": "eq60_quality_flag_SPEEDING_zh",
+                        "section_key": "quality_notice",
+                        "title": "作答质量细节"
+                    },
+                    {
+                        "content": "本次答卷质量等级为 **C**：存在明显作答风格或一致性问题，结果用于自我参考更合适；建议在精力更稳定时复测。",
+                        "id": "eq60_quality_level_C_zh",
+                        "section_key": "quality_notice",
+                        "title": "作答质量提示"
+                    },
+                    {
+                        "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**C**。",
+                        "id": "eq60_global_overview_zh",
+                        "section_key": "global_overview",
+                        "title": "综合概览"
+                    },
+                    {
+                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
+                        "id": "eq60_sa_proficient_zh",
+                        "section_key": "self_awareness",
+                        "title": "自我情绪认知 · 成熟（Proficient）"
+                    },
+                    {
+                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
+                        "id": "eq60_er_proficient_zh",
+                        "section_key": "emotion_regulation",
+                        "title": "情绪调节与控制 · 成熟（Proficient）"
+                    },
+                    {
+                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
+                        "id": "eq60_em_proficient_zh",
+                        "section_key": "empathy",
+                        "title": "同理心与社会感知 · 成熟（Proficient）"
+                    },
+                    {
+                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
+                        "id": "eq60_rm_proficient_zh",
+                        "section_key": "relationship_management",
+                        "title": "社交技能与人际管理 · 成熟（Proficient）"
+                    },
+                    {
+                        "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n这份免费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在这份免费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
+                        "id": "eq60_profile_balanced_high_zh",
+                        "section_key": "cross_quadrant_insight",
+                        "title": "四维均衡高"
+                    },
+                    {
+                        "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
+                        "id": "eq60_plan_maintenance_zh",
+                        "section_key": "action_plan_14d",
+                        "title": "高水平巩固"
+                    },
+                    {
+                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                        "id": "eq60_methodology_zh",
+                        "section_key": "methodology",
+                        "title": "方法说明"
+                    },
+                    {
+                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                        "id": "eq60_disclaimer_bottom_zh",
+                        "section_key": "disclaimer_bottom",
+                        "title": "结尾提示"
+                    }
+                ],
+                "paid_blocks": []
             },
-            "ER": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+            "legacy_scores": {
+                "EM": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "ER": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "RM": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "SA": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "emotion_regulation": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "empathy": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "global": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 240,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "relationship_management": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                },
+                "self_awareness": {
+                    "level": "proficient",
+                    "percentile": 80.69,
+                    "pomp": 75,
+                    "raw_mean": 4,
+                    "raw_sum": 60,
+                    "std_score": 113,
+                    "z": 0.866667
+                }
             },
-            "RM": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
+            "purpose": "legacy_renderer_compatibility_only",
+            "report_tags": [
+                "quality_level:C",
+                "quality_flag:SPEEDING",
+                "profile:balanced_high_eq"
+            ],
+            "schema_version": "eq_60.legacy_compat.v1",
+            "scorer_report": {
+                "primary_profile": "profile:balanced_high_eq",
+                "tags": [
+                    "quality_level:C",
+                    "quality_flag:SPEEDING",
+                    "profile:balanced_high_eq"
+                ]
             },
-            "SA": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "emotion_regulation": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "empathy": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "global": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 240,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "relationship_management": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            },
-            "self_awareness": {
-                "level": "proficient",
-                "percentile": 80.69,
-                "pomp": 75,
-                "raw_mean": 4,
-                "raw_sum": 60,
-                "std_score": 113,
-                "z": 0.866667
-            }
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
+                            "id": "eq60_disclaimer_top_zh",
+                            "title": "重要声明",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "eq_core",
+                    "title": "重要声明"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "完成用时 **90 秒**，明显偏短。快速作答会降低区分度，建议复测以获得更稳的画像。",
+                            "id": "eq60_quality_flag_SPEEDING_zh",
+                            "title": "作答质量细节",
+                            "type": "markdown"
+                        },
+                        {
+                            "content": "本次答卷质量等级为 **C**：存在明显作答风格或一致性问题，结果用于自我参考更合适；建议在精力更稳定时复测。",
+                            "id": "eq60_quality_level_C_zh",
+                            "title": "作答质量提示",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "quality_notice",
+                    "module_code": "eq_core",
+                    "title": "作答质量提示"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**C**。",
+                            "id": "eq60_global_overview_zh",
+                            "title": "综合概览",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "global_overview",
+                    "module_code": "eq_core",
+                    "title": "综合概览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
+                            "id": "eq60_sa_proficient_zh",
+                            "title": "自我情绪认知 · 成熟（Proficient）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "self_awareness",
+                    "module_code": "eq_core",
+                    "title": "自我情绪认知"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
+                            "id": "eq60_er_proficient_zh",
+                            "title": "情绪调节与控制 · 成熟（Proficient）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "emotion_regulation",
+                    "module_code": "eq_core",
+                    "title": "情绪调节与控制"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
+                            "id": "eq60_em_proficient_zh",
+                            "title": "同理心与社会感知 · 成熟（Proficient）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "empathy",
+                    "module_code": "eq_core",
+                    "title": "同理心与社会感知"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
+                            "id": "eq60_rm_proficient_zh",
+                            "title": "社交技能与人际管理 · 成熟（Proficient）",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "relationship_management",
+                    "module_code": "eq_core",
+                    "title": "社交技能与人际管理"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n这份免费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在这份免费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
+                            "id": "eq60_profile_balanced_high_zh",
+                            "title": "四维均衡高",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "cross_quadrant_insight",
+                    "module_code": "eq_cross_insights",
+                    "title": "交叉洞察长文"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
+                            "id": "eq60_plan_maintenance_zh",
+                            "title": "高水平巩固",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "action_plan_14d",
+                    "module_code": "eq_growth_plan",
+                    "title": "14 天游程"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
+                            "id": "eq60_methodology_zh",
+                            "title": "方法说明",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "methodology",
+                    "module_code": "eq_core",
+                    "title": "方法说明"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
+                            "id": "eq60_disclaimer_bottom_zh",
+                            "title": "结尾提示",
+                            "type": "markdown"
+                        }
+                    ],
+                    "key": "disclaimer_bottom",
+                    "module_code": "eq_core",
+                    "title": "结尾提示"
+                }
+            ],
+            "user_visible": false
         },
         "locale": "zh-CN",
         "measurement_type": "self_report_trait_mixed_ei",
@@ -1158,19 +1353,6 @@
             },
             "neutral_rate": 0
         },
-        "report": {
-            "primary_profile": "profile:balanced_high_eq",
-            "tags": [
-                "quality_level:C",
-                "quality_flag:SPEEDING",
-                "profile:balanced_high_eq"
-            ]
-        },
-        "report_tags": [
-            "quality_level:C",
-            "quality_flag:SPEEDING",
-            "profile:balanced_high_eq"
-        ],
         "scale_code": "EQ_60",
         "schema_version": "eq_60.report.v2",
         "scores": {
@@ -1216,168 +1398,6 @@
                 "standard_score": 113
             }
         },
-        "sections": [
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "本测评为自评问卷，用于自我探索与能力训练方向参考，不构成医疗诊断或心理治疗建议。\n结果受作答状态、理解方式与作答质量影响。\n当你出现持续的情绪困扰、睡眠显著受影响、工作/学习/关系功能受损时，建议寻求专业心理支持。",
-                        "id": "eq60_disclaimer_top_zh",
-                        "title": "重要声明",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_top",
-                "module_code": "eq_core",
-                "title": "重要声明"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "完成用时 **90 秒**，明显偏短。快速作答会降低区分度，建议复测以获得更稳的画像。",
-                        "id": "eq60_quality_flag_SPEEDING_zh",
-                        "title": "作答质量细节",
-                        "type": "markdown"
-                    },
-                    {
-                        "content": "本次答卷质量等级为 **C**：存在明显作答风格或一致性问题，结果用于自我参考更合适；建议在精力更稳定时复测。",
-                        "id": "eq60_quality_level_C_zh",
-                        "title": "作答质量提示",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "quality_notice",
-                "module_code": "eq_core",
-                "title": "作答质量提示"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "你的综合 EQ 标准分为 **113**（人群平均 100，标准差 15），处于第 **80.69** 百分位。\n\n本测评基于四项能力：自我情绪认知（SA）、情绪调节（ER）、同理心与社会感知（EM）、社交管理（RM）。报告会给出各维度的标准分与发展阶段，用于定位优势与训练重点。\n\n本次作答质量等级：**C**。",
-                        "id": "eq60_global_overview_zh",
-                        "title": "综合概览",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "global_overview",
-                "module_code": "eq_core",
-                "title": "综合概览"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：自我情绪认知（Self‑Awareness）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对情绪变化敏锐，能在情绪刚出现时就捕捉到信号，并用具体词汇命名。你也能看见情绪背后的价值与需求，从而做出更稳的选择。你往往能提前发现自己进入“紧绷/烦躁/防御”状态，并及时调整表达方式。\n\n**练习提示**：遇到强烈情绪时先做“命名→允许→转向”（不压抑、不放任）。",
-                        "id": "eq60_sa_proficient_zh",
-                        "title": "自我情绪认知 · 成熟（Proficient）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "self_awareness",
-                "module_code": "eq_core",
-                "title": "自我情绪认知"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：情绪调节与控制（Emotion Regulation）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你在压力下仍能保持清晰，能较快从负面情绪里“翻篇”，并用更有建设性的方式回应。你做决定时能减少情绪噪音，也更少在关系中失控。你的优势在于：既能接纳情绪，又能把情绪转化为行动。\n\n**练习提示**：用“事实—感受—请求”三句式沟通，避免情绪升级。",
-                        "id": "eq60_er_proficient_zh",
-                        "title": "情绪调节与控制 · 成熟（Proficient）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "emotion_regulation",
-                "module_code": "eq_core",
-                "title": "情绪调节与控制"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：同理心与社会感知（Social Awareness & Empathy）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你对微表情、语气、节奏变化非常敏锐，能快速感知群体氛围与潜在张力。你往往能在冲突升温前捕捉信号并做预防，例如：及时降温、转移到更安全的沟通方式、让对方感到被看见。\n\n**练习提示**：在高压场景里先稳住情绪温度，再谈事实与方案。",
-                        "id": "eq60_em_proficient_zh",
-                        "title": "同理心与社会感知 · 成熟（Proficient）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "empathy",
-                "module_code": "eq_core",
-                "title": "同理心与社会感知"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**本维度：社交技能与人际管理（Relationship Management）**\n\n标准分：**113**（第 80.69 百分位），阶段：**成熟（Proficient）**。\n\n你很会营造氛围、建立连接，也能在冲突里找到双赢路径。你不只“会聊”，更能让对方感到被理解与被尊重。你往往能在团队中自然形成影响力，推动协作发生。\n\n**练习提示**：用“感谢—具体反馈—邀请”三段式，提升关系质量。",
-                        "id": "eq60_rm_proficient_zh",
-                        "title": "社交技能与人际管理 · 成熟（Proficient）",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "relationship_management",
-                "module_code": "eq_core",
-                "title": "社交技能与人际管理"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**你的主要画像：四维均衡高（高自我觉察 + 高调节 + 高共情 + 高社交）**\n\n你的四个维度都处在较高区间，说明你能把“看见情绪—管理情绪—理解他人—影响关系”串成一个完整闭环。你不仅能识别与表达，也能在压力下保持稳定；不仅能共情，也能把关系带到更合作的方向。\n\n**你常见的优势**\n- 自我稳定：能在情绪起伏中保持清醒与行动力。\n- 关系连接：能让别人感到被理解，同时不丢失边界。\n- 影响力：更容易建立信任，并在冲突中促成共识。\n\n**需要留意的风险**\n- 过度承担：在高共情与高影响力下，容易把“照顾他人”变成习惯性任务。\n- 高标准疲劳：对自己与他人期待都很高，长期会累。\n- 输出大于恢复：在高强度社交与工作中，需要刻意安排恢复。\n\n**升级方向：把优势沉淀为系统**\n这份免费报告会把你的优势拆成可复用的“能力模块”，并提供 14 天游程用于巩固与升级：\n1) 情绪复盘：把觉察变成可迁移的经验。\n2) 影响力脚本：在冲突与协作中持续产出“低摩擦沟通”。\n3) 恢复策略：让高水平输出保持可持续。\n\n**你会在这份免费报告里得到什么**\n- 你的高分护城河：哪些能力最能支撑你长期发展。\n- 风险预警：在高强度环境里最容易掉坑的点。\n- 14 天游程：巩固优势、建立恢复、升级领导力。",
-                        "id": "eq60_profile_balanced_high_zh",
-                        "title": "四维均衡高",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "cross_quadrant_insight",
-                "module_code": "eq_cross_insights",
-                "title": "交叉洞察长文"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**14 天游程：高水平巩固与恢复（每天 10–15 分钟）**\n\n目标：巩固你的高分能力，避免过度承担，建立稳定恢复节奏。\n\n| 天数 | 主题 | 今日练习 |\n|---|---|---|\n| Day 1 | 优势地图 | 写下你最稳的 2 个维度与最常用的行为表现。 |\n| Day 2 | 边界确认 | 写 3 条边界原则（时间/情绪/行动），放在手机备忘。 |\n| Day 3 | 高压预案 | 列出 3 个高压场景，对应 1 个降温动作与 1 个求助对象。 |\n| Day 4 | 关系投资 | 选择 1 段重要关系，做一次高质量连接（倾听+反馈）。 |\n| Day 5 | 冲突脚本 | 写一个你常用的“共情→目标→下一步”模板并复读 3 次。 |\n| Day 6 | 输出与恢复 | 记录一天的输出/恢复比，安排 20 分钟恢复性活动。 |\n| Day 7 | 情绪复盘 | 复盘一件事：情绪信号→选择→结果→下次更优动作。 |\n| Day 8 | 影响力伦理 | 写下你坚持的 3 条影响力原则（不操控/尊重选择等）。 |\n| Day 9 | 可持续关怀 | 对一位伙伴给出支持，同时明确时长与边界。 |\n| Day10 | 真实表达 | 说出一次真实感受 + 需求 + 请求，保持温和与清晰。 |\n| Day11 | 复杂对话 | 选择一个难对话，写 5 句脚本：开场/共情/边界/方案/收尾。 |\n| Day12 | 精力管理 | 给自己的精力打分 0–10，低于 6 时主动减负。 |\n| Day13 | 学习升级 | 选择一个沟通微技能（提问/反馈/协商），刻意练习 10 分钟。 |\n| Day14 | 巩固与计划 | 总结本周期最有效的 3 个动作，写下下一周期计划。 |\n\n**使用方式**：高水平的关键在于节奏与边界，让长期稳定成为默认。",
-                        "id": "eq60_plan_maintenance_zh",
-                        "title": "高水平巩固",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "action_plan_14d",
-                "module_code": "eq_growth_plan",
-                "title": "14 天游程"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**计分方法（上线版 v1.0）**\n\n1) 60 题采用 5 点量表作答；反向题在计分前做翻转（6−选项值）。\n2) 每个维度 15 题，先得到原始分，再转为标准分：平均 100、标准差 15。\n3) 同时计算作答质量指标（耗时、直线作答、极端/中立偏好、内部一致性）。质量等级为 A/B 的数据进入常模库。\n4) 免费报告包含跨维度洞察与 14 天训练计划，目标是把“理解”转化为“可执行的行为改变”。",
-                        "id": "eq60_methodology_zh",
-                        "title": "方法说明",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "methodology",
-                "module_code": "eq_core",
-                "title": "方法说明"
-            },
-            {
-                "access_level": "free",
-                "blocks": [
-                    {
-                        "content": "**使用建议**：本报告用于自我理解与训练方向参考。复测周期建议不少于 14 天，以减少短期情绪波动带来的噪音。\n本平台不会把单次测评结果用于任何“贴标签式”的决策。",
-                        "id": "eq60_disclaimer_bottom_zh",
-                        "title": "结尾提示",
-                        "type": "markdown"
-                    }
-                ],
-                "key": "disclaimer_bottom",
-                "module_code": "eq_core",
-                "title": "结尾提示"
-            }
-        ],
         "variant": "full"
     },
     "report_access": {


### PR DESCRIPTION
## Summary
- Move legacy EQ report sections, compat blocks, scorer report, legacy scores, and report tags under `report.legacy_compat`.
- Add `report.display_contract` to declare v5 resolved assets as the user-visible authority.
- Update EQ v1.9 canonical fixtures and report contract tests so old compatibility blocks are explicitly `user_visible=false`.

## Why
EQ v1.9 result rendering is assets-driven, but `/report` still exposed legacy `sections`, `report_tags`, and old scorer report fields at the report root. The frontend was not rendering them, but keeping those fields at the same level as the v5 contract increased future renderer misread risk.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' UPDATE_EQ60_V5_FIXTURES=true php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportDeliveryTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent`
- `git diff --check`
- `git diff --cached --check`
- JSON parse over `backend/tests/Fixtures/eq/v5/*.json`

Note: PHPUnit reported existing warnings in these focused suites, but all assertions passed.

## Intentionally deferred
- No frontend changes.
- No EQ scoring, question, norm, SJT, commerce, or content rewrite changes.
- No production deploy or smoke in this PR.

## Repository rule impact
EQ report content authority remains backend/composer/content-pack driven. This PR clarifies the API contract boundary: v5 resolved assets are user-visible authority, legacy compatibility payload is explicitly non-user-visible.
