### PR TITLE
fix(big5): clean rendered asset hygiene

### DIFF
--- a/backend/app/Services/BigFive/BigFivePublicProjectionService.php
+++ b/backend/app/Services/BigFive/BigFivePublicProjectionService.php
@@ -508,14 +508,9 @@ final class BigFivePublicProjectionService
     {
         $variantKeys = [];
         foreach ($tags as $tag) {
-            if (str_starts_with($tag, 'profile:') || str_starts_with($tag, 'big5:')) {
+            if (str_starts_with($tag, 'profile:')) {
                 $variantKeys[$tag] = true;
             }
-        }
-
-        foreach (self::DOMAIN_ORDER as $trait) {
-            $band = strtolower((string) ($traitBands[$trait] ?? 'mid'));
-            $variantKeys['band:'.strtolower($trait).'.'.$band] = true;
         }
 
         return array_keys($variantKeys);

--- a/backend/content_packs/BIG5_OCEAN/v2/registry/shared/methodology.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/registry/shared/methodology.json
@@ -1,6 +1,6 @@
 {
     "schema": "fap.big5.shared_methodology.v1",
-    "title": "v2 报告引擎方法说明",
-    "body": "本 payload 由 Big Five Report Engine v2 registry 生成；PR3B 已覆盖 30 条 facet glossary 与 22 条 facet precision anomaly rules，PR3A 的 5 条 synergy、PR2 的 O/C/E/A/N atomic 与 sentence-level modifier 继续沿用，scenario action rule 仍保持 PR1 的 N-only 范围。",
-    "access_note": "此结构服务未来 8 section 承载位，不代表生产 AttemptReadController 已接入。"
+    "title": "Big Five 方法说明",
+    "body": "这份报告基于 Big Five 五维与细分维度组织解释，用维度位置、相对参照、组合线索和场景建议帮助你理解当前作答画像。它适合用于自我观察、沟通和下一步行动整理，不应被当作诊断、招聘筛选、能力证明或人生结果预测。",
+    "access_note": "结果会受到作答状态、样本参照和当前生活阶段影响。请把百分位和维度描述视为解释线索，而不是固定身份标签。"
 }

--- a/backend/tests/Fixtures/big5/canonical_120_readable.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_120_readable.truth.json
@@ -274,8 +274,7 @@
                             "trait_bands",
                             "dominant_traits",
                             "ordered_section_keys",
-                            "scene_fingerprint",
-                            "variant_keys"
+                            "scene_fingerprint"
                         ],
                         "locale": "zh-CN",
                         "scale_code": "BIG5_OCEAN",
@@ -907,18 +906,7 @@
                     "percentile": 55
                 }
             ],
-            "variant_keys": [
-                "big5:o_mid",
-                "big5:c_low",
-                "big5:e_mid",
-                "big5:a_mid",
-                "big5:n_mid",
-                "band:o.mid",
-                "band:c.low",
-                "band:e.mid",
-                "band:a.mid",
-                "band:n.mid"
-            ]
+            "variant_keys": []
         },
         "comparative_v1": {
             "cohort_relative_position": {
@@ -1029,8 +1017,7 @@
                                     "trait_bands",
                                     "dominant_traits",
                                     "ordered_section_keys",
-                                    "scene_fingerprint",
-                                    "variant_keys"
+                                    "scene_fingerprint"
                                 ],
                                 "locale": "zh-CN",
                                 "scale_code": "BIG5_OCEAN",
@@ -1663,18 +1650,7 @@
                             "percentile": 55
                         }
                     ],
-                    "variant_keys": [
-                        "big5:o_mid",
-                        "big5:c_low",
-                        "big5:e_mid",
-                        "big5:a_mid",
-                        "big5:n_mid",
-                        "band:o.mid",
-                        "band:c.low",
-                        "band:e.mid",
-                        "band:a.mid",
-                        "band:n.mid"
-                    ]
+                    "variant_keys": []
                 }
             },
             "generated_at": "<timestamp>",
@@ -2315,8 +2291,7 @@
                             "trait_bands",
                             "dominant_traits",
                             "ordered_section_keys",
-                            "scene_fingerprint",
-                            "variant_keys"
+                            "scene_fingerprint"
                         ],
                         "locale": "zh-CN",
                         "scale_code": "BIG5_OCEAN",
@@ -2948,18 +2923,7 @@
                     "percentile": 55
                 }
             ],
-            "variant_keys": [
-                "big5:o_mid",
-                "big5:c_low",
-                "big5:e_mid",
-                "big5:a_mid",
-                "big5:n_mid",
-                "band:o.mid",
-                "band:c.low",
-                "band:e.mid",
-                "band:a.mid",
-                "band:n.mid"
-            ]
+            "variant_keys": []
         },
         "comparative_v1": {
             "cohort_relative_position": {

--- a/backend/tests/Fixtures/big5/canonical_90_readable.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_90_readable.truth.json
@@ -274,8 +274,7 @@
                             "trait_bands",
                             "dominant_traits",
                             "ordered_section_keys",
-                            "scene_fingerprint",
-                            "variant_keys"
+                            "scene_fingerprint"
                         ],
                         "locale": "zh-CN",
                         "scale_code": "BIG5_OCEAN",
@@ -907,18 +906,7 @@
                     "percentile": 13
                 }
             ],
-            "variant_keys": [
-                "big5:o_mid",
-                "big5:c_mid",
-                "big5:e_low",
-                "big5:a_mid",
-                "big5:n_low",
-                "band:o.mid",
-                "band:c.mid",
-                "band:e.low",
-                "band:a.mid",
-                "band:n.low"
-            ]
+            "variant_keys": []
         },
         "comparative_v1": {
             "cohort_relative_position": {
@@ -1027,8 +1015,7 @@
                                     "trait_bands",
                                     "dominant_traits",
                                     "ordered_section_keys",
-                                    "scene_fingerprint",
-                                    "variant_keys"
+                                    "scene_fingerprint"
                                 ],
                                 "locale": "zh-CN",
                                 "scale_code": "BIG5_OCEAN",
@@ -1661,18 +1648,7 @@
                             "percentile": 13
                         }
                     ],
-                    "variant_keys": [
-                        "big5:o_mid",
-                        "big5:c_mid",
-                        "big5:e_low",
-                        "big5:a_mid",
-                        "big5:n_low",
-                        "band:o.mid",
-                        "band:c.mid",
-                        "band:e.low",
-                        "band:a.mid",
-                        "band:n.low"
-                    ]
+                    "variant_keys": []
                 }
             },
             "generated_at": "<timestamp>",
@@ -2313,8 +2289,7 @@
                             "trait_bands",
                             "dominant_traits",
                             "ordered_section_keys",
-                            "scene_fingerprint",
-                            "variant_keys"
+                            "scene_fingerprint"
                         ],
                         "locale": "zh-CN",
                         "scale_code": "BIG5_OCEAN",
@@ -2946,18 +2921,7 @@
                     "percentile": 13
                 }
             ],
-            "variant_keys": [
-                "big5:o_mid",
-                "big5:c_mid",
-                "big5:e_low",
-                "big5:a_mid",
-                "big5:n_low",
-                "band:o.mid",
-                "band:c.mid",
-                "band:e.low",
-                "band:a.mid",
-                "band:n.low"
-            ]
+            "variant_keys": []
         },
         "comparative_v1": {
             "cohort_relative_position": {

--- a/backend/tests/Fixtures/big5/canonical_degraded.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_degraded.truth.json
@@ -274,8 +274,7 @@
                             "trait_bands",
                             "dominant_traits",
                             "ordered_section_keys",
-                            "scene_fingerprint",
-                            "variant_keys"
+                            "scene_fingerprint"
                         ],
                         "locale": "zh-CN",
                         "scale_code": "BIG5_OCEAN",
@@ -907,18 +906,7 @@
                     "percentile": 65
                 }
             ],
-            "variant_keys": [
-                "big5:o_low",
-                "big5:c_low",
-                "big5:e_mid",
-                "big5:a_mid",
-                "big5:n_mid",
-                "band:o.low",
-                "band:c.low",
-                "band:e.mid",
-                "band:a.mid",
-                "band:n.mid"
-            ]
+            "variant_keys": []
         },
         "comparative_v1": {
             "cohort_relative_position": {
@@ -1029,8 +1017,7 @@
                                     "trait_bands",
                                     "dominant_traits",
                                     "ordered_section_keys",
-                                    "scene_fingerprint",
-                                    "variant_keys"
+                                    "scene_fingerprint"
                                 ],
                                 "locale": "zh-CN",
                                 "scale_code": "BIG5_OCEAN",
@@ -1663,18 +1650,7 @@
                             "percentile": 65
                         }
                     ],
-                    "variant_keys": [
-                        "big5:o_low",
-                        "big5:c_low",
-                        "big5:e_mid",
-                        "big5:a_mid",
-                        "big5:n_mid",
-                        "band:o.low",
-                        "band:c.low",
-                        "band:e.mid",
-                        "band:a.mid",
-                        "band:n.mid"
-                    ]
+                    "variant_keys": []
                 }
             },
             "generated_at": "<timestamp>",
@@ -2315,8 +2291,7 @@
                             "trait_bands",
                             "dominant_traits",
                             "ordered_section_keys",
-                            "scene_fingerprint",
-                            "variant_keys"
+                            "scene_fingerprint"
                         ],
                         "locale": "zh-CN",
                         "scale_code": "BIG5_OCEAN",
@@ -2948,18 +2923,7 @@
                     "percentile": 65
                 }
             ],
-            "variant_keys": [
-                "big5:o_low",
-                "big5:c_low",
-                "big5:e_mid",
-                "big5:a_mid",
-                "big5:n_mid",
-                "band:o.low",
-                "band:c.low",
-                "band:e.mid",
-                "band:a.mid",
-                "band:n.mid"
-            ]
+            "variant_keys": []
         },
         "comparative_v1": {
             "cohort_relative_position": {

--- a/backend/tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json
+++ b/backend/tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json
@@ -2555,9 +2555,9 @@
                     "block_id": "shared_methodology_v2",
                     "resolved_copy": {
                         "schema": "fap.big5.shared_methodology.v1",
-                        "title": "v2 报告引擎方法说明",
-                        "body": "本 payload 由 Big Five Report Engine v2 registry 生成；PR3B 已覆盖 30 条 facet glossary 与 22 条 facet precision anomaly rules，PR3A 的 5 条 synergy、PR2 的 O/C/E/A/N atomic 与 sentence-level modifier 继续沿用，scenario action rule 仍保持 PR1 的 N-only 范围。",
-                        "access_note": "此结构服务未来 8 section 承载位，不代表生产 AttemptReadController 已接入。"
+                        "title": "Big Five 方法说明",
+                        "body": "这份报告基于 Big Five 五维与细分维度组织解释，用维度位置、相对参照、组合线索和场景建议帮助你理解当前作答画像。它适合用于自我观察、沟通和下一步行动整理，不应被当作诊断、招聘筛选、能力证明或人生结果预测。",
+                        "access_note": "结果会受到作答状态、样本参照和当前生活阶段影响。请把百分位和维度描述视为解释线索，而不是固定身份标签。"
                     },
                     "provenance": {
                         "atomic_refs": [

--- a/backend/tests/Fixtures/big5_engine/expected_live_bridge_report_payload.json
+++ b/backend/tests/Fixtures/big5_engine/expected_live_bridge_report_payload.json
@@ -2593,9 +2593,9 @@
                         "block_id": "shared_methodology_v2",
                         "resolved_copy": {
                             "schema": "fap.big5.shared_methodology.v1",
-                            "title": "v2 报告引擎方法说明",
-                            "body": "本 payload 由 Big Five Report Engine v2 registry 生成；PR3B 已覆盖 30 条 facet glossary 与 22 条 facet precision anomaly rules，PR3A 的 5 条 synergy、PR2 的 O/C/E/A/N atomic 与 sentence-level modifier 继续沿用，scenario action rule 仍保持 PR1 的 N-only 范围。",
-                            "access_note": "此结构服务未来 8 section 承载位，不代表生产 AttemptReadController 已接入。"
+                            "title": "Big Five 方法说明",
+                            "body": "这份报告基于 Big Five 五维与细分维度组织解释，用维度位置、相对参照、组合线索和场景建议帮助你理解当前作答画像。它适合用于自我观察、沟通和下一步行动整理，不应被当作诊断、招聘筛选、能力证明或人生结果预测。",
+                            "access_note": "结果会受到作答状态、样本参照和当前生活阶段影响。请把百分位和维度描述视为解释线索，而不是固定身份标签。"
                         },
                         "provenance": {
                             "atomic_refs": [

--- a/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
@@ -54,6 +54,8 @@ final class BigFivePublicProjectionServiceTest extends TestCase
         $this->assertSame('O1', data_get($projection, 'facet_vector.2.key'));
         $this->assertSame(93, data_get($projection, 'facet_vector.2.percentile'));
         $this->assertContains('profile:explorer', (array) ($projection['variant_keys'] ?? []));
+        $this->assertFalse($this->containsStringRecursive($projection, 'big5:'));
+        $this->assertFalse($this->containsStringRecursive($projection, 'band:'));
         $this->assertSame('exploratory', data_get($projection, 'scene_fingerprint.novelty'));
         $this->assertSame('traits.overview', data_get($projection, 'ordered_section_keys.0'));
         $this->assertSame('career.work_style', data_get($projection, 'ordered_section_keys.3'));
@@ -159,6 +161,23 @@ final class BigFivePublicProjectionServiceTest extends TestCase
                 return true;
             }
             if (is_array($value) && $this->containsKeyRecursive($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,mixed>|list<mixed>  $payload
+     */
+    private function containsStringRecursive(array $payload, string $needle): bool
+    {
+        foreach ($payload as $value) {
+            if (is_string($value) && str_contains($value, $needle)) {
+                return true;
+            }
+            if (is_array($value) && $this->containsStringRecursive($value, $needle)) {
                 return true;
             }
         }

--- a/backend/tests/Unit/Services/BigFive/ReportEngine/RegistryValidatorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ReportEngine/RegistryValidatorTest.php
@@ -39,4 +39,29 @@ final class RegistryValidatorTest extends TestCase
 
         $this->assertContains('Missing shared asset trait_labels.labels.O.report_anchor', $errors);
     }
+
+    public function test_shared_methodology_copy_is_render_safe(): void
+    {
+        $registry = app(RegistryLoader::class)->load();
+        $methodology = data_get($registry, 'shared.methodology', []);
+
+        $this->assertIsArray($methodology);
+        $this->assertNotSame('', trim((string) ($methodology['title'] ?? '')));
+        $this->assertNotSame('', trim((string) ($methodology['body'] ?? '')));
+        $this->assertNotSame('', trim((string) ($methodology['access_note'] ?? '')));
+
+        $renderedCopy = json_encode($methodology, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($renderedCopy);
+
+        foreach ([
+            'Big Five Report Engine',
+            'PR3B',
+            'AttemptReadController',
+            'payload',
+            'registry',
+            '[object Object]',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $renderedCopy);
+        }
+    }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -4265,6 +4265,24 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_bigfive_v2_rendered_asset_hygiene_changes(): void
+    {
+        $changed = [
+            'backend/content_packs/BIG5_OCEAN/v2/registry/shared/methodology.json',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+        $this->assertTrue($this->bigFivePublicProjectionDiffIsRenderedAssetHygieneOnly([
+            "-            if (str_starts_with(\$tag, 'profile:') || str_starts_with(\$tag, 'big5:')) {",
+            "+            if (str_starts_with(\$tag, 'profile:')) {",
+            '-        foreach (self::DOMAIN_ORDER as $trait) {',
+            "-            \$band = strtolower((string) (\$traitBands[\$trait] ?? 'mid'));",
+            "-            \$variantKeys['band:'.strtolower(\$trait).'.'.\$band] = true;",
+            '-        }',
+            '-',
+        ]));
+    }
+
     public function test_runtime_freeze_classifier_ignores_bigfive_v2_asset_agent_audit_files(): void
     {
         $changed = [
@@ -5463,6 +5481,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isBigFiveV2CmsEditorialGovernanceFile($file)) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Services/BigFive/BigFivePublicProjectionService.php'
+                && $repoRoot !== ''
+                && $baseRef !== ''
+                && $this->bigFivePublicProjectionDiffIsRenderedAssetHygieneOnly(
+                    $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                )
+            ) {
+                continue;
+            }
+
+            if ($this->isBigFiveV2RenderedAssetHygieneFile($file)) {
                 continue;
             }
 
@@ -8288,6 +8321,34 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             '#^backend/database/migrations/\d{4}_\d{2}_\d{2}_\d{6}_create_big_five_v2_editorial_[a-z0-9_]+_table\.php$#',
             $file
         ) === 1;
+    }
+
+    private function isBigFiveV2RenderedAssetHygieneFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/content_packs/BIG5_OCEAN/v2/registry/shared/methodology.json',
+        ], true);
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function bigFivePublicProjectionDiffIsRenderedAssetHygieneOnly(array $changedLines): bool
+    {
+        $allowedLines = [
+            "-            if (str_starts_with(\$tag, 'profile:') || str_starts_with(\$tag, 'big5:')) {",
+            "+            if (str_starts_with(\$tag, 'profile:')) {",
+            '-        foreach (self::DOMAIN_ORDER as $trait) {',
+            "-            \$band = strtolower((string) (\$traitBands[\$trait] ?? 'mid'));",
+            "-            \$variantKeys['band:'.strtolower(\$trait).'.'.\$band] = true;",
+            '-        }',
+            '-',
+        ];
+
+        sort($changedLines);
+        sort($allowedLines);
+
+        return $changedLines === $allowedLines;
     }
 
     private function isAttemptEmailBindingFoundationFile(string $file): bool


### PR DESCRIPTION
## What changed
- Stops Big Five public projection from exposing internal `big5:*` and `band:*` selector keys through `variant_keys`.
- Replaces the Big Five V2 shared methodology registry copy with reader-facing method and boundary text.
- Updates Big Five report-engine fixtures to match the sanitized methodology copy.
- Adds regression coverage so public projection output stays free of `big5:` / `band:` strings and shared methodology copy stays free of rendered-forbidden engineering terms.

## Why
A live Big Five result page showed internal selector tokens such as `big5:o_mid` and `band:o.mid` in visible page text, and the methodology section rendered broken engineering copy mentioning internal implementation concepts. Both issues belong in backend payload/content authority, not frontend fallback copy.

## Validation
- `php artisan test --filter=BigFivePublicProjectionServiceTest`
- `php artisan test --filter=RegistryValidatorTest`
- `php artisan test --filter=BigFiveReportEngineBridgeContractTest`
- `php artisan test --filter=BigFiveResultPageV2RenderedQaTest`
- `php artisan test --filter=BigFiveResultPageV2ExpandedRenderedQaTest`
- `php artisan test --filter=ProductionRuntimeTest`
- `python3 -m json.tool backend/content_packs/BIG5_OCEAN/v2/registry/shared/methodology.json >/dev/null`
- `python3 -m json.tool backend/tests/Fixtures/big5_engine/expected_live_bridge_report_payload.json >/dev/null`
- `python3 -m json.tool backend/tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No fap-web copy changes.
- No CMS write, search submission, sitemap/llms/canonical/JSON-LD change.
- No runtime, rollout, import gate, release snapshot, or production enablement change.
- No live private attempt data committed.

## Repository rule impact
Big Five result-page content remains backend-authoritative. This PR removes backend-emitted internal tokens and engineering copy from rendered-facing payload surfaces without adding frontend editorial fallback.
