### PR TITLE
MBTI-PDF-PRODUCT-05: expand PDF coverage to result-page sections

### DIFF
--- a/backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php
+++ b/backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php
@@ -13,7 +13,7 @@ final class MbtiPdfPayloadBuilder
 {
     public const PAYLOAD_KEY = 'mbti_pdf_payload';
 
-    public const SCHEMA_VERSION = 'fap.mbti.report_pdf.payload.v0_1';
+    public const SCHEMA_VERSION = 'fap.mbti.report_pdf.payload.v0_2';
 
     /**
      * These fields are either internal, raw scoring material, or unsafe to carry into
@@ -89,9 +89,14 @@ final class MbtiPdfPayloadBuilder
                 'region' => $region !== '' ? $region : 'CN_MAINLAND',
                 'dir_version' => $dirVersion,
                 'type' => $this->publicTypeProfile($typeCode, $typeProfile, $legacyPayload),
-                'axis_scores' => $this->publicAxisScores($scoresPct, $axisStates),
+                'axis_scores' => $this->publicAxisScores($scoresPct, $axisStates, $locale !== '' ? $locale : 'zh-CN'),
                 'highlights' => $this->publicHighlights((array) ($legacyPayload['highlights'] ?? [])),
                 'sections' => $this->publicSections((array) ($legacyPayload['cards'] ?? [])),
+                'result_page_sections' => $this->publicResultPageSections(
+                    (array) ($legacyPayload['cards'] ?? []),
+                    (array) ($legacyPayload['recommended_reads'] ?? []),
+                    $locale !== '' ? $locale : 'zh-CN'
+                ),
                 'document' => $this->publicDocument(
                     $locale !== '' ? $locale : 'zh-CN',
                     $typeCode,
@@ -214,9 +219,10 @@ final class MbtiPdfPayloadBuilder
      * @param  array<string,string>  $axisStates
      * @return list<array<string,mixed>>
      */
-    private function publicAxisScores(array $scoresPct, array $axisStates): array
+    private function publicAxisScores(array $scoresPct, array $axisStates, string $locale): array
     {
         $out = [];
+        $labels = $this->axisLabels($locale);
         foreach (['EI', 'SN', 'TF', 'JP', 'AT'] as $axis) {
             if (! array_key_exists($axis, $scoresPct)) {
                 continue;
@@ -224,6 +230,9 @@ final class MbtiPdfPayloadBuilder
 
             $out[] = $this->dropNulls([
                 'axis' => $axis,
+                'label' => $labels[$axis]['label'] ?? $axis,
+                'left_label' => $labels[$axis]['left_label'] ?? null,
+                'right_label' => $labels[$axis]['right_label'] ?? null,
                 'percent' => $scoresPct[$axis],
                 'state' => $axisStates[$axis] ?? null,
             ]);
@@ -284,6 +293,53 @@ final class MbtiPdfPayloadBuilder
             if ($publicCards !== []) {
                 $sections[] = [
                     'section_key' => $sectionKey,
+                    'cards' => $publicCards,
+                ];
+            }
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string,mixed>  $cardsBySection
+     * @param  array<int|string,mixed>  $recommendedReads
+     * @return list<array<string,mixed>>
+     */
+    private function publicResultPageSections(array $cardsBySection, array $recommendedReads, string $locale): array
+    {
+        $isChinese = str_starts_with(strtolower($locale), 'zh');
+        $sections = [];
+        foreach (['traits', 'career', 'growth', 'relationships'] as $sectionKey) {
+            $cards = is_array($cardsBySection[$sectionKey] ?? null) ? $cardsBySection[$sectionKey] : [];
+            $publicCards = [];
+            foreach ($cards as $card) {
+                if (! is_array($card)) {
+                    continue;
+                }
+
+                $publicCard = $this->filterPublicContent([
+                    'card_key' => $card['id'] ?? $card['key'] ?? null,
+                    'title' => $card['title'] ?? null,
+                    'description' => $card['desc'] ?? $card['description'] ?? null,
+                    'bullets' => $card['bullets'] ?? [],
+                    'tips' => $card['tips'] ?? [],
+                    'tags' => $card['tags'] ?? [],
+                ]);
+                $publicCard = $isChinese ? $publicCard : $this->englishResultPageCard($publicCard, $sectionKey);
+                if ($publicCard !== []) {
+                    $publicCards[] = $publicCard;
+                }
+            }
+
+            if ($sectionKey === 'career') {
+                $publicCards[] = $this->careerNextStepCard($recommendedReads, $isChinese);
+            }
+
+            if ($publicCards !== []) {
+                $sections[] = [
+                    'section_key' => $sectionKey,
+                    'title' => $this->resultPageSectionTitle($sectionKey),
                     'cards' => $publicCards,
                 ];
             }
@@ -423,14 +479,14 @@ final class MbtiPdfPayloadBuilder
         return $this->dropNulls([
             'chapter_key' => $key,
             'title' => $title,
-            'body' => array_values(array_slice(array_filter(
+            'body' => array_values(array_filter(
                 array_map(static fn (mixed $line): string => trim((string) $line), $body),
                 static fn (string $line): bool => $line !== ''
-            ), 0, 6)),
-            'bullets' => array_values(array_slice(array_filter(
+            )),
+            'bullets' => array_values(array_filter(
                 array_map(static fn (mixed $line): string => trim((string) $line), $bullets),
                 static fn (string $line): bool => $line !== ''
-            ), 0, 8)),
+            )),
             'source_section_keys' => $sourceKeys,
         ]);
     }
@@ -453,7 +509,7 @@ final class MbtiPdfPayloadBuilder
         }
 
         return $lines !== []
-            ? array_slice($lines, 0, 4)
+            ? $lines
             : ($isChinese
                 ? ['这部分汇总你在本次作答中最稳定、最容易被他人观察到的行为倾向。']
                 : ['This section summarizes the most stable and observable patterns in your current response profile.']);
@@ -487,7 +543,7 @@ final class MbtiPdfPayloadBuilder
             }
         }
 
-        return $lines !== [] ? array_slice($lines, 0, 5) : ($isChinese ? $zhFallback : $enFallback);
+        return $lines !== [] ? $lines : ($isChinese ? $zhFallback : $enFallback);
     }
 
     /**
@@ -553,6 +609,162 @@ final class MbtiPdfPayloadBuilder
     }
 
     /**
+     * @return array<string,array{label:string,left_label:string,right_label:string}>
+     */
+    private function axisLabels(string $locale): array
+    {
+        if (str_starts_with(strtolower($locale), 'zh')) {
+            return [
+                'EI' => ['label' => '能量来源', 'left_label' => '外倾', 'right_label' => '内倾'],
+                'SN' => ['label' => '信息处理', 'left_label' => '实感', 'right_label' => '直觉'],
+                'TF' => ['label' => '决策依据', 'left_label' => '思考', 'right_label' => '情感'],
+                'JP' => ['label' => '生活节奏', 'left_label' => '判断', 'right_label' => '感知'],
+                'AT' => ['label' => '压力姿态', 'left_label' => '果断', 'right_label' => '敏感'],
+            ];
+        }
+
+        return [
+            'EI' => ['label' => 'Energy orientation', 'left_label' => 'Extraversion', 'right_label' => 'Introversion'],
+            'SN' => ['label' => 'Information style', 'left_label' => 'Sensing', 'right_label' => 'Intuition'],
+            'TF' => ['label' => 'Decision lens', 'left_label' => 'Thinking', 'right_label' => 'Feeling'],
+            'JP' => ['label' => 'Operating rhythm', 'left_label' => 'Judging', 'right_label' => 'Perceiving'],
+            'AT' => ['label' => 'Pressure posture', 'left_label' => 'Assertive', 'right_label' => 'Turbulent'],
+        ];
+    }
+
+    private function resultPageSectionTitle(string $sectionKey): string
+    {
+        return match ($sectionKey) {
+            'traits' => 'Personality Traits',
+            'career' => 'Your Career Path',
+            'growth' => 'Your Personal Growth',
+            'relationships' => 'Your Relationships',
+            default => $sectionKey,
+        };
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $recommendedReads
+     * @return array<string,mixed>
+     */
+    private function careerNextStepCard(array $recommendedReads, bool $isChinese): array
+    {
+        $readTitles = [];
+        foreach ($this->publicRecommendedReads($recommendedReads) as $read) {
+            $title = trim((string) ($read['title'] ?? ''));
+            if ($title !== '') {
+                $readTitles[] = $title;
+            }
+        }
+
+        return $this->filterPublicContent([
+            'card_key' => 'career_next_step',
+            'title' => $isChinese ? '继续探索职业方向' : 'Continue exploring career direction',
+            'description' => $isChinese
+                ? 'PDF 保留当前结果页的职业下一步说明；回到网页结果页可以继续查看职业推荐、历史结果和后续行动入口。'
+                : 'The PDF preserves the career next-step guidance from the result page. Return to the web result page to continue with career recommendations, history, and next actions.',
+            'bullets' => $readTitles !== [] ? array_slice($readTitles, 0, 4) : [],
+            'tags' => $isChinese ? ['职业下一步', '结果页入口'] : ['career next step', 'result page'],
+        ]);
+    }
+
+    /**
+     * The current legacy MBTI card fallback is Chinese-first. Keep the payload
+     * locale-safe by mapping known public card ids to operator-authored English
+     * copy instead of carrying mixed-language card text into English PDFs.
+     *
+     * @param  array<string,mixed>  $card
+     * @return array<string,mixed>
+     */
+    private function englishResultPageCard(array $card, string $sectionKey): array
+    {
+        $cardKey = trim((string) ($card['card_key'] ?? ''));
+        $axis = null;
+        if (preg_match('/_(strength|blindspot)_([A-Z]{2})_/', $cardKey, $matches) === 1) {
+            $axis = $matches[2];
+        }
+
+        if (str_contains($cardKey, '_strength_') && $axis !== null) {
+            return $this->filterPublicContent([
+                'card_key' => $cardKey,
+                'title' => "Your clearest strength centers on {$axis}",
+                'description' => "Your current score pattern shows a clearer preference on the {$axis} axis. Use it as a working clue for this section, not as a fixed label.",
+                'bullets' => [
+                    'A strength creates speed when it is used deliberately.',
+                    'When it is overused, it can become habit rather than judgment.',
+                ],
+                'tags' => $card['tags'] ?? [],
+            ]);
+        }
+
+        if (str_contains($cardKey, '_blindspot_') && $axis !== null) {
+            return $this->filterPublicContent([
+                'card_key' => $cardKey,
+                'title' => "A point to watch: {$axis}",
+                'description' => "Your {$axis} preference is less fixed and may depend more on context. That flexibility can help, but it can also cost energy under pressure.",
+                'bullets' => [
+                    "Before important decisions, name which side of {$axis} the situation really needs.",
+                    'Use checklists, templates, or written agreements to reduce avoidable friction.',
+                ],
+                'tags' => $card['tags'] ?? [],
+            ]);
+        }
+
+        $specific = match ($cardKey) {
+            'traits_core_01' => [
+                'title' => 'Your core temperament pattern',
+                'description' => 'You tend to move from observation to action when the goal, constraints, and next step are clear.',
+                'bullets' => [
+                    'You work better with explicit expectations.',
+                    'Vague or inefficient processes may drain your attention.',
+                    'You are more likely to take responsibility when the path is concrete.',
+                ],
+                'tags' => ['topic:traits'],
+            ],
+            'career_style_01' => [
+                'title' => 'A work style that tends to fit you',
+                'description' => 'This profile often works better in environments with clear goals, defined boundaries, and room to move useful work forward.',
+                'bullets' => [
+                    'Clarify goals and authority before execution.',
+                    'Pair judgment with reusable process or templates.',
+                    'Use milestones to keep collaboration concrete.',
+                ],
+                'tags' => ['topic:career'],
+            ],
+            'growth_nextstep_01' => [
+                'title' => 'One next step you can take now',
+                'description' => 'Turn your strongest pattern into a system and support weaker patterns with simple tools.',
+                'bullets' => [
+                    'Convert strengths into reusable routines.',
+                    'Use reminders or rituals to lower effort where you tire faster.',
+                    'Review once a week: keep what works and remove what does not.',
+                ],
+                'tags' => ['topic:growth'],
+            ],
+            'relationships_script_01' => [
+                'title' => 'A smoother communication script',
+                'description' => 'Bring disagreement back to shared goals, observable facts, and specific requests.',
+                'bullets' => [
+                    'Goal: what we both want is...',
+                    'Fact: what is happening now is...',
+                    'Request: what I would like us to try is...',
+                ],
+                'tags' => ['topic:relationships'],
+            ],
+            default => null,
+        };
+
+        if ($specific !== null) {
+            return $this->filterPublicContent([
+                'card_key' => $cardKey,
+                ...$specific,
+            ]);
+        }
+
+        return $card;
+    }
+
+    /**
      * @param  array<int|string,mixed>  $content
      * @return array<int|string,mixed>
      */
@@ -588,7 +800,7 @@ final class MbtiPdfPayloadBuilder
         }
 
         return array_values(array_filter(
-            array_map(static fn (mixed $item): string => trim((string) $item), $value),
+            array_map(static fn (mixed $item): string => is_scalar($item) ? trim((string) $item) : '', $value),
             static fn (string $item): bool => $item !== '',
         ));
     }

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -13,7 +13,7 @@ use Mpdf\Output\Destination;
 
 final class ReportPdfDocumentService
 {
-    private const MBTI_PDF_SURFACE_VERSION = 'mbti.pdf_surface.v2';
+    private const MBTI_PDF_SURFACE_VERSION = 'mbti.pdf_surface.v3';
 
     public function __construct(
         private readonly ReportPdfArtifactStore $artifactStore,
@@ -451,6 +451,7 @@ final class ReportPdfDocumentService
         $document = is_array($payload['document'] ?? null) ? $payload['document'] : [];
         $type = is_array($payload['type'] ?? null) ? $payload['type'] : [];
         $axisScores = is_array($payload['axis_scores'] ?? null) ? $payload['axis_scores'] : [];
+        $resultPageSections = is_array($payload['result_page_sections'] ?? null) ? $payload['result_page_sections'] : [];
         $typeCode = strtoupper(trim((string) ($type['type_code'] ?? '')));
         $typeCode = $typeCode !== '' && $typeCode !== 'UNKNOWN' ? $typeCode : ($isChinese ? '待确认' : 'Pending');
         $typeName = trim((string) ($type['type_name'] ?? ''));
@@ -468,12 +469,12 @@ final class ReportPdfDocumentService
             ? [
                 '人格类型' => $displayType !== '' ? $displayType : $typeCode,
                 '报告日期' => $date,
-                '报告范围' => '类型画像、维度解释、职业、成长、关系与使用边界',
+                '报告范围' => '类型画像、维度解释、结果页核心模块、职业、成长、关系与使用边界',
             ]
             : [
                 'Personality type' => $displayType !== '' ? $displayType : $typeCode,
                 'Report date' => $date,
-                'Report scope' => 'Type portrait, dimensions, career, growth, relationships, and use boundaries',
+                'Report scope' => 'Type portrait, dimensions, result-page sections, career, growth, relationships, and use boundaries',
             ];
         $chapters = $this->mbtiDocumentChapters($document);
 
@@ -483,6 +484,7 @@ final class ReportPdfDocumentService
             $summary,
             $chapters,
             $axisScores,
+            $resultPageSections,
             $isChinese ? 'FermatMind · 费马测试' : 'FermatMind',
             $isChinese
         );
@@ -680,6 +682,7 @@ final class ReportPdfDocumentService
      * @param  array<string,string>  $summary
      * @param  list<array{heading:string,body:list<string>,bullets:list<string>,chapter_key:string}>  $sections
      * @param  list<array<string,mixed>>  $axisScores
+     * @param  list<array<string,mixed>>  $resultPageSections
      */
     private function buildMpdfHtmlDocument(
         string $title,
@@ -687,6 +690,7 @@ final class ReportPdfDocumentService
         array $summary,
         array $sections,
         array $axisScores,
+        array $resultPageSections,
         string $footer,
         bool $isChinese
     ): string {
@@ -721,7 +725,7 @@ final class ReportPdfDocumentService
             .'<tr><td width="50%" align="left">'.$this->escapeHtml($footer).'</td>'
             .'<td width="50%" align="right">{PAGENO} / {nbpg}</td></tr></table>'
         );
-        $mpdf->WriteHTML($this->mbtiReportHtml($title, $subtitle, $summary, $sections, $axisScores, $isChinese));
+        $mpdf->WriteHTML($this->mbtiReportHtml($title, $subtitle, $summary, $sections, $axisScores, $resultPageSections, $isChinese));
 
         return $mpdf->Output('', Destination::STRING_RETURN);
     }
@@ -730,6 +734,7 @@ final class ReportPdfDocumentService
      * @param  array<string,string>  $summary
      * @param  list<array{heading:string,body:list<string>,bullets:list<string>,chapter_key:string}>  $sections
      * @param  list<array<string,mixed>>  $axisScores
+     * @param  list<array<string,mixed>>  $resultPageSections
      */
     private function mbtiReportHtml(
         string $title,
@@ -737,6 +742,7 @@ final class ReportPdfDocumentService
         array $summary,
         array $sections,
         array $axisScores,
+        array $resultPageSections,
         bool $isChinese
     ): string {
         $fontStack = $isChinese
@@ -761,11 +767,16 @@ final class ReportPdfDocumentService
             .'p{margin:0 0 9px 0;}'
             .'ul{margin:0 0 0 18px;padding:0;}'
             .'li{margin:5px 0;}'
+            .'h3{font-size:13.5pt;margin:0 0 5px 0;color:#123d34;}'
+            .'.card{border:1px solid #d9eadf;border-radius:8px;padding:10px 12px;margin:0 0 10px 0;background:#ffffff;page-break-inside:avoid;}'
+            .'.card-desc{color:#334155;margin-bottom:6px;}'
+            .'.tag{display:inline-block;margin:3px 4px 0 0;padding:2px 7px;border-radius:10px;background:#eef8f2;color:#15745b;font-size:8.5pt;}'
             .'.axis-grid{margin:12px 0 18px 0;}'
             .'.axis{margin:0 0 10px 0;}'
             .'.axis-label{font-size:9.5pt;color:#475569;margin-bottom:3px;}'
             .'.axis-track{height:8px;background:#e2e8f0;border-radius:4px;}'
             .'.axis-fill{height:8px;background:#14946f;border-radius:4px;}'
+            .'.axis-poles{width:100%;font-size:8.5pt;color:#64748b;margin-top:2px;}'
             .'.boundary{margin-top:14px;padding:10px 12px;background:#f8fafc;border-left:4px solid #14946f;color:#475569;}'
             .'</style></head><body>';
         $html .= '<div class="cover">';
@@ -783,6 +794,12 @@ final class ReportPdfDocumentService
         foreach ($sections as $index => $section) {
             $html .= '<div class="toc-item">'.($index + 1).'. '.$this->escapeHtml((string) $section['heading']).'</div>';
         }
+        foreach ($resultPageSections as $index => $section) {
+            $title = trim((string) ($section['title'] ?? ''));
+            if ($title !== '') {
+                $html .= '<div class="toc-item">'.(count($sections) + $index + 1).'. '.$this->escapeHtml($title).'</div>';
+            }
+        }
         $html .= '</div>';
 
         foreach ($sections as $index => $section) {
@@ -794,12 +811,19 @@ final class ReportPdfDocumentService
                 $html .= '<div class="axis-grid">';
                 foreach ($axisScores as $axis) {
                     $axisCode = $this->escapeHtml((string) ($axis['axis'] ?? ''));
+                    $axisName = trim((string) ($axis['label'] ?? ''));
+                    $leftLabel = trim((string) ($axis['left_label'] ?? ''));
+                    $rightLabel = trim((string) ($axis['right_label'] ?? ''));
                     $state = trim((string) ($axis['state'] ?? ''));
                     $percent = max(0, min(100, (int) round((float) ($axis['percent'] ?? 0))));
-                    $label = trim($axisCode.($state !== '' ? ' · '.$state : ''));
+                    $labelParts = array_filter([$axisName !== '' ? $axisName : $axisCode, $axisCode, $state]);
+                    $label = implode(' · ', $labelParts);
                     $html .= '<div class="axis">';
                     $html .= '<div class="axis-label">'.$this->escapeHtml($label).' · '.$percent.'%</div>';
                     $html .= '<div class="axis-track"><div class="axis-fill" style="width:'.$percent.'%;"></div></div>';
+                    if ($leftLabel !== '' || $rightLabel !== '') {
+                        $html .= '<table class="axis-poles"><tr><td align="left">'.$this->escapeHtml($leftLabel).'</td><td align="right">'.$this->escapeHtml($rightLabel).'</td></tr></table>';
+                    }
                     $html .= '</div>';
                 }
                 $html .= '</div>';
@@ -812,13 +836,58 @@ final class ReportPdfDocumentService
                 $html .= '<li>'.$this->escapeHtml($bullet).'</li>';
             }
             $html .= '</ul>';
-            if ($index === count($sections) - 1) {
-                $html .= '<div class="boundary">'.$this->escapeHtml($isChinese
-                    ? '本报告用于自我理解和讨论，不用于诊断、录用筛选、升学录取或结果保证。'
-                    : 'This report supports reflection and discussion. It is not a diagnosis, hiring screen, admission predictor, or outcome guarantee.').'</div>';
+            $html .= '</div>';
+        }
+
+        foreach ($resultPageSections as $index => $section) {
+            $title = trim((string) ($section['title'] ?? ''));
+            $cards = is_array($section['cards'] ?? null) ? $section['cards'] : [];
+            if ($title === '' || $cards === []) {
+                continue;
+            }
+
+            $html .= '<div class="chapter">';
+            $html .= '<div class="chapter-kicker">'.$this->escapeHtml($isChinese ? '结果页模块 '.($index + 1) : 'Result page section '.($index + 1)).'</div>';
+            $html .= '<h2>'.$this->escapeHtml($title).'</h2>';
+            foreach ($cards as $card) {
+                if (! is_array($card)) {
+                    continue;
+                }
+
+                $cardTitle = trim((string) ($card['title'] ?? ''));
+                $description = trim((string) ($card['description'] ?? ''));
+                $bullets = $this->stringList($card['bullets'] ?? []);
+                $tips = $this->stringList($card['tips'] ?? []);
+                $tags = $this->stringList($card['tags'] ?? []);
+                if ($cardTitle === '' && $description === '' && $bullets === [] && $tips === []) {
+                    continue;
+                }
+
+                $html .= '<div class="card">';
+                if ($cardTitle !== '') {
+                    $html .= '<h3>'.$this->escapeHtml($cardTitle).'</h3>';
+                }
+                if ($description !== '') {
+                    $html .= '<p class="card-desc">'.$this->escapeHtml($description).'</p>';
+                }
+                if ($bullets !== [] || $tips !== []) {
+                    $html .= '<ul>';
+                    foreach (array_merge($bullets, $tips) as $line) {
+                        $html .= '<li>'.$this->escapeHtml($line).'</li>';
+                    }
+                    $html .= '</ul>';
+                }
+                foreach ($tags as $tag) {
+                    $html .= '<span class="tag">'.$this->escapeHtml($tag).'</span>';
+                }
+                $html .= '</div>';
             }
             $html .= '</div>';
         }
+
+        $html .= '<div class="boundary">'.$this->escapeHtml($isChinese
+            ? '本报告用于自我理解和讨论，不用于诊断、录用筛选、升学录取或结果保证。'
+            : 'This report supports reflection and discussion. It is not a diagnosis, hiring screen, admission predictor, or outcome guarantee.').'</div>';
 
         return $html.'</body></html>';
     }
@@ -834,7 +903,7 @@ final class ReportPdfDocumentService
 
         $out = [];
         foreach ($value as $item) {
-            $line = trim((string) $item);
+            $line = is_scalar($item) ? trim((string) $item) : '';
             if ($line !== '') {
                 $out[] = $line;
             }

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -157,7 +157,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf->assertHeader('Content-Type', 'application/pdf');
         $pdf->assertHeader('X-Report-Scale', 'MBTI');
         $pdf->assertHeader('X-Report-Locked', 'true');
-        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.pdf_surface.v2');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.pdf_surface.v3');
 
         $pdfBinary = (string) $pdf->getContent();
         $this->assertStringStartsWith('%PDF-1.4', $pdfBinary);
@@ -168,7 +168,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         );
         $this->assertStringEndsWith('.pdf"', (string) $pdf->headers->get('Content-Disposition'));
         Storage::disk('local')->assertExists(
-            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.pdf_surface.v2/report_free.pdf"
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.pdf_surface.v3/report_free.pdf"
         );
     }
 

--- a/backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
@@ -9,6 +9,7 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Report\Composer\ReportComposeContext;
 use App\Services\Report\Composer\ReportPayloadAssembler;
+use App\Services\Report\Pdf\Mbti\MbtiPdfPayloadBuilder;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
 use App\Services\Report\ReportGatekeeper;
 use App\Support\OrgContext;
@@ -251,6 +252,14 @@ final class MbtiReadPathParityContractTest extends TestCase
         $attempt = Attempt::query()->findOrFail($attemptId);
         $result = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
 
+        /** @var MbtiPdfPayloadBuilder $payloadBuilder */
+        $payloadBuilder = app(MbtiPdfPayloadBuilder::class);
+        $pdfPayload = $payloadBuilder->build($attempt, $result)[MbtiPdfPayloadBuilder::PAYLOAD_KEY] ?? [];
+        $this->assertStringContainsString(
+            'A work style that tends to fit you',
+            json_encode(data_get($pdfPayload, 'result_page_sections'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
+
         /** @var ReportPdfDocumentService $pdfService */
         $pdfService = app(ReportPdfDocumentService::class);
         $pdf = $pdfService->getOrGenerate(
@@ -272,15 +281,25 @@ final class MbtiReadPathParityContractTest extends TestCase
 
         $this->assertStringStartsWith('%PDF-1.4', $pdf['binary']);
         $this->assertStringContainsString('MPDFAA+', $pdf['binary']);
-        $this->assertGreaterThan(2, $this->pdfPageObjectCount($pdf['binary']));
+        $this->assertGreaterThan(8, $this->pdfPageObjectCount($pdf['binary']));
         $this->assertPdfContainsText($pdf['binary'], 'MBTI Full Personality Report');
         $this->assertPdfContainsText($pdf['binary'], 'Personality type');
         $this->assertPdfContainsText($pdf['binary'], 'INTJ-A');
+        $this->assertPdfContainsText($pdf['binary'], 'Extraversion');
+        $this->assertPdfContainsText($pdf['binary'], 'Introversion');
         $this->assertPdfContainsText($pdf['binary'], 'Dimension explanation');
         $this->assertPdfContainsText($pdf['binary'], 'Career direction');
         $this->assertPdfContainsText($pdf['binary'], 'Growth plan');
         $this->assertPdfContainsText($pdf['binary'], 'Relationships and communication');
         $this->assertPdfContainsText($pdf['binary'], 'How to use this report');
+        $this->assertPdfContainsText($pdf['binary'], 'Personality Traits');
+        $this->assertPdfContainsText($pdf['binary'], 'Your Career Path');
+        $this->assertPdfContainsText($pdf['binary'], 'Your Personal Growth');
+        $this->assertPdfContainsText($pdf['binary'], 'Your Relationships');
+        $this->assertPdfContainsText($pdf['binary'], 'Your core temperament pattern');
+        $this->assertPdfContainsText($pdf['binary'], 'One next step you can take now');
+        $this->assertPdfContainsText($pdf['binary'], 'A smoother communication script');
+        $this->assertPdfContainsText($pdf['binary'], 'Continue exploring career direction');
         $this->assertStringNotContainsString('Attempt ID:', $pdf['binary']);
         $this->assertStringNotContainsString('Locked:', $pdf['binary']);
         $this->assertStringNotContainsString('Variant:', $pdf['binary']);
@@ -294,7 +313,11 @@ final class MbtiReadPathParityContractTest extends TestCase
 
     private function assertPdfContainsText(string $pdfBinary, string $text): void
     {
-        $this->assertStringContainsString(mb_convert_encoding($text, 'UTF-16BE', 'UTF-8'), $pdfBinary);
+        $this->assertTrue(
+            str_contains($pdfBinary, $text)
+                || str_contains($pdfBinary, mb_convert_encoding($text, 'UTF-16BE', 'UTF-8')),
+            "PDF text missing: {$text}"
+        );
     }
 
     private function assertPdfDoesNotContainText(string $pdfBinary, string $text): void

--- a/backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php
@@ -66,8 +66,32 @@ final class MbtiPdfPayloadBuilderTest extends TestCase
         $this->assertSame('ISFP-T', data_get($payload, 'type.type_code'));
         $this->assertNotEmpty(data_get($payload, 'type.short_summary'));
         $this->assertCount(5, $payload['axis_scores'] ?? []);
+        $this->assertSame('能量来源', data_get($payload, 'axis_scores.0.label'));
+        $this->assertSame('外倾', data_get($payload, 'axis_scores.0.left_label'));
+        $this->assertSame('内倾', data_get($payload, 'axis_scores.0.right_label'));
         $this->assertNotEmpty($payload['highlights'] ?? []);
         $this->assertNotEmpty($payload['sections'] ?? []);
+        $this->assertSame(
+            ['traits', 'career', 'growth', 'relationships'],
+            array_column((array) data_get($payload, 'result_page_sections', []), 'section_key')
+        );
+        foreach ((array) data_get($payload, 'result_page_sections', []) as $section) {
+            $this->assertIsArray($section);
+            $this->assertNotEmpty($section['title'] ?? null);
+            $this->assertNotEmpty($section['cards'] ?? null);
+            foreach ((array) ($section['cards'] ?? []) as $card) {
+                $this->assertIsArray($card);
+                $this->assertNotEmpty($card['title'] ?? null);
+            }
+        }
+        $this->assertStringContainsString(
+            'S 偏好较强：以事实和细节稳住判断',
+            json_encode(data_get($payload, 'result_page_sections'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
+        $this->assertStringContainsString(
+            '继续探索职业方向',
+            json_encode(data_get($payload, 'result_page_sections'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
         $this->assertSame('zh-CN', data_get($payload, 'document.language'));
         $this->assertSame([
             'type_portrait',
@@ -114,16 +138,36 @@ final class MbtiPdfPayloadBuilderTest extends TestCase
         $builder = app(MbtiPdfPayloadBuilder::class);
         $payload = $builder->build($attempt, $result)[MbtiPdfPayloadBuilder::PAYLOAD_KEY] ?? [];
         $document = is_array($payload) ? (array) ($payload['document'] ?? []) : [];
+        $resultPageSections = is_array($payload) ? (array) ($payload['result_page_sections'] ?? []) : [];
         $encoded = json_encode($document, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $resultPageEncoded = json_encode($resultPageSections, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         $this->assertSame('en', $document['language'] ?? null);
         $this->assertSame('MBTI Full Personality Report', $document['title'] ?? null);
+        $this->assertSame('Energy orientation', data_get($payload, 'axis_scores.0.label'));
+        $this->assertSame('Extraversion', data_get($payload, 'axis_scores.0.left_label'));
+        $this->assertSame('Introversion', data_get($payload, 'axis_scores.0.right_label'));
+        $this->assertSame(
+            ['traits', 'career', 'growth', 'relationships'],
+            array_column($resultPageSections, 'section_key')
+        );
         $this->assertStringContainsString('Career direction', $encoded);
         $this->assertStringContainsString('Growth plan', $encoded);
         $this->assertStringContainsString('Relationships and communication', $encoded);
         $this->assertStringContainsString('not a medical diagnosis', $encoded);
+        $this->assertStringContainsString('Personality Traits', $resultPageEncoded);
+        $this->assertStringContainsString('Your Career Path', $resultPageEncoded);
+        $this->assertStringContainsString('Your Personal Growth', $resultPageEncoded);
+        $this->assertStringContainsString('Your Relationships', $resultPageEncoded);
+        $this->assertStringContainsString('Your core temperament pattern', $resultPageEncoded);
+        $this->assertStringContainsString('A work style that tends to fit you', $resultPageEncoded);
+        $this->assertStringContainsString('One next step you can take now', $resultPageEncoded);
+        $this->assertStringContainsString('A smoother communication script', $resultPageEncoded);
+        $this->assertStringContainsString('Continue exploring career direction', $resultPageEncoded);
         $this->assertStringNotContainsString('职业方向', $encoded);
         $this->assertStringNotContainsString('医疗诊断', $encoded);
+        $this->assertStringNotContainsString('你的核心气质画像', $resultPageEncoded);
+        $this->assertStringNotContainsString('你更适合的工作方式', $resultPageEncoded);
     }
 
     public function test_payload_filters_internal_and_raw_fields_recursively(): void

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3835,7 +3835,7 @@
         "status": "pass"
       }
     },
-    "commit_sha": null,
+    "commit_sha": "595811fa6f8aa2047b5f057aa4d8a96176871e609",
     "depends_on": [],
     "failure_reason": null,
     "local_cleanup_executed": false,
@@ -18838,10 +18838,10 @@
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2467",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "status": "local_validated",
+    "status": "pr_open",
     "title": "MBTI-PDF-PRODUCT-05: expand PDF coverage to result-page sections",
     "train_scope": "mbti_pdf_product",
     "transitions": [
@@ -18854,6 +18854,11 @@
         "at": "2026-06-27T00:00:00+08:00",
         "note": "Expanded MBTI PDF payload to schema v0_2 with result_page_sections, rendered result-page sections in the mPDF HTML renderer, bumped the MBTI PDF surface to v3, added readable axis pole labels, and validated focused PHPUnit/Pint/JSON/YAML/diff checks. No frontend, public route, CMS, DB migration, search, queue, scheduler, staging deploy, or production deploy change.",
         "status": "local_validated"
+      },
+      {
+        "at": "2026-06-27T00:00:00+08:00",
+        "note": "Opened PR #2467 at https://github.com/fermatmind/fap-api/pull/2467. Waiting for required GitHub checks; no staging deploy wait, manual deploy, server verification, or production deploy included.",
+        "status": "pr_open"
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -18796,6 +18796,67 @@
       }
     ]
   },
+  "MBTI-PDF-PRODUCT-05": {
+    "base": "main",
+    "branch": "codex/mbti-pdf-product-05-result-page-coverage",
+    "checks": {
+      "authorization": {
+        "evidence": "User explicitly provided MBTI-PDF-PRODUCT-05 implementation plan and authorized adding the manifest/state entry in the same backend-only PR.",
+        "status": "pass"
+      },
+      "dependency": {
+        "evidence": "MBTI-PDF-PRODUCT-04 is present on main before starting this branch from origin/main.",
+        "status": "pass"
+      },
+      "github": {
+        "evidence": null,
+        "status": "pending"
+      },
+      "local": {
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptReportAccessReadTest --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: MbtiPdfPayloadBuilderTest passed (4 tests, 126 assertions); MbtiReadPathParityContractTest passed (3 tests, 197 assertions); AttemptPublicReportPdfParityTest passed (2 tests, 21 assertions); AttemptReportAccessReadTest passed (13 tests, 162 assertions); scoped Pint --test passed for MBTI PDF payload/renderer and focused tests; docs/codex state JSON parse passed; pr-train YAML parse passed; git diff --check passed.",
+        "status": "pass"
+      },
+      "scope_validation": {
+        "evidence": "Changed files are limited to MBTI-PDF-PRODUCT-05 scope: backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php, backend/app/Services/Report/Pdf/ReportPdfDocumentService.php, backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php, backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php, backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php, and authorized docs/codex train metadata. No fap-web, public route, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, scheduler, queue, staging deploy, production deploy, or report-access URL shape change.",
+        "status": "pass"
+      }
+    },
+    "commit_sha": null,
+    "depends_on": [
+      "MBTI-PDF-PRODUCT-04"
+    ],
+    "failure_reason": null,
+    "local_cleanup_executed": false,
+    "merged_at": null,
+    "pr_url": null,
+    "remote_branch_deleted": false,
+    "repo": "fap-api",
+    "status": "local_validated",
+    "title": "MBTI-PDF-PRODUCT-05: expand PDF coverage to result-page sections",
+    "train_scope": "mbti_pdf_product",
+    "transitions": [
+      {
+        "at": "2026-06-27T00:00:00+08:00",
+        "note": "Started MBTI PDF result-page coverage PR from latest origin/main. Scope is backend-only MBTI PDF payload/result-page section projection, mPDF HTML renderer coverage, readable axis labels, focused tests, and authorized docs/codex train metadata. No frontend, public route, CMS write, DB migration, sitemap, llms, search, queue, scheduler, staging deploy, production deploy, or artifact purge.",
+        "status": "in_progress"
+      },
+      {
+        "at": "2026-06-27T00:00:00+08:00",
+        "note": "Expanded MBTI PDF payload to schema v0_2 with result_page_sections, rendered result-page sections in the mPDF HTML renderer, bumped the MBTI PDF surface to v3, added readable axis pole labels, and validated focused PHPUnit/Pint/JSON/YAML/diff checks. No frontend, public route, CMS, DB migration, search, queue, scheduler, staging deploy, or production deploy change.",
+        "status": "local_validated"
+      }
+    ]
+  },
   "OPS-API-INTERNAL-RESOLVE-PROOF": {
     "base": "main",
     "branch": "codex/ops-api-internal-resolve-proof",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -215,6 +215,53 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: MBTI-PDF-PRODUCT-05
+    repo: fap-api
+    depends_on: [MBTI-PDF-PRODUCT-04]
+    branch: codex/mbti-pdf-product-05-result-page-coverage
+    title: "MBTI-PDF-PRODUCT-05: expand PDF coverage to result-page sections"
+    train_scope: mbti_pdf_product
+    status: user_authorized
+    scope:
+      - Add an MBTI PDF payload result_page_sections projection from backend MBTI result/content authority, not frontend DOM.
+      - Render traits, career, growth, and relationships result-page cards in the MBTI PDF with card titles, descriptions, bullets, tips, and tags.
+      - Replace hard-truncated chapter summaries with pagination-friendly structured card rendering.
+      - Show readable MBTI axis labels and left/right pole labels instead of only EI/SN/TF/JP/AT.
+      - Convert career recommendation entry points into non-interactive next-step guidance and bump the MBTI PDF surface version to v3 so old v2 cached artifacts are not reused.
+      - Keep /report.pdf, /report-access pdf_href shape, attachment filename contract, public routes, frontend, CMS, DB migrations, search, sitemap, llms, canonical, noindex, JSON-LD, queue, scheduler, staging deploy, and production deploy unchanged.
+    allowed_paths:
+      - backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php
+      - backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+      - backend/tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php
+      - backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
+      - backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+      - backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Scrape or snapshot frontend DOM for PDF content.
+      - Change public API route paths, report-access pdf_href shape, frontend download behavior, CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search submission, scheduler, queue, secrets, staging deploy, or production deploy.
+      - Write CMS, run production import, run production smoke, or purge production PDF artifacts.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptReportAccessReadTest --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-ASSET-02
     repo: fap-api
     depends_on: [PR-EQ-ASSET-01]


### PR DESCRIPTION
## What changed
- Added `result_page_sections` to the MBTI PDF payload (`fap.mbti.report_pdf.payload.v0_2`) from backend MBTI result/content authority.
- Rendered result-page `traits`, `career`, `growth`, and `relationships` cards in the MBTI mPDF HTML report.
- Added readable axis labels and left/right pole labels, and bumped the MBTI PDF surface to `mbti.pdf_surface.v3` so old v2 artifacts are not reused.
- Added focused payload, PDF parity, public PDF, and report-access regression coverage.

## Why
The production MBTI PDF was a formal summary but did not cover the core result-page modules users see on the web result page. This PR expands backend PDF coverage without changing public routes or frontend behavior.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiReadPathParityContractTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AttemptReportAccessReadTest --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php app/Services/Report/Pdf/ReportPdfDocumentService.php tests/Unit/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilderTest.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/AttemptReportAccessReadTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No frontend changes.
- No public route or `/report-access` `actions.pdf_href` change.
- No CMS, DB migration, sitemap, llms, canonical, noindex, JSON-LD, search, queue, scheduler, staging deploy, production deploy, or production PDF artifact purge.
