### PR TITLE
PDF-ENGINE-SPIKE-01A: validate Gotenberg Chromium PDF engine

### DIFF
--- a/backend/app/Console/Commands/PdfGotenbergSpikeCommand.php
+++ b/backend/app/Console/Commands/PdfGotenbergSpikeCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Report\Pdf\GotenbergChromiumPdfClient;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class PdfGotenbergSpikeCommand extends Command
+{
+    protected $signature = 'pdf:gotenberg-spike
+        {--html-file= : Local HTML file to convert through Gotenberg Chromium}
+        {--print-url= : Internal/private result print URL to convert through Gotenberg Chromium}
+        {--output= : Output PDF path}
+        {--json : Emit sanitized JSON evidence}';
+
+    protected $description = 'Validate the disabled-by-default Gotenberg Chromium PDF engine without changing public report routes.';
+
+    public function __construct(
+        private readonly GotenbergChromiumPdfClient $client,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $output = trim((string) $this->option('output'));
+        $htmlFile = trim((string) $this->option('html-file'));
+        $printUrl = trim((string) $this->option('print-url'));
+
+        if ($output === '' || ($htmlFile === '' && $printUrl === '') || ($htmlFile !== '' && $printUrl !== '')) {
+            $this->error('Provide exactly one of --html-file or --print-url, plus --output.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $pdf = $htmlFile !== ''
+                ? $this->client->convertHtml($this->readHtmlFile($htmlFile))
+                : $this->client->convertUrl($printUrl);
+
+            $dir = dirname($output);
+            if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+                throw new \RuntimeException('Unable to create output directory.');
+            }
+
+            file_put_contents($output, $pdf);
+
+            $payload = [
+                'ok' => true,
+                'engine' => 'gotenberg_chromium',
+                'mode' => $htmlFile !== '' ? 'html' : 'url',
+                'bytes' => strlen($pdf),
+                'pdf_magic' => str_starts_with($pdf, '%PDF-'),
+                'output' => $output,
+                'api_route_changed' => false,
+                'public_exposure_allowed' => false,
+            ];
+        } catch (Throwable $e) {
+            $payload = [
+                'ok' => false,
+                'engine' => 'gotenberg_chromium',
+                'error' => class_basename($e),
+                'message' => $e->getMessage(),
+                'api_route_changed' => false,
+                'public_exposure_allowed' => false,
+            ];
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) ?: '{}');
+        } else {
+            foreach ($payload as $key => $value) {
+                $this->line($key.'='.json_encode($value, JSON_UNESCAPED_SLASHES));
+            }
+        }
+
+        return ($payload['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function readHtmlFile(string $path): string
+    {
+        if (! is_file($path)) {
+            throw new \InvalidArgumentException('HTML file does not exist.');
+        }
+
+        $html = file_get_contents($path);
+        if (! is_string($html) || trim($html) === '') {
+            throw new \InvalidArgumentException('HTML file is empty.');
+        }
+
+        return $html;
+    }
+}

--- a/backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php
+++ b/backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Report\Pdf;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use RuntimeException;
+
+final class GotenbergChromiumPdfClient
+{
+    public function enabled(): bool
+    {
+        return (bool) config('gotenberg.enabled', false);
+    }
+
+    public function baseUrl(): string
+    {
+        return rtrim(trim((string) config('gotenberg.base_url', '')), '/');
+    }
+
+    /**
+     * @param  array<string,string|int|float|bool|null>  $options
+     *
+     * @throws RequestException
+     */
+    public function convertHtml(string $html, array $options = []): string
+    {
+        $baseUrl = $this->validatedBaseUrl();
+        $payloadOptions = $this->normalizeOptions($options);
+
+        $response = Http::connectTimeout((int) config('gotenberg.connect_timeout_seconds', 5))
+            ->timeout((int) config('gotenberg.timeout_seconds', 30))
+            ->accept('application/pdf')
+            ->attach('files', $html, 'index.html', ['Content-Type' => 'text/html; charset=UTF-8'])
+            ->post($baseUrl.'/forms/chromium/convert/html', $payloadOptions);
+
+        $response->throw();
+
+        $body = $response->body();
+        if (! str_starts_with($body, '%PDF-')) {
+            throw new RuntimeException('Gotenberg did not return a PDF document.');
+        }
+
+        return $body;
+    }
+
+    /**
+     * @param  array<string,string|int|float|bool|null>  $options
+     *
+     * @throws RequestException
+     */
+    public function convertUrl(string $printUrl, array $options = []): string
+    {
+        $baseUrl = $this->validatedBaseUrl();
+        $this->assertPrivateHttpUrl($printUrl, 'print URL');
+        $payloadOptions = $this->normalizeOptions(['url' => $printUrl, ...$options]);
+
+        $response = Http::connectTimeout((int) config('gotenberg.connect_timeout_seconds', 5))
+            ->timeout((int) config('gotenberg.timeout_seconds', 30))
+            ->accept('application/pdf')
+            ->asMultipart()
+            ->post($baseUrl.'/forms/chromium/convert/url', $payloadOptions);
+
+        $response->throw();
+
+        $body = $response->body();
+        if (! str_starts_with($body, '%PDF-')) {
+            throw new RuntimeException('Gotenberg did not return a PDF document.');
+        }
+
+        return $body;
+    }
+
+    public function assertPrivateHttpUrl(string $url, string $label = 'URL'): void
+    {
+        $parts = parse_url($url);
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower(trim((string) ($parts['host'] ?? '')));
+
+        if ($scheme !== 'http') {
+            throw new InvalidArgumentException($label.' must use http on a private network.');
+        }
+
+        if ($host === '' || ! $this->isPrivateHost($host)) {
+            throw new InvalidArgumentException($label.' must resolve to a private/internal host.');
+        }
+    }
+
+    private function validatedBaseUrl(): string
+    {
+        if (! $this->enabled()) {
+            throw new RuntimeException('Gotenberg PDF engine is disabled.');
+        }
+
+        $baseUrl = $this->baseUrl();
+        $this->assertPrivateHttpUrl($baseUrl, 'Gotenberg base URL');
+
+        return $baseUrl;
+    }
+
+    private function isPrivateHost(string $host): bool
+    {
+        $host = trim($host, '[]');
+        if (in_array($host, ['localhost', '127.0.0.1', '::1'], true)) {
+            return true;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return ! filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+        }
+
+        if ((bool) config('gotenberg.allow_single_label_hosts', true) && ! str_contains($host, '.')) {
+            return true;
+        }
+
+        foreach ((array) config('gotenberg.allowed_private_suffixes', []) as $suffix) {
+            $suffix = strtolower(trim((string) $suffix));
+            if ($suffix !== '' && str_ends_with($host, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,string|int|float|bool|null>  $options
+     * @return array<string,string>
+     */
+    private function normalizeOptions(array $options): array
+    {
+        $merged = [
+            ...((array) config('gotenberg.default_pdf_options', [])),
+            ...$options,
+        ];
+
+        $normalized = [];
+        foreach ($merged as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $normalized[(string) $key] = is_bool($value) ? ($value ? 'true' : 'false') : (string) $value;
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/config/gotenberg.php
+++ b/backend/config/gotenberg.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'enabled' => (bool) env('GOTENBERG_PDF_ENABLED', false),
+    'base_url' => env('GOTENBERG_BASE_URL', ''),
+    'timeout_seconds' => (int) env('GOTENBERG_TIMEOUT_SECONDS', 30),
+    'connect_timeout_seconds' => (int) env('GOTENBERG_CONNECT_TIMEOUT_SECONDS', 5),
+    'allow_single_label_hosts' => (bool) env('GOTENBERG_ALLOW_SINGLE_LABEL_HOSTS', true),
+    'allowed_private_suffixes' => array_values(array_filter(array_map(
+        static fn ($suffix) => strtolower(trim((string) $suffix)),
+        explode(',', (string) env('GOTENBERG_ALLOWED_PRIVATE_SUFFIXES', '.internal,.local,.lan,.svc,.cluster.local'))
+    ))),
+    'default_pdf_options' => [
+        'paperWidth' => env('GOTENBERG_PAPER_WIDTH', '8.27'),
+        'paperHeight' => env('GOTENBERG_PAPER_HEIGHT', '11.69'),
+        'marginTop' => env('GOTENBERG_MARGIN_TOP', '0.35'),
+        'marginBottom' => env('GOTENBERG_MARGIN_BOTTOM', '0.35'),
+        'marginLeft' => env('GOTENBERG_MARGIN_LEFT', '0.35'),
+        'marginRight' => env('GOTENBERG_MARGIN_RIGHT', '0.35'),
+        'printBackground' => env('GOTENBERG_PRINT_BACKGROUND', 'true'),
+    ],
+];

--- a/backend/tests/Feature/Report/PdfGotenbergEngineSpikeTest.php
+++ b/backend/tests/Feature/Report/PdfGotenbergEngineSpikeTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Services\Report\Pdf\GotenbergChromiumPdfClient;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+final class PdfGotenbergEngineSpikeTest extends TestCase
+{
+    public function test_chromium_html_conversion_returns_pdf_without_changing_public_report_route(): void
+    {
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'http://gotenberg:3000');
+
+        Http::fake([
+            'gotenberg:3000/forms/chromium/convert/html' => Http::response('%PDF-1.4 gotenberg spike', 200, [
+                'Content-Type' => 'application/pdf',
+            ]),
+        ]);
+
+        $pdf = app(GotenbergChromiumPdfClient::class)->convertHtml($this->resultPrintHtml());
+
+        $this->assertStringStartsWith('%PDF-', $pdf);
+        Http::assertSent(function ($request): bool {
+            return $request->url() === 'http://gotenberg:3000/forms/chromium/convert/html'
+                && $request->method() === 'POST'
+                && str_contains($request->body(), 'Personality Traits')
+                && str_contains($request->body(), 'Your Career Path')
+                && str_contains($request->body(), 'Your Personal Growth')
+                && str_contains($request->body(), 'Your Relationships')
+                && str_contains($request->body(), 'Noto Sans SC');
+        });
+
+        $route = Route::getRoutes()->match(Request::create('/api/v0.3/attempts/00000000-0000-0000-0000-000000000000/report.pdf', 'GET'));
+
+        $this->assertStringContainsString('AttemptReadController@reportPdf', $route->getActionName());
+    }
+
+    public function test_spike_command_emits_attachment_ready_pdf_evidence(): void
+    {
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'http://127.0.0.1:3000');
+
+        Http::fake([
+            '127.0.0.1:3000/forms/chromium/convert/html' => Http::response('%PDF-1.4 gotenberg command spike', 200, [
+                'Content-Type' => 'application/pdf',
+            ]),
+        ]);
+
+        $htmlFile = tempnam(sys_get_temp_dir(), 'fm-gotenberg-spike-').'.html';
+        $output = tempnam(sys_get_temp_dir(), 'fm-gotenberg-spike-').'.pdf';
+        file_put_contents($htmlFile, $this->resultPrintHtml());
+
+        $exitCode = Artisan::call('pdf:gotenberg-spike', [
+            '--html-file' => $htmlFile,
+            '--output' => $output,
+            '--json' => true,
+        ]);
+
+        $commandOutput = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('"ok": true', $commandOutput);
+        $this->assertStringContainsString('gotenberg_chromium', $commandOutput);
+        $this->assertStringContainsString('api_route_changed', $commandOutput);
+        $this->assertStringContainsString('public_exposure_allowed', $commandOutput);
+
+        $this->assertStringStartsWith('%PDF-', (string) file_get_contents($output));
+    }
+
+    public function test_public_gotenberg_or_print_urls_are_rejected(): void
+    {
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'https://pdf.fermatmind.com');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Gotenberg base URL must use http on a private network.');
+
+        app(GotenbergChromiumPdfClient::class)->convertHtml($this->resultPrintHtml());
+    }
+
+    public function test_public_print_url_is_rejected_even_with_private_gotenberg(): void
+    {
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'http://10.0.0.12:3000');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('print URL must resolve to a private/internal host.');
+
+        app(GotenbergChromiumPdfClient::class)->convertUrl('http://fermatmind.com/zh/result/example/print');
+    }
+
+    private function resultPrintHtml(): string
+    {
+        return <<<'HTML'
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: "Noto Sans SC", "Noto Sans CJK SC", sans-serif; }
+    section { break-inside: avoid; page-break-inside: avoid; }
+  </style>
+</head>
+<body>
+  <main data-result-print-root="true">
+    <section><h1>MBTI 完整人格报告</h1><p>中文字体正常。</p></section>
+    <section><h2>Personality Traits</h2><p>Trait cards render in print mode.</p></section>
+    <section><h2>Your Career Path</h2><p>Career cards render in print mode.</p></section>
+    <section><h2>Your Personal Growth</h2><p>Growth cards render in print mode.</p></section>
+    <section><h2>Your Relationships</h2><p>Relationship cards render in print mode.</p></section>
+  </main>
+</body>
+</html>
+HTML;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -524,6 +524,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_disabled_gotenberg_pdf_engine_spike_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PdfGotenbergSpikeCommand.php',
+            'backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_eq_cross_assessment_context_guard_changes(): void
     {
         $changed = [
@@ -4744,6 +4754,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isGotenbergPdfEngineSpikeFile($file)) {
+                continue;
+            }
+
             if ($this->isPublicContentReleaseGuardCommandFile($file)) {
                 continue;
             }
@@ -6199,6 +6213,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isMbtiPdfPayloadAuthorityFile(string $file): bool
     {
         return $file === 'backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php';
+    }
+
+    private function isGotenbergPdfEngineSpikeFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PdfGotenbergSpikeCommand.php',
+            'backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php',
+        ], true);
     }
 
     private function isPublicContentReleaseGuardCommandFile(string $file): bool


### PR DESCRIPTION
## What changed
- Add a disabled-by-default Gotenberg Chromium PDF client with private-network base URL validation.
- Add a bounded `pdf:gotenberg-spike` command for local/internal HTML or private print URL conversion evidence.
- Add focused PHPUnit coverage that verifies PDF magic bytes, Chinese-font print HTML handling, public route stability, and public URL rejection.

## Why
This validates the safer long-term PDF engine path before wiring production `/report.pdf` to Chromium rendering. The existing API route remains unchanged in this PR.

## Validation
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PdfGotenbergEngineSpikeTest --display-warnings --no-ansi`
- `vendor/bin/pint --test config/gotenberg.php app/Services/Report/Pdf/GotenbergChromiumPdfClient.php app/Console/Commands/PdfGotenbergSpikeCommand.php tests/Feature/Report/PdfGotenbergEngineSpikeTest.php --ansi`
- `php artisan route:list --path=api/v0.3/attempts --no-ansi | rg 'report\.pdf|AttemptReadController'`
- `git diff --check`

## Intentionally deferred
- No production route switch.
- No Gotenberg deployment or service exposure.
- No frontend print route.
- No CMS, DB, queue, search, indexing, scheduler, or production deploy changes.

## Repository rule impact
Backend-only infrastructure spike. No content authority, publishing, SEO, or public content ownership changes.