### PR TITLE
fix(seo): honor article closeout holds

### DIFF
--- a/backend/app/Services/Cms/ArticleReleaseCloseoutService.php
+++ b/backend/app/Services/Cms/ArticleReleaseCloseoutService.php
@@ -9,11 +9,26 @@ use App\Models\ArticleCategory;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTag;
 use App\Models\ArticleTranslationRevision;
+use App\Support\PublicMediaUrlGuard;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 final class ArticleReleaseCloseoutService
 {
+    /**
+     * Closeout audits historical Media Library article references that are already
+     * public-rendered. Keep this narrower than the general API media sanitizer.
+     *
+     * @var list<string>
+     */
+    private const CLOSEOUT_PUBLIC_MEDIA_HOSTS = [
+        'api.fermatmind.com',
+        'assets.fermatmind.com',
+        'fermatmind.com',
+        'www.fermatmind.com',
+        'ops.fermatmind.com',
+    ];
+
     public const COMPLETE_SEARCH_OBSERVATION_PENDING = 'ARTICLE_RELEASE_COMPLETE_SEARCH_OBSERVATION_PENDING';
 
     public const BLOCKED_DISCOVERABILITY_GAP = 'BLOCKED_DISCOVERABILITY_GAP';
@@ -452,28 +467,38 @@ final class ArticleReleaseCloseoutService
         $package = is_array($schema['editorial_package_v1'] ?? null) ? $schema['editorial_package_v1'] : [];
         $hreflang = is_array($package['hreflang_gate_v1'] ?? null) ? $package['hreflang_gate_v1'] : null;
 
+        $schemaHold = (bool) ($package['schema_hold'] ?? false);
+        $hreflangHold = (bool) ($package['hreflang_hold'] ?? false);
         $articleSchemaEnabled = (bool) ($package['article_schema_enabled'] ?? false);
         $breadcrumbSchemaEnabled = (bool) ($package['breadcrumb_schema_enabled'] ?? false);
         $faqSchemaEnabled = (bool) ($package['faq_schema_enabled'] ?? false);
+        $hasNoHreflangPolicy = is_array($hreflang)
+            && ($hreflang['enabled'] ?? null) === false
+            && ($hreflang['policy'] ?? null) === 'no_hreflang';
 
-        if (! $articleSchemaEnabled) {
+        if (! $schemaHold && ! $articleSchemaEnabled) {
             $issues[] = $this->issue('schema.article_schema_enabled', 'article_schema_not_enabled', 'Article schema gate is not enabled.');
         }
-        if (! $breadcrumbSchemaEnabled) {
+        if (! $schemaHold && ! $breadcrumbSchemaEnabled) {
             $issues[] = $this->issue('schema.breadcrumb_schema_enabled', 'breadcrumb_schema_not_enabled', 'Breadcrumb schema gate is not enabled.');
         }
         if ($faqSchemaEnabled) {
             $issues[] = $this->issue('schema.faq_schema_enabled', 'faq_schema_not_held', 'FAQ schema should remain held unless explicitly reviewed.');
         }
-        if (! is_array($hreflang) || ($hreflang['enabled'] ?? null) !== false || ($hreflang['policy'] ?? null) !== 'no_hreflang') {
+        if (! $hreflangHold && ! $hasNoHreflangPolicy) {
             $issues[] = $this->issue('hreflang_gate_v1', 'hreflang_policy_missing', 'Hreflang gate must be enabled reciprocally or record no_hreflang policy.');
         }
 
         return [
             'ok' => $issues === [],
+            'schema_state' => $schemaHold ? 'held' : 'enabled_required',
+            'hreflang_state' => $hreflangHold ? 'held' : 'policy_required',
+            'schema_hold' => $schemaHold,
+            'hreflang_hold' => $hreflangHold,
             'article_schema_enabled' => $articleSchemaEnabled,
             'breadcrumb_schema_enabled' => $breadcrumbSchemaEnabled,
             'faq_schema_enabled' => $faqSchemaEnabled,
+            'hreflang_no_hreflang_policy_recorded' => $hasNoHreflangPolicy,
             'hreflang_gate_v1' => $hreflang,
             'issues' => $issues,
         ];
@@ -657,14 +682,23 @@ final class ArticleReleaseCloseoutService
 
     private function isPublicMediaUrl(string $url): bool
     {
-        $host = parse_url($url, PHP_URL_HOST);
+        if (PublicMediaUrlGuard::isAllowedPublicMediaUrl($url)) {
+            return true;
+        }
 
-        return in_array($host, [
-            'api.fermatmind.com',
-            'assets.fermatmind.com',
-            'fermatmind.com',
-            'www.fermatmind.com',
-        ], true);
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        $host = parse_url($url, PHP_URL_HOST);
+        $port = (int) (parse_url($url, PHP_URL_PORT) ?? 443);
+
+        if ($scheme !== 'https' || ! is_string($host) || $port !== 443) {
+            return false;
+        }
+
+        if (parse_url($url, PHP_URL_USER) !== null || parse_url($url, PHP_URL_PASS) !== null) {
+            return false;
+        }
+
+        return in_array(strtolower(trim($host, "[] \t\n\r\0\x0B.")), self::CLOSEOUT_PUBLIC_MEDIA_HOSTS, true);
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php
@@ -63,6 +63,51 @@ final class ArticleReleaseCloseoutCommandTest extends TestCase
         $this->assertFalse($payload['sitemap_llms_mutation_attempted']);
     }
 
+    public function test_closeout_accepts_ops_media_library_origin_and_explicit_schema_hreflang_holds(): void
+    {
+        $article = $this->createReleasedArticle([
+            'content_md' => '# 高考出分后专业太多怎么筛？'."\n\n![流程图](https://ops.fermatmind.com/storage/media-library/body.png)\n\n正文。",
+            'content_html' => '<h1>高考出分后专业太多怎么筛？</h1><img src="https://ops.fermatmind.com/storage/media-library/body.png">',
+            'cover_image_url' => 'https://ops.fermatmind.com/storage/media-library/cover.jpg',
+        ]);
+        $article->seoMeta?->forceFill([
+            'og_image_url' => 'https://ops.fermatmind.com/storage/media-library/og.jpg',
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'schema_hold' => true,
+                    'hreflang_hold' => true,
+                    'article_schema_enabled' => false,
+                    'breadcrumb_schema_enabled' => false,
+                    'faq_schema_enabled' => false,
+                ],
+            ],
+        ])->save();
+
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue(data_get($payload, 'checks.media.ok'));
+        $this->assertSame('held', data_get($payload, 'checks.schema_hreflang.schema_state'));
+        $this->assertSame('held', data_get($payload, 'checks.schema_hreflang.hreflang_state'));
+        $this->assertTrue(data_get($payload, 'checks.schema_hreflang.schema_hold'));
+        $this->assertTrue(data_get($payload, 'checks.schema_hreflang.hreflang_hold'));
+        $this->assertErrorCodeMissing($payload, 'media_url_not_public_origin');
+        $this->assertErrorCodeMissing($payload, 'article_schema_not_enabled');
+        $this->assertErrorCodeMissing($payload, 'breadcrumb_schema_not_enabled');
+        $this->assertErrorCodeMissing($payload, 'hreflang_policy_missing');
+    }
+
     public function test_missing_search_queue_blocks_search_closeout(): void
     {
         $article = $this->createReleasedArticle();
@@ -358,6 +403,17 @@ final class ArticleReleaseCloseoutCommandTest extends TestCase
     private function assertErrorCode(array $payload, string $code): void
     {
         $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            (array) ($payload['issues'] ?? [])
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCodeMissing(array $payload, string $code): void
+    {
+        $this->assertNotContains($code, array_map(
             static fn (array $error): string => (string) ($error['code'] ?? ''),
             (array) ($payload['issues'] ?? [])
         ));


### PR DESCRIPTION
## Summary
- allow the article release closeout checker to treat already public-rendered `ops.fermatmind.com` Media Library URLs as closeout-safe media origins
- treat explicit `schema_hold=true` and `hreflang_hold=true` metadata as held policy states instead of operator blockers
- add focused coverage for ops Media Library URLs plus schema/hreflang holds

## Why
Daily SEO article closeout was reporting two noisy blockers after a successful release:
- Media Library URLs on `ops.fermatmind.com` were publicly reachable but failed the closeout origin check.
- Article/Breadcrumb schema and hreflang were intentionally held, but the closeout command reported them as missing operator input.

This keeps the fix scoped to the closeout evidence command. It does not change CMS content, public rendering, schema output, hreflang output, search submission, sitemap/llms behavior, or Media Library storage.

## Validation
- `cd backend && ./vendor/bin/pint app/Services/Cms/ArticleReleaseCloseoutService.php tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php`
- `cd backend && php artisan test tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php`
- `git diff --check`

## Intentionally deferred
- production deploy
- rerunning production `articles:release-closeout` for article 58 after deploy
- schema rollout
- hreflang rollout
- changing the broader public API media sanitizer policy

## Repository rule impact
This is backend CMS/SEO closeout tooling only. It does not move content authority, media authority, sitemap/llms enumeration, schema generation, or hreflang generation out of backend-controlled workflows.
