### PR TITLE
fix(seo): require canonical media assets for SEO packages

### DIFF
--- a/backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php
+++ b/backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php
@@ -106,6 +106,11 @@ final class SeoImageBundleImporter
         $resolved = $this->resolvedMetadataFromPlans($writtenPlans, $locales, false);
         $resolvedPackage = null;
         if ($writeResolvedPackage) {
+            $this->validateResolvedMetadataReadyForCms($resolved, $errors);
+            if ($errors !== []) {
+                return $this->summary(false, false, 'media_asset_cdn_not_ready', $package, $translationGroupId, $writtenPlans, $resolved, $errors, $warnings);
+            }
+
             $resolvedPackage = $this->writeResolvedPackageCopy($package, $resolved, $resolvedOutputDir, $warnings);
         }
 
@@ -617,14 +622,49 @@ final class SeoImageBundleImporter
 
     private function publicMediaUrlForImportedRecord(string $disk, mixed $path, mixed $url, string $syncStatus, string $cdnStatus): ?string
     {
-        if ($syncStatus === MediaAsset::SYNC_SKIPPED || $cdnStatus === MediaAsset::CDN_SKIPPED) {
-            $appStorageUrl = PublicMediaUrlGuard::publicAppStorageUrlForPath($disk, $path);
-            if ($appStorageUrl !== null) {
-                return $appStorageUrl;
-            }
+        if ($syncStatus !== MediaAsset::SYNC_SYNCED || $cdnStatus !== MediaAsset::CDN_VERIFIED) {
+            return null;
         }
 
         return PublicMediaUrlGuard::canonicalMediaUrl($disk, $path, $url);
+    }
+
+    /**
+     * @param  array<string,mixed>  $resolved
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateResolvedMetadataReadyForCms(array $resolved, array &$errors): void
+    {
+        foreach (['cover_image_url', 'og_image_url', 'twitter_image_url'] as $field) {
+            $this->assertCanonicalAssetUrl($resolved[$field] ?? null, $field, $errors);
+        }
+
+        if (filled($resolved['body_visual_asset_key'] ?? null)) {
+            $this->assertCanonicalAssetUrl($resolved['body_visual_image_url'] ?? null, 'body_visual_image_url', $errors);
+        }
+
+        foreach ((array) ($resolved['cover_image_variants'] ?? []) as $variantKey => $variant) {
+            if (! is_array($variant)) {
+                $errors[] = $this->issue('cover_image_variants.'.$variantKey, 'media_asset_cdn_not_ready', 'Cover image variant metadata is not ready for CMS package use.');
+
+                continue;
+            }
+
+            $this->assertCanonicalAssetUrl($variant['url'] ?? null, 'cover_image_variants.'.$variantKey.'.url', $errors);
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function assertCanonicalAssetUrl(mixed $url, string $field, array &$errors): void
+    {
+        $candidate = PublicMediaUrlGuard::sanitizeNullableUrl($url);
+        $canonicalOrigin = PublicMediaUrlGuard::canonicalAssetOrigin();
+
+        if ($candidate === null || ! str_starts_with($candidate, $canonicalOrigin.'/')) {
+            $errors[] = $this->issue($field, 'media_asset_cdn_not_ready', 'Media asset must be synced and CDN-verified on the canonical public asset origin before writing a CMS-ready resolved package.');
+        }
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php
@@ -87,6 +87,14 @@ final class ArticleUpdateImageMetadataCommandTest extends TestCase
             ->assertOk()
             ->json('article');
         $this->assertSame(
+            'https://assets.fermatmind.com/articles/career-map/hero_1600x900.jpg',
+            data_get($publicPayload, 'cover_image_url')
+        );
+        $this->assertSame(
+            'https://assets.fermatmind.com/articles/career-map/hero_1600x900.jpg',
+            data_get($publicPayload, 'cover_image_variants.hero.url')
+        );
+        $this->assertSame(
             'https://assets.fermatmind.com/articles/career-map/body_1600x900.jpg',
             data_get($publicPayload, 'body_visual.image_url')
         );

--- a/backend/tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php
+++ b/backend/tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php
@@ -9,6 +9,7 @@ use App\Models\MediaAsset;
 use App\Models\MediaVariant;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -177,14 +178,16 @@ final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
         $this->assertSame(MediaAsset::STATUS_PUBLISHED, (string) $asset->status);
         $this->assertTrue((bool) $asset->is_public);
         $this->assertSame(MediaAsset::CDN_SKIPPED, (string) $asset->cdn_status);
-        $this->assertArrayHasKey('hero', $payload['resolved_metadata']['cover_image_variants']);
-        $this->assertSame($payload['resolved_metadata']['og_image_url'], $payload['resolved_metadata']['twitter_image_url']);
+        $this->assertNull($payload['resolved_metadata']['cover_image_url']);
+        $this->assertNull($payload['resolved_metadata']['cover_image_variants']['hero']['url']);
+        $this->assertNull($payload['resolved_metadata']['og_image_url']);
+        $this->assertNull($payload['resolved_metadata']['twitter_image_url']);
         Storage::disk('public')->assertExists((string) $asset->path);
     }
 
-    public function test_non_dry_run_uses_public_api_storage_urls_when_cdn_sync_is_skipped(): void
+    public function test_non_dry_run_does_not_emit_app_storage_urls_when_cdn_sync_is_skipped(): void
     {
-        config(['app.url' => 'https://api.fermatmind.com']);
+        config(['app.url' => 'https://ops.fermatmind.com']);
         Storage::fake('public');
         $package = $this->writeImageBundlePackage();
 
@@ -194,9 +197,67 @@ final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
 
         $payload = $this->jsonOutput();
         $this->assertSame(0, $exitCode);
-        $this->assertStringStartsWith('https://api.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['cover_image_url']);
-        $this->assertStringStartsWith('https://api.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['og_image_url']);
-        $this->assertStringStartsWith('https://api.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['cover_image_variants']['hero']['url']);
+        $this->assertNull($payload['resolved_metadata']['cover_image_url']);
+        $this->assertNull($payload['resolved_metadata']['og_image_url']);
+        $this->assertNull($payload['resolved_metadata']['cover_image_variants']['hero']['url']);
+    }
+
+    public function test_write_resolved_package_fails_when_media_asset_is_not_cdn_ready(): void
+    {
+        config(['app.url' => 'https://ops.fermatmind.com']);
+        Storage::fake('public');
+        $package = $this->writeImageBundlePackage();
+        $output = sys_get_temp_dir().'/fm-image-bundle-not-ready-'.Str::random(12);
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--json' => true,
+            '--write-resolved-package' => true,
+            '--resolved-output-dir' => $output,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('media_asset_cdn_not_ready', $payload['action']);
+        $this->assertErrorCode($payload, 'media_asset_cdn_not_ready');
+        $this->assertDirectoryDoesNotExist($output);
+        $this->assertNull($payload['resolved_metadata']['cover_image_url']);
+    }
+
+    public function test_write_resolved_package_requires_and_outputs_canonical_assets_origin_urls(): void
+    {
+        Storage::fake('public');
+        Storage::fake('s3');
+        Http::fake([
+            'assets.fermatmind.com/*' => Http::response('', 200, ['Content-Type' => 'image/jpeg']),
+        ]);
+        config([
+            'app.url' => 'https://ops.fermatmind.com',
+            'fap.media.oss_sync_enabled' => true,
+            'fap.media.oss_disk' => 's3',
+            'fap.media.oss_key_prefix' => 'storage',
+            'fap.media.cdn_verify_enabled' => true,
+        ]);
+        $package = $this->writeImageBundlePackage();
+        $output = sys_get_temp_dir().'/fm-image-bundle-canonical-'.Str::random(12);
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--json' => true,
+            '--write-resolved-package' => true,
+            '--resolved-output-dir' => $output,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertStringStartsWith('https://assets.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['cover_image_url']);
+        $this->assertStringStartsWith('https://assets.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['og_image_url']);
+        $this->assertStringStartsWith('https://assets.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['cover_image_variants']['hero']['url']);
+        $this->assertStringNotContainsString('ops.fermatmind.com', json_encode($payload['resolved_metadata'], JSON_THROW_ON_ERROR));
+
+        $draft = json_decode((string) file_get_contents($output.'/cms/CMS_IMPORT_DRAFT_en_demo.json'), true);
+        $this->assertStringStartsWith('https://assets.fermatmind.com/storage/media-library/variants/', $draft['cover_image_url']);
+        $this->assertStringNotContainsString('ops.fermatmind.com', json_encode($draft, JSON_THROW_ON_ERROR));
     }
 
     public function test_dry_run_does_not_write_existing_asset_or_storage(): void
@@ -271,6 +332,16 @@ final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
     public function test_write_resolved_package_outputs_safe_copy_with_cms_metadata(): void
     {
         Storage::fake('public');
+        Storage::fake('s3');
+        Http::fake([
+            'assets.fermatmind.com/*' => Http::response('', 200, ['Content-Type' => 'image/jpeg']),
+        ]);
+        config([
+            'fap.media.oss_sync_enabled' => true,
+            'fap.media.oss_disk' => 's3',
+            'fap.media.oss_key_prefix' => 'storage',
+            'fap.media.cdn_verify_enabled' => true,
+        ]);
         $package = $this->writeImageBundlePackage();
         $output = sys_get_temp_dir().'/fm-image-bundle-resolved-'.Str::random(12);
 


### PR DESCRIPTION
## What changed
- Require SEO image bundle resolved packages to use canonical `assets.fermatmind.com` media URLs before writing CMS-ready package metadata.
- Stop falling back to app storage URLs when Media Library OSS sync or CDN verification is skipped/not ready, so production-style packages do not emit `ops.fermatmind.com` URLs.
- Return a clear `media_asset_cdn_not_ready` blocker when `--write-resolved-package` is requested before CDN-ready image metadata exists.
- Extend tests for skipped CDN sync, canonical assets-origin package output, and public article image metadata readback.

## Why
Public articles must not expose Ops/admin media origins. The backend Media Library/CMS package path is the authority for article image metadata, and production-resolved packages should only become CMS input after the target public asset origin is ready and verified.

## Validation
- `./vendor/bin/pint app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php`
- `php artisan test tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php tests/Feature/V0_5/MediaLibraryOssSyncTest.php`
- `php artisan route:list --path=api/v0.5/media-assets`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- Production backend deploy.
- Article 58 Media Library/CDN sync/readiness execution.
- Article 58 image metadata repair and content-release revalidation.
- Public article smoke after revalidation.
- URL Truth, sitemap/llms, schema/hreflang, Search Channel, IndexNow/GSC/Baidu changes.

## Repository rule impact
This PR reinforces existing content authority rules: mutable article images remain Media Library/CMS metadata, and the backend remains the authority for public article media URLs. No frontend origin allowlist relaxation is introduced.
