### PR TITLE
Enneagram: add result page content asset gap plan

### DIFF
--- a/backend/content_assets/enneagram/result_page/content_gap_plan/v0_1/README.md
+++ b/backend/content_assets/enneagram/result_page/content_gap_plan/v0_1/README.md
@@ -1,0 +1,44 @@
+# Enneagram Result Page Content Gap Plan
+
+This directory is a planning and workspace packet for Enneagram result-page content asset thickening.
+
+It maps the current backend asset streams to the rendered page inventory captured in fap-web PR #1462, then defines how future agent runs may draft module-level content safely. It is not a content generation run.
+
+## Files
+
+- `content_asset_gap_plan_v0_1.json`: machine-readable ledger of rendered sections, known gaps, source asset coverage, and future PR slices.
+- `content_asset_pack_workspace_v0_1.md`: human-editable workspace for GPT/Codex module-by-module enrichment.
+- `agent_generation_contract_v0_1.json`: allowed inputs, outputs, safety gates, and forbidden output contract for future small-batch agent work.
+
+## Source Alignment
+
+- Backend source ledger: `content_assets/enneagram/result_page/source_ledger/source_ledger.json`
+- Backend asset streams: `batch_1r_a` through `batch_1r_h`
+- Current candidate baseline: `a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0`
+- Runtime registry hash: `ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f`
+- Rendered inventory reference: fap-web PR #1462 merge commit `41039084935ea7b7fadba93be62771d2a50d10b6`
+
+## Benchmark Direction
+
+The workspace may benchmark public result-page structure from:
+
+- 123test Enneagram test: `https://www.123test.com/enneagram-test/`
+- Truity Enneagram Personality Test: `https://www.truity.com/test/enneagram-personality-test`
+- Truity Enneagram chart explanation: `https://www.truity.com/blog/how-do-you-read-enneagram-chart`
+
+These references are for structure and product coverage only. Do not copy proprietary wording, scoring claims, charts, or conclusions.
+
+## Negative Guarantees
+
+This packet does not:
+
+- generate official result-page content,
+- export a candidate package,
+- import an inactive release,
+- activate production,
+- switch runtime,
+- write production data,
+- write CMS data,
+- change frontend code.
+
+Future content PRs must remain one module or one small batch per PR and must pass source mapping, metadata leakage, forbidden claim, FC144 boundary, rendered QA, and rollback checks before any candidate export is considered.

--- a/backend/content_assets/enneagram/result_page/content_gap_plan/v0_1/agent_generation_contract_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/content_gap_plan/v0_1/agent_generation_contract_v0_1.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "fap.enneagram.result_page.agent_generation_contract.v0.1",
+  "status": "contract_only",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "agent_may_generate_bulk_content": false,
+  "agent_may_export_candidate": false,
+  "agent_may_import_candidate": false,
+  "agent_may_activate_runtime": false,
+  "agent_may_write_production": false,
+  "agent_may_write_cms": false,
+  "agent_may_change_frontend": false,
+  "allowed_inputs": {
+    "source_ledger_row": true,
+    "target_module_id": true,
+    "target_type_or_pair": true,
+    "target_scope": true,
+    "rendered_gap_id": true,
+    "forbidden_claim_policy": true,
+    "benchmark_structure_notes": true,
+    "existing_backend_asset_refs": true
+  },
+  "allowed_outputs": {
+    "draft_payload_json": true,
+    "source_mapping_report_json": true,
+    "safety_report_json": true,
+    "diff_report_json": true,
+    "rollback_plan_md": true,
+    "rendered_expectation_notes": true
+  },
+  "draft_payload_contract": {
+    "required_fields": [
+      "schema_version",
+      "module_id",
+      "locale",
+      "type_code_or_pair",
+      "scope",
+      "public_payload",
+      "source_trace",
+      "safety_flags",
+      "rollback_notes"
+    ],
+    "public_payload_required_fields": [
+      "heading",
+      "lead",
+      "body",
+      "reflection_prompt",
+      "boundary_note"
+    ],
+    "source_trace_required_fields": [
+      "source_ledger_row_id",
+      "source_asset_batch",
+      "source_asset_key",
+      "benchmark_refs_used",
+      "copy_policy"
+    ],
+    "safety_flags_required_fields": [
+      "non_diagnostic",
+      "non_hiring",
+      "no_hard_typing",
+      "no_accuracy_superiority",
+      "no_score_vector_leak",
+      "public_safe_only"
+    ]
+  },
+  "public_benchmark_policy": {
+    "allowed_benchmark_refs": [
+      "https://www.123test.com/enneagram-test/",
+      "https://www.truity.com/test/enneagram-personality-test",
+      "https://www.truity.com/blog/how-do-you-read-enneagram-chart"
+    ],
+    "allowed_use": [
+      "section structure benchmark",
+      "reader journey benchmark",
+      "public-safe explanatory pattern benchmark"
+    ],
+    "forbidden_use": [
+      "copying proprietary wording",
+      "copying scoring claims",
+      "copying charts as assets",
+      "claiming external endorsement",
+      "claiming Enneagram is more accurate than other assessments"
+    ]
+  },
+  "forbidden_claim_families": [
+    "final_typing_you_are_this_type_claim",
+    "fixed_type_certainty_claim",
+    "diagnosis_therapy_treatment_claim",
+    "hiring_screen_or_employment_suitability_claim",
+    "success_salary_performance_prediction_claim",
+    "e105_fc144_score_comparison",
+    "fc144_more_accurate_or_replacement_result_claim",
+    "big_five_or_mbti_replacement_claim",
+    "raw_score_vector_public_leak",
+    "attempt_id_public_leak",
+    "private_report_payload_publication",
+    "internal_hash_or_schema_public_leak"
+  ],
+  "public_surface_forbidden_fields": [
+    "attempt_id",
+    "raw_score",
+    "raw_scores",
+    "score",
+    "score_vector",
+    "raw_score_vector",
+    "dominance_gap",
+    "profile_entropy",
+    "selector_trace",
+    "internal_metadata",
+    "source_selection_notes",
+    "candidate_manifest_sha256",
+    "runtime_registry_sha256",
+    "content_release_hash",
+    "private_report_payload",
+    "private_report_url"
+  ],
+  "future_pr_rules": {
+    "one_module_or_small_batch_per_pr": true,
+    "must_include_source_mapping": true,
+    "must_include_safety_report": true,
+    "must_include_diff_report": true,
+    "must_include_rollback_plan": true,
+    "must_not_update_candidate_baseline_silently": true,
+    "must_not_activate_or_import": true
+  },
+  "negative_guarantees": {
+    "generated_official_content": false,
+    "candidate_payloads_written": false,
+    "candidate_export_happened": false,
+    "inactive_import_happened": false,
+    "production_activation_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "cms_write_happened": false,
+    "frontend_change_happened": false
+  }
+}

--- a/backend/content_assets/enneagram/result_page/content_gap_plan/v0_1/content_asset_gap_plan_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/content_gap_plan/v0_1/content_asset_gap_plan_v0_1.json
@@ -1,0 +1,510 @@
+{
+  "schema_version": "fap.enneagram.result_page.content_gap_plan.v0.1",
+  "artifact_id": "enneagram_result_page_content_gap_plan_20260627",
+  "status": "planning_workspace_only",
+  "verdict": "READY_FOR_MODULE_WORKSPACE_REVIEW_NOT_CONTENT_GENERATION",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "activation_happened": false,
+  "candidate_export_happened": false,
+  "inactive_import_happened": false,
+  "bulk_content_generation_happened": false,
+  "source_refs": {
+    "backend_source_ledger": {
+      "repo": "fap-api",
+      "path": "content_assets/enneagram/result_page/source_ledger/source_ledger.json",
+      "schema_version": "fap.enneagram.result_page.source_ledger.v0.1"
+    },
+    "backend_asset_streams": [
+      {
+        "batch": "1R-A",
+        "path": "content_assets/enneagram/result_page/batch_1r_a/v0_1/assets.json",
+        "manifest_asset_count": 315,
+        "primary_modules": [
+          "instant_summary",
+          "all9_profile",
+          "type_deep_dive_summary",
+          "methodology_boundary_card"
+        ]
+      },
+      {
+        "batch": "1R-B",
+        "path": "content_assets/enneagram/result_page/batch_1r_b/v0_1/assets.json",
+        "manifest_asset_count": 423,
+        "primary_modules": [
+          "type_deep_dive_summary",
+          "growth_axis",
+          "relationship_need",
+          "stress_trigger",
+          "work_style_summary",
+          "seven_day_observation",
+          "methodology_boundary_card"
+        ]
+      },
+      {
+        "batch": "1R-C",
+        "path": "content_assets/enneagram/result_page/batch_1r_c/v0_1/assets.json",
+        "manifest_asset_count": 108,
+        "primary_modules": [
+          "methodology_boundary_card"
+        ]
+      },
+      {
+        "batch": "1R-D",
+        "path": "content_assets/enneagram/result_page/batch_1r_d/v0_1/assets.json",
+        "manifest_asset_count": 90,
+        "primary_modules": [
+          "all9_profile",
+          "close_call_card",
+          "growth_axis",
+          "relationship_need",
+          "stress_trigger",
+          "type_deep_dive_summary",
+          "work_style_summary",
+          "methodology_boundary_card"
+        ]
+      },
+      {
+        "batch": "1R-E",
+        "path": "content_assets/enneagram/result_page/batch_1r_e/v0_1/assets.json",
+        "manifest_asset_count": 108,
+        "primary_modules": [
+          "all9_profile",
+          "methodology_boundary_card"
+        ]
+      },
+      {
+        "batch": "1R-F",
+        "path": "content_assets/enneagram/result_page/batch_1r_f/v0_1/assets.json",
+        "manifest_asset_count": 36,
+        "primary_modules": [
+          "close_call_pair_card"
+        ]
+      },
+      {
+        "batch": "1R-G",
+        "path": "content_assets/enneagram/result_page/batch_1r_g/v0_1/assets.json",
+        "manifest_asset_count": 162,
+        "primary_modules": [
+          "scene_localization"
+        ]
+      },
+      {
+        "batch": "1R-H",
+        "path": "content_assets/enneagram/result_page/batch_1r_h/v0_1/assets.json",
+        "manifest_asset_count": 90,
+        "primary_modules": [
+          "form_recommendation"
+        ]
+      }
+    ],
+    "candidate_contract": {
+      "baseline_candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+      "runtime_registry_manifest_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+      "expected_candidate_payload_count": 630,
+      "launch_scope": [
+        "1R-A",
+        "1R-B",
+        "1R-C",
+        "1R-D",
+        "1R-E",
+        "1R-F",
+        "1R-G",
+        "1R-H"
+      ],
+      "out_of_launch_scope": [
+        "1R-I",
+        "1R-J"
+      ]
+    },
+    "rendered_inventory": {
+      "repo": "fap-web",
+      "pull_request": 1462,
+      "merge_commit": "41039084935ea7b7fadba93be62771d2a50d10b6",
+      "files": [
+        "docs/audits/enneagram-result-assets/01_rendered_asset_inventory.json",
+        "docs/audits/enneagram-result-assets/01_rendered_asset_inventory.md",
+        "tests/contracts/enneagram-rendered-asset-inventory.contract.test.ts"
+      ]
+    },
+    "benchmark_refs": [
+      {
+        "label": "123test Enneagram test",
+        "url": "https://www.123test.com/enneagram-test/",
+        "allowed_use": "public structure benchmark only",
+        "copy_allowed": false
+      },
+      {
+        "label": "Truity Enneagram Personality Test",
+        "url": "https://www.truity.com/test/enneagram-personality-test",
+        "allowed_use": "public structure benchmark only",
+        "copy_allowed": false
+      },
+      {
+        "label": "Truity Enneagram chart explanation",
+        "url": "https://www.truity.com/blog/how-do-you-read-enneagram-chart",
+        "allowed_use": "chart-reading UX benchmark only",
+        "copy_allowed": false
+      }
+    ]
+  },
+  "observed_rendered_gaps": [
+    {
+      "gap_id": "rendered_close_call_scaffold_copy",
+      "severity": "p1_content_gap",
+      "surface": "result_page",
+      "observed_issue": "Close-call section may render scaffold copy instead of final pair differentiation copy.",
+      "inventory_ref": "fap-web PR #1462",
+      "recommended_fix_lane": "close_call_pair_differentiation"
+    },
+    {
+      "gap_id": "rendered_raw_score_like_numbers",
+      "severity": "p1_public_boundary",
+      "surface": "result_page",
+      "observed_issue": "Rendered page inventory recorded raw-like numeric score displays such as 10000, 9270, 9554, and 9028.",
+      "inventory_ref": "fap-web PR #1462",
+      "recommended_fix_lane": "confidence_dominance_public_copy"
+    },
+    {
+      "gap_id": "rendered_internal_metric_copy",
+      "severity": "p1_public_boundary",
+      "surface": "result_page",
+      "observed_issue": "Dominance gap and profile entropy are useful QA metrics but should not become public result copy.",
+      "inventory_ref": "fap-web PR #1462",
+      "recommended_fix_lane": "confidence_dominance_public_copy"
+    },
+    {
+      "gap_id": "zh_cn_type_label_depth",
+      "severity": "p2_localization_depth",
+      "surface": "result_page",
+      "observed_issue": "English type labels may appear as the primary label in zh-CN user-facing sections.",
+      "inventory_ref": "fap-web PR #1462",
+      "recommended_fix_lane": "primary_type_deep_dive"
+    },
+    {
+      "gap_id": "certainty_copy_boundary",
+      "severity": "p1_claim_boundary",
+      "surface": "result_page",
+      "observed_issue": "Clear-state copy must avoid final typing certainty and keep leans-toward language.",
+      "inventory_ref": "fap-web PR #1462",
+      "recommended_fix_lane": "result_overview_hero"
+    },
+    {
+      "gap_id": "share_entry_gap",
+      "severity": "p2_surface_gap",
+      "surface": "share_pdf_history_compare",
+      "observed_issue": "Public-safe share entry and share/PDF/history/compare consumption need explicit module mapping.",
+      "inventory_ref": "fap-web PR #1462",
+      "recommended_fix_lane": "public_safe_share_pdf_history_compare"
+    },
+    {
+      "gap_id": "growth_module_repeated_copy_risk",
+      "severity": "p2_content_quality",
+      "surface": "result_page",
+      "observed_issue": "Growth and reflection modules may repeat generic phrasing instead of adding new motivation, relationship, and stress-pattern insight.",
+      "inventory_ref": "fap-web PR #1462",
+      "recommended_fix_lane": "growth_spectrum"
+    }
+  ],
+  "module_gap_plan": [
+    {
+      "module_id": "result_overview_hero",
+      "display_surface": "top summary and primary leaning",
+      "existing_backend_sources": [
+        "batch_1r_a.instant_summary",
+        "batch_1r_a.type_deep_dive_summary"
+      ],
+      "rendered_gap_refs": [
+        "certainty_copy_boundary"
+      ],
+      "workspace_status": "needs_boundary_copy_review",
+      "content_goal": "Explain the current leading tendency as a reflection cue, not a final type verdict.",
+      "future_pr_scope": "one small copy-boundary PR or one module asset PR",
+      "agent_allowed_output": [
+        "module payload draft",
+        "source mapping row",
+        "claim safety report",
+        "rendered diff expectation"
+      ]
+    },
+    {
+      "module_id": "top3_candidate_reading",
+      "display_surface": "top three type tendencies",
+      "existing_backend_sources": [
+        "batch_1r_a.all9_profile",
+        "batch_1r_d.all9_profile",
+        "batch_1r_e.all9_profile"
+      ],
+      "rendered_gap_refs": [
+        "rendered_raw_score_like_numbers",
+        "rendered_internal_metric_copy"
+      ],
+      "workspace_status": "needs_public_score_translation",
+      "content_goal": "Turn numeric ordering into public-safe tendency language and short comparison cues.",
+      "future_pr_scope": "top3 public-safe display PR",
+      "agent_allowed_output": [
+        "score-free ranking language",
+        "close-call caution language",
+        "source mapping row",
+        "leakage report"
+      ]
+    },
+    {
+      "module_id": "primary_type_deep_dive",
+      "display_surface": "primary type explanation",
+      "existing_backend_sources": [
+        "batch_1r_a.type_deep_dive_summary",
+        "batch_1r_b.type_deep_dive_summary",
+        "batch_1r_d.type_deep_dive_summary"
+      ],
+      "rendered_gap_refs": [
+        "zh_cn_type_label_depth"
+      ],
+      "workspace_status": "needs_depth_and_localization_review",
+      "content_goal": "Add motivation, defense pattern, stress clue, and growth cue without diagnosing or fixing identity.",
+      "future_pr_scope": "primary type deep-dive asset PR",
+      "agent_allowed_output": [
+        "module payload draft",
+        "localization notes",
+        "forbidden claim report"
+      ]
+    },
+    {
+      "module_id": "all9_profile_score_band",
+      "display_surface": "all nine type profile",
+      "existing_backend_sources": [
+        "batch_1r_a.all9_profile",
+        "batch_1r_d.all9_profile",
+        "batch_1r_e.all9_profile"
+      ],
+      "rendered_gap_refs": [
+        "rendered_raw_score_like_numbers"
+      ],
+      "workspace_status": "needs_score_band_policy",
+      "content_goal": "Describe relative prominence with labels such as stronger, present, mixed, or quieter instead of raw score display.",
+      "future_pr_scope": "all9 profile banding PR",
+      "agent_allowed_output": [
+        "band copy",
+        "display policy",
+        "negative leakage assertions"
+      ]
+    },
+    {
+      "module_id": "confidence_dominance_public_copy",
+      "display_surface": "confidence and result boundary",
+      "existing_backend_sources": [
+        "batch_1r_a.methodology_boundary_card",
+        "batch_1r_b.methodology_boundary_card",
+        "batch_1r_c.methodology_boundary_card",
+        "batch_1r_d.methodology_boundary_card",
+        "batch_1r_e.methodology_boundary_card"
+      ],
+      "rendered_gap_refs": [
+        "rendered_internal_metric_copy",
+        "certainty_copy_boundary"
+      ],
+      "workspace_status": "needs_public_metric_boundary",
+      "content_goal": "Explain confidence as a reading boundary without exposing dominance gap, entropy, raw scores, or vectors.",
+      "future_pr_scope": "confidence boundary PR",
+      "agent_allowed_output": [
+        "public confidence labels",
+        "private metric exclusion list",
+        "metadata leakage report"
+      ]
+    },
+    {
+      "module_id": "close_call_pair_differentiation",
+      "display_surface": "top two close-call comparison",
+      "existing_backend_sources": [
+        "batch_1r_d.close_call_card",
+        "batch_1r_f.close_call_pair_card"
+      ],
+      "rendered_gap_refs": [
+        "rendered_close_call_scaffold_copy"
+      ],
+      "workspace_status": "highest_priority_true_gap",
+      "content_goal": "Replace scaffold text with pair-specific motivation contrast, shared pattern, and reflection prompt.",
+      "future_pr_scope": "close-call pair asset PR",
+      "agent_allowed_output": [
+        "pair-specific public payload",
+        "source mapping report",
+        "scaffold-removal diff"
+      ]
+    },
+    {
+      "module_id": "work_reality",
+      "display_surface": "work style and task environment",
+      "existing_backend_sources": [
+        "batch_1r_b.work_style_summary",
+        "batch_1r_g.scene_localization"
+      ],
+      "rendered_gap_refs": [],
+      "workspace_status": "needs_depth_quality_review",
+      "content_goal": "Describe work-pattern reflection without employment-screening fit, screening, salary, success, or performance predictions.",
+      "future_pr_scope": "work module thickening PR",
+      "agent_allowed_output": [
+        "work reflection copy",
+        "hiring claim safety report"
+      ]
+    },
+    {
+      "module_id": "growth_spectrum",
+      "display_surface": "growth, stress, and seven-day observation",
+      "existing_backend_sources": [
+        "batch_1r_b.growth_axis",
+        "batch_1r_b.stress_trigger",
+        "batch_1r_b.seven_day_observation",
+        "batch_1r_d.growth_axis",
+        "batch_1r_d.stress_trigger"
+      ],
+      "rendered_gap_refs": [
+        "growth_module_repeated_copy_risk"
+      ],
+      "workspace_status": "needs_specificity_and_de_duplication",
+      "content_goal": "Make growth copy concrete, type-specific, and non-therapeutic while avoiding repetitive advice.",
+      "future_pr_scope": "growth module de-dup PR",
+      "agent_allowed_output": [
+        "growth payload draft",
+        "repetition report",
+        "clinical claim safety report"
+      ]
+    },
+    {
+      "module_id": "relationship_conflict",
+      "display_surface": "relationship and conflict reflection",
+      "existing_backend_sources": [
+        "batch_1r_b.relationship_need",
+        "batch_1r_g.scene_localization"
+      ],
+      "rendered_gap_refs": [],
+      "workspace_status": "needs_social_share_depth_review",
+      "content_goal": "Support relationship reflection and social discussion without diagnosing other people or assigning fixed roles.",
+      "future_pr_scope": "relationship module thickening PR",
+      "agent_allowed_output": [
+        "relationship reflection copy",
+        "public-safe share excerpt",
+        "forbidden claim report"
+      ]
+    },
+    {
+      "module_id": "method_observation_next",
+      "display_surface": "methodology, observation, and next test recommendation",
+      "existing_backend_sources": [
+        "batch_1r_a.methodology_boundary_card",
+        "batch_1r_b.methodology_boundary_card",
+        "batch_1r_c.methodology_boundary_card",
+        "batch_1r_h.form_recommendation"
+      ],
+      "rendered_gap_refs": [],
+      "workspace_status": "needs_cross_test_positioning",
+      "content_goal": "Position Enneagram as motivation-pattern reflection that complements Big Five and MBTI without superiority claims.",
+      "future_pr_scope": "method and cross-test CTA PR",
+      "agent_allowed_output": [
+        "method boundary copy",
+        "cross-test CTA copy",
+        "FC144 boundary report"
+      ]
+    },
+    {
+      "module_id": "public_safe_share_pdf_history_compare",
+      "display_surface": "share, PDF, history, compare",
+      "existing_backend_sources": [
+        "batch_1r_h.form_recommendation",
+        "controlled_pilot_observation",
+        "production_manual_gate"
+      ],
+      "rendered_gap_refs": [
+        "share_entry_gap"
+      ],
+      "workspace_status": "surface_contract_gap",
+      "content_goal": "Define public-safe excerpts and surface-specific exclusions for share cards, PDF, history, and compare views.",
+      "future_pr_scope": "share PDF history compare contract PR",
+      "agent_allowed_output": [
+        "surface-specific allowed fields",
+        "negative leakage assertions",
+        "public-safe summary draft"
+      ]
+    }
+  ],
+  "recommended_pr_sequence": [
+    {
+      "sequence": 1,
+      "title": "Enneagram close-call pair content workspace and scaffold removal",
+      "module_ids": [
+        "close_call_pair_differentiation"
+      ],
+      "reason": "This is the clearest true content gap because rendered inventory recorded scaffold copy."
+    },
+    {
+      "sequence": 2,
+      "title": "Enneagram score-free ranking and confidence copy",
+      "module_ids": [
+        "top3_candidate_reading",
+        "all9_profile_score_band",
+        "confidence_dominance_public_copy"
+      ],
+      "reason": "This removes raw-like numbers and private metric language from user-facing result copy."
+    },
+    {
+      "sequence": 3,
+      "title": "Enneagram primary type and zh-CN label depth",
+      "module_ids": [
+        "primary_type_deep_dive",
+        "result_overview_hero"
+      ],
+      "reason": "This improves depth while preserving leans-toward language."
+    },
+    {
+      "sequence": 4,
+      "title": "Enneagram growth and relationship thickening",
+      "module_ids": [
+        "growth_spectrum",
+        "relationship_conflict"
+      ],
+      "reason": "This targets the strategic motivation, stress, and relationship reflection layer."
+    },
+    {
+      "sequence": 5,
+      "title": "Enneagram work, method, and cross-test CTA thickening",
+      "module_ids": [
+        "work_reality",
+        "method_observation_next"
+      ],
+      "reason": "This adds practical reflection and Big Five/MBTI complement positioning without career screening claims."
+    },
+    {
+      "sequence": 6,
+      "title": "Enneagram public-safe share PDF history compare surface contract",
+      "module_ids": [
+        "public_safe_share_pdf_history_compare"
+      ],
+      "reason": "This turns public sharing into a safe growth surface without leaking private result state."
+    }
+  ],
+  "validation_requirements_for_future_content_prs": [
+    "source_mapping_zero_failures",
+    "metadata_leakage_zero",
+    "forbidden_claim_zero",
+    "fc144_boundary_zero",
+    "scaffold_copy_zero",
+    "raw_score_public_display_zero",
+    "fixed_type_certainty_zero",
+    "rendered_inventory_updated",
+    "rollback_plan_updated"
+  ],
+  "negative_guarantees": {
+    "generated_official_content": false,
+    "candidate_payloads_written": false,
+    "candidate_export_happened": false,
+    "inactive_import_happened": false,
+    "production_activation_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "cms_write_happened": false,
+    "frontend_change_happened": false,
+    "benchmark_copying_allowed": false
+  }
+}

--- a/backend/content_assets/enneagram/result_page/content_gap_plan/v0_1/content_asset_pack_workspace_v0_1.md
+++ b/backend/content_assets/enneagram/result_page/content_gap_plan/v0_1/content_asset_pack_workspace_v0_1.md
@@ -1,0 +1,289 @@
+# Enneagram Result Page Content Asset Workspace v0.1
+
+This is the editable workspace for Enneagram result-page content asset thickening. Use it to draft one small module or batch at a time, then convert the approved draft into repo-owned payloads in a future PR.
+
+This file is not runtime content. It is not a candidate package. It is not imported or activated.
+
+## Global Rules
+
+- Write for reflection: motivation, repeated patterns, stress cues, relationship tendencies, growth observations.
+- Do not write final type verdicts. Use "leans toward", "shows stronger signals", or "current result is closer to".
+- Do not diagnose, recommend treatment, screen for hiring, predict salary, predict success, or claim fixed identity.
+- Do not expose raw scores, score vectors, attempt ids, dominance gap, entropy, selector traces, release hashes, or private report payloads.
+- Benchmark 123test and Truity for section shape only. Do not copy their wording or claims.
+- Keep Big Five and MBTI as complements, not replacements or inferior alternatives.
+
+## Benchmark Links
+
+- 123test Enneagram test: https://www.123test.com/enneagram-test/
+- Truity Enneagram Personality Test: https://www.truity.com/test/enneagram-personality-test
+- Truity Enneagram chart explanation: https://www.truity.com/blog/how-do-you-read-enneagram-chart
+
+## Module 1: Result Overview Hero
+
+Current objective:
+Explain the user's current leading Enneagram tendency as a reflection cue.
+
+Observed gap:
+Clear-state copy must avoid direct identity-verdict phrasing and remain non-final.
+
+Existing backend sources:
+- `batch_1r_a.instant_summary`
+- `batch_1r_a.type_deep_dive_summary`
+
+Agent task:
+Draft short zh-CN copy for the hero, using score-free and non-final language.
+
+Output skeleton:
+
+```json
+{
+  "module_id": "result_overview_hero",
+  "locale": "zh-CN",
+  "type_code_or_pair": "TBD",
+  "scope": "clear|close_call|diffuse",
+  "public_payload": {
+    "heading": "",
+    "lead": "",
+    "body": "",
+    "reflection_prompt": "",
+    "boundary_note": ""
+  },
+  "source_trace": {
+    "source_ledger_row_id": "",
+    "source_asset_batch": "",
+    "source_asset_key": "",
+    "benchmark_refs_used": [],
+    "copy_policy": "original_paraphrase_only"
+  },
+  "safety_flags": {
+    "non_diagnostic": true,
+    "non_hiring": true,
+    "no_hard_typing": true,
+    "no_accuracy_superiority": true,
+    "no_score_vector_leak": true,
+    "public_safe_only": true
+  },
+  "rollback_notes": ""
+}
+```
+
+## Module 2: Top Three Candidate Reading
+
+Current objective:
+Explain the top three type tendencies without raw numbers.
+
+Observed gap:
+Rendered inventory found raw-like score displays and private metric language risk.
+
+Existing backend sources:
+- `batch_1r_a.all9_profile`
+- `batch_1r_d.all9_profile`
+- `batch_1r_e.all9_profile`
+
+Agent task:
+Write score-free ranking language: strongest signal, secondary signal, quieter but present signal.
+
+Avoid:
+- numeric scores,
+- percentage-like confidence,
+- dominance gap,
+- "this proves your type".
+
+## Module 3: Primary Type Deep Dive
+
+Current objective:
+Make the primary type section feel complete, localized, and useful.
+
+Content slots:
+- core motivation,
+- likely defense pattern,
+- stress reaction,
+- relationship cue,
+- growth cue,
+- reflection prompt.
+
+Existing backend sources:
+- `batch_1r_a.type_deep_dive_summary`
+- `batch_1r_b.type_deep_dive_summary`
+- `batch_1r_d.type_deep_dive_summary`
+
+Agent task:
+Draft one type at a time. Keep each paragraph specific enough to feel useful, but never fixed or diagnostic.
+
+## Module 4: All Nine Profile Score Band
+
+Current objective:
+Turn all-nine ordering into readable public-safe bands.
+
+Allowed public bands:
+- stronger signal,
+- present signal,
+- mixed signal,
+- quieter signal.
+
+Forbidden:
+- raw score,
+- score vector,
+- exact rank confidence,
+- private metric labels.
+
+Existing backend sources:
+- `batch_1r_a.all9_profile`
+- `batch_1r_d.all9_profile`
+- `batch_1r_e.all9_profile`
+
+Agent task:
+Write a short band explanation and a per-type micro-summary.
+
+## Module 5: Confidence and Dominance Boundary
+
+Current objective:
+Explain why results are a reading, not a verdict.
+
+Observed gap:
+Dominance gap and entropy should not appear in user-facing content.
+
+Existing backend sources:
+- `batch_1r_a.methodology_boundary_card`
+- `batch_1r_b.methodology_boundary_card`
+- `batch_1r_c.methodology_boundary_card`
+- `batch_1r_d.methodology_boundary_card`
+- `batch_1r_e.methodology_boundary_card`
+
+Agent task:
+Replace private metrics with public-safe guidance: clear leaning, close call, diffuse pattern, low-quality result.
+
+## Module 6: Close-Call Pair Differentiation
+
+Current objective:
+Replace scaffold copy with pair-specific contrast.
+
+Observed gap:
+Rendered inventory recorded scaffold text in the close-call section.
+
+Existing backend sources:
+- `batch_1r_d.close_call_card`
+- `batch_1r_f.close_call_pair_card`
+
+Agent task:
+For one pair at a time, write:
+- where the two types can look similar,
+- what motivation difference separates them,
+- what stress or relationship cue helps reflect,
+- a non-final boundary note.
+
+This is the highest-priority true content gap.
+
+## Module 7: Work Reality
+
+Current objective:
+Explain work style as reflection, not employment screening.
+
+Existing backend sources:
+- `batch_1r_b.work_style_summary`
+- `batch_1r_g.scene_localization`
+
+Forbidden:
+- employment-screening fit,
+- job fit judgment,
+- salary,
+- performance prediction,
+- promotion likelihood.
+
+Agent task:
+Write practical work-pattern reflection: attention, conflict, feedback, energy, overuse risk.
+
+## Module 8: Growth Spectrum
+
+Current objective:
+Make growth content concrete and not repetitive.
+
+Observed gap:
+Rendered inventory flagged repeated-copy risk.
+
+Existing backend sources:
+- `batch_1r_b.growth_axis`
+- `batch_1r_b.stress_trigger`
+- `batch_1r_b.seven_day_observation`
+- `batch_1r_d.growth_axis`
+- `batch_1r_d.stress_trigger`
+
+Agent task:
+Write type-specific observations and one seven-day experiment. Avoid therapy claims.
+
+## Module 9: Relationship and Conflict Reflection
+
+Current objective:
+Support social discussion and relationship reflection safely.
+
+Existing backend sources:
+- `batch_1r_b.relationship_need`
+- `batch_1r_g.scene_localization`
+
+Agent task:
+Write language users can discuss with friends or partners without labeling the other person.
+
+Avoid:
+- "your partner is",
+- diagnosis,
+- fixed role assignment,
+- manipulation advice.
+
+## Module 10: Method, Observation, and Next Step
+
+Current objective:
+Explain method boundaries and cross-test complement positioning.
+
+Existing backend sources:
+- `batch_1r_a.methodology_boundary_card`
+- `batch_1r_b.methodology_boundary_card`
+- `batch_1r_c.methodology_boundary_card`
+- `batch_1r_h.form_recommendation`
+
+Agent task:
+Position:
+- Enneagram as motivation-pattern reflection,
+- Big Five as trait structure,
+- MBTI as preference and communication style,
+- FC144 as a second lens only, not a more accurate replacement.
+
+## Module 11: Public-Safe Share, PDF, History, Compare
+
+Current objective:
+Define surface-safe excerpts for share/PDF/history/compare.
+
+Observed gap:
+Share entry and related surfaces need explicit public/private contract mapping.
+
+Allowed share content:
+- type ranking labels,
+- short public-safe tendency summary,
+- boundary note,
+- CTA.
+
+Forbidden share/PDF/history/compare content:
+- attempt id,
+- raw score,
+- score vector,
+- dominance gap,
+- entropy,
+- release hash,
+- schema version,
+- private report payload,
+- selector trace,
+- internal metadata.
+
+Agent task:
+Draft surface-specific allowed fields and negative assertions before writing any content payload.
+
+## Future PR Slicing
+
+1. Close-call pair content workspace and scaffold removal.
+2. Score-free ranking and confidence copy.
+3. Primary type and zh-CN label depth.
+4. Growth and relationship thickening.
+5. Work, method, and cross-test CTA thickening.
+6. Public-safe share/PDF/history/compare contract.
+
+Each future PR must include source mapping, safety report, diff report, rollback notes, and targeted tests.

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageContentGapPlanTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageContentGapPlanTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use Tests\TestCase;
+
+final class EnneagramResultPageContentGapPlanTest extends TestCase
+{
+    public function test_content_gap_plan_maps_rendered_inventory_to_backend_asset_streams_without_runtime_permissions(): void
+    {
+        $root = base_path('content_assets/enneagram/result_page/content_gap_plan/v0_1');
+        $plan = $this->readJson($root.'/content_asset_gap_plan_v0_1.json');
+
+        $this->assertSame('fap.enneagram.result_page.content_gap_plan.v0.1', $plan['schema_version'] ?? null);
+        $this->assertSame('planning_workspace_only', $plan['status'] ?? null);
+        $this->assertSame('not_runtime', $plan['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($plan['production_use_allowed'] ?? true));
+        $this->assertFalse((bool) ($plan['candidate_export_happened'] ?? true));
+        $this->assertFalse((bool) ($plan['inactive_import_happened'] ?? true));
+        $this->assertFalse((bool) ($plan['activation_happened'] ?? true));
+        $this->assertFalse((bool) ($plan['cms_write_performed'] ?? true));
+        $this->assertFalse((bool) ($plan['frontend_fallback_allowed'] ?? true));
+
+        $this->assertSame(
+            'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0',
+            data_get($plan, 'source_refs.candidate_contract.baseline_candidate_manifest_sha256')
+        );
+        $this->assertSame(
+            'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f',
+            data_get($plan, 'source_refs.candidate_contract.runtime_registry_manifest_sha256')
+        );
+        $this->assertSame(630, (int) data_get($plan, 'source_refs.candidate_contract.expected_candidate_payload_count'));
+        $this->assertSame(['1R-I', '1R-J'], data_get($plan, 'source_refs.candidate_contract.out_of_launch_scope'));
+        $this->assertSame('41039084935ea7b7fadba93be62771d2a50d10b6', data_get($plan, 'source_refs.rendered_inventory.merge_commit'));
+
+        $moduleIds = array_map(
+            static fn (array $module): string => (string) ($module['module_id'] ?? ''),
+            (array) ($plan['module_gap_plan'] ?? [])
+        );
+
+        foreach ([
+            'result_overview_hero',
+            'top3_candidate_reading',
+            'primary_type_deep_dive',
+            'all9_profile_score_band',
+            'confidence_dominance_public_copy',
+            'close_call_pair_differentiation',
+            'work_reality',
+            'growth_spectrum',
+            'relationship_conflict',
+            'method_observation_next',
+            'public_safe_share_pdf_history_compare',
+        ] as $expectedModule) {
+            $this->assertContains($expectedModule, $moduleIds);
+        }
+
+        $gapIds = array_map(
+            static fn (array $gap): string => (string) ($gap['gap_id'] ?? ''),
+            (array) ($plan['observed_rendered_gaps'] ?? [])
+        );
+
+        foreach ([
+            'rendered_close_call_scaffold_copy',
+            'rendered_raw_score_like_numbers',
+            'rendered_internal_metric_copy',
+            'zh_cn_type_label_depth',
+            'certainty_copy_boundary',
+            'share_entry_gap',
+            'growth_module_repeated_copy_risk',
+        ] as $expectedGap) {
+            $this->assertContains($expectedGap, $gapIds);
+        }
+
+        $benchmarkUrls = array_map(
+            static fn (array $ref): string => (string) ($ref['url'] ?? ''),
+            (array) data_get($plan, 'source_refs.benchmark_refs', [])
+        );
+        $this->assertContains('https://www.123test.com/enneagram-test/', $benchmarkUrls);
+        $this->assertContains('https://www.truity.com/test/enneagram-personality-test', $benchmarkUrls);
+
+        foreach ((array) ($plan['negative_guarantees'] ?? []) as $guarantee) {
+            $this->assertFalse((bool) $guarantee);
+        }
+    }
+
+    public function test_agent_generation_contract_blocks_private_fields_and_forbidden_claim_families(): void
+    {
+        $root = base_path('content_assets/enneagram/result_page/content_gap_plan/v0_1');
+        $contract = $this->readJson($root.'/agent_generation_contract_v0_1.json');
+
+        $this->assertSame('fap.enneagram.result_page.agent_generation_contract.v0.1', $contract['schema_version'] ?? null);
+        $this->assertFalse((bool) ($contract['agent_may_generate_bulk_content'] ?? true));
+        $this->assertFalse((bool) ($contract['agent_may_export_candidate'] ?? true));
+        $this->assertFalse((bool) ($contract['agent_may_import_candidate'] ?? true));
+        $this->assertFalse((bool) ($contract['agent_may_activate_runtime'] ?? true));
+        $this->assertFalse((bool) ($contract['agent_may_write_production'] ?? true));
+        $this->assertFalse((bool) ($contract['agent_may_write_cms'] ?? true));
+        $this->assertFalse((bool) ($contract['agent_may_change_frontend'] ?? true));
+
+        foreach ([
+            'final_typing_you_are_this_type_claim',
+            'fixed_type_certainty_claim',
+            'diagnosis_therapy_treatment_claim',
+            'hiring_screen_or_employment_suitability_claim',
+            'success_salary_performance_prediction_claim',
+            'e105_fc144_score_comparison',
+            'fc144_more_accurate_or_replacement_result_claim',
+            'raw_score_vector_public_leak',
+            'attempt_id_public_leak',
+            'private_report_payload_publication',
+        ] as $blockedFamily) {
+            $this->assertContains($blockedFamily, (array) ($contract['forbidden_claim_families'] ?? []));
+        }
+
+        foreach ([
+            'attempt_id',
+            'raw_score',
+            'score_vector',
+            'dominance_gap',
+            'profile_entropy',
+            'selector_trace',
+            'candidate_manifest_sha256',
+            'runtime_registry_sha256',
+            'private_report_payload',
+        ] as $blockedField) {
+            $this->assertContains($blockedField, (array) ($contract['public_surface_forbidden_fields'] ?? []));
+        }
+
+        foreach ((array) ($contract['negative_guarantees'] ?? []) as $guarantee) {
+            $this->assertFalse((bool) $guarantee);
+        }
+    }
+
+    public function test_workspace_is_editable_but_not_runtime_content(): void
+    {
+        $root = base_path('content_assets/enneagram/result_page/content_gap_plan/v0_1');
+        $workspace = (string) file_get_contents($root.'/content_asset_pack_workspace_v0_1.md');
+
+        foreach ([
+            'Module 1: Result Overview Hero',
+            'Module 6: Close-Call Pair Differentiation',
+            'Module 11: Public-Safe Share, PDF, History, Compare',
+            'This file is not runtime content.',
+            'Benchmark 123test and Truity for section shape only.',
+            'Do not expose raw scores',
+            'Do not write final type verdicts',
+        ] as $expectedText) {
+            $this->assertStringContainsString($expectedText, $workspace);
+        }
+
+        foreach ([
+            '/Users/rainie/',
+            '/private/tmp/',
+            'you are this type',
+            'FC144 is more accurate',
+            'salary prediction',
+            'hiring suitability',
+            'production_activation_happened\": true',
+        ] as $forbiddenText) {
+            $this->assertStringNotContainsString($forbiddenText, $workspace);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, $path.' must decode to an array');
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Summary
- Add a backend-owned Enneagram result-page content gap plan that maps fap-web rendered inventory findings to existing 1R-A through 1R-H backend asset streams.
- Add a module-by-module content workspace for GPT/Codex drafting, including close-call, score-free ranking, type deep-dive, growth, relationship, method, and public-safe share/PDF/history/compare lanes.
- Add an agent generation contract that locks allowed inputs/outputs, benchmark-use rules, forbidden claim families, private-field exclusions, and future PR boundaries.
- Add a focused unit test for the plan, workspace, and contract.

## Why
This gives the Enneagram content agent the same practical first step as the Big Five gap-plan flow: inventory and workspace first, then small scoped content PRs. It avoids turning the current asset pool into untraceable or non-importable generated content.

## Validation
- `php -l tests/Unit/Services/Enneagram/Assets/EnneagramResultPageContentGapPlanTest.php`
- `for f in content_assets/enneagram/result_page/content_gap_plan/v0_1/*.json; do php -r 'json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR); echo $argv[1].PHP_EOL;' "$f"; done`\n- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageContentGapPlanTest.php --no-ansi`\n- `git diff --check`\n\n## Intentionally Deferred\n- No official content generation.\n- No candidate payload export.\n- No inactive import.\n- No production activation.\n- No runtime switch.\n- No production or CMS writes.\n- No frontend changes.\n\n## Repository Rule Impact\nThis is backend-owned planning/workspace metadata for Enneagram result-page content assets. It does not introduce runtime content authority, frontend fallback content, CMS writes, or a new publishable surface.