### PR TITLE
fix(media): require confirmed OSS writes before synced status

### DIFF
--- a/backend/app/Services/Cms/MediaAssetStorageSyncService.php
+++ b/backend/app/Services/Cms/MediaAssetStorageSyncService.php
@@ -125,11 +125,25 @@ final class MediaAssetStorageSyncService
                 return false;
             }
 
-            Storage::disk($targetDisk)->put(
-                $this->targetPath($sourcePath),
+            $targetPath = $this->targetPath($sourcePath);
+            $target = Storage::disk($targetDisk);
+            $putResult = $target->put(
+                $targetPath,
                 Storage::disk($sourceDisk)->get($sourcePath),
                 'public'
             );
+
+            if ($putResult !== true) {
+                $failures[] = 'target write failed: '.$targetDisk.':'.$targetPath;
+
+                return false;
+            }
+
+            if (! $target->exists($targetPath)) {
+                $failures[] = 'target missing after write: '.$targetDisk.':'.$targetPath;
+
+                return false;
+            }
 
             return true;
         } catch (\Throwable $throwable) {

--- a/backend/tests/Feature/V0_5/MediaLibraryOssSyncTest.php
+++ b/backend/tests/Feature/V0_5/MediaLibraryOssSyncTest.php
@@ -6,8 +6,10 @@ namespace Tests\Feature\V0_5;
 
 use App\Models\AdminUser;
 use App\Models\MediaAsset;
+use App\Models\MediaVariant;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Services\Cms\MediaAssetStorageSyncService;
 use App\Support\Rbac\PermissionNames;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -97,6 +99,85 @@ final class MediaLibraryOssSyncTest extends TestCase
         $asset = MediaAsset::query()->withoutGlobalScopes()->where('asset_key', 'pr-media-01-failed-cover')->firstOrFail();
         $this->assertSame(MediaAsset::SYNC_FAILED, (string) $asset->sync_status);
         $this->assertNotSame('', trim((string) $asset->last_error));
+    }
+
+    public function test_media_sync_does_not_mark_synced_when_target_put_returns_false(): void
+    {
+        config([
+            'fap.media.oss_sync_enabled' => true,
+            'fap.media.oss_disk' => 's3',
+            'fap.media.oss_key_prefix' => 'storage',
+            'fap.media.cdn_verify_enabled' => false,
+        ]);
+
+        $asset = MediaAsset::query()->create([
+            'org_id' => 0,
+            'asset_key' => 'pr-media-01-put-false-cover',
+            'disk' => 'public',
+            'path' => 'media-library/sources/pr-media-01-put-false-cover/source.jpg',
+            'url' => null,
+            'mime_type' => 'image/jpeg',
+            'width' => 1600,
+            'height' => 900,
+            'bytes' => 1234,
+            'alt' => 'Put false cover',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'sync_status' => MediaAsset::SYNC_PENDING,
+            'cdn_status' => MediaAsset::CDN_NOT_VERIFIED,
+        ]);
+        MediaVariant::query()->create([
+            'media_asset_id' => (int) $asset->id,
+            'variant_key' => 'hero',
+            'path' => 'media-library/variants/pr-media-01-put-false-cover/hero_1600x900.jpg',
+            'url' => null,
+            'mime_type' => 'image/jpeg',
+            'width' => 1600,
+            'height' => 900,
+            'bytes' => 1234,
+            'sync_status' => MediaAsset::SYNC_PENDING,
+            'cdn_status' => MediaAsset::CDN_NOT_VERIFIED,
+        ]);
+
+        $sourceDisk = \Mockery::mock();
+        $sourceDisk->shouldReceive('exists')
+            ->with('media-library/sources/pr-media-01-put-false-cover/source.jpg')
+            ->andReturnTrue();
+        $sourceDisk->shouldReceive('exists')
+            ->with('media-library/variants/pr-media-01-put-false-cover/hero_1600x900.jpg')
+            ->andReturnTrue();
+        $sourceDisk->shouldReceive('get')
+            ->with('media-library/sources/pr-media-01-put-false-cover/source.jpg')
+            ->andReturn('source-binary');
+        $sourceDisk->shouldReceive('get')
+            ->with('media-library/variants/pr-media-01-put-false-cover/hero_1600x900.jpg')
+            ->andReturn('variant-binary');
+
+        $targetDisk = \Mockery::mock();
+        $targetDisk->shouldReceive('put')
+            ->with('storage/media-library/sources/pr-media-01-put-false-cover/source.jpg', 'source-binary', 'public')
+            ->andReturnFalse();
+        $targetDisk->shouldReceive('put')
+            ->with('storage/media-library/variants/pr-media-01-put-false-cover/hero_1600x900.jpg', 'variant-binary', 'public')
+            ->andReturnFalse();
+        $targetDisk->shouldNotReceive('exists');
+
+        Storage::shouldReceive('disk')->with('public')->andReturn($sourceDisk);
+        Storage::shouldReceive('disk')->with('s3')->andReturn($targetDisk);
+
+        app(MediaAssetStorageSyncService::class)->sync($asset);
+
+        $fresh = $asset->fresh('variants');
+        $this->assertSame(MediaAsset::SYNC_FAILED, (string) $fresh->sync_status);
+        $this->assertSame(MediaAsset::CDN_NOT_VERIFIED, (string) $fresh->cdn_status);
+        $this->assertStringContainsString('target write failed: s3:storage/media-library/sources/pr-media-01-put-false-cover/source.jpg', (string) $fresh->last_error);
+        $this->assertNull($fresh->synced_at);
+
+        $variant = $fresh->variants->firstWhere('variant_key', 'hero');
+        $this->assertNotNull($variant);
+        $this->assertSame(MediaAsset::SYNC_FAILED, (string) $variant->sync_status);
+        $this->assertStringContainsString('target write failed: s3:storage/media-library/variants/pr-media-01-put-false-cover/hero_1600x900.jpg', (string) $variant->last_error);
+        $this->assertNull($variant->synced_at);
     }
 
     private function actingAsContentWriter(): self


### PR DESCRIPTION
## What changed
- Hardened `MediaAssetStorageSyncService` so a target OSS write only counts as synced when `Storage::put()` returns `true`.
- Added a post-write target `exists()` check before returning sync success.
- Added a Media Library OSS sync regression test proving a misconfigured target disk / `put=false` marks both asset and variant as `sync_failed` and preserves `last_error`.

## Why
- Prevents false-positive `sync_status=synced` rows when OSS/CDN storage is misconfigured or silently rejects writes.
- Keeps Media Library / CMS image readiness fail-closed before article image metadata can be trusted for public assets-origin repair.

## Validation
- `php artisan test tests/Feature/V0_5/MediaLibraryOssSyncTest.php --no-ansi`
- `php artisan test tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php --no-ansi`
- `./vendor/bin/pint app/Services/Cms/MediaAssetStorageSyncService.php tests/Feature/V0_5/MediaLibraryOssSyncTest.php`
- `php artisan test tests/Feature/V0_5/MediaLibraryOssSyncTest.php tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php --no-ansi`
- `php artisan route:list --path=api/v0.5/internal/media-assets --no-ansi`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No production env/DNS/CDN/nginx writes.
- No CMS article metadata write.
- No publish, URL Truth, sitemap/llms, schema/hreflang, Search Channel, deploy, or article 58 image repair/revalidation.

## Repository rule impact
- Backend remains the source of truth for Media Library sync status and public media readiness.
- This does not add frontend fallback content or change content ownership; it tightens backend-authoritative media state.