### PR TITLE
MBTI64-NEXT-BATCH-6-COMPETITOR-GAP-CONTENT-EXPANSION-V2-APPROVAL-QUEUE-CONTRACT-PATCH-01: accept V2 QA state

### DIFF
--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
@@ -552,7 +552,7 @@ final class PersonalityAgentApprovalQueueWriter
     {
         $identity = $this->identityForRecommendation($recommendation);
         $recommendationJson = $this->jsonString($recommendation);
-        $qaDecision = (string) ($qaResult['decision'] ?? $qaResult['status'] ?? $qaResult['qa_status'] ?? '');
+        $qaDecision = (string) ($qaResult['decision'] ?? $qaResult['qa_decision'] ?? $qaResult['status'] ?? $qaResult['qa_status'] ?? '');
         $blockedReason = $this->blockedReason($recommendation, $qaResult, $identity, $recommendationJson);
 
         return [
@@ -599,7 +599,7 @@ final class PersonalityAgentApprovalQueueWriter
             return 'qa_result_missing';
         }
 
-        $decision = (string) ($qaResult['decision'] ?? $qaResult['status'] ?? $qaResult['qa_status'] ?? '');
+        $decision = (string) ($qaResult['decision'] ?? $qaResult['qa_decision'] ?? $qaResult['status'] ?? $qaResult['qa_status'] ?? '');
         if (! $this->qaDecisionPasses($decision)) {
             return 'qa_not_pass';
         }
@@ -719,6 +719,7 @@ final class PersonalityAgentApprovalQueueWriter
             'PASS_READY_FOR_APPROVAL_QUEUE',
             'PASS_READY_FOR_APPROVAL_REVIEW',
             'PASS_READY_FOR_APPROVAL_HANDOFF',
+            'PASS_READY_FOR_EDITORIAL_REVIEW_AND_APPROVAL_QUEUE_REPAIR',
             'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW',
             'READY_QUERY_BACKED_LOW_RISK_DRAFT_REVIEW',
         ], true);

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
@@ -994,12 +994,12 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
             'artifact' => 'MBTI64-NEXT-BATCH-6-COMPETITOR-GAP-CONTENT-EXPANSION-QA-01',
             'final_decision' => 'PASS_READY_FOR_EDITORIAL_REVIEW_AND_APPROVAL_QUEUE_REPAIR',
             'page_results' => [
-                $this->qaRow('https://fermatmind.com/zh/personality/intp-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
-                $this->qaRow('https://fermatmind.com/zh/personality/esfp-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
-                $this->qaRow('https://fermatmind.com/en/personality/enfj-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
-                $this->qaRow('https://fermatmind.com/en/personality/intp-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
-                $this->qaRow('https://fermatmind.com/en/personality/esfp-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
-                $this->qaRow('https://fermatmind.com/zh/personality/enfj-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
+                $this->qaDecisionRow('https://fermatmind.com/zh/personality/intp-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
+                $this->qaDecisionRow('https://fermatmind.com/zh/personality/esfp-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
+                $this->qaDecisionRow('https://fermatmind.com/en/personality/enfj-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
+                $this->qaDecisionRow('https://fermatmind.com/en/personality/intp-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
+                $this->qaDecisionRow('https://fermatmind.com/en/personality/esfp-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
+                $this->qaDecisionRow('https://fermatmind.com/zh/personality/enfj-a', 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW'),
             ],
         ];
     }
@@ -1126,6 +1126,19 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
         return [
             'target_url' => $targetUrl,
             'decision' => $decision,
+            'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $blockers
+     * @return array<string,mixed>
+     */
+    private function qaDecisionRow(string $targetUrl, string $decision, array $blockers = []): array
+    {
+        return [
+            'target_url' => $targetUrl,
+            'qa_decision' => $decision,
             'blockers' => $blockers,
         ];
     }


### PR DESCRIPTION
## Summary
- Allow the personality agent approval queue to treat `PASS_READY_FOR_EDITORIAL_REVIEW_AND_APPROVAL_QUEUE_REPAIR` as a queueable QA final decision.
- Accept per-page `qa_decision` fields in addition to the existing `decision` / `status` / `qa_status` shapes.
- Update the focused approval queue contract test to use the same `qa_decision` row shape emitted by the MBTI64 next-batch 6 competitor-gap expansion v2 QA artifact.

## Why
The backend artifact sync for MBTI64 next-batch 6 expansion v2 made the package available to fap-api, but the approval queue planner still blocked all 6 rows because the v2 QA artifact uses:

- top-level `final_decision=PASS_READY_FOR_EDITORIAL_REVIEW_AND_APPROVAL_QUEUE_REPAIR`
- per-page `qa_decision=PASS_READY_FOR_CONTENT_EXPANSION_REVIEW`

This patch lets those QA-passed rows enter human approval queue planning while preserving the write gate.

## Validation
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php --display-warnings`
- `php artisan personality:agent-approval-queue --dry-run --json --package=docs/seo/personality/mbti64-next-batch-6-competitor-gap-content-expansion-v2-2026-06-27.json --qa=docs/seo/personality/mbti64-next-batch-6-competitor-gap-content-expansion-v2-qa-2026-06-27.json`
  - `ok=true`
  - `planned_item_count=6`
  - `blocked_item_count=0`
  - `created_item_count=0`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only `PersonalityAgentApprovalQueueWriter.php` and `PersonalityAgentApprovalQueueCommandTest.php` changed.

## Deferred
- No approval queue write.
- No CMS draft write.
- No live content promotion.
- No publish/index/search.
- No sitemap/llms mutation.
- No frontend changes.
- No production deploy.
