### PR TITLE
BIG5-METHOD-BOUNDARY-RENDERED-PREVIEW-QA-01

### DIFF
--- a/backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1/README.md
+++ b/backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1/README.md
@@ -1,0 +1,32 @@
+# Big Five Method / Boundary Rendered Preview QA v0.1
+
+Status: pass
+
+This backend-only QA package checks the merged Method / Boundary v0.5 staging import against rendered-preview expectations for result page, PDF, share, history, and compare surfaces. It is evidence only: no runtime flag, production import, rollout, frontend copy, CMS write, SEO change, or live URL verification is included.
+
+## Source
+- Staging import: `content_assets/big5/result_page_v2/staging_candidate_imports/method_boundary_v0_5_staging_import`
+- Selector candidates: 14
+- Content candidates: 14
+
+## Surface Results
+- result_page: pass (method_boundary_cards_in_backend_defined_modules)
+- pdf: pass (private_report_boundary_notes_only)
+- share: pass (summary_only_share_safe_boundary)
+- history: pass (summary_only_no_private_detail)
+- compare: pass (summary_only_no_ranking_claim)
+
+## Hygiene And Copy Quality
+- Rendered hygiene hit count: 0
+- Too-long item count: 0
+- Duplicate title count: 0
+- Duplicate body count: 0
+- Max body chars: 188
+
+## Holds
+- no_runtime_enablement
+- no_production_import
+- no_rollout_change
+- no_frontend_copy
+- no_cms_or_search_publication
+- live_rendered_page_qa_deferred_until_accessible_fixture_or_pilot_url

--- a/backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1/SHA256SUMS
+++ b/backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1/SHA256SUMS
@@ -1,0 +1,2 @@
+8bda998f8725d98caf1d5fb0a5fb4e992a854f79cb08d2bef92c8c646bbabe62  README.md
+c1b5b40f5c433438215eb53d84ef9376f86bcf46579561c0fc82af2c8ece8c9d  big5_method_boundary_rendered_preview_qa_v0_1.json

--- a/backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1/big5_method_boundary_rendered_preview_qa_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1/big5_method_boundary_rendered_preview_qa_v0_1.json
@@ -1,0 +1,311 @@
+{
+  "schema": "fap.big5.result_page_v2.method_boundary.rendered_preview_qa.v0_1",
+  "package_key": "big5_result_page_v2.method_boundary_v0_5.rendered_preview_qa.v0_1",
+  "created_at_utc": "2026-06-28T00:00:00Z",
+  "mode": "backend_fixture_rendered_preview_qa",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "ready_for_asset_review": true,
+  "ready_for_pilot": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "source": {
+    "staging_import_dir": "content_assets/big5/result_page_v2/staging_candidate_imports/method_boundary_v0_5_staging_import",
+    "candidate_dir": "content_assets/big5/result_page_v2/agent_runs/method_boundary_v0_5_normalized",
+    "staging_import_validation_status": "pass",
+    "staging_write_performed": true
+  },
+  "counts": {
+    "selector_asset_candidates": 14,
+    "content_asset_candidates": 14,
+    "surface_count": 5,
+    "module_counts": {
+      "module_00_trust_bar": 1,
+      "module_08_share_save": 1,
+      "module_10_method_privacy": 12
+    },
+    "slot_counts": {
+      "module_00_trust_bar.boundary.non_type_boundary": 1,
+      "module_08_share_save.boundary.share_boundary": 1,
+      "module_10_method_privacy.boundary.low_quality_boundary": 1,
+      "module_10_method_privacy.boundary.non_clinical_prediction_boundary": 1,
+      "module_10_method_privacy.boundary.non_screening_boundary": 1,
+      "module_10_method_privacy.boundary.sensitive_content_boundary": 1,
+      "module_10_method_privacy.method.facet_method": 2,
+      "module_10_method_privacy.method.norm_method": 2,
+      "module_10_method_privacy.method.retest_method": 1,
+      "module_10_method_privacy.method.review_method": 1,
+      "module_10_method_privacy.method.score_band_boundary": 1,
+      "module_10_method_privacy.method.score_method": 1
+    }
+  },
+  "rendered_preview_scope": {
+    "evidence_type": "backend_fixture_only",
+    "final_result_contract_generated": false,
+    "frontend_copy_added": false,
+    "cms_or_search_changed": false,
+    "production_gate_changed": false,
+    "live_url_verified": false
+  },
+  "surface_matrix": [
+    {
+      "surface": "result_page",
+      "status": "pass",
+      "render_strategy": "method_boundary_cards_in_backend_defined_modules",
+      "expected_modules": [
+        "module_00_trust_bar",
+        "module_08_share_save",
+        "module_10_method_privacy"
+      ],
+      "candidate_count": 14,
+      "safety_notes": [
+        "full text allowed only in private result context",
+        "visible text scan has zero internal-token hits"
+      ]
+    },
+    {
+      "surface": "pdf",
+      "status": "pass",
+      "render_strategy": "private_report_boundary_notes_only",
+      "expected_modules": [
+        "module_10_method_privacy"
+      ],
+      "candidate_count": 0,
+      "safety_notes": [
+        "no private URL evidence stored",
+        "no score evidence stored"
+      ]
+    },
+    {
+      "surface": "share",
+      "status": "pass",
+      "render_strategy": "summary_only_share_safe_boundary",
+      "expected_modules": [
+        "module_08_share_save"
+      ],
+      "candidate_count": 1,
+      "safety_notes": [
+        "share card uses summary boundary only",
+        "no score or rank evidence stored"
+      ]
+    },
+    {
+      "surface": "history",
+      "status": "pass",
+      "render_strategy": "summary_only_no_private_detail",
+      "expected_modules": [
+        "module_10_method_privacy"
+      ],
+      "candidate_count": 14,
+      "safety_notes": [
+        "history can reference method boundary as short summary only"
+      ]
+    },
+    {
+      "surface": "compare",
+      "status": "pass",
+      "render_strategy": "summary_only_no_ranking_claim",
+      "expected_modules": [
+        "module_10_method_privacy"
+      ],
+      "candidate_count": 14,
+      "safety_notes": [
+        "compare must not turn method boundary into rank or diagnosis"
+      ]
+    }
+  ],
+  "visible_text_quality": {
+    "status": "pass",
+    "max_title_chars": 17,
+    "max_short_body_chars": 40,
+    "max_body_chars": 188,
+    "max_cta_chars": 47,
+    "too_long_count": 0,
+    "too_long_items": [],
+    "duplicate_title_count": 0,
+    "duplicate_body_count": 0,
+    "paragraph_count_min": 2,
+    "paragraph_count_max": 2,
+    "sentence_like_count_min": 4,
+    "sentence_like_count_max": 5,
+    "asset_metrics": [
+      {
+        "asset_key": "candidate.method_boundary.trust_bar_non_type_short.v0_5",
+        "module_key": "module_00_trust_bar",
+        "slot_key": "module_00_trust_bar.boundary.non_type_boundary",
+        "title_chars": 11,
+        "short_body_chars": 30,
+        "body_chars": 142,
+        "cta_chars": 30,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.scoring_layers_explained.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.method.score_method",
+        "title_chars": 8,
+        "short_body_chars": 38,
+        "body_chars": 176,
+        "cta_chars": 41,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.band_ranges_not_cutoffs.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.method.score_band_boundary",
+        "title_chars": 10,
+        "short_body_chars": 34,
+        "body_chars": 157,
+        "cta_chars": 37,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.thirty_facets_inference.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.method.facet_method",
+        "title_chars": 14,
+        "short_body_chars": 33,
+        "body_chars": 176,
+        "cta_chars": 44,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.facet_domain_mismatch_reading.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.method.facet_method",
+        "title_chars": 14,
+        "short_body_chars": 38,
+        "body_chars": 153,
+        "cta_chars": 38,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.norm_three_state_reading.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.method.norm_method",
+        "title_chars": 7,
+        "short_body_chars": 36,
+        "body_chars": 165,
+        "cta_chars": 47,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.norm_unavailable_still_useful.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.method.norm_method",
+        "title_chars": 14,
+        "short_body_chars": 34,
+        "body_chars": 167,
+        "cta_chars": 40,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.low_quality_show_soften_hide.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.boundary.low_quality_boundary",
+        "title_chars": 13,
+        "short_body_chars": 30,
+        "body_chars": 175,
+        "cta_chars": 33,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 4
+      },
+      {
+        "asset_key": "candidate.method_boundary.surface_privacy_matrix.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.boundary.sensitive_content_boundary",
+        "title_chars": 11,
+        "short_body_chars": 40,
+        "body_chars": 182,
+        "cta_chars": 37,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 4
+      },
+      {
+        "asset_key": "candidate.method_boundary.share_safe_boundary.v0_5",
+        "module_key": "module_08_share_save",
+        "slot_key": "module_08_share_save.boundary.share_boundary",
+        "title_chars": 13,
+        "short_body_chars": 31,
+        "body_chars": 166,
+        "cta_chars": 36,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 4
+      },
+      {
+        "asset_key": "candidate.method_boundary.organization_use_boundary.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.boundary.non_screening_boundary",
+        "title_chars": 17,
+        "short_body_chars": 35,
+        "body_chars": 188,
+        "cta_chars": 32,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.clinical_and_prediction_limit.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.boundary.non_clinical_prediction_boundary",
+        "title_chars": 13,
+        "short_body_chars": 33,
+        "body_chars": 180,
+        "cta_chars": 36,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      },
+      {
+        "asset_key": "candidate.method_boundary.retest_frequency_and_trend.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.method.retest_method",
+        "title_chars": 10,
+        "short_body_chars": 32,
+        "body_chars": 167,
+        "cta_chars": 37,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 4
+      },
+      {
+        "asset_key": "candidate.method_boundary.deep_reading_evidence_strength.v0_5",
+        "module_key": "module_10_method_privacy",
+        "slot_key": "module_10_method_privacy.method.review_method",
+        "title_chars": 11,
+        "short_body_chars": 29,
+        "body_chars": 176,
+        "cta_chars": 41,
+        "body_paragraph_count": 2,
+        "sentence_like_count": 5
+      }
+    ]
+  },
+  "rendered_hygiene_scan": {
+    "status": "pass",
+    "scan_scope": "staging_candidate_visible_text_fields_only",
+    "hit_count": 0,
+    "hits": [],
+    "rule_count": 11
+  },
+  "acceptance": {
+    "result_page_position_correct": true,
+    "share_boundary_present": true,
+    "pdf_share_history_compare_safe": true,
+    "no_rendered_hygiene_hits": true,
+    "copy_quality_pass": true
+  },
+  "remaining_holds": [
+    "no_runtime_enablement",
+    "no_production_import",
+    "no_rollout_change",
+    "no_frontend_copy",
+    "no_cms_or_search_publication",
+    "live_rendered_page_qa_deferred_until_accessible_fixture_or_pilot_url"
+  ],
+  "status": "pass"
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -1389,6 +1389,87 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_committed_method_boundary_v0_5_rendered_preview_qa_is_redacted_and_non_runtime(): void
+    {
+        $qaDir = base_path('content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1');
+
+        foreach ([
+            'README.md',
+            'SHA256SUMS',
+            'big5_method_boundary_rendered_preview_qa_v0_1.json',
+        ] as $filename) {
+            $this->assertFileExists($qaDir.'/'.$filename);
+        }
+
+        $report = $this->readJson($qaDir.'/big5_method_boundary_rendered_preview_qa_v0_1.json');
+
+        $this->assertSame('fap.big5.result_page_v2.method_boundary.rendered_preview_qa.v0_1', $report['schema'] ?? null);
+        $this->assertSame('pass', $report['status'] ?? null);
+        $this->assertSame('not_runtime', $report['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_pilot'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_runtime'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_production'] ?? true));
+        $this->assertSame(
+            'content_assets/big5/result_page_v2/staging_candidate_imports/method_boundary_v0_5_staging_import',
+            data_get($report, 'source.staging_import_dir')
+        );
+        $this->assertSame(14, data_get($report, 'counts.selector_asset_candidates'));
+        $this->assertSame(14, data_get($report, 'counts.content_asset_candidates'));
+        $this->assertSame(1, data_get($report, 'counts.module_counts.module_00_trust_bar'));
+        $this->assertSame(1, data_get($report, 'counts.module_counts.module_08_share_save'));
+        $this->assertSame(12, data_get($report, 'counts.module_counts.module_10_method_privacy'));
+
+        $surfaces = collect((array) ($report['surface_matrix'] ?? []))->pluck('status', 'surface');
+        foreach (['result_page', 'pdf', 'share', 'history', 'compare'] as $surface) {
+            $this->assertSame('pass', $surfaces->get($surface), $surface);
+        }
+
+        $this->assertSame('pass', data_get($report, 'visible_text_quality.status'));
+        $this->assertSame(0, data_get($report, 'visible_text_quality.too_long_count'));
+        $this->assertSame(0, data_get($report, 'visible_text_quality.duplicate_title_count'));
+        $this->assertSame(0, data_get($report, 'visible_text_quality.duplicate_body_count'));
+        $this->assertLessThanOrEqual(360, (int) data_get($report, 'visible_text_quality.max_body_chars'));
+        $this->assertSame('pass', data_get($report, 'rendered_hygiene_scan.status'));
+        $this->assertSame(0, data_get($report, 'rendered_hygiene_scan.hit_count'));
+        $this->assertSame([], data_get($report, 'rendered_hygiene_scan.hits'));
+        $this->assertTrue((bool) data_get($report, 'acceptance.result_page_position_correct'));
+        $this->assertTrue((bool) data_get($report, 'acceptance.share_boundary_present'));
+        $this->assertTrue((bool) data_get($report, 'acceptance.pdf_share_history_compare_safe'));
+        $this->assertTrue((bool) data_get($report, 'acceptance.no_rendered_hygiene_hits'));
+        $this->assertTrue((bool) data_get($report, 'acceptance.copy_quality_pass'));
+        $this->assertContains('no_runtime_enablement', (array) ($report['remaining_holds'] ?? []));
+        $this->assertContains('live_rendered_page_qa_deferred_until_accessible_fixture_or_pilot_url', (array) ($report['remaining_holds'] ?? []));
+
+        $allArtifacts = implode("\n", array_map(
+            static fn (string $path): string => (string) file_get_contents($path),
+            glob($qaDir.'/*') ?: []
+        ));
+
+        foreach ([
+            'private_url',
+            'attempt_id',
+            'raw_score',
+            'raw score',
+            'percentile',
+            'fixed_type',
+            'user_confirmed_type',
+            'type_code',
+            'big5:',
+            'band:',
+            'payload',
+            'registry',
+            'PR3B',
+            'AttemptReadController',
+            'Big Five Report Engine',
+            '[object Object]',
+            '本 由 生成',
+            '不代表生产 已接入',
+        ] as $forbiddenToken) {
+            $this->assertStringNotContainsString($forbiddenToken, $allArtifacts, $forbiddenToken);
+        }
+    }
+
     public function test_strict_mode_rejects_public_payload_and_shareable_score_leaks(): void
     {
         $root = $this->tempDir('big5-v2-agent-leak');


### PR DESCRIPTION
## What changed
- Added a backend-only Method / Boundary rendered preview QA package for the merged v0.5 staging import.
- Covered result page, PDF, share, history, and compare surface expectations with redacted evidence.
- Added a committed artifact PHPUnit guard to keep the package non-runtime, production-disallowed, redacted, and hygiene-clean.

## Why
The Method / Boundary candidates had passed normalization and staging import, but still needed rendered-preview evidence before any future fixture/runtime discussion.

## Validation
- php artisan test --filter=BigFiveResultPageV2AssetAgentTest
- php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest
- python3 -m json.tool backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1/big5_method_boundary_rendered_preview_qa_v0_1.json
- cd backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1 && shasum -a 256 -c SHA256SUMS
- rg -n "big5:|band:|payload|registry|PR3B|AttemptReadController|Big Five Report Engine|\[object Object\]|private_url|attempt_id|raw_score|raw score|percentile|fixed_type|user_confirmed_type|type_code" backend/content_assets/big5/result_page_v2/qa/method_boundary_rendered_preview/v0_1 || true
- git diff --check

## Intentionally deferred
- No runtime enablement.
- No production import, rollout, or gate change.
- No fap-web copy.
- No CMS, SEO, search, or deploy action.
- Live rendered page verification remains deferred until an accessible fixture or pilot URL is authorized.

## Repository rule impact
This is a backend QA artifact-only change. Big Five result-page content authority remains in backend content assets; no frontend or CMS authority changes are introduced.