### PR TITLE
MBTI-PDF-GOTENBERG-PRODUCTION-01: prefer Gotenberg for MBTI PDFs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -43,6 +43,16 @@ OPS_CONTENT_RELEASE_CACHE_INVALIDATION_URLS=
 OPS_CONTENT_RELEASE_CACHE_INVALIDATION_SECRET=
 
 # =========================
+# PDF rendering
+# =========================
+GOTENBERG_PDF_ENABLED=false
+GOTENBERG_BASE_URL=
+# Private/internal frontend origin for Chromium result-page printing.
+# Must be HTTP on localhost, VPC, or an internal DNS name; do not use public HTTPS.
+GOTENBERG_RESULT_PRINT_BASE_URL=
+GOTENBERG_RESULT_PRINT_PATH_TEMPLATE=/{locale}/attempts/{attempt_id}/report
+
+# =========================
 # DB (CI-safe default)
 # =========================
 DB_CONNECTION=sqlite

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -10,14 +10,16 @@ use App\Models\Result;
 use App\Services\Report\Pdf\Mbti\MbtiPdfPayloadBuilder;
 use Mpdf\Mpdf;
 use Mpdf\Output\Destination;
+use Throwable;
 
 final class ReportPdfDocumentService
 {
-    private const MBTI_PDF_SURFACE_VERSION = 'mbti.pdf_surface.v3';
+    private const MBTI_PDF_SURFACE_VERSION = 'mbti.pdf_surface.v4';
 
     public function __construct(
         private readonly ReportPdfArtifactStore $artifactStore,
         private readonly MbtiPdfPayloadBuilder $mbtiPdfPayloadBuilder,
+        private readonly GotenbergChromiumPdfClient $gotenbergChromiumPdfClient,
     ) {}
 
     public function normalizeVariant(string $variant): string
@@ -445,6 +447,11 @@ final class ReportPdfDocumentService
 
     private function buildMbtiDocument(Attempt $attempt, ?Result $result): string
     {
+        $gotenbergPdf = $this->buildMbtiGotenbergDocument($attempt);
+        if (is_string($gotenbergPdf)) {
+            return $gotenbergPdf;
+        }
+
         $locale = strtolower(trim((string) ($attempt->locale ?? '')));
         $isChinese = str_starts_with($locale, 'zh');
         $payload = $this->mbtiPdfPayload($attempt, $result);
@@ -488,6 +495,48 @@ final class ReportPdfDocumentService
             $isChinese ? 'FermatMind · 费马测试' : 'FermatMind',
             $isChinese
         );
+    }
+
+    private function buildMbtiGotenbergDocument(Attempt $attempt): ?string
+    {
+        if (! $this->gotenbergChromiumPdfClient->enabled()) {
+            return null;
+        }
+
+        $printUrl = $this->mbtiResultPrintUrl($attempt);
+        if ($printUrl === null) {
+            return null;
+        }
+
+        try {
+            return $this->gotenbergChromiumPdfClient->convertUrl($printUrl);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function mbtiResultPrintUrl(Attempt $attempt): ?string
+    {
+        $baseUrl = rtrim(trim((string) config('gotenberg.result_print_base_url', '')), '/');
+        if ($baseUrl === '') {
+            return null;
+        }
+
+        $locale = trim((string) ($attempt->locale ?? ''));
+        $locale = $locale !== '' ? $locale : 'en';
+        $attemptId = trim((string) $attempt->id);
+        if ($attemptId === '') {
+            return null;
+        }
+
+        $pathTemplate = trim((string) config('gotenberg.result_print_path_template', '/{locale}/attempts/{attempt_id}/report'));
+        $pathTemplate = $pathTemplate !== '' ? $pathTemplate : '/{locale}/attempts/{attempt_id}/report';
+        $path = strtr($pathTemplate, [
+            '{locale}' => rawurlencode($locale),
+            '{attempt_id}' => rawurlencode($attemptId),
+        ]);
+
+        return $baseUrl.'/'.ltrim($path, '/');
     }
 
     /**

--- a/backend/config/gotenberg.php
+++ b/backend/config/gotenberg.php
@@ -3,6 +3,11 @@
 return [
     'enabled' => (bool) env('GOTENBERG_PDF_ENABLED', false),
     'base_url' => env('GOTENBERG_BASE_URL', ''),
+    'result_print_base_url' => env('GOTENBERG_RESULT_PRINT_BASE_URL', ''),
+    'result_print_path_template' => env(
+        'GOTENBERG_RESULT_PRINT_PATH_TEMPLATE',
+        '/{locale}/attempts/{attempt_id}/report'
+    ),
     'timeout_seconds' => (int) env('GOTENBERG_TIMEOUT_SECONDS', 30),
     'connect_timeout_seconds' => (int) env('GOTENBERG_CONNECT_TIMEOUT_SECONDS', 5),
     'allow_single_label_hosts' => (bool) env('GOTENBERG_ALLOW_SINGLE_LABEL_HOSTS', true),

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -9,6 +9,7 @@ use App\Models\Result;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -157,7 +158,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf->assertHeader('Content-Type', 'application/pdf');
         $pdf->assertHeader('X-Report-Scale', 'MBTI');
         $pdf->assertHeader('X-Report-Locked', 'true');
-        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.pdf_surface.v3');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.pdf_surface.v4');
 
         $pdfBinary = (string) $pdf->getContent();
         $this->assertStringStartsWith('%PDF-1.4', $pdfBinary);
@@ -168,7 +169,69 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         );
         $this->assertStringEndsWith('.pdf"', (string) $pdf->headers->get('Content-Disposition'));
         Storage::disk('local')->assertExists(
-            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.pdf_surface.v3/report_free.pdf"
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.pdf_surface.v4/report_free.pdf"
+        );
+    }
+
+    public function test_public_mbti_report_pdf_prefers_gotenberg_result_print_route_when_enabled(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'http://gotenberg:3000');
+        config()->set('gotenberg.result_print_base_url', 'http://frontend:3000');
+        Storage::fake('local');
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_mbti_pdf_gotenberg';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, 'MBTI', $anonId);
+        $this->createResult($attemptId);
+
+        $gotenbergPdf = implode("\n", [
+            '%PDF-1.4',
+            '<< /Producer (Chromium) >>',
+            'MBTI 完整人格报告',
+            'Personality Traits',
+            'Your Career Path',
+            'Your Personal Growth',
+            'Your Relationships',
+            '%%EOF',
+        ]);
+
+        Http::fake([
+            'gotenberg:3000/forms/chromium/convert/url' => Http::response($gotenbergPdf, 200, [
+                'Content-Type' => 'application/pdf',
+            ]),
+        ]);
+
+        $headers = [
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ];
+
+        $pdf = $this->withHeaders($headers)->get("/api/v0.3/attempts/{$attemptId}/report.pdf");
+
+        $pdf->assertStatus(200);
+        $pdf->assertHeader('Content-Type', 'application/pdf');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.pdf_surface.v4');
+
+        $pdfBinary = (string) $pdf->getContent();
+        $this->assertStringStartsWith('%PDF-1.4', $pdfBinary);
+        $this->assertStringContainsString('/Producer (Chromium)', $pdfBinary);
+        $this->assertStringNotContainsString('mPDF', $pdfBinary);
+        $this->assertStringContainsString('Personality Traits', $pdfBinary);
+        $this->assertStringContainsString('Your Career Path', $pdfBinary);
+        $this->assertStringContainsString('Your Personal Growth', $pdfBinary);
+        $this->assertStringContainsString('Your Relationships', $pdfBinary);
+
+        Http::assertSent(function ($request): bool {
+            return $request->method() === 'POST'
+                && $request->url() === 'http://gotenberg:3000/forms/chromium/convert/url';
+        });
+
+        Storage::disk('local')->assertExists(
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.pdf_surface.v4/report_free.pdf"
         );
     }
 


### PR DESCRIPTION
## What changed
- Routes MBTI `report.pdf` generation through the existing Gotenberg Chromium client when `GOTENBERG_PDF_ENABLED=true` and a private `GOTENBERG_RESULT_PRINT_BASE_URL` is configured.
- Uses the frontend private/noindex print route path template `/{locale}/attempts/{attempt_id}/report` as the print target.
- Keeps the existing mPDF renderer as fallback when Gotenberg is disabled, not configured, or fails.
- Bumps MBTI PDF surface version to `mbti.pdf_surface.v4` so old mPDF artifacts do not continue to satisfy new downloads.
- Adds non-secret `.env.example` guidance for the required private frontend print origin.

## Why
The production Gotenberg runtime exists, but the MBTI public PDF path still generated from the backend mPDF renderer. That kept downloads as partial/report-summary PDFs rather than Chromium prints of the result-page surface.

## Validation
- `php artisan test tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/Report/PdfGotenbergEngineSpikeTest.php tests/Feature/V0_3/MbtiReadPathParityContractTest.php --no-ansi`
- `./vendor/bin/pint --dirty --no-interaction`
- `git diff --check`
- `RUN_BIG5_OCEAN_GATE=0 RUN_ENNEAGRAM_GATE=0 RUN_PARTNER_API_SMOKE=0 RUN_OPENAPI_DIFF_GATE=0 RUN_FULL_SCALE_REGRESSION=0 RUN_MBTI_SMOKE=1 ACCEPT_PHONE=0 bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No frontend changes.
- No CMS, DB, queue, search, indexing, or scheduler changes.
- No production deploy.
- Runtime still needs Ops to set `GOTENBERG_RESULT_PRINT_BASE_URL` to a private/internal frontend origin before production Chromium rendering can take effect.
