### PR TITLE
BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01: Add Big Five content asset benchmark rubric

### DIFF
--- a/backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1/README.md
+++ b/backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1/README.md
@@ -1,0 +1,28 @@
+# Big Five Content Asset Benchmark Rubric v0.1
+
+Status: pass
+
+This backend-only package defines the first-pass content thickening standard for Big Five V2 result-page assets. It uses 123test and Truity as structure and quality references only; it does not copy their wording, questions, report text, or proprietary layouts.
+
+This package is not runtime content. It does not generate candidate assets, stage content, build a final result contract, write CMS, modify fap-web, trigger SEO/search, or change runtime/production gates.
+
+## What It Standardizes
+
+- Commercial-report depth expectations for domain bands, facets, couplings, profiles, scenarios, safe surfaces, and edge states.
+- Safety boundaries for non-diagnostic, non-hiring, non-clinical, non-deterministic Big Five explanations.
+- SEO/GEO readability requirements: clear definitions, answerable sections, method boundaries, and AI-search-safe summaries.
+- Rendered hygiene expectations for future candidate/staging PRs.
+
+## Future PRs
+
+The train sequence after this rubric is:
+
+1. BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01
+2. BIG5-FACET-CONTENT-THICKENING-01
+3. BIG5-COUPLING-CONTENT-THICKENING-01
+4. BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01
+5. BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01
+6. BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01
+7. BIG5-NORM-LOW-QUALITY-EDGE-STATE-CONTENT-01
+
+All future content PRs must remain backend-authoritative and keep `production_use_allowed=false` until a separate reviewed production path is authorized.

--- a/backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1/SHA256SUMS
+++ b/backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1/SHA256SUMS
@@ -1,0 +1,2 @@
+b48fea404621efe56fa8df07e6383825d242da23c15dfc4f2853f7529486aa1a  README.md
+b97ee090ec2a3edfdb3ede7d0f0f5721f7d6e1a9738627a33de5670b0179b3ee  big5_content_asset_benchmark_rubric_v0_1.json

--- a/backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1/big5_content_asset_benchmark_rubric_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1/big5_content_asset_benchmark_rubric_v0_1.json
@@ -1,0 +1,332 @@
+{
+  "schema": "fap.big5.result_page_v2.content_asset_benchmark_rubric.v0_1",
+  "package_key": "big5_result_page_v2.content_asset_benchmark_rubric.v0_1",
+  "created_at_utc": "2026-06-28T00:00:00Z",
+  "status": "pass",
+  "mode": "benchmark_rubric_only",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "ready_for_pilot": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "scope": {
+    "fap_api_only": true,
+    "candidate_generation_performed": false,
+    "staging_import_performed": false,
+    "final_result_contract_generated": false,
+    "frontend_copy_added": false,
+    "cms_or_search_changed": false,
+    "runtime_or_production_gate_changed": false
+  },
+  "reference_sources": [
+    {
+      "source_id": "source_123test_big_five_test",
+      "label": "structure_reference_only",
+      "url": "https://www.123test.com/personality-test/",
+      "allowed_use": [
+        "module_coverage_reference",
+        "reader_expectation_reference",
+        "commercial_depth_reference"
+      ],
+      "forbidden_use": [
+        "copy_text",
+        "copy_questions",
+        "copy_report_language",
+        "copy_proprietary_layout"
+      ],
+      "notes": "Use as a high-level reference for free report expectations, 30 subscale awareness, instruction clarity, and extended-report information density."
+    },
+    {
+      "source_id": "source_123test_big_five_theory",
+      "label": "structure_reference_only",
+      "url": "https://www.123test.com/big-five-personality-theory/",
+      "allowed_use": [
+        "methodology_structure_reference",
+        "trait_overview_reference",
+        "faq_structure_reference"
+      ],
+      "forbidden_use": [
+        "copy_text",
+        "copy_claims_without_review",
+        "copy_references_without_source_review"
+      ],
+      "notes": "Use as a reference for theory-page structure and plain-language trait explanation patterns."
+    },
+    {
+      "source_id": "source_truity_big_five_test",
+      "label": "structure_reference_only",
+      "url": "https://www.truity.com/test/big-five-personality-test",
+      "allowed_use": [
+        "result_expectation_reference",
+        "faq_structure_reference",
+        "trust_signal_reference",
+        "trait_spectrum_reference"
+      ],
+      "forbidden_use": [
+        "copy_text",
+        "copy_questions",
+        "copy_report_language",
+        "copy_paid_report_positioning"
+      ],
+      "notes": "Use as a reference for spectrum framing, FAQ coverage, and user-facing trust cues while preserving FermatMind free-full-report positioning."
+    },
+    {
+      "source_id": "source_ipip_open_psychometrics_big_five",
+      "label": "public_domain_source",
+      "url": "https://openpsychometrics.org/tests/IPIP-BFFM/",
+      "allowed_use": [
+        "open_measurement_context",
+        "scale_response_structure_reference"
+      ],
+      "forbidden_use": [
+        "unreviewed_item_copy_into_result_page",
+        "replace_fermatmind_scoring_authority"
+      ],
+      "notes": "Use only for open measurement context and source-boundary clarity; FermatMind scoring and result contracts remain backend authority."
+    }
+  ],
+  "content_asset_rubric": {
+    "global_requirements": [
+      "Every candidate must be user-readable without internal implementation terms.",
+      "Every candidate must explain what the result can suggest and what it cannot prove.",
+      "Every candidate must include at least one practical reading or action frame when the slot is not purely policy text.",
+      "Every candidate must preserve continuous-trait language rather than fixed personality type language.",
+      "Every candidate must remain useful when rendered in Chinese first, with later bilingual expansion possible."
+    ],
+    "commercial_depth_components": [
+      "plain_language_explanation",
+      "strength_or_useful_signal",
+      "risk_or_overuse_pattern",
+      "common_misread",
+      "action_guidance",
+      "boundary_statement",
+      "scenario_or_reflection_prompt"
+    ],
+    "seo_geo_components": [
+      "OCEAN_term_alignment",
+      "reader_question_answerability",
+      "definition_before_application",
+      "comparison_safe_language",
+      "method_boundary_visibility",
+      "FAQ_ready_atomic_claims",
+      "AI_search_quote_safe_summary"
+    ],
+    "editorial_quality_thresholds": {
+      "title_zh_max_chars": 36,
+      "short_body_zh_target_chars": "24-80",
+      "body_zh_target_chars": "140-360",
+      "cta_zh_max_chars": 80,
+      "minimum_sentence_like_count": 3,
+      "maximum_repeated_body_hash_count": 1,
+      "avoid_template_density": true,
+      "avoid_strategy_jargon": true
+    },
+    "safety_requirements": [
+      "non_diagnostic",
+      "non_hiring",
+      "non_clinical",
+      "non_deterministic",
+      "non_income_prediction",
+      "non_relationship_destiny",
+      "no_hard_typing",
+      "no_frontend_fallback_copy",
+      "share_safe_when_public"
+    ]
+  },
+  "module_rubric": [
+    {
+      "module": "method_boundary",
+      "next_pr": "already_seeded_by_method_boundary_v0_5",
+      "quality_target": "Keep trust, scoring, norm, privacy, low-quality, and claim-boundary explanations concise, warm, and audit-safe.",
+      "must_cover": [
+        "method",
+        "scoring_chain",
+        "facet_boundary",
+        "norm_state",
+        "low_quality_degrade",
+        "privacy_surface_boundary"
+      ],
+      "must_not": [
+        "template_fragments",
+        "production_gate_language",
+        "internal implementation terms"
+      ]
+    },
+    {
+      "module": "domain_bands",
+      "next_pr": "BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01",
+      "quality_target": "Each OCEAN band should feel like a complete mini-report section rather than a label definition.",
+      "must_cover": [
+        "definition",
+        "high_or_low_expression",
+        "strength",
+        "risk",
+        "misread",
+        "action",
+        "boundary"
+      ],
+      "must_not": [
+        "good_bad_ranking",
+        "ability_or_value_judgment",
+        "fixed_identity"
+      ]
+    },
+    {
+      "module": "facets_30",
+      "next_pr": "BIG5-FACET-CONTENT-THICKENING-01",
+      "quality_target": "Each facet should clarify a specific behavioral signal while keeping precision bounded.",
+      "must_cover": [
+        "facet_meaning",
+        "high_low_reading",
+        "domain_relationship",
+        "example",
+        "misread",
+        "action"
+      ],
+      "must_not": [
+        "overclaim_facet_independence",
+        "clinical_interpretation",
+        "unsupported_population_rank"
+      ]
+    },
+    {
+      "module": "coupling_variants",
+      "next_pr": "BIG5-COUPLING-CONTENT-THICKENING-01",
+      "quality_target": "Trait combinations should explain tension, synergy, and use cases without inventing types.",
+      "must_cover": [
+        "combined_signal",
+        "benefit_cost",
+        "conflict_resolution",
+        "common_misread",
+        "scenario_bridge"
+      ],
+      "must_not": [
+        "type_label_as_identity",
+        "destiny_claim",
+        "career_guarantee"
+      ]
+    },
+    {
+      "module": "canonical_profiles",
+      "next_pr": "BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01",
+      "quality_target": "Profiles should act as entry narratives that organize evidence without replacing the five traits.",
+      "must_cover": [
+        "assistive_label_boundary",
+        "trait_pattern",
+        "strength",
+        "risk",
+        "application",
+        "reflection"
+      ],
+      "must_not": [
+        "MBTI_style_typing",
+        "single_label_identity",
+        "hard_typing_language"
+      ]
+    },
+    {
+      "module": "scenario_action",
+      "next_pr": "BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01",
+      "quality_target": "Scenario guidance should be practical, repeatable, and low-risk.",
+      "must_cover": [
+        "work",
+        "learning",
+        "communication",
+        "stress",
+        "relationship",
+        "collaboration",
+        "self_management"
+      ],
+      "must_not": [
+        "prescriptive_life_advice",
+        "medical_or_therapy_claim",
+        "hiring_screening_language"
+      ]
+    },
+    {
+      "module": "safe_surfaces",
+      "next_pr": "BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01",
+      "quality_target": "Every public or semi-public surface should have a clear safe-summary variant.",
+      "must_cover": [
+        "share_summary_only",
+        "pdf_private_boundary",
+        "history_summary",
+        "compare_no_ranking",
+        "redaction_policy"
+      ],
+      "must_not": [
+        "private_identifier",
+        "score_detail_in_public_share",
+        "internal implementation terms"
+      ]
+    },
+    {
+      "module": "norm_low_quality_edge_state",
+      "next_pr": "BIG5-NORM-LOW-QUALITY-EDGE-STATE-CONTENT-01",
+      "quality_target": "Uncertain states should still help the user read cautiously instead of pretending confidence.",
+      "must_cover": [
+        "norm_unavailable",
+        "low_quality",
+        "insufficient_confidence",
+        "show_soften_hide",
+        "retest_guidance"
+      ],
+      "must_not": [
+        "false_certainty",
+        "unsupported_comparison",
+        "punitive_language"
+      ]
+    }
+  ],
+  "forbidden_visible_text_rules": [
+    {
+      "rule": "selector_code_prefix",
+      "pattern_label": "internal selector code prefix"
+    },
+    {
+      "rule": "band_code_prefix",
+      "pattern_label": "internal band code prefix"
+    },
+    {
+      "rule": "internal_contract_terms",
+      "pattern_label": "internal contract or implementation terms"
+    },
+    {
+      "rule": "broken_template_fragments",
+      "pattern_label": "broken generated-template fragments"
+    },
+    {
+      "rule": "private_or_score_detail",
+      "pattern_label": "private identifiers or score-detail leakage on public-safe surfaces"
+    }
+  ],
+  "acceptance_for_future_prs": {
+    "candidate_artifacts_required": true,
+    "human_review_manifest_required": true,
+    "staging_artifact_required": true,
+    "qa_summary_required": true,
+    "repair_log_required": true,
+    "rendered_hygiene_scan_required": true,
+    "all_runtime_flags_false": true,
+    "production_use_allowed_false": true,
+    "no_external_copy_evidence_required": true
+  },
+  "train_sequence": [
+    "BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01",
+    "BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01",
+    "BIG5-FACET-CONTENT-THICKENING-01",
+    "BIG5-COUPLING-CONTENT-THICKENING-01",
+    "BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01",
+    "BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01",
+    "BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01",
+    "BIG5-NORM-LOW-QUALITY-EDGE-STATE-CONTENT-01"
+  ],
+  "remaining_holds": [
+    "no_runtime_enablement",
+    "no_production_import",
+    "no_rollout_change",
+    "no_frontend_copy",
+    "no_cms_or_search_publication",
+    "no_deploy_action"
+  ]
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -1470,6 +1470,101 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_committed_big5_content_asset_benchmark_rubric_is_non_runtime_and_source_bounded(): void
+    {
+        $rubricDir = base_path('content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1');
+
+        foreach ([
+            'README.md',
+            'SHA256SUMS',
+            'big5_content_asset_benchmark_rubric_v0_1.json',
+        ] as $filename) {
+            $this->assertFileExists($rubricDir.'/'.$filename);
+        }
+
+        $rubric = $this->readJson($rubricDir.'/big5_content_asset_benchmark_rubric_v0_1.json');
+
+        $this->assertSame('fap.big5.result_page_v2.content_asset_benchmark_rubric.v0_1', $rubric['schema'] ?? null);
+        $this->assertSame('pass', $rubric['status'] ?? null);
+        $this->assertSame('benchmark_rubric_only', $rubric['mode'] ?? null);
+        $this->assertSame('not_runtime', $rubric['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($rubric['production_use_allowed'] ?? true));
+        $this->assertFalse((bool) ($rubric['ready_for_pilot'] ?? true));
+        $this->assertFalse((bool) ($rubric['ready_for_runtime'] ?? true));
+        $this->assertFalse((bool) ($rubric['ready_for_production'] ?? true));
+        $this->assertFalse((bool) data_get($rubric, 'scope.candidate_generation_performed', true));
+        $this->assertFalse((bool) data_get($rubric, 'scope.staging_import_performed', true));
+        $this->assertFalse((bool) data_get($rubric, 'scope.final_result_contract_generated', true));
+        $this->assertFalse((bool) data_get($rubric, 'scope.frontend_copy_added', true));
+        $this->assertFalse((bool) data_get($rubric, 'scope.cms_or_search_changed', true));
+        $this->assertFalse((bool) data_get($rubric, 'scope.runtime_or_production_gate_changed', true));
+
+        $sourceLabels = collect((array) ($rubric['reference_sources'] ?? []))->pluck('label', 'source_id');
+        $this->assertSame('structure_reference_only', $sourceLabels->get('source_123test_big_five_test'));
+        $this->assertSame('structure_reference_only', $sourceLabels->get('source_truity_big_five_test'));
+        $this->assertSame('public_domain_source', $sourceLabels->get('source_ipip_open_psychometrics_big_five'));
+        foreach ((array) ($rubric['reference_sources'] ?? []) as $source) {
+            $this->assertNotSame([], (array) ($source['forbidden_use'] ?? []));
+            if (($source['label'] ?? null) === 'structure_reference_only') {
+                $this->assertContains('copy_text', (array) ($source['forbidden_use'] ?? []));
+            }
+        }
+
+        $this->assertContains('plain_language_explanation', (array) data_get($rubric, 'content_asset_rubric.commercial_depth_components', []));
+        $this->assertContains('FAQ_ready_atomic_claims', (array) data_get($rubric, 'content_asset_rubric.seo_geo_components', []));
+        $this->assertContains('non_diagnostic', (array) data_get($rubric, 'content_asset_rubric.safety_requirements', []));
+        $this->assertSame(8, count((array) ($rubric['module_rubric'] ?? [])));
+        $this->assertSame([
+            'BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01',
+            'BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01',
+            'BIG5-FACET-CONTENT-THICKENING-01',
+            'BIG5-COUPLING-CONTENT-THICKENING-01',
+            'BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01',
+            'BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01',
+            'BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01',
+            'BIG5-NORM-LOW-QUALITY-EDGE-STATE-CONTENT-01',
+        ], (array) ($rubric['train_sequence'] ?? []));
+
+        foreach ([
+            'candidate_artifacts_required',
+            'human_review_manifest_required',
+            'staging_artifact_required',
+            'qa_summary_required',
+            'repair_log_required',
+            'rendered_hygiene_scan_required',
+            'all_runtime_flags_false',
+            'production_use_allowed_false',
+            'no_external_copy_evidence_required',
+        ] as $acceptanceKey) {
+            $this->assertTrue((bool) data_get($rubric, 'acceptance_for_future_prs.'.$acceptanceKey), $acceptanceKey);
+        }
+
+        $allArtifacts = implode("\n", array_map(
+            static fn (string $path): string => (string) file_get_contents($path),
+            glob($rubricDir.'/*') ?: []
+        ));
+
+        foreach ([
+            'private_url',
+            'attempt_id',
+            'raw_score',
+            'percentile',
+            'fixed_type',
+            'user_confirmed_type',
+            'type_code',
+            'big5:',
+            'band:',
+            'payload',
+            'registry',
+            'PR3B',
+            'AttemptReadController',
+            'Big Five Report Engine',
+            '[object Object]',
+        ] as $forbiddenToken) {
+            $this->assertStringNotContainsString($forbiddenToken, $allArtifacts, $forbiddenToken);
+        }
+    }
+
     public function test_strict_mode_rejects_public_payload_and_shareable_score_leaks(): void
     {
         $root = $this->tempDir('big5-v2-agent-leak');

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -63738,7 +63738,7 @@
     "branch": "codex/big5-content-asset-benchmark-rubric-01",
     "title": "BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01: Add Big Five content asset benchmark rubric",
     "train_scope": "big5_result_page_content_asset_thickening",
-    "status": "committed_pending_push",
+    "status": "pr_open",
     "depends_on": [],
     "checks": {
       "authorization": {
@@ -63771,11 +63771,11 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #2489 opened; GitHub checks pending."
       }
     },
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2489",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -63808,6 +63808,11 @@
         "at": "2026-06-28T01:24:00Z",
         "status": "committed_pending_push",
         "note": "Commit SHA will be recorded from GitHub PR head/merge evidence to avoid self-referential stale SHA inside the same commit."
+      },
+      {
+        "at": "2026-06-28T01:28:00Z",
+        "status": "pr_open",
+        "note": "Opened PR #2489 for benchmark rubric scope."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -63731,5 +63731,315 @@
       }
     ],
     "notes": "PR-EQ-V20-01 imports direct-mapped v2.3 assets only; career overlays, route matrix activation, dynamic depth modules, canonical fixtures, and frontend consumption remain deferred."
+  },
+  "BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/big5-content-asset-benchmark-rubric-01",
+    "title": "BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01: Add Big Five content asset benchmark rubric",
+    "train_scope": "big5_result_page_content_asset_thickening",
+    "status": "committed_pending_push",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized updating fap-api pr-train manifest/state with 8 Big Five content asset thickening entries and executing the /goal train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "First PR in this train; branch created from origin/main 43e4a8f937982ebf967d20df80d6bb2217fcebd0."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi",
+          "find backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \\\\;",
+          "cd backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1 && shasum -a 256 -c SHA256SUMS",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "rg -n \"big5:|band:|payload|registry|PR3B|AttemptReadController|Big Five Report Engine|\\\\[object Object\\\\]|private_url|attempt_id|raw_score|percentile|fixed_type|user_confirmed_type|type_code\" backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1 || true",
+          "git diff --check"
+        ],
+        "evidence": "Strict audit, focused PHPUnit, artifact JSON parse, checksum validation, YAML/state parse, forbidden-token scan, diff check, and path scope validation passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to benchmark rubric QA artifacts, BigFiveResultPageV2AssetAgentTest, and authorized docs/codex train metadata."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit authorization to add 8 Big Five content asset thickening PR train entries.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "note": "Initialized under user-authorized Big Five result-page content asset thickening train."
+      },
+      {
+        "at": "2026-06-28T01:20:00Z",
+        "status": "local_validation_passed",
+        "note": "Local validation and scope validation passed before commit."
+      },
+      {
+        "at": "2026-06-28T01:22:00Z",
+        "status": "committed",
+        "note": "Committed local changes before push."
+      },
+      {
+        "at": "2026-06-28T01:24:00Z",
+        "status": "committed_pending_push",
+        "note": "Commit SHA will be recorded from GitHub PR head/merge evidence to avoid self-referential stale SHA inside the same commit."
+      }
+    ]
+  },
+  "BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/big5-domain-bands-content-thickening-01",
+    "title": "BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01: Thicken Big Five domain band content assets",
+    "train_scope": "big5_result_page_content_asset_thickening",
+    "status": "pending",
+    "depends_on": [
+      "BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01"
+    ],
+    "checks": {},
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit authorization to add 8 Big Five content asset thickening PR train entries.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "note": "Initialized under user-authorized Big Five result-page content asset thickening train."
+      }
+    ]
+  },
+  "BIG5-FACET-CONTENT-THICKENING-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/big5-facet-content-thickening-01",
+    "title": "BIG5-FACET-CONTENT-THICKENING-01: Thicken Big Five facet content assets",
+    "train_scope": "big5_result_page_content_asset_thickening",
+    "status": "pending",
+    "depends_on": [
+      "BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01"
+    ],
+    "checks": {},
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit authorization to add 8 Big Five content asset thickening PR train entries.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "note": "Initialized under user-authorized Big Five result-page content asset thickening train."
+      }
+    ]
+  },
+  "BIG5-COUPLING-CONTENT-THICKENING-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/big5-coupling-content-thickening-01",
+    "title": "BIG5-COUPLING-CONTENT-THICKENING-01: Thicken Big Five coupling content assets",
+    "train_scope": "big5_result_page_content_asset_thickening",
+    "status": "pending",
+    "depends_on": [
+      "BIG5-FACET-CONTENT-THICKENING-01"
+    ],
+    "checks": {},
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit authorization to add 8 Big Five content asset thickening PR train entries.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "note": "Initialized under user-authorized Big Five result-page content asset thickening train."
+      }
+    ]
+  },
+  "BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/big5-canonical-profile-content-thickening-01",
+    "title": "BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01: Thicken Big Five canonical profile content assets",
+    "train_scope": "big5_result_page_content_asset_thickening",
+    "status": "pending",
+    "depends_on": [
+      "BIG5-COUPLING-CONTENT-THICKENING-01"
+    ],
+    "checks": {},
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit authorization to add 8 Big Five content asset thickening PR train entries.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "note": "Initialized under user-authorized Big Five result-page content asset thickening train."
+      }
+    ]
+  },
+  "BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/big5-scenario-action-content-thickening-01",
+    "title": "BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01: Thicken Big Five scenario action content assets",
+    "train_scope": "big5_result_page_content_asset_thickening",
+    "status": "pending",
+    "depends_on": [
+      "BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01"
+    ],
+    "checks": {},
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit authorization to add 8 Big Five content asset thickening PR train entries.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "note": "Initialized under user-authorized Big Five result-page content asset thickening train."
+      }
+    ]
+  },
+  "BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/big5-share-pdf-history-compare-safe-content-01",
+    "title": "BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01: Thicken Big Five safe surface content assets",
+    "train_scope": "big5_result_page_content_asset_thickening",
+    "status": "pending",
+    "depends_on": [
+      "BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01"
+    ],
+    "checks": {},
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit authorization to add 8 Big Five content asset thickening PR train entries.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "note": "Initialized under user-authorized Big Five result-page content asset thickening train."
+      }
+    ]
+  },
+  "BIG5-NORM-LOW-QUALITY-EDGE-STATE-CONTENT-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/big5-norm-low-quality-edge-state-content-01",
+    "title": "BIG5-NORM-LOW-QUALITY-EDGE-STATE-CONTENT-01: Thicken Big Five norm and edge-state content assets",
+    "train_scope": "big5_result_page_content_asset_thickening",
+    "status": "pending",
+    "depends_on": [
+      "BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01"
+    ],
+    "checks": {},
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit authorization to add 8 Big Five content asset thickening PR train entries.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "note": "Initialized under user-authorized Big Five result-page content asset thickening train."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -29595,3 +29595,304 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+
+  - id: BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01
+    repo: fap-api
+    branch: codex/big5-content-asset-benchmark-rubric-01
+    title: "BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01: Add Big Five content asset benchmark rubric"
+    train_scope: big5_result_page_content_asset_thickening
+    status: user_authorized
+    scope:
+      - Add a backend-only benchmark rubric for Big Five result-page content asset thickening.
+      - Define structure, depth, safety, SEO/GEO readability, rendered hygiene, and commercial-report quality criteria using 123test and Truity as structure references only.
+      - Keep this PR as standards and QA artifact only; do not import, generate, or stage content candidates.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Copy 123test, Truity, BFI-2, or other proprietary wording, test items, report text, or layouts verbatim.
+      - Generate final frontend-facing big5_result_page_v2 payloads.
+      - Write CMS, trigger SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, search submission, publish, staging deploy, production import, rollout, or production deploy.
+      - Change runtime gates, production gates, scoring, questions, norms, report access, payment, or PDF delivery behavior.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
+      - find backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - cd backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1 && shasum -a 256 -c SHA256SUMS
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01
+    repo: fap-api
+    depends_on: [BIG5-CONTENT-ASSET-BENCHMARK-RUBRIC-01]
+    branch: codex/big5-domain-bands-content-thickening-01
+    title: "BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01: Thicken Big Five domain band content assets"
+    train_scope: big5_result_page_content_asset_thickening
+    status: user_authorized
+    scope:
+      - Thicken OCEAN domain band content assets for existing 5-domain band coverage.
+      - Include explanation, strengths, risks, common misreads, action guidance, and boundary language.
+      - Output reviewed backend candidate/staging artifacts only.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/agent_runs/domain_bands_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/staging_candidate_imports/domain_bands_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/qa/domain_bands_content_thickening/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, CMS, SEO runtime, scoring, questions, norms, runtime gates, production import, rollout, deploy, or search submission.
+      - Copy external wording or generate final frontend-facing big5_result_page_v2 payloads.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-FACET-CONTENT-THICKENING-01
+    repo: fap-api
+    depends_on: [BIG5-DOMAIN-BANDS-CONTENT-THICKENING-01]
+    branch: codex/big5-facet-content-thickening-01
+    title: "BIG5-FACET-CONTENT-THICKENING-01: Thicken Big Five facet content assets"
+    train_scope: big5_result_page_content_asset_thickening
+    status: user_authorized
+    scope:
+      - Thicken 30 facet content assets across high/low interpretation, facet-domain mismatch, practical examples, misreads, and action guidance.
+      - Keep facet precision bounded and non-deterministic.
+      - Output reviewed backend candidate/staging artifacts only.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/agent_runs/facet_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/staging_candidate_imports/facet_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/qa/facet_content_thickening/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, CMS, SEO runtime, scoring, questions, norms, runtime gates, production import, rollout, deploy, or search submission.
+      - Copy external wording or generate final frontend-facing big5_result_page_v2 payloads.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-COUPLING-CONTENT-THICKENING-01
+    repo: fap-api
+    depends_on: [BIG5-FACET-CONTENT-THICKENING-01]
+    branch: codex/big5-coupling-content-thickening-01
+    title: "BIG5-COUPLING-CONTENT-THICKENING-01: Thicken Big Five coupling content assets"
+    train_scope: big5_result_page_content_asset_thickening
+    status: user_authorized
+    scope:
+      - Thicken core and supplemental trait coupling content assets.
+      - Include combination explanation, benefits and costs, conflict resolution, common misread, and scenario bridge.
+      - Output reviewed backend candidate/staging artifacts only.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/agent_runs/coupling_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/staging_candidate_imports/coupling_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/qa/coupling_content_thickening/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, CMS, SEO runtime, scoring, questions, norms, runtime gates, production import, rollout, deploy, or search submission.
+      - Copy external wording or generate final frontend-facing big5_result_page_v2 payloads.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01
+    repo: fap-api
+    depends_on: [BIG5-COUPLING-CONTENT-THICKENING-01]
+    branch: codex/big5-canonical-profile-content-thickening-01
+    title: "BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01: Thicken Big Five canonical profile content assets"
+    train_scope: big5_result_page_content_asset_thickening
+    status: user_authorized
+    scope:
+      - Thicken canonical profile assets while keeping labels assistive and non-fixed.
+      - Improve narrative, strengths, risks, application, and reflection prompts.
+      - Output reviewed backend candidate/staging artifacts only.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/agent_runs/canonical_profile_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/staging_candidate_imports/canonical_profile_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/qa/canonical_profile_content_thickening/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, CMS, SEO runtime, scoring, questions, norms, runtime gates, production import, rollout, deploy, or search submission.
+      - Copy external wording or generate final frontend-facing big5_result_page_v2 payloads.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01
+    repo: fap-api
+    depends_on: [BIG5-CANONICAL-PROFILE-CONTENT-THICKENING-01]
+    branch: codex/big5-scenario-action-content-thickening-01
+    title: "BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01: Thicken Big Five scenario action content assets"
+    train_scope: big5_result_page_content_asset_thickening
+    status: user_authorized
+    scope:
+      - Thicken scenario/action assets for work, learning, communication, stress, relationship, collaboration, and self-management.
+      - Make guidance practical but non-prescriptive.
+      - Output reviewed backend candidate/staging artifacts only.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/agent_runs/scenario_action_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/staging_candidate_imports/scenario_action_content_thickening/**
+      - backend/content_assets/big5/result_page_v2/qa/scenario_action_content_thickening/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, CMS, SEO runtime, scoring, questions, norms, runtime gates, production import, rollout, deploy, or search submission.
+      - Copy external wording or generate final frontend-facing big5_result_page_v2 payloads.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01
+    repo: fap-api
+    depends_on: [BIG5-SCENARIO-ACTION-CONTENT-THICKENING-01]
+    branch: codex/big5-share-pdf-history-compare-safe-content-01
+    title: "BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01: Thicken Big Five safe surface content assets"
+    train_scope: big5_result_page_content_asset_thickening
+    status: user_authorized
+    scope:
+      - Thicken safe content for share, PDF, history, and compare surfaces.
+      - Keep share summary-only and public-safe; keep PDF/history/compare free of private, internal, and score-detail leakage.
+      - Output reviewed backend candidate/staging artifacts only.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/agent_runs/share_pdf_history_compare_safe_content/**
+      - backend/content_assets/big5/result_page_v2/staging_candidate_imports/share_pdf_history_compare_safe_content/**
+      - backend/content_assets/big5/result_page_v2/qa/share_pdf_history_compare_safe_content/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, CMS, SEO runtime, scoring, questions, norms, runtime gates, production import, rollout, deploy, or search submission.
+      - Copy external wording or generate final frontend-facing big5_result_page_v2 payloads.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-NORM-LOW-QUALITY-EDGE-STATE-CONTENT-01
+    repo: fap-api
+    depends_on: [BIG5-SHARE-PDF-HISTORY-COMPARE-SAFE-CONTENT-01]
+    branch: codex/big5-norm-low-quality-edge-state-content-01
+    title: "BIG5-NORM-LOW-QUALITY-EDGE-STATE-CONTENT-01: Thicken Big Five norm and edge-state content assets"
+    train_scope: big5_result_page_content_asset_thickening
+    status: user_authorized
+    scope:
+      - Thicken norm unavailable, low quality, insufficient confidence, and edge-state content assets.
+      - Define show/soften/hide behavior in content terms without pretending certainty.
+      - Output reviewed backend candidate/staging artifacts only.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/agent_runs/norm_low_quality_edge_state_content/**
+      - backend/content_assets/big5/result_page_v2/staging_candidate_imports/norm_low_quality_edge_state_content/**
+      - backend/content_assets/big5/result_page_v2/qa/norm_low_quality_edge_state_content/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, CMS, SEO runtime, scoring, questions, norms, runtime gates, production import, rollout, deploy, or search submission.
+      - Copy external wording or generate final frontend-facing big5_result_page_v2 payloads.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added the user-authorized Big Five result-page content asset thickening PR train entries to docs/codex.
- Added a backend-only benchmark rubric package for Big Five V2 content asset thickening.
- Added a committed artifact guard covering source boundaries, non-runtime status, future PR acceptance rules, and redaction/hygiene constraints.

## Why
This establishes the shared quality standard before thickening domain bands, facets, couplings, profiles, scenarios, safe surfaces, and edge states. 123test and Truity are used only as structure/depth references; no external wording, items, report text, or proprietary layout is copied.

## Validation
- cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest --no-ansi
- find backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
- cd backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1 && shasum -a 256 -c SHA256SUMS
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- rg -n "big5:|band:|payload|registry|PR3B|AttemptReadController|Big Five Report Engine|\[object Object\]|private_url|attempt_id|raw_score|percentile|fixed_type|user_confirmed_type|type_code" backend/content_assets/big5/result_page_v2/qa/content_asset_benchmark_rubric/v0_1 || true
- git diff --check

## Intentionally deferred
- No content candidate generation or staging import in this PR.
- No final big5_result_page_v2 contract generation.
- No fap-web copy.
- No CMS write, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, search submission, or publish.
- No runtime gate, production import, rollout, deploy, or manual server action.

## Repository rule impact
Backend content assets remain the authority for Big Five result-page content. This PR only adds backend QA/rubric artifacts and authorized train metadata; it does not move content authority to frontend or CMS fallback.