### PR TITLE
MBTI-PDF-RESULT-EXPORT-01: export MBTI result page PDF via Gotenberg

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -2884,6 +2884,109 @@ class AttemptReadController extends Controller
     }
 
     /**
+     * GET /api/v0.3/attempts/{id}/result-page.pdf
+     */
+    public function resultPagePdf(Request $request, string $id): Response
+    {
+        $orgId = $this->currentOrgContext()->orgId();
+        $userId = $this->resolveUserId($request);
+        $anonId = $this->resolveAnonId($request);
+        $result = Result::where('org_id', $orgId)->where('attempt_id', $id)->firstOrFail();
+        $responseCodes = $this->resolveResponseScaleCodes($result);
+        $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
+        $attempt = $this->resolveAttemptForReportRead($request, $id, $scaleCode);
+
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== 'MBTI') {
+            abort(400, 'result-page PDF export is only available for MBTI attempts.');
+        }
+
+        $gate = $this->reportGatekeeper->resolve(
+            $orgId,
+            $id,
+            $userId !== null ? (string) $userId : null,
+            $anonId,
+            $this->currentOrgContext()->role(),
+            false,
+            false,
+        );
+
+        if (! ($gate['ok'] ?? false)) {
+            $status = (int) ($gate['status'] ?? 0);
+            if ($status <= 0) {
+                $error = strtoupper((string) data_get($gate, 'error_code', data_get($gate, 'error', 'REPORT_FAILED')));
+                $status = match ($error) {
+                    'ATTEMPT_REQUIRED', 'SCALE_REQUIRED' => 400,
+                    'ATTEMPT_NOT_FOUND', 'RESULT_NOT_FOUND', 'SCALE_NOT_FOUND' => 404,
+                    default => 500,
+                };
+            }
+
+            abort($status, (string) ($gate['message'] ?? 'report generation failed.'));
+        }
+
+        $variant = $this->reportPdfDocumentService->normalizeVariant((string) ($gate['variant'] ?? 'free'));
+        $locked = (bool) ($gate['locked'] ?? false);
+        $date = $attempt->submitted_at?->format('Y-m-d')
+            ?? $attempt->created_at?->format('Y-m-d')
+            ?? now()->format('Y-m-d');
+        $fileName = sprintf('fermatmind-mbti-result-page-%s.pdf', $date);
+        $inline = in_array(strtolower(trim((string) $request->query('inline', '0'))), ['1', 'true', 'yes', 'on'], true);
+        $disposition = $inline ? 'inline' : 'attachment';
+
+        $request->merge(['attempt_id' => (string) $attempt->id]);
+        $this->eventRecorder->recordFromRequest($request, 'result_page_pdf_export_view', $this->resolveUserId($request), [
+            'scale_code' => 'MBTI',
+            'pack_id' => (string) ($attempt->pack_id ?? ''),
+            'dir_version' => (string) ($attempt->dir_version ?? ''),
+            'type_code' => (string) ($result->type_code ?? ''),
+            'attempt_id' => (string) $attempt->id,
+            'locked' => $locked,
+            'variant' => $variant,
+            'surface' => ReportPdfDocumentService::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+            'engine' => ReportPdfDocumentService::RESULT_PAGE_EXPORT_ENGINE,
+        ]);
+
+        try {
+            $generated = $this->reportPdfDocumentService->getOrGenerateMbtiResultPageExport($attempt, $gate, $result);
+        } catch (\Throwable $e) {
+            $traceId = (string) \Illuminate\Support\Str::uuid();
+            $printBaseHost = parse_url((string) config('gotenberg.result_print_base_url', ''), PHP_URL_HOST);
+            Log::error('MBTI_RESULT_PAGE_PDF_EXPORT_FAILED', [
+                'attempt_id' => (string) $attempt->id,
+                'user_id' => $userId !== null ? (string) $userId : null,
+                'surface' => ReportPdfDocumentService::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+                'engine' => ReportPdfDocumentService::RESULT_PAGE_EXPORT_ENGINE,
+                'gotenberg_url_host' => is_string($printBaseHost) ? $printBaseHost : null,
+                'trace_id' => $traceId,
+                'exception_class' => $e::class,
+                'message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
+            ]);
+
+            abort(503, 'result-page PDF export failed.');
+        }
+
+        $pdfBinary = (string) ($generated['binary'] ?? '');
+        $variant = (string) ($generated['variant'] ?? $variant);
+        $locked = (bool) ($generated['locked'] ?? $locked);
+
+        return response($pdfBinary, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => $disposition.'; filename="'.$fileName.'"',
+            'Cache-Control' => 'private, no-store',
+            'X-Report-Scale' => 'MBTI',
+            'X-Report-Variant' => $variant,
+            'X-Report-Locked' => $locked ? 'true' : 'false',
+            'X-Report-Filename-Hint' => $fileName,
+            'X-Report-Pdf-Engine' => (string) ($generated['engine'] ?? ReportPdfDocumentService::RESULT_PAGE_EXPORT_ENGINE),
+            'X-Pdf-Surface' => (string) ($generated['surface'] ?? 'mbti_result_page_export'),
+            'X-Pdf-Surface-Version' => (string) ($generated['surface_version'] ?? ReportPdfDocumentService::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION),
+            'X-Pdf-Artifact-Cache' => ((bool) ($generated['cached'] ?? false)) ? 'HIT' : 'MISS',
+            'X-Legacy-Mpdf-Fallback' => 'false',
+            'X-Gotenberg-Trace' => (string) ($generated['trace_id'] ?? ''),
+        ]);
+    }
+
+    /**
      * GET /api/v0.3/attempts/{id}/enneagram/observation
      */
     public function enneagramObservation(Request $request, string $id): JsonResponse

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -8,6 +8,7 @@ use App\Models\Attempt;
 use App\Models\ReportSnapshot;
 use App\Models\Result;
 use App\Services\Report\Pdf\Mbti\MbtiPdfPayloadBuilder;
+use Illuminate\Support\Str;
 use Mpdf\Mpdf;
 use Mpdf\Output\Destination;
 use Throwable;
@@ -15,6 +16,10 @@ use Throwable;
 final class ReportPdfDocumentService
 {
     private const MBTI_PDF_SURFACE_VERSION = 'mbti.pdf_surface.v4';
+
+    public const MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION = 'mbti.result_page_export.v1';
+
+    public const RESULT_PAGE_EXPORT_ENGINE = 'gotenberg_chromium';
 
     public function __construct(
         private readonly ReportPdfArtifactStore $artifactStore,
@@ -352,6 +357,108 @@ final class ReportPdfDocumentService
     }
 
     /**
+     * @param  array<string,mixed>  $gate
+     * @return array{
+     *   binary:string,
+     *   storage_path:string,
+     *   variant:string,
+     *   locked:bool,
+     *   manifest_hash:string,
+     *   cached:bool,
+     *   engine:string,
+     *   surface:string,
+     *   surface_version:string,
+     *   trace_id:string
+     * }
+     */
+    public function getOrGenerateMbtiResultPageExport(Attempt $attempt, array $gate, ?Result $result = null): array
+    {
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($scaleCode !== 'MBTI') {
+            throw new \RuntimeException('Result-page PDF export is only available for MBTI attempts.');
+        }
+
+        $variant = $this->normalizeVariant((string) ($gate['variant'] ?? 'free'));
+        $locked = (bool) ($gate['locked'] ?? true);
+        $traceId = (string) Str::uuid();
+        $manifestHash = $this->resolveResultPageExportManifestHash($attempt, $gate, $result);
+        $path = $this->artifactStore->path('MBTI', (string) $attempt->id, $manifestHash, $variant);
+
+        $cached = $this->artifactStore->get($path);
+        if (is_string($cached) && $cached !== '') {
+            return [
+                'binary' => $cached,
+                'storage_path' => $path,
+                'variant' => $variant,
+                'locked' => $locked,
+                'manifest_hash' => $manifestHash,
+                'cached' => true,
+                'engine' => self::RESULT_PAGE_EXPORT_ENGINE,
+                'surface' => 'mbti_result_page_export',
+                'surface_version' => self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+                'trace_id' => $traceId,
+            ];
+        }
+
+        $pdfBinary = $this->buildMbtiResultPageExportDocument($attempt, $gate, $traceId);
+        $this->artifactStore->put($path, $pdfBinary);
+
+        return [
+            'binary' => $pdfBinary,
+            'storage_path' => $path,
+            'variant' => $variant,
+            'locked' => $locked,
+            'manifest_hash' => $manifestHash,
+            'cached' => false,
+            'engine' => self::RESULT_PAGE_EXPORT_ENGINE,
+            'surface' => 'mbti_result_page_export',
+            'surface_version' => self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+            'trace_id' => $traceId,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $gate
+     */
+    private function resolveResultPageExportManifestHash(Attempt $attempt, array $gate, ?Result $result = null): string
+    {
+        $baseHash = $this->baseContentManifestHash($attempt, $result);
+        $rawLocale = strtolower(trim((string) ($attempt->locale ?? '')));
+        $locale = str_starts_with($rawLocale, 'zh') ? 'zh' : 'en';
+        $variant = $this->normalizeVariant((string) ($gate['variant'] ?? 'free'));
+        $entitlement = ((bool) ($gate['locked'] ?? true)) ? 'locked' : 'unlocked';
+
+        return implode('-', [
+            $baseHash,
+            self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+            self::RESULT_PAGE_EXPORT_ENGINE,
+            preg_replace('/[^a-z0-9_.-]+/i', '_', $locale) ?: 'locale',
+            $entitlement,
+            $variant,
+        ]);
+    }
+
+    private function baseContentManifestHash(Attempt $attempt, ?Result $result = null): string
+    {
+        $summary = is_array($attempt->answers_summary_json ?? null) ? $attempt->answers_summary_json : [];
+        $meta = is_array($summary['meta'] ?? null) ? $summary['meta'] : [];
+        $hash = trim((string) ($meta['pack_release_manifest_hash'] ?? ''));
+        if ($hash !== '') {
+            return $hash;
+        }
+
+        $resultPayload = is_array($result?->result_json ?? null) ? $result?->result_json : [];
+        $hash = trim((string) (
+            data_get($resultPayload, 'version_snapshot.content_manifest_hash')
+            ?? data_get($resultPayload, 'normed_json.version_snapshot.content_manifest_hash')
+            ?? data_get($resultPayload, 'content_manifest_hash')
+            ?? ''
+        ));
+
+        return $hash !== '' ? $hash : 'nohash';
+    }
+
+    /**
      * @param  array<string,mixed>  $report
      * @return array<string,mixed>
      */
@@ -515,28 +622,108 @@ final class ReportPdfDocumentService
         }
     }
 
-    private function mbtiResultPrintUrl(Attempt $attempt): ?string
+    /**
+     * @param  array<string,mixed>  $gate
+     */
+    private function buildMbtiResultPageExportDocument(Attempt $attempt, array $gate, string $traceId): string
+    {
+        if (! $this->gotenbergChromiumPdfClient->enabled()) {
+            throw new \RuntimeException('Gotenberg result-page PDF engine is disabled.');
+        }
+
+        $printUrl = $this->mbtiResultPrintUrl($attempt, $gate);
+        if ($printUrl === null) {
+            throw new \RuntimeException('Gotenberg result-page print URL is not configured.');
+        }
+
+        return $this->gotenbergChromiumPdfClient->convertUrl($printUrl, [
+            'printBackground' => true,
+            'preferCssPageSize' => true,
+            'emulatedMediaType' => 'print',
+            'waitForExpression' => 'window.__FERMAT_PDF_READY__ === true',
+            'failOnHttpStatusCodes' => '400,401,403,404,500,502,503',
+            'extraHttpHeaders' => json_encode([
+                'X-Fermat-Pdf-Trace' => $traceId,
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $gate
+     */
+    private function mbtiResultPrintUrl(Attempt $attempt, array $gate = []): ?string
     {
         $baseUrl = rtrim(trim((string) config('gotenberg.result_print_base_url', '')), '/');
         if ($baseUrl === '') {
             return null;
         }
 
-        $locale = trim((string) ($attempt->locale ?? ''));
-        $locale = $locale !== '' ? $locale : 'en';
+        $rawLocale = strtolower(trim((string) ($attempt->locale ?? '')));
+        $locale = str_starts_with($rawLocale, 'zh') ? 'zh' : 'en';
         $attemptId = trim((string) $attempt->id);
         if ($attemptId === '') {
             return null;
         }
 
-        $pathTemplate = trim((string) config('gotenberg.result_print_path_template', '/{locale}/attempts/{attempt_id}/report'));
-        $pathTemplate = $pathTemplate !== '' ? $pathTemplate : '/{locale}/attempts/{attempt_id}/report';
+        $pathTemplate = trim((string) config('gotenberg.result_print_path_template', '/{locale}/result/{attempt_id}'));
+        $pathTemplate = $pathTemplate !== '' ? $pathTemplate : '/{locale}/result/{attempt_id}';
         $path = strtr($pathTemplate, [
             '{locale}' => rawurlencode($locale),
             '{attempt_id}' => rawurlencode($attemptId),
         ]);
 
-        return $baseUrl.'/'.ltrim($path, '/');
+        $url = $baseUrl.'/'.ltrim($path, '/');
+        if (self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION !== '') {
+            $separator = str_contains($url, '?') ? '&' : '?';
+            $url .= $separator.http_build_query([
+                'pdf' => '1',
+                'surface' => self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+                'pdf_token' => $this->resultPageExportToken($attempt, $gate, $locale),
+            ], '', '&', PHP_QUERY_RFC3986);
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param  array<string,mixed>  $gate
+     */
+    private function resultPageExportToken(Attempt $attempt, array $gate, string $locale): string
+    {
+        $expiresAt = now()->addMinutes(10)->getTimestamp();
+        $payload = [
+            'v' => 1,
+            'typ' => 'mbti_result_page_pdf',
+            'attempt_id' => (string) $attempt->id,
+            'user_id' => (string) ($attempt->user_id ?? ''),
+            'owner_id' => (string) (($attempt->user_id ?? null) ?: ($attempt->anon_id ?? '')),
+            'locale' => $locale,
+            'surface' => self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+            'engine' => self::RESULT_PAGE_EXPORT_ENGINE,
+            'entitlement' => ((bool) ($gate['locked'] ?? true)) ? 'locked' : 'unlocked',
+            'variant' => $this->normalizeVariant((string) ($gate['variant'] ?? 'free')),
+            'exp' => $expiresAt,
+        ];
+
+        $encodedPayload = $this->base64UrlEncode(json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        $signature = hash_hmac('sha256', $encodedPayload, $this->resultPageExportTokenSecret());
+
+        return $encodedPayload.'.'.$signature;
+    }
+
+    private function resultPageExportTokenSecret(): string
+    {
+        $secret = trim((string) config('gotenberg.result_print_token_secret', ''));
+        if ($secret !== '') {
+            return $secret;
+        }
+
+        return 'fap-result-page-pdf-local-key';
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
     }
 
     /**

--- a/backend/config/gotenberg.php
+++ b/backend/config/gotenberg.php
@@ -6,8 +6,9 @@ return [
     'result_print_base_url' => env('GOTENBERG_RESULT_PRINT_BASE_URL', ''),
     'result_print_path_template' => env(
         'GOTENBERG_RESULT_PRINT_PATH_TEMPLATE',
-        '/{locale}/attempts/{attempt_id}/report'
+        '/{locale}/result/{attempt_id}'
     ),
+    'result_print_token_secret' => env('GOTENBERG_RESULT_PRINT_TOKEN_SECRET', ''),
     'timeout_seconds' => (int) env('GOTENBERG_TIMEOUT_SECONDS', 30),
     'connect_timeout_seconds' => (int) env('GOTENBERG_CONNECT_TIMEOUT_SECONDS', 5),
     'allow_single_label_hosts' => (bool) env('GOTENBERG_ALLOW_SINGLE_LABEL_HOSTS', true),

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -701,6 +701,30 @@
                 "x-laravel-name": "api.v0_3.attempts.result"
             }
         },
+        "/api/v0.3/attempts/{id}/result-page.pdf": {
+            "get": {
+                "operationId": "api.v0_3.attempts.result_page_pdf",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@resultPagePdf",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.result_page_pdf"
+            }
+        },
         "/api/v0.3/attempts/{id}/share": {
             "get": {
                 "operationId": "get_api_v0_3_attempts_id_share",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -298,6 +298,10 @@ Route::prefix('v0.3')->middleware([
                 ->middleware('uuid:id')
                 ->defaults('public_realm', true)
                 ->name('api.v0_3.attempts.report_pdf');
+            Route::get('/attempts/{id}/result-page.pdf', [AttemptReadController::class, 'resultPagePdf'])
+                ->middleware('uuid:id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.result_page_pdf');
             Route::get('/attempts/{id}/enneagram/observation', [AttemptReadController::class, 'enneagramObservation'])
                 ->middleware([\App\Http\Middleware\FmTokenAuth::class, 'uuid:id'])
                 ->defaults('public_realm', true)

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -261,4 +261,184 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf = $this->withHeaders($headers)->get("/api/v0.3/attempts/{$attemptId}/report.pdf");
         $pdf->assertStatus(404);
     }
+
+    public function test_public_mbti_result_page_pdf_uses_strict_gotenberg_surface(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'http://gotenberg:3000');
+        config()->set('gotenberg.result_print_base_url', 'http://frontend:3000');
+        config()->set('gotenberg.result_print_token_secret', 'test-result-print-secret');
+        Storage::fake('local');
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_mbti_result_page_pdf';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, 'MBTI', $anonId);
+        $this->createResult($attemptId);
+
+        $gotenbergPdf = implode("\n", [
+            '%PDF-1.4',
+            '<< /Producer (Chromium) >>',
+            'Personality Traits',
+            'Your Career Path',
+            'Your Personal Growth',
+            'Your Relationships',
+            '%%EOF',
+        ]);
+
+        Http::fake([
+            'gotenberg:3000/forms/chromium/convert/url' => Http::response($gotenbergPdf, 200, [
+                'Content-Type' => 'application/pdf',
+            ]),
+        ]);
+
+        $headers = [
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ];
+
+        $pdf = $this->withHeaders($headers)->get("/api/v0.3/attempts/{$attemptId}/result-page.pdf");
+
+        $pdf->assertStatus(200);
+        $pdf->assertHeader('Content-Type', 'application/pdf');
+        $pdf->assertHeader('X-Report-Pdf-Engine', 'gotenberg_chromium');
+        $pdf->assertHeader('X-Pdf-Surface', 'mbti_result_page_export');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_export.v1');
+        $pdf->assertHeader('X-Pdf-Artifact-Cache', 'MISS');
+        $pdf->assertHeader('X-Legacy-Mpdf-Fallback', 'false');
+        $this->assertNotSame('', (string) $pdf->headers->get('X-Gotenberg-Trace'));
+
+        $pdfBinary = (string) $pdf->getContent();
+        $this->assertStringStartsWith('%PDF-1.4', $pdfBinary);
+        $this->assertStringContainsString('/Producer (Chromium)', $pdfBinary);
+        $this->assertStringNotContainsString('mPDF', $pdfBinary);
+        $this->assertStringContainsString('Personality Traits', $pdfBinary);
+        $this->assertStringContainsString('Your Career Path', $pdfBinary);
+        $this->assertStringContainsString('Your Personal Growth', $pdfBinary);
+        $this->assertStringContainsString('Your Relationships', $pdfBinary);
+
+        Http::assertSent(function ($request) use ($attemptId): bool {
+            $body = $request->body();
+
+            return $request->method() === 'POST'
+                && $request->url() === 'http://gotenberg:3000/forms/chromium/convert/url'
+                && str_contains($body, "/zh/result/{$attemptId}")
+                && str_contains($body, 'pdf=1')
+                && str_contains($body, 'surface=mbti.result_page_export.v1')
+                && str_contains($body, 'pdf_token=')
+                && str_contains($body, 'waitForExpression')
+                && str_contains($body, 'window.__FERMAT_PDF_READY__ === true')
+                && str_contains($body, 'failOnHttpStatusCodes');
+        });
+
+        Storage::disk('local')->assertExists(
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_export.v1-gotenberg_chromium-zh-locked-free/report_free.pdf"
+        );
+    }
+
+    public function test_public_mbti_result_page_pdf_does_not_fallback_to_mpdf_when_gotenberg_fails(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'http://gotenberg:3000');
+        config()->set('gotenberg.result_print_base_url', 'http://frontend:3000');
+        Storage::fake('local');
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_mbti_result_page_pdf_fail';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, 'MBTI', $anonId);
+        $this->createResult($attemptId);
+
+        Http::fake([
+            'gotenberg:3000/forms/chromium/convert/url' => Http::response('upstream unavailable', 503),
+        ]);
+
+        $pdf = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->get("/api/v0.3/attempts/{$attemptId}/result-page.pdf");
+
+        $pdf->assertStatus(503);
+        Storage::disk('local')->assertMissing(
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_export.v1-gotenberg_chromium-zh-locked-free/report_free.pdf"
+        );
+    }
+
+    public function test_public_mbti_result_page_pdf_does_not_hit_legacy_mpdf_surface_cache(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'http://gotenberg:3000');
+        config()->set('gotenberg.result_print_base_url', 'http://frontend:3000');
+        Storage::fake('local');
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_mbti_result_page_pdf_cache';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, 'MBTI', $anonId);
+        $this->createResult($attemptId);
+
+        Storage::disk('local')->put(
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.pdf_surface.v4/report_free.pdf",
+            '%PDF-1.4 old mPDF artifact'
+        );
+
+        Http::fake([
+            'gotenberg:3000/forms/chromium/convert/url' => Http::response('%PDF-1.4 new chromium export', 200, [
+                'Content-Type' => 'application/pdf',
+            ]),
+        ]);
+
+        $pdf = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->get("/api/v0.3/attempts/{$attemptId}/result-page.pdf");
+
+        $pdf->assertStatus(200);
+        $pdf->assertHeader('X-Pdf-Artifact-Cache', 'MISS');
+        $this->assertStringContainsString('new chromium export', (string) $pdf->getContent());
+        $this->assertStringNotContainsString('old mPDF artifact', (string) $pdf->getContent());
+    }
+
+    public function test_public_mbti_result_page_pdf_cache_hit_preserves_engine_headers(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+        config()->set('gotenberg.enabled', true);
+        config()->set('gotenberg.base_url', 'http://gotenberg:3000');
+        config()->set('gotenberg.result_print_base_url', 'http://frontend:3000');
+        Storage::fake('local');
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_mbti_result_page_pdf_hit';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, 'MBTI', $anonId);
+        $this->createResult($attemptId);
+
+        Storage::disk('local')->put(
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_export.v1-gotenberg_chromium-zh-locked-free/report_free.pdf",
+            '%PDF-1.4 cached chromium export'
+        );
+
+        Http::fake();
+
+        $pdf = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->get("/api/v0.3/attempts/{$attemptId}/result-page.pdf");
+
+        $pdf->assertStatus(200);
+        $pdf->assertHeader('X-Report-Pdf-Engine', 'gotenberg_chromium');
+        $pdf->assertHeader('X-Pdf-Surface', 'mbti_result_page_export');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_export.v1');
+        $pdf->assertHeader('X-Pdf-Artifact-Cache', 'HIT');
+        $pdf->assertHeader('X-Legacy-Mpdf-Fallback', 'false');
+        $this->assertStringContainsString('cached chromium export', (string) $pdf->getContent());
+        Http::assertNothingSent();
+    }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -279,6 +279,26 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_result_page_pdf_export_route_changes(): void
+    {
+        $changed = [
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            "+            Route::get('/attempts/{id}/result-page.pdf', [AttemptReadController::class, 'resultPagePdf'])",
+            "+                ->middleware('uuid:id')",
+            "+                ->defaults('public_realm', true)",
+            "+                ->name('api.v0_3.attempts.result_page_pdf');",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_variant_seo_metadata_refresh_files(): void
     {
         $changed = [
@@ -5454,6 +5474,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsMbtiResultPagePdfExportOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
             if ($this->isBigFiveV2PilotSupportFile($file)) {
                 continue;
             }
@@ -10566,6 +10593,31 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
         $allowedLines = [
             "+    Route::get('/personality/comparisons/{comparison}', [PersonalityController::class, 'comparison']);",
+        ];
+
+        foreach ($changedLines as $line) {
+            if (! in_array($line, $allowedLines, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsMbtiResultPagePdfExportOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        $allowedLines = [
+            "+            Route::get('/attempts/{id}/result-page.pdf', [AttemptReadController::class, 'resultPagePdf'])",
+            "+                ->middleware('uuid:id')",
+            "+                ->defaults('public_realm', true)",
+            "+                ->name('api.v0_3.attempts.result_page_pdf');",
         ];
 
         foreach ($changedLines as $line) {


### PR DESCRIPTION
## What changed
- Added `GET /api/v0.3/attempts/{id}/result-page.pdf` for MBTI result-page PDF exports.
- Routes this export through strict Gotenberg/Chromium URL conversion using the frontend private/noindex result page as the print source.
- Keeps the existing `/report.pdf` mPDF/full-report path separate and does not fallback to mPDF for this result-page export.
- Adds surface/version/cache headers and focused parity coverage for cache miss, cache hit, legacy-cache isolation, and upstream failure behavior.

## Why
The current download path mixed the full-report mPDF template with the user's expectation of exporting the visible result page. This PR adds a separate backend result-page export endpoint so the browser-rendered result page can be captured as the PDF source.

## Validation
- `php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi`
- `php artisan route:list --path=api/v0.3/attempts --no-ansi | rg "result-page|report.pdf|report-access"`
- `./vendor/bin/pint --dirty --ansi`
- `git diff --check`

## Intentionally deferred
- No production deploy.
- No server configuration change.
- No frontend route/button wiring in this backend PR.
- No CMS, DB, queue, search, indexing, sitemap, llms, canonical, or JSON-LD changes.
