### PR TITLE
MBTI-PDF-GOTENBERG-FORM-FIX-01: fix Gotenberg status code form field

### DIFF
--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -641,7 +641,7 @@ final class ReportPdfDocumentService
             'preferCssPageSize' => true,
             'emulatedMediaType' => 'print',
             'waitForExpression' => 'window.__FERMAT_PDF_READY__ === true',
-            'failOnHttpStatusCodes' => '400,401,403,404,500,502,503',
+            'failOnHttpStatusCodes' => '[400,401,403,404,500,502,503]',
             'extraHttpHeaders' => json_encode([
                 'X-Fermat-Pdf-Trace' => $traceId,
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -330,7 +330,9 @@ final class AttemptPublicReportPdfParityTest extends TestCase
                 && str_contains($body, 'pdf_token=')
                 && str_contains($body, 'waitForExpression')
                 && str_contains($body, 'window.__FERMAT_PDF_READY__ === true')
-                && str_contains($body, 'failOnHttpStatusCodes');
+                && str_contains($body, 'failOnHttpStatusCodes')
+                && str_contains($body, '[400,401,403,404,500,502,503]')
+                && ! str_contains($body, "\r\n400,401,403,404,500,502,503\r\n");
         });
 
         Storage::disk('local')->assertExists(


### PR DESCRIPTION
## What changed
- Changed the MBTI result-page PDF Gotenberg request to send `failOnHttpStatusCodes` as a JSON array string instead of a comma-delimited string.
- Tightened the MBTI result-page PDF parity test so it rejects the old invalid comma-delimited multipart value.

## Why
Production Gotenberg 8 rejects the previous value with HTTP 400:
`Invalid form data: form field 'failOnHttpStatusCodes' is invalid`.
This keeps fail-on-status behavior while using a format Gotenberg can parse.

## Validation
- `php artisan route:list --path=api/v0.3/attempts --no-ansi`
- `vendor/bin/pint --dirty --test`
- `php artisan test --filter=test_public_mbti_result_page_pdf_uses_strict_gotenberg_surface --no-ansi`
- `php artisan test tests/Feature/Report/PdfGotenbergEngineSpikeTest.php --no-ansi`
- `php artisan test tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php --no-ansi`
- `git diff --check origin/main...HEAD`

## Intentionally deferred
- No frontend changes.
- No CMS, DB, queue, search, indexing, or deploy changes.
- Production deploy and live PDF smoke require separate readiness and exact SHA approval.

## Repository rule impact
- Backend runtime behavior only; no content ownership or publishing authority changes.
