### PR TITLE
fix(report): bridge result print token for PDF export

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -43,6 +43,7 @@ use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\InviteUnlockSummaryBuilder;
 use App\Services\Report\MbtiPreviewContractBuilder;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
+use App\Services\Report\Pdf\ResultPagePdfTokenService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportGatekeeper;
 use App\Services\Results\ResultEmailReadAccessService;
@@ -70,6 +71,7 @@ class AttemptReadController extends Controller
         private AttemptSubmissionService $attemptSubmissionService,
         private ReportGatekeeper $reportGatekeeper,
         private ReportPdfDocumentService $reportPdfDocumentService,
+        private ResultPagePdfTokenService $resultPagePdfTokenService,
         private BigFivePublicProjectionService $bigFivePublicProjectionService,
         private BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
         private EnneagramPublicProjectionService $enneagramPublicProjectionService,
@@ -2460,6 +2462,11 @@ class AttemptReadController extends Controller
 
     private function resolveAttemptForResultAccessToken(Request $request, int $orgId, string $attemptId): ?Attempt
     {
+        $pdfTokenAttempt = $this->resolveAttemptForResultPagePdfToken($request, $orgId, $attemptId);
+        if ($pdfTokenAttempt instanceof Attempt) {
+            return $pdfTokenAttempt;
+        }
+
         if (! $this->resultEmailReadAccess()->activeTokenBindingForRequest($request, $orgId, $attemptId)) {
             return null;
         }
@@ -2478,6 +2485,56 @@ class AttemptReadController extends Controller
         }
 
         return $attempt;
+    }
+
+    private function resolveAttemptForResultPagePdfToken(Request $request, int $orgId, string $attemptId): ?Attempt
+    {
+        $token = $this->resultAccessTokenCandidate($request);
+        if ($token === '') {
+            return null;
+        }
+
+        $grant = $this->resultPagePdfTokenService->verifyMbtiResultPageExport($token, $orgId, $attemptId);
+        if (! is_array($grant)) {
+            return null;
+        }
+
+        $attempt = Attempt::query()
+            ->where('org_id', $orgId)
+            ->where('id', $attemptId)
+            ->first();
+        if (! $attempt instanceof Attempt) {
+            return null;
+        }
+
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($scaleCode !== 'MBTI' || ! $this->isPublicResultScale($scaleCode) || in_array($scaleCode, self::SENSITIVE_RESULT_READ_SCALES, true)) {
+            return null;
+        }
+
+        return $attempt;
+    }
+
+    private function resultAccessTokenCandidate(Request $request): string
+    {
+        $candidates = [
+            $request->header('X-Result-Access-Token'),
+            $request->query('result_access_token'),
+            $request->query('access_token'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_string($candidate) && ! is_numeric($candidate)) {
+                continue;
+            }
+
+            $normalized = trim((string) $candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return '';
     }
 
     private function enforceEmailBindingForRead(Request $request, int $orgId, Attempt $attempt, string $scaleCode): void

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -25,6 +25,7 @@ final class ReportPdfDocumentService
         private readonly ReportPdfArtifactStore $artifactStore,
         private readonly MbtiPdfPayloadBuilder $mbtiPdfPayloadBuilder,
         private readonly GotenbergChromiumPdfClient $gotenbergChromiumPdfClient,
+        private readonly ResultPagePdfTokenService $resultPagePdfTokenService,
     ) {}
 
     public function normalizeVariant(string $variant): string
@@ -674,56 +675,17 @@ final class ReportPdfDocumentService
 
         $url = $baseUrl.'/'.ltrim($path, '/');
         if (self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION !== '') {
+            $pdfToken = $this->resultPagePdfTokenService->issueForMbtiResultPageExport($attempt, $gate, $locale);
             $separator = str_contains($url, '?') ? '&' : '?';
             $url .= $separator.http_build_query([
                 'pdf' => '1',
                 'surface' => self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
-                'pdf_token' => $this->resultPageExportToken($attempt, $gate, $locale),
+                'pdf_token' => $pdfToken,
+                'result_access_token' => $pdfToken,
             ], '', '&', PHP_QUERY_RFC3986);
         }
 
         return $url;
-    }
-
-    /**
-     * @param  array<string,mixed>  $gate
-     */
-    private function resultPageExportToken(Attempt $attempt, array $gate, string $locale): string
-    {
-        $expiresAt = now()->addMinutes(10)->getTimestamp();
-        $payload = [
-            'v' => 1,
-            'typ' => 'mbti_result_page_pdf',
-            'attempt_id' => (string) $attempt->id,
-            'user_id' => (string) ($attempt->user_id ?? ''),
-            'owner_id' => (string) (($attempt->user_id ?? null) ?: ($attempt->anon_id ?? '')),
-            'locale' => $locale,
-            'surface' => self::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
-            'engine' => self::RESULT_PAGE_EXPORT_ENGINE,
-            'entitlement' => ((bool) ($gate['locked'] ?? true)) ? 'locked' : 'unlocked',
-            'variant' => $this->normalizeVariant((string) ($gate['variant'] ?? 'free')),
-            'exp' => $expiresAt,
-        ];
-
-        $encodedPayload = $this->base64UrlEncode(json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
-        $signature = hash_hmac('sha256', $encodedPayload, $this->resultPageExportTokenSecret());
-
-        return $encodedPayload.'.'.$signature;
-    }
-
-    private function resultPageExportTokenSecret(): string
-    {
-        $secret = trim((string) config('gotenberg.result_print_token_secret', ''));
-        if ($secret !== '') {
-            return $secret;
-        }
-
-        return 'fap-result-page-pdf-local-key';
-    }
-
-    private function base64UrlEncode(string $value): string
-    {
-        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
     }
 
     /**

--- a/backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php
+++ b/backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Report\Pdf;
+
+use App\Models\Attempt;
+
+final class ResultPagePdfTokenService
+{
+    /**
+     * @param  array<string,mixed>  $gate
+     */
+    public function issueForMbtiResultPageExport(Attempt $attempt, array $gate, string $locale): string
+    {
+        $payload = [
+            'v' => 1,
+            'typ' => 'mbti_result_page_pdf',
+            'attempt_id' => (string) $attempt->id,
+            'user_id' => (string) ($attempt->user_id ?? ''),
+            'owner_id' => (string) (($attempt->user_id ?? null) ?: ($attempt->anon_id ?? '')),
+            'locale' => $locale,
+            'surface' => ReportPdfDocumentService::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+            'engine' => ReportPdfDocumentService::RESULT_PAGE_EXPORT_ENGINE,
+            'entitlement' => ((bool) ($gate['locked'] ?? true)) ? 'locked' : 'unlocked',
+            'variant' => $this->normalizeVariant((string) ($gate['variant'] ?? 'free')),
+            'exp' => now()->addMinutes(10)->getTimestamp(),
+        ];
+
+        $encodedPayload = $this->base64UrlEncode(json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+
+        return $encodedPayload.'.'.$this->sign($encodedPayload);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function verifyMbtiResultPageExport(string $token, int $orgId, string $attemptId): ?array
+    {
+        $token = trim($token);
+        if ($token === '' || substr_count($token, '.') !== 1) {
+            return null;
+        }
+
+        [$encodedPayload, $signature] = explode('.', $token, 2);
+        if ($encodedPayload === '' || $signature === '' || ! hash_equals($this->sign($encodedPayload), $signature)) {
+            return null;
+        }
+
+        $payloadJson = $this->base64UrlDecode($encodedPayload);
+        if ($payloadJson === null) {
+            return null;
+        }
+
+        $payload = json_decode($payloadJson, true);
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        if (
+            (int) ($payload['v'] ?? 0) !== 1
+            || (string) ($payload['typ'] ?? '') !== 'mbti_result_page_pdf'
+            || (string) ($payload['attempt_id'] ?? '') !== $attemptId
+            || (string) ($payload['surface'] ?? '') !== ReportPdfDocumentService::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION
+            || (string) ($payload['engine'] ?? '') !== ReportPdfDocumentService::RESULT_PAGE_EXPORT_ENGINE
+            || (int) ($payload['exp'] ?? 0) <= now()->getTimestamp()
+        ) {
+            return null;
+        }
+
+        $attempt = Attempt::query()
+            ->where('org_id', max(0, $orgId))
+            ->where('id', $attemptId)
+            ->first();
+
+        if (! $attempt instanceof Attempt || strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== 'MBTI') {
+            return null;
+        }
+
+        return $payload;
+    }
+
+    private function normalizeVariant(string $variant): string
+    {
+        $variant = strtolower(trim($variant));
+
+        return in_array($variant, ['free', 'full'], true) ? $variant : 'free';
+    }
+
+    private function sign(string $encodedPayload): string
+    {
+        return hash_hmac('sha256', $encodedPayload, $this->secret());
+    }
+
+    private function secret(): string
+    {
+        $secret = trim((string) config('gotenberg.result_print_token_secret', ''));
+        if ($secret !== '') {
+            return $secret;
+        }
+
+        return 'fap-result-page-pdf-local-key';
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function base64UrlDecode(string $value): ?string
+    {
+        $normalized = strtr($value, '-_', '+/');
+        $padded = str_pad($normalized, strlen($normalized) + ((4 - strlen($normalized) % 4) % 4), '=', STR_PAD_RIGHT);
+        $decoded = base64_decode($padded, true);
+
+        return is_string($decoded) ? $decoded : null;
+    }
+}

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Report\Pdf\ResultPagePdfTokenService;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -328,6 +329,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
                 && str_contains($body, 'pdf=1')
                 && str_contains($body, 'surface=mbti.result_page_export.v1')
                 && str_contains($body, 'pdf_token=')
+                && str_contains($body, 'result_access_token=')
                 && str_contains($body, 'waitForExpression')
                 && str_contains($body, 'window.__FERMAT_PDF_READY__ === true')
                 && str_contains($body, 'failOnHttpStatusCodes')
@@ -338,6 +340,39 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         Storage::disk('local')->assertExists(
             "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_export.v1-gotenberg_chromium-zh-locked-free/report_free.pdf"
         );
+    }
+
+    public function test_mbti_result_page_pdf_token_grants_only_matching_private_print_result_read(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+        config()->set('gotenberg.result_print_token_secret', 'test-result-print-secret');
+
+        $attemptId = (string) Str::uuid();
+        $otherAttemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_pdf_print_token');
+        $this->createResult($attemptId);
+        $this->createAttempt($otherAttemptId, 'MBTI', 'anon_pdf_print_token_other');
+        $this->createResult($otherAttemptId);
+
+        $attempt = Attempt::query()->where('id', $attemptId)->firstOrFail();
+        $token = app(ResultPagePdfTokenService::class)->issueForMbtiResultPageExport($attempt, [
+            'locked' => false,
+            'variant' => 'full',
+        ], 'zh');
+
+        $result = $this->withHeaders([
+            'X-Result-Access-Token' => $token,
+        ])->get("/api/v0.3/attempts/{$attemptId}/result?locale=zh-CN");
+
+        $result->assertStatus(200);
+        $this->assertSame('INTJ-A', $result->json('type_code'));
+
+        $wrongAttempt = $this->withHeaders([
+            'X-Result-Access-Token' => $token,
+        ])->get("/api/v0.3/attempts/{$otherAttemptId}/result?locale=zh-CN");
+
+        $wrongAttempt->assertStatus(404);
     }
 
     public function test_public_mbti_result_page_pdf_does_not_fallback_to_mpdf_when_gotenberg_fails(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -554,6 +554,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_result_page_pdf_token_bridge_files(): void
+    {
+        $changed = [
+            'backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_eq_cross_assessment_context_guard_changes(): void
     {
         $changed = [
@@ -4778,6 +4787,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiResultPagePdfTokenBridgeFile($file)) {
+                continue;
+            }
+
             if ($this->isPublicContentReleaseGuardCommandFile($file)) {
                 continue;
             }
@@ -6248,6 +6261,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/PdfGotenbergSpikeCommand.php',
             'backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php',
         ], true);
+    }
+
+    private function isMbtiResultPagePdfTokenBridgeFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php';
     }
 
     private function isPublicContentReleaseGuardCommandFile(string $file): bool


### PR DESCRIPTION
## What changed
- Added a backend ResultPagePdfTokenService for MBTI result-page PDF print tokens.
- Added the short-lived print token to the private Gotenberg print URL as result_access_token, so the existing frontend result client can read the report APIs during print rendering.
- Allowed the API read path to accept this token only for the matching MBTI attempt.
- Added regression coverage for the print URL token bridge and attempt isolation.

## Why
The production Gotenberg service and private print proxy are healthy, but the Gotenberg browser has no user Safari session or anon storage. The print page could open with pdf_token, but the client-side result/report fetches had no read token, so window.__FERMAT_PDF_READY__ never became true and the backend timed out.

## Validation
- php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi
- php artisan test --filter=AttemptReportAccessReadTest --no-ansi
- php artisan test --filter=MbtiReadPathParityContractTest --no-ansi
- vendor/bin/pint --test app/Services/Report/Pdf/ResultPagePdfTokenService.php app/Services/Report/Pdf/ReportPdfDocumentService.php app/Http/Controllers/API/V0_3/AttemptReadController.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
- git diff --check

## Deferred
- No deployment in this PR.
- No frontend changes.
- No CMS, DB, queue, search, indexing, or scheduler changes.