### PR TITLE
[codex] MBTI64-REMAINING-58-COMPETITOR-GAP-ARTIFACT-SYNC-01

### DIFF
--- a/backend/docs/seo/personality/mbti64-remaining-58-competitor-gap-content-expansion-v2-2026-06-28.json
+++ b/backend/docs/seo/personality/mbti64-remaining-58-competitor-gap-content-expansion-v2-2026-06-28.json
@@ -1,0 +1,10241 @@
+{
+  "artifact": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01",
+  "generated_at": "2026-06-28T12:00:00.000Z",
+  "status": "pass",
+  "target_count": 58,
+  "final_decision": "PASS_READY_FOR_CONTENT_EXPANSION_REVIEW",
+  "input_artifacts": [
+    "docs/seo/personality/mbti64-next-batch-6-competitor-gap-content-expansion-v2-2026-06-27.json",
+    "docs/seo/personality/mbti64-agent-expansion-88-recommendations-2026-06-21.json",
+    "docs/seo/personality/mbti64-agent-expansion-88-qa-2026-06-21.json",
+    "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+  ],
+  "exclusion_policy": {
+    "remaining_58_definition": "64 MBTI A/T variant URLs minus the six already completed V2 next-batch URLs",
+    "completed_v2_paths_excluded": [
+      "/en/personality/enfj-a",
+      "/en/personality/esfp-a",
+      "/en/personality/intp-a",
+      "/zh/personality/enfj-a",
+      "/zh/personality/esfp-a",
+      "/zh/personality/intp-a"
+    ],
+    "comparison_pages_excluded": true
+  },
+  "source_ledger": [
+    {
+      "source_id": "competitor_16personalities",
+      "source_type": "competitor_gap_structure",
+      "url": "https://www.16personalities.com/",
+      "how_used": "Mapped durable SERP modules around strengths, weaknesses, A/T intent, career/workplace, relationships and FAQ depth; no wording copied."
+    },
+    {
+      "source_id": "competitor_123test",
+      "source_type": "competitor_gap_structure",
+      "url": "https://www.123test.com/personality-types/",
+      "how_used": "Mapped concise type overview and practical interpretation structure; no wording copied."
+    },
+    {
+      "source_id": "competitor_truity",
+      "source_type": "competitor_gap_structure",
+      "url": "https://www.truity.com/personality-type/",
+      "how_used": "Mapped long-tail user intent around strengths, blind spots, work, relationships and practical use; no wording copied."
+    },
+    {
+      "source_id": "competitor_personality_junkie",
+      "source_type": "competitor_gap_structure",
+      "url": "https://personalityjunkie.com/",
+      "how_used": "Mapped demand for cognitive-function language as a depth differentiator; no wording copied."
+    },
+    {
+      "source_id": "method_boundary_myers_briggs_safe_use",
+      "source_type": "method_boundary",
+      "url": "https://www.themyersbriggs.com/",
+      "how_used": "Used only to keep affiliation, diagnostic, hiring-screen and deterministic-claim boundaries explicit."
+    }
+  ],
+  "golden_pattern_summary": {
+    "source_artifact": "docs/seo/personality/mbti64-next-batch-6-competitor-gap-content-expansion-v2-2026-06-27.json",
+    "source_target_count": 6,
+    "required_modules": [
+      "how_to_read",
+      "at_difference_table",
+      "cognitive_function_mechanism",
+      "work_scenario",
+      "relationship_communication",
+      "stress_growth",
+      "common_misreads",
+      "how_to_use_not_use"
+    ]
+  },
+  "reference_pack_summary": {
+    "source_artifact": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+    "reference_pack_status": "pass"
+  },
+  "recommendations": [
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/enfj-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/enfj-t",
+      "path": "/en/personality/enfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENFJ-T",
+      "mbti_type": "ENFJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/enfj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENFJ-T Meaning: Turbulent Protagonist Traits | FermatMind",
+        "description": "Explore ENFJ-T through people leadership, encouragement and shared direction, A/T differences, Fe-Ni-Se-Ti behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ENFJ-T Meaning",
+        "quick_answer": "ENFJ-T combines the ENFJ core pattern with an turbulent expression: it usually shows up around people leadership, encouragement and shared direction and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ENFJ-T first",
+            "body": "ENFJ-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving people leadership, encouragement and shared direction, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENFJ-T vs ENFJ-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ENFJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ENFJ-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Fe-Ni-Se-Ti",
+            "body": "ENFJ is often described through interpersonal organization Fe, directional intuition Ni, present sensing Se and logic checking Ti. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ENFJ-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: team reset, mentoring and cross-functional alignment",
+            "body": "In team reset, mentoring and cross-functional alignment, ENFJ-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: supporting without taking over responsibility",
+            "body": "ENFJ-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ENFJ-T may overuse the same strengths that support people leadership, encouragement and shared direction: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "supportive does not mean people-pleasing. Type describes preference, not character, intelligence, mental health or career worth. Healthy ENFJ-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ENFJ-T mean?",
+            "answer": "ENFJ-T combines the ENFJ core pattern with an turbulent expression, often visible in people leadership, encouragement and shared direction, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ENFJ-T and ENFJ-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ENFJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ENFJ-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ENFJ-T?",
+            "answer": "Strengths usually appear around people leadership, encouragement and shared direction, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ENFJ-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ENFJ-T watch in relationships?",
+            "answer": "supporting without taking over responsibility, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfj-a",
+            "anchor_text": "ENFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfj-a-vs-enfj-t",
+            "anchor_text": "ENFJ-A vs ENFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/enfj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENFJ-T is anchored on people leadership, encouragement and shared direction.",
+          "Cognitive-function vocabulary: Fe-Ni-Se-Ti.",
+          "Primary scenario: team reset, mentoring and cross-functional alignment."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/enfp-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/enfp-a",
+      "path": "/en/personality/enfp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENFP-A",
+      "mbti_type": "ENFP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/enfp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENFP-A Meaning: Assertive Campaigner Traits | FermatMind",
+        "description": "Explore ENFP-A through possibility, connection and creative momentum, A/T differences, Ne-Fi-Te-Si behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ENFP-A Meaning",
+        "quick_answer": "ENFP-A combines the ENFP core pattern with an assertive expression: it usually shows up around possibility, connection and creative momentum and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ENFP-A first",
+            "body": "ENFP-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving possibility, connection and creative momentum, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENFP-A vs ENFP-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ENFP-A leans toward steadier self-trust, feedback recovery and follow-through, while ENFP-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ne-Fi-Te-Si",
+            "body": "ENFP is often described through possibility exploration Ne, private values Fi, organizing thinking Te and memory calibration Si. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ENFP-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: creative sprints, community building and opportunity discovery",
+            "body": "In creative sprints, community building and opportunity discovery, ENFP-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: turning enthusiasm into reliable follow-through",
+            "body": "ENFP-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ENFP-A may overuse the same strengths that support possibility, connection and creative momentum: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "many interests do not mean no depth. Type describes preference, not character, intelligence, mental health or career worth. Healthy ENFP-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ENFP-A mean?",
+            "answer": "ENFP-A combines the ENFP core pattern with an assertive expression, often visible in possibility, connection and creative momentum, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ENFP-A and ENFP-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ENFP-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ENFP-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ENFP-A?",
+            "answer": "Strengths usually appear around possibility, connection and creative momentum, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ENFP-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ENFP-A watch in relationships?",
+            "answer": "turning enthusiasm into reliable follow-through, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfp-t",
+            "anchor_text": "ENFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfp-a-vs-enfp-t",
+            "anchor_text": "ENFP-A vs ENFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/enfp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENFP-A is anchored on possibility, connection and creative momentum.",
+          "Cognitive-function vocabulary: Ne-Fi-Te-Si.",
+          "Primary scenario: creative sprints, community building and opportunity discovery."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/enfp-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/enfp-t",
+      "path": "/en/personality/enfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENFP-T",
+      "mbti_type": "ENFP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/enfp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENFP-T Meaning: Turbulent Campaigner Traits | FermatMind",
+        "description": "Explore ENFP-T through possibility, connection and creative momentum, A/T differences, Ne-Fi-Te-Si behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ENFP-T Meaning",
+        "quick_answer": "ENFP-T combines the ENFP core pattern with an turbulent expression: it usually shows up around possibility, connection and creative momentum and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ENFP-T first",
+            "body": "ENFP-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving possibility, connection and creative momentum, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENFP-T vs ENFP-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ENFP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ENFP-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ne-Fi-Te-Si",
+            "body": "ENFP is often described through possibility exploration Ne, private values Fi, organizing thinking Te and memory calibration Si. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ENFP-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: creative sprints, community building and opportunity discovery",
+            "body": "In creative sprints, community building and opportunity discovery, ENFP-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: turning enthusiasm into reliable follow-through",
+            "body": "ENFP-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ENFP-T may overuse the same strengths that support possibility, connection and creative momentum: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "many interests do not mean no depth. Type describes preference, not character, intelligence, mental health or career worth. Healthy ENFP-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ENFP-T mean?",
+            "answer": "ENFP-T combines the ENFP core pattern with an turbulent expression, often visible in possibility, connection and creative momentum, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ENFP-T and ENFP-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ENFP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ENFP-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ENFP-T?",
+            "answer": "Strengths usually appear around possibility, connection and creative momentum, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ENFP-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ENFP-T watch in relationships?",
+            "answer": "turning enthusiasm into reliable follow-through, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfp-a",
+            "anchor_text": "ENFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfp-a-vs-enfp-t",
+            "anchor_text": "ENFP-A vs ENFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/enfp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENFP-T is anchored on possibility, connection and creative momentum.",
+          "Cognitive-function vocabulary: Ne-Fi-Te-Si.",
+          "Primary scenario: creative sprints, community building and opportunity discovery."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/entj-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/entj-a",
+      "path": "/en/personality/entj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENTJ-A",
+      "mbti_type": "ENTJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/entj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENTJ-A Meaning: Assertive Commander Traits | FermatMind",
+        "description": "Explore ENTJ-A through decisions, systems leadership and operational follow-through, A/T differences, Te-Ni-Se-Fi behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ENTJ-A Meaning",
+        "quick_answer": "ENTJ-A combines the ENTJ core pattern with an assertive expression: it usually shows up around decisions, systems leadership and operational follow-through and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ENTJ-A first",
+            "body": "ENTJ-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving decisions, systems leadership and operational follow-through, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENTJ-A vs ENTJ-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ENTJ-A leans toward steadier self-trust, feedback recovery and follow-through, while ENTJ-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Te-Ni-Se-Fi",
+            "body": "ENTJ is often described through organizing thinking Te, directional intuition Ni, real-time sensing Se and private values Fi. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ENTJ-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: decision meetings, operating cadences and accountability resets",
+            "body": "In decision meetings, operating cadences and accountability resets, ENTJ-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: making room for consent and emotion before moving to action",
+            "body": "ENTJ-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ENTJ-A may overuse the same strengths that support decisions, systems leadership and operational follow-through: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "directness is not the same as not caring. Type describes preference, not character, intelligence, mental health or career worth. Healthy ENTJ-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ENTJ-A mean?",
+            "answer": "ENTJ-A combines the ENTJ core pattern with an assertive expression, often visible in decisions, systems leadership and operational follow-through, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ENTJ-A and ENTJ-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ENTJ-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ENTJ-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ENTJ-A?",
+            "answer": "Strengths usually appear around decisions, systems leadership and operational follow-through, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ENTJ-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ENTJ-A watch in relationships?",
+            "answer": "making room for consent and emotion before moving to action, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entj-t",
+            "anchor_text": "ENTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entj-a-vs-entj-t",
+            "anchor_text": "ENTJ-A vs ENTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/entj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENTJ-A is anchored on decisions, systems leadership and operational follow-through.",
+          "Cognitive-function vocabulary: Te-Ni-Se-Fi.",
+          "Primary scenario: decision meetings, operating cadences and accountability resets."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/entj-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/entj-t",
+      "path": "/en/personality/entj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENTJ-T",
+      "mbti_type": "ENTJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/entj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENTJ-T Meaning: Turbulent Commander Traits | FermatMind",
+        "description": "Explore ENTJ-T through decisions, systems leadership and operational follow-through, A/T differences, Te-Ni-Se-Fi behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ENTJ-T Meaning",
+        "quick_answer": "ENTJ-T combines the ENTJ core pattern with an turbulent expression: it usually shows up around decisions, systems leadership and operational follow-through and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ENTJ-T first",
+            "body": "ENTJ-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving decisions, systems leadership and operational follow-through, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENTJ-T vs ENTJ-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ENTJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ENTJ-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Te-Ni-Se-Fi",
+            "body": "ENTJ is often described through organizing thinking Te, directional intuition Ni, real-time sensing Se and private values Fi. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ENTJ-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: decision meetings, operating cadences and accountability resets",
+            "body": "In decision meetings, operating cadences and accountability resets, ENTJ-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: making room for consent and emotion before moving to action",
+            "body": "ENTJ-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ENTJ-T may overuse the same strengths that support decisions, systems leadership and operational follow-through: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "directness is not the same as not caring. Type describes preference, not character, intelligence, mental health or career worth. Healthy ENTJ-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ENTJ-T mean?",
+            "answer": "ENTJ-T combines the ENTJ core pattern with an turbulent expression, often visible in decisions, systems leadership and operational follow-through, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ENTJ-T and ENTJ-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ENTJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ENTJ-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ENTJ-T?",
+            "answer": "Strengths usually appear around decisions, systems leadership and operational follow-through, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ENTJ-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ENTJ-T watch in relationships?",
+            "answer": "making room for consent and emotion before moving to action, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entj-a",
+            "anchor_text": "ENTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entj-a-vs-entj-t",
+            "anchor_text": "ENTJ-A vs ENTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/entj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENTJ-T is anchored on decisions, systems leadership and operational follow-through.",
+          "Cognitive-function vocabulary: Te-Ni-Se-Fi.",
+          "Primary scenario: decision meetings, operating cadences and accountability resets."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/entp-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/entp-a",
+      "path": "/en/personality/entp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENTP-A",
+      "mbti_type": "ENTP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/entp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENTP-A Meaning: Assertive Debater Traits | FermatMind",
+        "description": "Explore ENTP-A through experimentation, debate and fast idea testing, A/T differences, Ne-Ti-Fe-Si behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ENTP-A Meaning",
+        "quick_answer": "ENTP-A combines the ENTP core pattern with an assertive expression: it usually shows up around experimentation, debate and fast idea testing and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ENTP-A first",
+            "body": "ENTP-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving experimentation, debate and fast idea testing, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENTP-A vs ENTP-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ENTP-A leans toward steadier self-trust, feedback recovery and follow-through, while ENTP-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ne-Ti-Fe-Si",
+            "body": "ENTP is often described through possibility exploration Ne, internal logic Ti, social feedback Fe and memory calibration Si. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ENTP-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: product experiments, debate-heavy planning and early-stage problem framing",
+            "body": "In product experiments, debate-heavy planning and early-stage problem framing, ENTP-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: checking whether debate feels playful or exhausting to others",
+            "body": "ENTP-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ENTP-A may overuse the same strengths that support experimentation, debate and fast idea testing: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "arguing a possibility is not the same as believing it. Type describes preference, not character, intelligence, mental health or career worth. Healthy ENTP-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ENTP-A mean?",
+            "answer": "ENTP-A combines the ENTP core pattern with an assertive expression, often visible in experimentation, debate and fast idea testing, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ENTP-A and ENTP-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ENTP-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ENTP-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ENTP-A?",
+            "answer": "Strengths usually appear around experimentation, debate and fast idea testing, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ENTP-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ENTP-A watch in relationships?",
+            "answer": "checking whether debate feels playful or exhausting to others, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entp-t",
+            "anchor_text": "ENTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entp-a-vs-entp-t",
+            "anchor_text": "ENTP-A vs ENTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/entp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENTP-A is anchored on experimentation, debate and fast idea testing.",
+          "Cognitive-function vocabulary: Ne-Ti-Fe-Si.",
+          "Primary scenario: product experiments, debate-heavy planning and early-stage problem framing."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/entp-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/entp-t",
+      "path": "/en/personality/entp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENTP-T",
+      "mbti_type": "ENTP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/entp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENTP-T Meaning: Turbulent Debater Traits | FermatMind",
+        "description": "Explore ENTP-T through experimentation, debate and fast idea testing, A/T differences, Ne-Ti-Fe-Si behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ENTP-T Meaning",
+        "quick_answer": "ENTP-T combines the ENTP core pattern with an turbulent expression: it usually shows up around experimentation, debate and fast idea testing and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ENTP-T first",
+            "body": "ENTP-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving experimentation, debate and fast idea testing, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENTP-T vs ENTP-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ENTP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ENTP-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ne-Ti-Fe-Si",
+            "body": "ENTP is often described through possibility exploration Ne, internal logic Ti, social feedback Fe and memory calibration Si. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ENTP-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: product experiments, debate-heavy planning and early-stage problem framing",
+            "body": "In product experiments, debate-heavy planning and early-stage problem framing, ENTP-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: checking whether debate feels playful or exhausting to others",
+            "body": "ENTP-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ENTP-T may overuse the same strengths that support experimentation, debate and fast idea testing: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "arguing a possibility is not the same as believing it. Type describes preference, not character, intelligence, mental health or career worth. Healthy ENTP-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ENTP-T mean?",
+            "answer": "ENTP-T combines the ENTP core pattern with an turbulent expression, often visible in experimentation, debate and fast idea testing, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ENTP-T and ENTP-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ENTP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ENTP-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ENTP-T?",
+            "answer": "Strengths usually appear around experimentation, debate and fast idea testing, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ENTP-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ENTP-T watch in relationships?",
+            "answer": "checking whether debate feels playful or exhausting to others, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entp-a",
+            "anchor_text": "ENTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entp-a-vs-entp-t",
+            "anchor_text": "ENTP-A vs ENTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/entp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENTP-T is anchored on experimentation, debate and fast idea testing.",
+          "Cognitive-function vocabulary: Ne-Ti-Fe-Si.",
+          "Primary scenario: product experiments, debate-heavy planning and early-stage problem framing."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/esfj-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/esfj-a",
+      "path": "/en/personality/esfj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESFJ-A",
+      "mbti_type": "ESFJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/esfj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESFJ-A Meaning: Assertive Consul Traits | FermatMind",
+        "description": "Explore ESFJ-A through support, belonging and practical coordination, A/T differences, Fe-Si-Ne-Ti behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ESFJ-A Meaning",
+        "quick_answer": "ESFJ-A combines the ESFJ core pattern with an assertive expression: it usually shows up around support, belonging and practical coordination and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ESFJ-A first",
+            "body": "ESFJ-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving support, belonging and practical coordination, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESFJ-A vs ESFJ-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ESFJ-A leans toward steadier self-trust, feedback recovery and follow-through, while ESFJ-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Fe-Si-Ne-Ti",
+            "body": "ESFJ is often described through interpersonal organization Fe, memory calibration Si, possibility checking Ne and internal logic Ti. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ESFJ-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: community operations, customer care and team coordination",
+            "body": "In community operations, customer care and team coordination, ESFJ-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: keeping warmth while making boundaries explicit",
+            "body": "ESFJ-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ESFJ-A may overuse the same strengths that support support, belonging and practical coordination: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "social awareness is not superficial conformity. Type describes preference, not character, intelligence, mental health or career worth. Healthy ESFJ-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ESFJ-A mean?",
+            "answer": "ESFJ-A combines the ESFJ core pattern with an assertive expression, often visible in support, belonging and practical coordination, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ESFJ-A and ESFJ-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ESFJ-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ESFJ-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ESFJ-A?",
+            "answer": "Strengths usually appear around support, belonging and practical coordination, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ESFJ-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ESFJ-A watch in relationships?",
+            "answer": "keeping warmth while making boundaries explicit, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfj-t",
+            "anchor_text": "ESFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfj-a-vs-esfj-t",
+            "anchor_text": "ESFJ-A vs ESFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/esfj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESFJ-A is anchored on support, belonging and practical coordination.",
+          "Cognitive-function vocabulary: Fe-Si-Ne-Ti.",
+          "Primary scenario: community operations, customer care and team coordination."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/esfj-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/esfj-t",
+      "path": "/en/personality/esfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESFJ-T",
+      "mbti_type": "ESFJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/esfj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESFJ-T Meaning: Turbulent Consul Traits | FermatMind",
+        "description": "Explore ESFJ-T through support, belonging and practical coordination, A/T differences, Fe-Si-Ne-Ti behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ESFJ-T Meaning",
+        "quick_answer": "ESFJ-T combines the ESFJ core pattern with an turbulent expression: it usually shows up around support, belonging and practical coordination and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ESFJ-T first",
+            "body": "ESFJ-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving support, belonging and practical coordination, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESFJ-T vs ESFJ-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ESFJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ESFJ-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Fe-Si-Ne-Ti",
+            "body": "ESFJ is often described through interpersonal organization Fe, memory calibration Si, possibility checking Ne and internal logic Ti. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ESFJ-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: community operations, customer care and team coordination",
+            "body": "In community operations, customer care and team coordination, ESFJ-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: keeping warmth while making boundaries explicit",
+            "body": "ESFJ-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ESFJ-T may overuse the same strengths that support support, belonging and practical coordination: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "social awareness is not superficial conformity. Type describes preference, not character, intelligence, mental health or career worth. Healthy ESFJ-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ESFJ-T mean?",
+            "answer": "ESFJ-T combines the ESFJ core pattern with an turbulent expression, often visible in support, belonging and practical coordination, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ESFJ-T and ESFJ-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ESFJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ESFJ-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ESFJ-T?",
+            "answer": "Strengths usually appear around support, belonging and practical coordination, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ESFJ-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ESFJ-T watch in relationships?",
+            "answer": "keeping warmth while making boundaries explicit, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfj-a",
+            "anchor_text": "ESFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfj-a-vs-esfj-t",
+            "anchor_text": "ESFJ-A vs ESFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/esfj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESFJ-T is anchored on support, belonging and practical coordination.",
+          "Cognitive-function vocabulary: Fe-Si-Ne-Ti.",
+          "Primary scenario: community operations, customer care and team coordination."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/esfp-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/esfp-t",
+      "path": "/en/personality/esfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESFP-T",
+      "mbti_type": "ESFP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/esfp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESFP-T Meaning: Turbulent Entertainer Traits | FermatMind",
+        "description": "Explore ESFP-T through energy, presence and shared experience, A/T differences, Se-Fi-Te-Ni behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ESFP-T Meaning",
+        "quick_answer": "ESFP-T combines the ESFP core pattern with an turbulent expression: it usually shows up around energy, presence and shared experience and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ESFP-T first",
+            "body": "ESFP-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving energy, presence and shared experience, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESFP-T vs ESFP-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ESFP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ESFP-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Se-Fi-Te-Ni",
+            "body": "ESFP is often described through present sensing Se, private values Fi, organizing thinking Te and directional intuition Ni. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ESFP-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: events, customer experience and live recovery",
+            "body": "In events, customer experience and live recovery, ESFP-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: bringing warmth while naming real boundaries",
+            "body": "ESFP-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ESFP-T may overuse the same strengths that support energy, presence and shared experience: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "energetic is not shallow. Type describes preference, not character, intelligence, mental health or career worth. Healthy ESFP-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ESFP-T mean?",
+            "answer": "ESFP-T combines the ESFP core pattern with an turbulent expression, often visible in energy, presence and shared experience, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ESFP-T and ESFP-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ESFP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ESFP-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ESFP-T?",
+            "answer": "Strengths usually appear around energy, presence and shared experience, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ESFP-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ESFP-T watch in relationships?",
+            "answer": "bringing warmth while naming real boundaries, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfp-a",
+            "anchor_text": "ESFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfp-a-vs-esfp-t",
+            "anchor_text": "ESFP-A vs ESFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/esfp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESFP-T is anchored on energy, presence and shared experience.",
+          "Cognitive-function vocabulary: Se-Fi-Te-Ni.",
+          "Primary scenario: events, customer experience and live recovery."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/estj-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/estj-a",
+      "path": "/en/personality/estj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESTJ-A",
+      "mbti_type": "ESTJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/estj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESTJ-A Meaning: Assertive Executive Traits | FermatMind",
+        "description": "Explore ESTJ-A through structure, decisions and practical accountability, A/T differences, Te-Si-Ne-Fi behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ESTJ-A Meaning",
+        "quick_answer": "ESTJ-A combines the ESTJ core pattern with an assertive expression: it usually shows up around structure, decisions and practical accountability and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ESTJ-A first",
+            "body": "ESTJ-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving structure, decisions and practical accountability, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESTJ-A vs ESTJ-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ESTJ-A leans toward steadier self-trust, feedback recovery and follow-through, while ESTJ-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Te-Si-Ne-Fi",
+            "body": "ESTJ is often described through organizing thinking Te, memory calibration Si, possibility checking Ne and private values Fi. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ESTJ-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: operating rhythm, role clarity and quality control",
+            "body": "In operating rhythm, role clarity and quality control, ESTJ-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: balancing practical fixes with emotional recognition",
+            "body": "ESTJ-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ESTJ-A may overuse the same strengths that support structure, decisions and practical accountability: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "structured does not mean insensitive. Type describes preference, not character, intelligence, mental health or career worth. Healthy ESTJ-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ESTJ-A mean?",
+            "answer": "ESTJ-A combines the ESTJ core pattern with an assertive expression, often visible in structure, decisions and practical accountability, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ESTJ-A and ESTJ-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ESTJ-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ESTJ-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ESTJ-A?",
+            "answer": "Strengths usually appear around structure, decisions and practical accountability, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ESTJ-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ESTJ-A watch in relationships?",
+            "answer": "balancing practical fixes with emotional recognition, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estj-t",
+            "anchor_text": "ESTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estj-a-vs-estj-t",
+            "anchor_text": "ESTJ-A vs ESTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/estj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESTJ-A is anchored on structure, decisions and practical accountability.",
+          "Cognitive-function vocabulary: Te-Si-Ne-Fi.",
+          "Primary scenario: operating rhythm, role clarity and quality control."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/estj-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/estj-t",
+      "path": "/en/personality/estj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESTJ-T",
+      "mbti_type": "ESTJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/estj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESTJ-T Meaning: Turbulent Executive Traits | FermatMind",
+        "description": "Explore ESTJ-T through structure, decisions and practical accountability, A/T differences, Te-Si-Ne-Fi behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ESTJ-T Meaning",
+        "quick_answer": "ESTJ-T combines the ESTJ core pattern with an turbulent expression: it usually shows up around structure, decisions and practical accountability and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ESTJ-T first",
+            "body": "ESTJ-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving structure, decisions and practical accountability, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESTJ-T vs ESTJ-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ESTJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ESTJ-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Te-Si-Ne-Fi",
+            "body": "ESTJ is often described through organizing thinking Te, memory calibration Si, possibility checking Ne and private values Fi. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ESTJ-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: operating rhythm, role clarity and quality control",
+            "body": "In operating rhythm, role clarity and quality control, ESTJ-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: balancing practical fixes with emotional recognition",
+            "body": "ESTJ-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ESTJ-T may overuse the same strengths that support structure, decisions and practical accountability: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "structured does not mean insensitive. Type describes preference, not character, intelligence, mental health or career worth. Healthy ESTJ-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ESTJ-T mean?",
+            "answer": "ESTJ-T combines the ESTJ core pattern with an turbulent expression, often visible in structure, decisions and practical accountability, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ESTJ-T and ESTJ-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ESTJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ESTJ-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ESTJ-T?",
+            "answer": "Strengths usually appear around structure, decisions and practical accountability, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ESTJ-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ESTJ-T watch in relationships?",
+            "answer": "balancing practical fixes with emotional recognition, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estj-a",
+            "anchor_text": "ESTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estj-a-vs-estj-t",
+            "anchor_text": "ESTJ-A vs ESTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/estj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESTJ-T is anchored on structure, decisions and practical accountability.",
+          "Cognitive-function vocabulary: Te-Si-Ne-Fi.",
+          "Primary scenario: operating rhythm, role clarity and quality control."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/estp-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/estp-a",
+      "path": "/en/personality/estp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESTP-A",
+      "mbti_type": "ESTP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/estp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESTP-A Meaning: Assertive Entrepreneur Traits | FermatMind",
+        "description": "Explore ESTP-A through action, opportunity and real-time adaptation, A/T differences, Se-Ti-Fe-Ni behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ESTP-A Meaning",
+        "quick_answer": "ESTP-A combines the ESTP core pattern with an assertive expression: it usually shows up around action, opportunity and real-time adaptation and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ESTP-A first",
+            "body": "ESTP-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving action, opportunity and real-time adaptation, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESTP-A vs ESTP-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ESTP-A leans toward steadier self-trust, feedback recovery and follow-through, while ESTP-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Se-Ti-Fe-Ni",
+            "body": "ESTP is often described through present sensing Se, internal logic Ti, social feedback Fe and directional intuition Ni. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ESTP-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: negotiation, sales floors and fast operational recovery",
+            "body": "In negotiation, sales floors and fast operational recovery, ESTP-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: slowing down enough for trust and follow-through",
+            "body": "ESTP-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ESTP-A may overuse the same strengths that support action, opportunity and real-time adaptation: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "fast action is not lack of thought. Type describes preference, not character, intelligence, mental health or career worth. Healthy ESTP-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ESTP-A mean?",
+            "answer": "ESTP-A combines the ESTP core pattern with an assertive expression, often visible in action, opportunity and real-time adaptation, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ESTP-A and ESTP-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ESTP-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ESTP-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ESTP-A?",
+            "answer": "Strengths usually appear around action, opportunity and real-time adaptation, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ESTP-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ESTP-A watch in relationships?",
+            "answer": "slowing down enough for trust and follow-through, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estp-t",
+            "anchor_text": "ESTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estp-a-vs-estp-t",
+            "anchor_text": "ESTP-A vs ESTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/estp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESTP-A is anchored on action, opportunity and real-time adaptation.",
+          "Cognitive-function vocabulary: Se-Ti-Fe-Ni.",
+          "Primary scenario: negotiation, sales floors and fast operational recovery."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/estp-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/estp-t",
+      "path": "/en/personality/estp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESTP-T",
+      "mbti_type": "ESTP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/estp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESTP-T Meaning: Turbulent Entrepreneur Traits | FermatMind",
+        "description": "Explore ESTP-T through action, opportunity and real-time adaptation, A/T differences, Se-Ti-Fe-Ni behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ESTP-T Meaning",
+        "quick_answer": "ESTP-T combines the ESTP core pattern with an turbulent expression: it usually shows up around action, opportunity and real-time adaptation and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ESTP-T first",
+            "body": "ESTP-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving action, opportunity and real-time adaptation, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESTP-T vs ESTP-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ESTP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ESTP-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Se-Ti-Fe-Ni",
+            "body": "ESTP is often described through present sensing Se, internal logic Ti, social feedback Fe and directional intuition Ni. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ESTP-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: negotiation, sales floors and fast operational recovery",
+            "body": "In negotiation, sales floors and fast operational recovery, ESTP-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: slowing down enough for trust and follow-through",
+            "body": "ESTP-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ESTP-T may overuse the same strengths that support action, opportunity and real-time adaptation: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "fast action is not lack of thought. Type describes preference, not character, intelligence, mental health or career worth. Healthy ESTP-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ESTP-T mean?",
+            "answer": "ESTP-T combines the ESTP core pattern with an turbulent expression, often visible in action, opportunity and real-time adaptation, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ESTP-T and ESTP-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ESTP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ESTP-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ESTP-T?",
+            "answer": "Strengths usually appear around action, opportunity and real-time adaptation, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ESTP-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ESTP-T watch in relationships?",
+            "answer": "slowing down enough for trust and follow-through, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estp-a",
+            "anchor_text": "ESTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estp-a-vs-estp-t",
+            "anchor_text": "ESTP-A vs ESTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/estp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESTP-T is anchored on action, opportunity and real-time adaptation.",
+          "Cognitive-function vocabulary: Se-Ti-Fe-Ni.",
+          "Primary scenario: negotiation, sales floors and fast operational recovery."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/infj-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/infj-a",
+      "path": "/en/personality/infj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INFJ-A",
+      "mbti_type": "INFJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/infj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INFJ-A Meaning: Assertive Advocate Traits | FermatMind",
+        "description": "Explore INFJ-A through meaning, pattern insight and values-led direction, A/T differences, Ni-Fe-Ti-Se behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "INFJ-A Meaning",
+        "quick_answer": "INFJ-A combines the INFJ core pattern with an assertive expression: it usually shows up around meaning, pattern insight and values-led direction and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read INFJ-A first",
+            "body": "INFJ-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving meaning, pattern insight and values-led direction, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INFJ-A vs INFJ-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. INFJ-A leans toward steadier self-trust, feedback recovery and follow-through, while INFJ-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ni-Fe-Ti-Se",
+            "body": "INFJ is often described through directional intuition Ni, interpersonal attunement Fe, internal logic Ti and present sensing Se. This is not a clinical mechanism. It is a behavior vocabulary for noticing how INFJ-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: mission framing, mentoring and long-range people problems",
+            "body": "In mission framing, mentoring and long-range people problems, INFJ-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: naming expectations before quiet disappointment builds",
+            "body": "INFJ-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, INFJ-A may overuse the same strengths that support meaning, pattern insight and values-led direction: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "private processing is not hidden judgment. Type describes preference, not character, intelligence, mental health or career worth. Healthy INFJ-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does INFJ-A mean?",
+            "answer": "INFJ-A combines the INFJ core pattern with an assertive expression, often visible in meaning, pattern insight and values-led direction, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between INFJ-A and INFJ-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. INFJ-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does INFJ-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for INFJ-A?",
+            "answer": "Strengths usually appear around meaning, pattern insight and values-led direction, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can INFJ-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should INFJ-A watch in relationships?",
+            "answer": "naming expectations before quiet disappointment builds, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infj-t",
+            "anchor_text": "INFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infj-a-vs-infj-t",
+            "anchor_text": "INFJ-A vs INFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/infj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INFJ-A is anchored on meaning, pattern insight and values-led direction.",
+          "Cognitive-function vocabulary: Ni-Fe-Ti-Se.",
+          "Primary scenario: mission framing, mentoring and long-range people problems."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/infj-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/infj-t",
+      "path": "/en/personality/infj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INFJ-T",
+      "mbti_type": "INFJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/infj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INFJ-T Meaning: Turbulent Advocate Traits | FermatMind",
+        "description": "Explore INFJ-T through meaning, pattern insight and values-led direction, A/T differences, Ni-Fe-Ti-Se behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "INFJ-T Meaning",
+        "quick_answer": "INFJ-T combines the INFJ core pattern with an turbulent expression: it usually shows up around meaning, pattern insight and values-led direction and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read INFJ-T first",
+            "body": "INFJ-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving meaning, pattern insight and values-led direction, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INFJ-T vs INFJ-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. INFJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while INFJ-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ni-Fe-Ti-Se",
+            "body": "INFJ is often described through directional intuition Ni, interpersonal attunement Fe, internal logic Ti and present sensing Se. This is not a clinical mechanism. It is a behavior vocabulary for noticing how INFJ-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: mission framing, mentoring and long-range people problems",
+            "body": "In mission framing, mentoring and long-range people problems, INFJ-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: naming expectations before quiet disappointment builds",
+            "body": "INFJ-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, INFJ-T may overuse the same strengths that support meaning, pattern insight and values-led direction: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "private processing is not hidden judgment. Type describes preference, not character, intelligence, mental health or career worth. Healthy INFJ-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does INFJ-T mean?",
+            "answer": "INFJ-T combines the INFJ core pattern with an turbulent expression, often visible in meaning, pattern insight and values-led direction, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between INFJ-T and INFJ-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. INFJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does INFJ-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for INFJ-T?",
+            "answer": "Strengths usually appear around meaning, pattern insight and values-led direction, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can INFJ-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should INFJ-T watch in relationships?",
+            "answer": "naming expectations before quiet disappointment builds, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infj-a",
+            "anchor_text": "INFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infj-a-vs-infj-t",
+            "anchor_text": "INFJ-A vs INFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/infj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INFJ-T is anchored on meaning, pattern insight and values-led direction.",
+          "Cognitive-function vocabulary: Ni-Fe-Ti-Se.",
+          "Primary scenario: mission framing, mentoring and long-range people problems."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/infp-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/infp-a",
+      "path": "/en/personality/infp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INFP-A",
+      "mbti_type": "INFP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/infp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INFP-A Meaning: Assertive Mediator Traits | FermatMind",
+        "description": "Explore INFP-A through personal meaning, values and empathetic imagination, A/T differences, Fi-Ne-Si-Te behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "INFP-A Meaning",
+        "quick_answer": "INFP-A combines the INFP core pattern with an assertive expression: it usually shows up around personal meaning, values and empathetic imagination and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read INFP-A first",
+            "body": "INFP-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving personal meaning, values and empathetic imagination, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INFP-A vs INFP-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. INFP-A leans toward steadier self-trust, feedback recovery and follow-through, while INFP-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Fi-Ne-Si-Te",
+            "body": "INFP is often described through private values Fi, possibility exploration Ne, memory calibration Si and organizing thinking Te. This is not a clinical mechanism. It is a behavior vocabulary for noticing how INFP-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: values-led creative work, counseling-style listening and narrative design",
+            "body": "In values-led creative work, counseling-style listening and narrative design, INFP-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: separating deep care from unspoken expectations",
+            "body": "INFP-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, INFP-A may overuse the same strengths that support personal meaning, values and empathetic imagination: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "soft expression is not weak conviction. Type describes preference, not character, intelligence, mental health or career worth. Healthy INFP-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does INFP-A mean?",
+            "answer": "INFP-A combines the INFP core pattern with an assertive expression, often visible in personal meaning, values and empathetic imagination, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between INFP-A and INFP-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. INFP-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does INFP-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for INFP-A?",
+            "answer": "Strengths usually appear around personal meaning, values and empathetic imagination, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can INFP-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should INFP-A watch in relationships?",
+            "answer": "separating deep care from unspoken expectations, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infp-t",
+            "anchor_text": "INFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infp-a-vs-infp-t",
+            "anchor_text": "INFP-A vs INFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/infp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INFP-A is anchored on personal meaning, values and empathetic imagination.",
+          "Cognitive-function vocabulary: Fi-Ne-Si-Te.",
+          "Primary scenario: values-led creative work, counseling-style listening and narrative design."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/infp-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/infp-t",
+      "path": "/en/personality/infp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INFP-T",
+      "mbti_type": "INFP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/infp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INFP-T Meaning: Turbulent Mediator Traits | FermatMind",
+        "description": "Explore INFP-T through personal meaning, values and empathetic imagination, A/T differences, Fi-Ne-Si-Te behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "INFP-T Meaning",
+        "quick_answer": "INFP-T combines the INFP core pattern with an turbulent expression: it usually shows up around personal meaning, values and empathetic imagination and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read INFP-T first",
+            "body": "INFP-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving personal meaning, values and empathetic imagination, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INFP-T vs INFP-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. INFP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while INFP-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Fi-Ne-Si-Te",
+            "body": "INFP is often described through private values Fi, possibility exploration Ne, memory calibration Si and organizing thinking Te. This is not a clinical mechanism. It is a behavior vocabulary for noticing how INFP-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: values-led creative work, counseling-style listening and narrative design",
+            "body": "In values-led creative work, counseling-style listening and narrative design, INFP-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: separating deep care from unspoken expectations",
+            "body": "INFP-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, INFP-T may overuse the same strengths that support personal meaning, values and empathetic imagination: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "soft expression is not weak conviction. Type describes preference, not character, intelligence, mental health or career worth. Healthy INFP-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does INFP-T mean?",
+            "answer": "INFP-T combines the INFP core pattern with an turbulent expression, often visible in personal meaning, values and empathetic imagination, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between INFP-T and INFP-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. INFP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does INFP-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for INFP-T?",
+            "answer": "Strengths usually appear around personal meaning, values and empathetic imagination, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can INFP-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should INFP-T watch in relationships?",
+            "answer": "separating deep care from unspoken expectations, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infp-a",
+            "anchor_text": "INFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infp-a-vs-infp-t",
+            "anchor_text": "INFP-A vs INFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/infp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INFP-T is anchored on personal meaning, values and empathetic imagination.",
+          "Cognitive-function vocabulary: Fi-Ne-Si-Te.",
+          "Primary scenario: values-led creative work, counseling-style listening and narrative design."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/intj-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/intj-a",
+      "path": "/en/personality/intj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INTJ-A",
+      "mbti_type": "INTJ",
+      "variant": "A",
+      "evidence_class": "agent_inventory",
+      "paired_path": "/zh/personality/intj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INTJ-A Meaning: Assertive Architect Traits | FermatMind",
+        "description": "Explore INTJ-A through strategy, independent standards and long-range systems, A/T differences, Ni-Te-Fi-Se behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "INTJ-A Meaning",
+        "quick_answer": "INTJ-A combines the INTJ core pattern with an assertive expression: it usually shows up around strategy, independent standards and long-range systems and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read INTJ-A first",
+            "body": "INTJ-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving strategy, independent standards and long-range systems, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INTJ-A vs INTJ-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. INTJ-A leans toward steadier self-trust, feedback recovery and follow-through, while INTJ-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ni-Te-Fi-Se",
+            "body": "INTJ is often described through directional intuition Ni, organizing thinking Te, private values Fi and present-moment sensing Se. This is not a clinical mechanism. It is a behavior vocabulary for noticing how INTJ-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: strategy review, architecture choices and long-range planning",
+            "body": "In strategy review, architecture choices and long-range planning, INTJ-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: translating standards into clear expectations instead of silent tests",
+            "body": "INTJ-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, INTJ-A may overuse the same strengths that support strategy, independent standards and long-range systems: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "reserved does not mean dismissive. Type describes preference, not character, intelligence, mental health or career worth. Healthy INTJ-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does INTJ-A mean?",
+            "answer": "INTJ-A combines the INTJ core pattern with an assertive expression, often visible in strategy, independent standards and long-range systems, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between INTJ-A and INTJ-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. INTJ-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does INTJ-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for INTJ-A?",
+            "answer": "Strengths usually appear around strategy, independent standards and long-range systems, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can INTJ-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should INTJ-A watch in relationships?",
+            "answer": "translating standards into clear expectations instead of silent tests, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/intj-t",
+            "anchor_text": "INTJ-T",
+            "reason": "Connect sibling A/T variant pages for same-type comparison.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/intj-a-vs-intj-t",
+            "anchor_text": "INTJ-A vs INTJ-T",
+            "reason": "Connect to the A-vs-T comparison page.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/intj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INTJ-A is anchored on strategy, independent standards and long-range systems.",
+          "Cognitive-function vocabulary: Ni-Te-Fi-Se.",
+          "Primary scenario: strategy review, architecture choices and long-range planning."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/intj-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/intj-t",
+      "path": "/en/personality/intj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INTJ-T",
+      "mbti_type": "INTJ",
+      "variant": "T",
+      "evidence_class": "agent_inventory",
+      "paired_path": "/zh/personality/intj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INTJ-T Meaning: Turbulent Architect Traits | FermatMind",
+        "description": "Explore INTJ-T through strategy, independent standards and long-range systems, A/T differences, Ni-Te-Fi-Se behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "INTJ-T Meaning",
+        "quick_answer": "INTJ-T combines the INTJ core pattern with an turbulent expression: it usually shows up around strategy, independent standards and long-range systems and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read INTJ-T first",
+            "body": "INTJ-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving strategy, independent standards and long-range systems, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INTJ-T vs INTJ-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. INTJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while INTJ-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ni-Te-Fi-Se",
+            "body": "INTJ is often described through directional intuition Ni, organizing thinking Te, private values Fi and present-moment sensing Se. This is not a clinical mechanism. It is a behavior vocabulary for noticing how INTJ-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: strategy review, architecture choices and long-range planning",
+            "body": "In strategy review, architecture choices and long-range planning, INTJ-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: translating standards into clear expectations instead of silent tests",
+            "body": "INTJ-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, INTJ-T may overuse the same strengths that support strategy, independent standards and long-range systems: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "reserved does not mean dismissive. Type describes preference, not character, intelligence, mental health or career worth. Healthy INTJ-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does INTJ-T mean?",
+            "answer": "INTJ-T combines the INTJ core pattern with an turbulent expression, often visible in strategy, independent standards and long-range systems, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between INTJ-T and INTJ-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. INTJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does INTJ-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for INTJ-T?",
+            "answer": "Strengths usually appear around strategy, independent standards and long-range systems, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can INTJ-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should INTJ-T watch in relationships?",
+            "answer": "translating standards into clear expectations instead of silent tests, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/intj-a",
+            "anchor_text": "INTJ-A",
+            "reason": "Connect sibling A/T variant pages for same-type comparison.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/intj-a-vs-intj-t",
+            "anchor_text": "INTJ-A vs INTJ-T",
+            "reason": "Connect to the A-vs-T comparison page.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/intj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INTJ-T is anchored on strategy, independent standards and long-range systems.",
+          "Cognitive-function vocabulary: Ni-Te-Fi-Se.",
+          "Primary scenario: strategy review, architecture choices and long-range planning."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/intp-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/intp-t",
+      "path": "/en/personality/intp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INTP-T",
+      "mbti_type": "INTP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/intp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INTP-T Meaning: Turbulent Logician Traits | FermatMind",
+        "description": "Explore INTP-T through analysis, model building and independent problem solving, A/T differences, Ti-Ne-Si-Fe behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "INTP-T Meaning",
+        "quick_answer": "INTP-T combines the INTP core pattern with an turbulent expression: it usually shows up around analysis, model building and independent problem solving and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read INTP-T first",
+            "body": "INTP-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving analysis, model building and independent problem solving, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INTP-T vs INTP-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. INTP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while INTP-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ti-Ne-Si-Fe",
+            "body": "INTP is often described through internal logic Ti, possibility exploration Ne, experience calibration Si and social feedback Fe. This is not a clinical mechanism. It is a behavior vocabulary for noticing how INTP-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: technical review, research framing and complex diagnosis",
+            "body": "In technical review, research framing and complex diagnosis, INTP-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: turning analysis into care that another person can feel",
+            "body": "INTP-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, INTP-T may overuse the same strengths that support analysis, model building and independent problem solving: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "calm analysis does not mean no feeling. Type describes preference, not character, intelligence, mental health or career worth. Healthy INTP-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does INTP-T mean?",
+            "answer": "INTP-T combines the INTP core pattern with an turbulent expression, often visible in analysis, model building and independent problem solving, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between INTP-T and INTP-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. INTP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does INTP-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for INTP-T?",
+            "answer": "Strengths usually appear around analysis, model building and independent problem solving, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can INTP-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should INTP-T watch in relationships?",
+            "answer": "turning analysis into care that another person can feel, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/intp-a",
+            "anchor_text": "INTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/intp-a-vs-intp-t",
+            "anchor_text": "INTP-A vs INTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/intp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INTP-T is anchored on analysis, model building and independent problem solving.",
+          "Cognitive-function vocabulary: Ti-Ne-Si-Fe.",
+          "Primary scenario: technical review, research framing and complex diagnosis."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/isfj-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/isfj-a",
+      "path": "/en/personality/isfj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISFJ-A",
+      "mbti_type": "ISFJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/isfj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISFJ-A Meaning: Assertive Defender Traits | FermatMind",
+        "description": "Explore ISFJ-A through care, continuity and dependable support, A/T differences, Si-Fe-Ti-Ne behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ISFJ-A Meaning",
+        "quick_answer": "ISFJ-A combines the ISFJ core pattern with an assertive expression: it usually shows up around care, continuity and dependable support and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ISFJ-A first",
+            "body": "ISFJ-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving care, continuity and dependable support, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISFJ-A vs ISFJ-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ISFJ-A leans toward steadier self-trust, feedback recovery and follow-through, while ISFJ-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Si-Fe-Ti-Ne",
+            "body": "ISFJ is often described through memory calibration Si, interpersonal attunement Fe, logic checking Ti and possibility exploration Ne. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ISFJ-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: service reliability, team support and careful handoff work",
+            "body": "In service reliability, team support and careful handoff work, ISFJ-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: asking for reciprocity instead of quietly over-giving",
+            "body": "ISFJ-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ISFJ-A may overuse the same strengths that support care, continuity and dependable support: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "quiet support is not lack of ambition. Type describes preference, not character, intelligence, mental health or career worth. Healthy ISFJ-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ISFJ-A mean?",
+            "answer": "ISFJ-A combines the ISFJ core pattern with an assertive expression, often visible in care, continuity and dependable support, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ISFJ-A and ISFJ-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ISFJ-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ISFJ-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ISFJ-A?",
+            "answer": "Strengths usually appear around care, continuity and dependable support, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ISFJ-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ISFJ-A watch in relationships?",
+            "answer": "asking for reciprocity instead of quietly over-giving, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfj-t",
+            "anchor_text": "ISFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfj-a-vs-isfj-t",
+            "anchor_text": "ISFJ-A vs ISFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/isfj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISFJ-A is anchored on care, continuity and dependable support.",
+          "Cognitive-function vocabulary: Si-Fe-Ti-Ne.",
+          "Primary scenario: service reliability, team support and careful handoff work."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/isfj-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/isfj-t",
+      "path": "/en/personality/isfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISFJ-T",
+      "mbti_type": "ISFJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/isfj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISFJ-T Meaning: Turbulent Defender Traits | FermatMind",
+        "description": "Explore ISFJ-T through care, continuity and dependable support, A/T differences, Si-Fe-Ti-Ne behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ISFJ-T Meaning",
+        "quick_answer": "ISFJ-T combines the ISFJ core pattern with an turbulent expression: it usually shows up around care, continuity and dependable support and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ISFJ-T first",
+            "body": "ISFJ-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving care, continuity and dependable support, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISFJ-T vs ISFJ-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ISFJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ISFJ-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Si-Fe-Ti-Ne",
+            "body": "ISFJ is often described through memory calibration Si, interpersonal attunement Fe, logic checking Ti and possibility exploration Ne. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ISFJ-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: service reliability, team support and careful handoff work",
+            "body": "In service reliability, team support and careful handoff work, ISFJ-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: asking for reciprocity instead of quietly over-giving",
+            "body": "ISFJ-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ISFJ-T may overuse the same strengths that support care, continuity and dependable support: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "quiet support is not lack of ambition. Type describes preference, not character, intelligence, mental health or career worth. Healthy ISFJ-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ISFJ-T mean?",
+            "answer": "ISFJ-T combines the ISFJ core pattern with an turbulent expression, often visible in care, continuity and dependable support, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ISFJ-T and ISFJ-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ISFJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ISFJ-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ISFJ-T?",
+            "answer": "Strengths usually appear around care, continuity and dependable support, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ISFJ-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ISFJ-T watch in relationships?",
+            "answer": "asking for reciprocity instead of quietly over-giving, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfj-a",
+            "anchor_text": "ISFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfj-a-vs-isfj-t",
+            "anchor_text": "ISFJ-A vs ISFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/isfj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISFJ-T is anchored on care, continuity and dependable support.",
+          "Cognitive-function vocabulary: Si-Fe-Ti-Ne.",
+          "Primary scenario: service reliability, team support and careful handoff work."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/isfp-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/isfp-a",
+      "path": "/en/personality/isfp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISFP-A",
+      "mbti_type": "ISFP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/isfp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISFP-A Meaning: Assertive Adventurer Traits | FermatMind",
+        "description": "Explore ISFP-A through taste, lived experience and quiet personal expression, A/T differences, Fi-Se-Ni-Te behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ISFP-A Meaning",
+        "quick_answer": "ISFP-A combines the ISFP core pattern with an assertive expression: it usually shows up around taste, lived experience and quiet personal expression and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ISFP-A first",
+            "body": "ISFP-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving taste, lived experience and quiet personal expression, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISFP-A vs ISFP-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ISFP-A leans toward steadier self-trust, feedback recovery and follow-through, while ISFP-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Fi-Se-Ni-Te",
+            "body": "ISFP is often described through private values Fi, present sensing Se, directional intuition Ni and organizing thinking Te. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ISFP-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: visual judgment, craft quality and human-scale experiences",
+            "body": "In visual judgment, craft quality and human-scale experiences, ISFP-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: making preferences explicit before resentment builds",
+            "body": "ISFP-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ISFP-A may overuse the same strengths that support taste, lived experience and quiet personal expression: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "quiet taste is not lack of standards. Type describes preference, not character, intelligence, mental health or career worth. Healthy ISFP-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ISFP-A mean?",
+            "answer": "ISFP-A combines the ISFP core pattern with an assertive expression, often visible in taste, lived experience and quiet personal expression, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ISFP-A and ISFP-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ISFP-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ISFP-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ISFP-A?",
+            "answer": "Strengths usually appear around taste, lived experience and quiet personal expression, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ISFP-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ISFP-A watch in relationships?",
+            "answer": "making preferences explicit before resentment builds, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfp-t",
+            "anchor_text": "ISFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfp-a-vs-isfp-t",
+            "anchor_text": "ISFP-A vs ISFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/isfp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISFP-A is anchored on taste, lived experience and quiet personal expression.",
+          "Cognitive-function vocabulary: Fi-Se-Ni-Te.",
+          "Primary scenario: visual judgment, craft quality and human-scale experiences."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/isfp-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/isfp-t",
+      "path": "/en/personality/isfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISFP-T",
+      "mbti_type": "ISFP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/isfp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISFP-T Meaning: Turbulent Adventurer Traits | FermatMind",
+        "description": "Explore ISFP-T through taste, lived experience and quiet personal expression, A/T differences, Fi-Se-Ni-Te behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ISFP-T Meaning",
+        "quick_answer": "ISFP-T combines the ISFP core pattern with an turbulent expression: it usually shows up around taste, lived experience and quiet personal expression and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ISFP-T first",
+            "body": "ISFP-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving taste, lived experience and quiet personal expression, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISFP-T vs ISFP-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ISFP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ISFP-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Fi-Se-Ni-Te",
+            "body": "ISFP is often described through private values Fi, present sensing Se, directional intuition Ni and organizing thinking Te. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ISFP-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: visual judgment, craft quality and human-scale experiences",
+            "body": "In visual judgment, craft quality and human-scale experiences, ISFP-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: making preferences explicit before resentment builds",
+            "body": "ISFP-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ISFP-T may overuse the same strengths that support taste, lived experience and quiet personal expression: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "quiet taste is not lack of standards. Type describes preference, not character, intelligence, mental health or career worth. Healthy ISFP-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ISFP-T mean?",
+            "answer": "ISFP-T combines the ISFP core pattern with an turbulent expression, often visible in taste, lived experience and quiet personal expression, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ISFP-T and ISFP-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ISFP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ISFP-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ISFP-T?",
+            "answer": "Strengths usually appear around taste, lived experience and quiet personal expression, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ISFP-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ISFP-T watch in relationships?",
+            "answer": "making preferences explicit before resentment builds, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfp-a",
+            "anchor_text": "ISFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfp-a-vs-isfp-t",
+            "anchor_text": "ISFP-A vs ISFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/isfp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISFP-T is anchored on taste, lived experience and quiet personal expression.",
+          "Cognitive-function vocabulary: Fi-Se-Ni-Te.",
+          "Primary scenario: visual judgment, craft quality and human-scale experiences."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/istj-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/istj-a",
+      "path": "/en/personality/istj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISTJ-A",
+      "mbti_type": "ISTJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/istj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISTJ-A Meaning: Assertive Logistician Traits | FermatMind",
+        "description": "Explore ISTJ-A through responsibility, precedent and reliable execution, A/T differences, Si-Te-Fi-Ne behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ISTJ-A Meaning",
+        "quick_answer": "ISTJ-A combines the ISTJ core pattern with an assertive expression: it usually shows up around responsibility, precedent and reliable execution and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ISTJ-A first",
+            "body": "ISTJ-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving responsibility, precedent and reliable execution, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISTJ-A vs ISTJ-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ISTJ-A leans toward steadier self-trust, feedback recovery and follow-through, while ISTJ-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Si-Te-Fi-Ne",
+            "body": "ISTJ is often described through memory calibration Si, organizing thinking Te, private values Fi and possibility exploration Ne. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ISTJ-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: process control, compliance review and dependable delivery",
+            "body": "In process control, compliance review and dependable delivery, ISTJ-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: making care visible instead of assuming duty is understood",
+            "body": "ISTJ-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ISTJ-A may overuse the same strengths that support responsibility, precedent and reliable execution: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "cautious is not closed-minded. Type describes preference, not character, intelligence, mental health or career worth. Healthy ISTJ-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ISTJ-A mean?",
+            "answer": "ISTJ-A combines the ISTJ core pattern with an assertive expression, often visible in responsibility, precedent and reliable execution, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ISTJ-A and ISTJ-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ISTJ-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ISTJ-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ISTJ-A?",
+            "answer": "Strengths usually appear around responsibility, precedent and reliable execution, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ISTJ-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ISTJ-A watch in relationships?",
+            "answer": "making care visible instead of assuming duty is understood, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istj-t",
+            "anchor_text": "ISTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istj-a-vs-istj-t",
+            "anchor_text": "ISTJ-A vs ISTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/istj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISTJ-A is anchored on responsibility, precedent and reliable execution.",
+          "Cognitive-function vocabulary: Si-Te-Fi-Ne.",
+          "Primary scenario: process control, compliance review and dependable delivery."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/istj-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/istj-t",
+      "path": "/en/personality/istj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISTJ-T",
+      "mbti_type": "ISTJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/istj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISTJ-T Meaning: Turbulent Logistician Traits | FermatMind",
+        "description": "Explore ISTJ-T through responsibility, precedent and reliable execution, A/T differences, Si-Te-Fi-Ne behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ISTJ-T Meaning",
+        "quick_answer": "ISTJ-T combines the ISTJ core pattern with an turbulent expression: it usually shows up around responsibility, precedent and reliable execution and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ISTJ-T first",
+            "body": "ISTJ-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving responsibility, precedent and reliable execution, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISTJ-T vs ISTJ-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ISTJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ISTJ-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Si-Te-Fi-Ne",
+            "body": "ISTJ is often described through memory calibration Si, organizing thinking Te, private values Fi and possibility exploration Ne. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ISTJ-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: process control, compliance review and dependable delivery",
+            "body": "In process control, compliance review and dependable delivery, ISTJ-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: making care visible instead of assuming duty is understood",
+            "body": "ISTJ-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ISTJ-T may overuse the same strengths that support responsibility, precedent and reliable execution: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "cautious is not closed-minded. Type describes preference, not character, intelligence, mental health or career worth. Healthy ISTJ-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ISTJ-T mean?",
+            "answer": "ISTJ-T combines the ISTJ core pattern with an turbulent expression, often visible in responsibility, precedent and reliable execution, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ISTJ-T and ISTJ-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ISTJ-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ISTJ-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ISTJ-T?",
+            "answer": "Strengths usually appear around responsibility, precedent and reliable execution, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ISTJ-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ISTJ-T watch in relationships?",
+            "answer": "making care visible instead of assuming duty is understood, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istj-a",
+            "anchor_text": "ISTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istj-a-vs-istj-t",
+            "anchor_text": "ISTJ-A vs ISTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/istj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISTJ-T is anchored on responsibility, precedent and reliable execution.",
+          "Cognitive-function vocabulary: Si-Te-Fi-Ne.",
+          "Primary scenario: process control, compliance review and dependable delivery."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/istp-a:v2",
+      "target_url": "https://fermatmind.com/en/personality/istp-a",
+      "path": "/en/personality/istp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISTP-A",
+      "mbti_type": "ISTP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/istp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISTP-A Meaning: Assertive Virtuoso Traits | FermatMind",
+        "description": "Explore ISTP-A through hands-on problem solving, autonomy and calm troubleshooting, A/T differences, Ti-Se-Ni-Fe behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ISTP-A Meaning",
+        "quick_answer": "ISTP-A combines the ISTP core pattern with an assertive expression: it usually shows up around hands-on problem solving, autonomy and calm troubleshooting and steadier self-trust, feedback recovery and follow-through. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ISTP-A first",
+            "body": "ISTP-A is not an ability ranking or fixed identity. A safer reading is that, in situations involving hands-on problem solving, autonomy and calm troubleshooting, this pattern often shows steadier self-trust, feedback recovery and follow-through in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISTP-A vs ISTP-T comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ISTP-A leans toward steadier self-trust, feedback recovery and follow-through, while ISTP-T shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Returns to judgment and next steps sooner",
+                "turbulent": "More likely to replay outside evaluation"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ti-Se-Ni-Fe",
+            "body": "ISTP is often described through internal logic Ti, present sensing Se, directional intuition Ni and social feedback Fe. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ISTP-A may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: incident response, tool use and practical system repair",
+            "body": "In incident response, tool use and practical system repair, ISTP-A is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: explaining space needs before they look like withdrawal",
+            "body": "ISTP-A is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ISTP-A may overuse the same strengths that support hands-on problem solving, autonomy and calm troubleshooting: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "independent does not mean unavailable. Type describes preference, not character, intelligence, mental health or career worth. Healthy ISTP-A uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ISTP-A mean?",
+            "answer": "ISTP-A combines the ISTP core pattern with an assertive expression, often visible in hands-on problem solving, autonomy and calm troubleshooting, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ISTP-A and ISTP-T?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ISTP-A leans toward steadier self-trust, feedback recovery and follow-through."
+          },
+          {
+            "question": "Does ISTP-A fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ISTP-A?",
+            "answer": "Strengths usually appear around hands-on problem solving, autonomy and calm troubleshooting, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ISTP-A have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ISTP-A watch in relationships?",
+            "answer": "explaining space needs before they look like withdrawal, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istp-t",
+            "anchor_text": "ISTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istp-a-vs-istp-t",
+            "anchor_text": "ISTP-A vs ISTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/istp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISTP-A is anchored on hands-on problem solving, autonomy and calm troubleshooting.",
+          "Cognitive-function vocabulary: Ti-Se-Ni-Fe.",
+          "Primary scenario: incident response, tool use and practical system repair."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/en/personality/istp-t:v2",
+      "target_url": "https://fermatmind.com/en/personality/istp-t",
+      "path": "/en/personality/istp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISTP-T",
+      "mbti_type": "ISTP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/zh/personality/istp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISTP-T Meaning: Turbulent Virtuoso Traits | FermatMind",
+        "description": "Explore ISTP-T through hands-on problem solving, autonomy and calm troubleshooting, A/T differences, Ti-Se-Ni-Fe behavior language, work and relationship examples, common misreads and safe-use boundaries.",
+        "h1": "ISTP-T Meaning",
+        "quick_answer": "ISTP-T combines the ISTP core pattern with an turbulent expression: it usually shows up around hands-on problem solving, autonomy and calm troubleshooting and stronger self-review, feedback sensitivity and pressure-based recalibration. Read it as behavior and self-regulation language for reflection, not as diagnosis, screening or a fixed life verdict.",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "How to read ISTP-T first",
+            "body": "ISTP-T is not an ability ranking or fixed identity. A safer reading is that, in situations involving hands-on problem solving, autonomy and calm troubleshooting, this pattern often shows stronger self-review, feedback sensitivity and pressure-based recalibration in uncertainty, feedback and action rhythm."
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISTP-T vs ISTP-A comparison table",
+            "body": "A/T is not a better-or-worse scale. It is a useful lens for pressure recovery, feedback processing and self-checking. ISTP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration, while ISTP-A shows a different calibration rhythm.",
+            "comparison_rows": [
+              {
+                "dimension": "After feedback",
+                "assertive": "Checks whether feedback exposes a blind spot",
+                "turbulent": "Brings stronger review and correction"
+              },
+              {
+                "dimension": "Action rhythm",
+                "assertive": "More willing to move with a workable version",
+                "turbulent": "More likely to keep checking risk and standards"
+              },
+              {
+                "dimension": "Growth focus",
+                "assertive": "Keep counterevidence and outside feedback open",
+                "turbulent": "Prevent review from becoming stuckness"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "Cognitive-function lens: Ti-Se-Ni-Fe",
+            "body": "ISTP is often described through internal logic Ti, present sensing Se, directional intuition Ni and social feedback Fe. This is not a clinical mechanism. It is a behavior vocabulary for noticing how ISTP-T may judge, communicate, collaborate and recover under pressure."
+          },
+          {
+            "key": "work_scenario",
+            "title": "Work scenario: incident response, tool use and practical system repair",
+            "body": "In incident response, tool use and practical system repair, ISTP-T is not defined by a job title. The useful pattern is how the person handles information, pacing and collaboration. The upgrade is turning preference into clear communication, reviewable action and concrete next steps."
+          },
+          {
+            "key": "relationship_communication",
+            "title": "Relationships and communication: explaining space needs before they look like withdrawal",
+            "body": "ISTP-T is often misread because of expression order rather than intent. A stronger communication pattern is to name the intention, state the boundary and ask whether the other person wants listening, advice or joint analysis."
+          },
+          {
+            "key": "stress_growth",
+            "title": "Stress, blind spots and growth",
+            "body": "Under stress, ISTP-T may overuse the same strengths that support hands-on problem solving, autonomy and calm troubleshooting: moving too fast, reviewing too much or narrowing the conversation. Growth means adding checkpoints, feedback loops and a sustainable rhythm, not changing type."
+          },
+          {
+            "key": "common_misreads",
+            "title": "Common misreads",
+            "body": "independent does not mean unavailable. Type describes preference, not character, intelligence, mental health or career worth. Healthy ISTP-T uses type as a reflection tool, not as a verdict on self or others.",
+            "bullets": [
+              "Steadiness and sensitivity are not ranks.",
+              "Fit depends on skills, interests, environment and choices, not type alone.",
+              "A/T differences should clarify stress and feedback style, not create a hierarchy."
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "How to use this page, and how not to use it",
+            "body": "Use this page for self-observation, communication review and growth planning. Do not use it for diagnosis, hiring screens, intelligence judgments, relationship prediction or career decisions. If a test result conflicts with long-term behavior, return to concrete context, feedback and real choices."
+          }
+        ],
+        "faq": [
+          {
+            "question": "What does ISTP-T mean?",
+            "answer": "ISTP-T combines the ISTP core pattern with an turbulent expression, often visible in hands-on problem solving, autonomy and calm troubleshooting, feedback recovery and self-regulation."
+          },
+          {
+            "question": "What is the main difference between ISTP-T and ISTP-A?",
+            "answer": "The difference is mainly pressure, feedback and self-checking rhythm, not which one is better. ISTP-T leans toward stronger self-review, feedback sensitivity and pressure-based recalibration."
+          },
+          {
+            "question": "Does ISTP-T fit certain careers?",
+            "answer": "It can suggest work preferences, but career fit still depends on skill, interest, training, opportunity, team context and values."
+          },
+          {
+            "question": "What strengths are common for ISTP-T?",
+            "answer": "Strengths usually appear around hands-on problem solving, autonomy and calm troubleshooting, but the expression depends on experience, maturity and environment."
+          },
+          {
+            "question": "What blind spots can ISTP-T have?",
+            "answer": "Blind spots often come from overusing strengths: missing feedback, delaying action, underestimating communication cost or treating stress reactions as facts."
+          },
+          {
+            "question": "What should ISTP-T watch in relationships?",
+            "answer": "explaining space needs before they look like withdrawal, while avoiding using type language to define the other person."
+          },
+          {
+            "question": "Is A/T a clinical or hiring signal?",
+            "answer": "No. This page treats A/T as stress and feedback-style language, not as diagnosis, hiring screen or ability measure."
+          },
+          {
+            "question": "How is this different from competitor pages?",
+            "answer": "This page emphasizes A/T comparison, cognitive-function language, scenario-based use and safe boundaries without copying competitor wording."
+          },
+          {
+            "question": "Is this affiliated with the MBTI trademark owner?",
+            "answer": "No. It is FermatMind public educational content and does not claim affiliation with the MBTI trademark owner or other personality sites."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istp-a",
+            "anchor_text": "ISTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istp-a-vs-istp-t",
+            "anchor_text": "ISTP-A vs ISTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /zh/personality/istp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "English headings and examples are written independently while preserving the same intent as the Chinese paired page."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISTP-T is anchored on hands-on problem solving, autonomy and calm troubleshooting.",
+          "Cognitive-function vocabulary: Ti-Se-Ni-Fe.",
+          "Primary scenario: incident response, tool use and practical system repair."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/enfj-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/enfj-t",
+      "path": "/zh/personality/enfj-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENFJ-T",
+      "mbti_type": "ENFJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/enfj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENFJ-T 人格特点：人际带动、鼓励和共同方向 | FermatMind",
+        "description": "深入了解 ENFJ-T 的人际带动、鼓励和共同方向、A/T 差异、Fe-Ni-Se-Ti 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ENFJ-T 人格特点",
+        "quick_answer": "ENFJ-T 可以理解为 ENFJ 核心模式加上 T 型表达：它通常围绕人际带动、鼓励和共同方向展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ENFJ-T",
+            "body": "ENFJ-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 人际带动、鼓励和共同方向 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENFJ-T 与 ENFJ-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ENFJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ENFJ-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Fe-Ni-Se-Ti 如何表现",
+            "body": "ENFJ 常被解释为以外向情感 Fe 组织关系，以内向直觉 Ni 收束方向，再由 Se 和 Ti 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ENFJ-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：团队重启、辅导和跨部门协调",
+            "body": "在团队重启、辅导和跨部门协调中，ENFJ-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：支持别人，但不替别人承担全部责任",
+            "body": "ENFJ-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ENFJ-T 可能会把 人际带动、鼓励和共同方向 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "支持别人不等于讨好。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ENFJ-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ENFJ-T 是什么意思？",
+            "answer": "ENFJ-T 指 ENFJ 核心模式加上 T 型表达，常体现在人际带动、鼓励和共同方向、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ENFJ-T 和 ENFJ-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ENFJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ENFJ-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ENFJ-T 的常见优势是什么？",
+            "answer": "常见优势会围绕人际带动、鼓励和共同方向展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ENFJ-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ENFJ-T 在关系中要注意什么？",
+            "answer": "支持别人，但不替别人承担全部责任，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfj-a",
+            "anchor_text": "ENFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfj-a-vs-enfj-t",
+            "anchor_text": "ENFJ-A 与 ENFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/enfj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENFJ-T is anchored on 人际带动、鼓励和共同方向.",
+          "Cognitive-function vocabulary: Fe-Ni-Se-Ti.",
+          "Primary scenario: 团队重启、辅导和跨部门协调."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/enfp-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/enfp-a",
+      "path": "/zh/personality/enfp-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENFP-A",
+      "mbti_type": "ENFP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/enfp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENFP-A 人格特点：可能性、人际连接和创意动力 | FermatMind",
+        "description": "深入了解 ENFP-A 的可能性、人际连接和创意动力、A/T 差异、Ne-Fi-Te-Si 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ENFP-A 人格特点",
+        "quick_answer": "ENFP-A 可以理解为 ENFP 核心模式加上 A 型表达：它通常围绕可能性、人际连接和创意动力展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ENFP-A",
+            "body": "ENFP-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 可能性、人际连接和创意动力 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENFP-A 与 ENFP-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ENFP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ENFP-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ne-Fi-Te-Si 如何表现",
+            "body": "ENFP 常被解释为以可能性探索 Ne 打开方向，以内在价值 Fi 选择意义，再由 Te 和 Si 落地。 这里的功能语言不是临床机制，而是解释行为的工具。对 ENFP-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：创意冲刺、社群连接和机会发现",
+            "body": "在创意冲刺、社群连接和机会发现中，ENFP-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：把热情转化为可靠行动",
+            "body": "ENFP-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ENFP-A 可能会把 可能性、人际连接和创意动力 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "兴趣很多不等于没有深度。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ENFP-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ENFP-A 是什么意思？",
+            "answer": "ENFP-A 指 ENFP 核心模式加上 A 型表达，常体现在可能性、人际连接和创意动力、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ENFP-A 和 ENFP-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ENFP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ENFP-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ENFP-A 的常见优势是什么？",
+            "answer": "常见优势会围绕可能性、人际连接和创意动力展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ENFP-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ENFP-A 在关系中要注意什么？",
+            "answer": "把热情转化为可靠行动，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfp-t",
+            "anchor_text": "ENFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfp-a-vs-enfp-t",
+            "anchor_text": "ENFP-A 与 ENFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/enfp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENFP-A is anchored on 可能性、人际连接和创意动力.",
+          "Cognitive-function vocabulary: Ne-Fi-Te-Si.",
+          "Primary scenario: 创意冲刺、社群连接和机会发现."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/enfp-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/enfp-t",
+      "path": "/zh/personality/enfp-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENFP-T",
+      "mbti_type": "ENFP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/enfp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENFP-T 人格特点：可能性、人际连接和创意动力 | FermatMind",
+        "description": "深入了解 ENFP-T 的可能性、人际连接和创意动力、A/T 差异、Ne-Fi-Te-Si 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ENFP-T 人格特点",
+        "quick_answer": "ENFP-T 可以理解为 ENFP 核心模式加上 T 型表达：它通常围绕可能性、人际连接和创意动力展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ENFP-T",
+            "body": "ENFP-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 可能性、人际连接和创意动力 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENFP-T 与 ENFP-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ENFP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ENFP-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ne-Fi-Te-Si 如何表现",
+            "body": "ENFP 常被解释为以可能性探索 Ne 打开方向，以内在价值 Fi 选择意义，再由 Te 和 Si 落地。 这里的功能语言不是临床机制，而是解释行为的工具。对 ENFP-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：创意冲刺、社群连接和机会发现",
+            "body": "在创意冲刺、社群连接和机会发现中，ENFP-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：把热情转化为可靠行动",
+            "body": "ENFP-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ENFP-T 可能会把 可能性、人际连接和创意动力 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "兴趣很多不等于没有深度。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ENFP-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ENFP-T 是什么意思？",
+            "answer": "ENFP-T 指 ENFP 核心模式加上 T 型表达，常体现在可能性、人际连接和创意动力、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ENFP-T 和 ENFP-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ENFP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ENFP-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ENFP-T 的常见优势是什么？",
+            "answer": "常见优势会围绕可能性、人际连接和创意动力展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ENFP-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ENFP-T 在关系中要注意什么？",
+            "answer": "把热情转化为可靠行动，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfp-a",
+            "anchor_text": "ENFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfp-a-vs-enfp-t",
+            "anchor_text": "ENFP-A 与 ENFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/enfp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENFP-T is anchored on 可能性、人际连接和创意动力.",
+          "Cognitive-function vocabulary: Ne-Fi-Te-Si.",
+          "Primary scenario: 创意冲刺、社群连接和机会发现."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/entj-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/entj-a",
+      "path": "/zh/personality/entj-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENTJ-A",
+      "mbti_type": "ENTJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/entj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENTJ-A 人格特点：决策、系统领导和运营推进 | FermatMind",
+        "description": "深入了解 ENTJ-A 的决策、系统领导和运营推进、A/T 差异、Te-Ni-Se-Fi 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ENTJ-A 人格特点",
+        "quick_answer": "ENTJ-A 可以理解为 ENTJ 核心模式加上 A 型表达：它通常围绕决策、系统领导和运营推进展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ENTJ-A",
+            "body": "ENTJ-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 决策、系统领导和运营推进 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENTJ-A 与 ENTJ-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ENTJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ENTJ-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Te-Ni-Se-Fi 如何表现",
+            "body": "ENTJ 常被解释为以外向思考 Te 组织资源，以内向直觉 Ni 收束方向，再用 Se 和 Fi 校准现实与价值。 这里的功能语言不是临床机制，而是解释行为的工具。对 ENTJ-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：决策会议、运营节奏和责任校准",
+            "body": "在决策会议、运营节奏和责任校准中，ENTJ-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：在推进行动前为同意、感受和边界留出空间",
+            "body": "ENTJ-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ENTJ-A 可能会把 决策、系统领导和运营推进 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "直接不等于不在乎。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ENTJ-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ENTJ-A 是什么意思？",
+            "answer": "ENTJ-A 指 ENTJ 核心模式加上 A 型表达，常体现在决策、系统领导和运营推进、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ENTJ-A 和 ENTJ-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ENTJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ENTJ-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ENTJ-A 的常见优势是什么？",
+            "answer": "常见优势会围绕决策、系统领导和运营推进展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ENTJ-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ENTJ-A 在关系中要注意什么？",
+            "answer": "在推进行动前为同意、感受和边界留出空间，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entj-t",
+            "anchor_text": "ENTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entj-a-vs-entj-t",
+            "anchor_text": "ENTJ-A 与 ENTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/entj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENTJ-A is anchored on 决策、系统领导和运营推进.",
+          "Cognitive-function vocabulary: Te-Ni-Se-Fi.",
+          "Primary scenario: 决策会议、运营节奏和责任校准."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/entj-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/entj-t",
+      "path": "/zh/personality/entj-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENTJ-T",
+      "mbti_type": "ENTJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/entj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENTJ-T 人格特点：决策、系统领导和运营推进 | FermatMind",
+        "description": "深入了解 ENTJ-T 的决策、系统领导和运营推进、A/T 差异、Te-Ni-Se-Fi 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ENTJ-T 人格特点",
+        "quick_answer": "ENTJ-T 可以理解为 ENTJ 核心模式加上 T 型表达：它通常围绕决策、系统领导和运营推进展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ENTJ-T",
+            "body": "ENTJ-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 决策、系统领导和运营推进 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENTJ-T 与 ENTJ-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ENTJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ENTJ-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Te-Ni-Se-Fi 如何表现",
+            "body": "ENTJ 常被解释为以外向思考 Te 组织资源，以内向直觉 Ni 收束方向，再用 Se 和 Fi 校准现实与价值。 这里的功能语言不是临床机制，而是解释行为的工具。对 ENTJ-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：决策会议、运营节奏和责任校准",
+            "body": "在决策会议、运营节奏和责任校准中，ENTJ-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：在推进行动前为同意、感受和边界留出空间",
+            "body": "ENTJ-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ENTJ-T 可能会把 决策、系统领导和运营推进 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "直接不等于不在乎。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ENTJ-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ENTJ-T 是什么意思？",
+            "answer": "ENTJ-T 指 ENTJ 核心模式加上 T 型表达，常体现在决策、系统领导和运营推进、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ENTJ-T 和 ENTJ-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ENTJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ENTJ-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ENTJ-T 的常见优势是什么？",
+            "answer": "常见优势会围绕决策、系统领导和运营推进展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ENTJ-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ENTJ-T 在关系中要注意什么？",
+            "answer": "在推进行动前为同意、感受和边界留出空间，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entj-a",
+            "anchor_text": "ENTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entj-a-vs-entj-t",
+            "anchor_text": "ENTJ-A 与 ENTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/entj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENTJ-T is anchored on 决策、系统领导和运营推进.",
+          "Cognitive-function vocabulary: Te-Ni-Se-Fi.",
+          "Primary scenario: 决策会议、运营节奏和责任校准."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/entp-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/entp-a",
+      "path": "/zh/personality/entp-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENTP-A",
+      "mbti_type": "ENTP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/entp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENTP-A 人格特点：实验、辩论和快速想法验证 | FermatMind",
+        "description": "深入了解 ENTP-A 的实验、辩论和快速想法验证、A/T 差异、Ne-Ti-Fe-Si 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ENTP-A 人格特点",
+        "quick_answer": "ENTP-A 可以理解为 ENTP 核心模式加上 A 型表达：它通常围绕实验、辩论和快速想法验证展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ENTP-A",
+            "body": "ENTP-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 实验、辩论和快速想法验证 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENTP-A 与 ENTP-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ENTP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ENTP-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ne-Ti-Fe-Si 如何表现",
+            "body": "ENTP 常被解释为以可能性探索 Ne 打开选项，再用逻辑 Ti、反馈 Fe 和经验 Si 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ENTP-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：产品实验、高密度讨论和早期问题定义",
+            "body": "在产品实验、高密度讨论和早期问题定义中，ENTP-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：确认辩论对别人是有趣还是消耗",
+            "body": "ENTP-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ENTP-A 可能会把 实验、辩论和快速想法验证 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "提出一种可能不等于真的相信它。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ENTP-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ENTP-A 是什么意思？",
+            "answer": "ENTP-A 指 ENTP 核心模式加上 A 型表达，常体现在实验、辩论和快速想法验证、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ENTP-A 和 ENTP-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ENTP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ENTP-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ENTP-A 的常见优势是什么？",
+            "answer": "常见优势会围绕实验、辩论和快速想法验证展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ENTP-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ENTP-A 在关系中要注意什么？",
+            "answer": "确认辩论对别人是有趣还是消耗，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entp-t",
+            "anchor_text": "ENTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entp-a-vs-entp-t",
+            "anchor_text": "ENTP-A 与 ENTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/entp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENTP-A is anchored on 实验、辩论和快速想法验证.",
+          "Cognitive-function vocabulary: Ne-Ti-Fe-Si.",
+          "Primary scenario: 产品实验、高密度讨论和早期问题定义."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/entp-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/entp-t",
+      "path": "/zh/personality/entp-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENTP-T",
+      "mbti_type": "ENTP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/entp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ENTP-T 人格特点：实验、辩论和快速想法验证 | FermatMind",
+        "description": "深入了解 ENTP-T 的实验、辩论和快速想法验证、A/T 差异、Ne-Ti-Fe-Si 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ENTP-T 人格特点",
+        "quick_answer": "ENTP-T 可以理解为 ENTP 核心模式加上 T 型表达：它通常围绕实验、辩论和快速想法验证展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ENTP-T",
+            "body": "ENTP-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 实验、辩论和快速想法验证 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ENTP-T 与 ENTP-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ENTP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ENTP-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ne-Ti-Fe-Si 如何表现",
+            "body": "ENTP 常被解释为以可能性探索 Ne 打开选项，再用逻辑 Ti、反馈 Fe 和经验 Si 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ENTP-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：产品实验、高密度讨论和早期问题定义",
+            "body": "在产品实验、高密度讨论和早期问题定义中，ENTP-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：确认辩论对别人是有趣还是消耗",
+            "body": "ENTP-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ENTP-T 可能会把 实验、辩论和快速想法验证 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "提出一种可能不等于真的相信它。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ENTP-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ENTP-T 是什么意思？",
+            "answer": "ENTP-T 指 ENTP 核心模式加上 T 型表达，常体现在实验、辩论和快速想法验证、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ENTP-T 和 ENTP-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ENTP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ENTP-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ENTP-T 的常见优势是什么？",
+            "answer": "常见优势会围绕实验、辩论和快速想法验证展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ENTP-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ENTP-T 在关系中要注意什么？",
+            "answer": "确认辩论对别人是有趣还是消耗，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entp-a",
+            "anchor_text": "ENTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entp-a-vs-entp-t",
+            "anchor_text": "ENTP-A 与 ENTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/entp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ENTP-T is anchored on 实验、辩论和快速想法验证.",
+          "Cognitive-function vocabulary: Ne-Ti-Fe-Si.",
+          "Primary scenario: 产品实验、高密度讨论和早期问题定义."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/esfj-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/esfj-a",
+      "path": "/zh/personality/esfj-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESFJ-A",
+      "mbti_type": "ESFJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/esfj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESFJ-A 人格特点：支持、归属和实际协调 | FermatMind",
+        "description": "深入了解 ESFJ-A 的支持、归属和实际协调、A/T 差异、Fe-Si-Ne-Ti 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ESFJ-A 人格特点",
+        "quick_answer": "ESFJ-A 可以理解为 ESFJ 核心模式加上 A 型表达：它通常围绕支持、归属和实际协调展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ESFJ-A",
+            "body": "ESFJ-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 支持、归属和实际协调 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESFJ-A 与 ESFJ-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ESFJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ESFJ-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Fe-Si-Ne-Ti 如何表现",
+            "body": "ESFJ 常被解释为以外向情感 Fe 组织关系，以 Si 维持稳定，再由 Ne 和 Ti 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ESFJ-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：社群运营、客户照顾和团队协调",
+            "body": "在社群运营、客户照顾和团队协调中，ESFJ-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：保持温暖，同时把边界说清楚",
+            "body": "ESFJ-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ESFJ-A 可能会把 支持、归属和实际协调 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "在意关系不等于肤浅从众。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ESFJ-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ESFJ-A 是什么意思？",
+            "answer": "ESFJ-A 指 ESFJ 核心模式加上 A 型表达，常体现在支持、归属和实际协调、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ESFJ-A 和 ESFJ-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ESFJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ESFJ-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ESFJ-A 的常见优势是什么？",
+            "answer": "常见优势会围绕支持、归属和实际协调展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ESFJ-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ESFJ-A 在关系中要注意什么？",
+            "answer": "保持温暖，同时把边界说清楚，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfj-t",
+            "anchor_text": "ESFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfj-a-vs-esfj-t",
+            "anchor_text": "ESFJ-A 与 ESFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/esfj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESFJ-A is anchored on 支持、归属和实际协调.",
+          "Cognitive-function vocabulary: Fe-Si-Ne-Ti.",
+          "Primary scenario: 社群运营、客户照顾和团队协调."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/esfj-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/esfj-t",
+      "path": "/zh/personality/esfj-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESFJ-T",
+      "mbti_type": "ESFJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/esfj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESFJ-T 人格特点：支持、归属和实际协调 | FermatMind",
+        "description": "深入了解 ESFJ-T 的支持、归属和实际协调、A/T 差异、Fe-Si-Ne-Ti 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ESFJ-T 人格特点",
+        "quick_answer": "ESFJ-T 可以理解为 ESFJ 核心模式加上 T 型表达：它通常围绕支持、归属和实际协调展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ESFJ-T",
+            "body": "ESFJ-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 支持、归属和实际协调 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESFJ-T 与 ESFJ-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ESFJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ESFJ-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Fe-Si-Ne-Ti 如何表现",
+            "body": "ESFJ 常被解释为以外向情感 Fe 组织关系，以 Si 维持稳定，再由 Ne 和 Ti 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ESFJ-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：社群运营、客户照顾和团队协调",
+            "body": "在社群运营、客户照顾和团队协调中，ESFJ-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：保持温暖，同时把边界说清楚",
+            "body": "ESFJ-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ESFJ-T 可能会把 支持、归属和实际协调 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "在意关系不等于肤浅从众。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ESFJ-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ESFJ-T 是什么意思？",
+            "answer": "ESFJ-T 指 ESFJ 核心模式加上 T 型表达，常体现在支持、归属和实际协调、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ESFJ-T 和 ESFJ-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ESFJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ESFJ-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ESFJ-T 的常见优势是什么？",
+            "answer": "常见优势会围绕支持、归属和实际协调展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ESFJ-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ESFJ-T 在关系中要注意什么？",
+            "answer": "保持温暖，同时把边界说清楚，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfj-a",
+            "anchor_text": "ESFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfj-a-vs-esfj-t",
+            "anchor_text": "ESFJ-A 与 ESFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/esfj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESFJ-T is anchored on 支持、归属和实际协调.",
+          "Cognitive-function vocabulary: Fe-Si-Ne-Ti.",
+          "Primary scenario: 社群运营、客户照顾和团队协调."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/esfp-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/esfp-t",
+      "path": "/zh/personality/esfp-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESFP-T",
+      "mbti_type": "ESFP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/esfp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESFP-T 人格特点：活力、现场感和共同体验 | FermatMind",
+        "description": "深入了解 ESFP-T 的活力、现场感和共同体验、A/T 差异、Se-Fi-Te-Ni 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ESFP-T 人格特点",
+        "quick_answer": "ESFP-T 可以理解为 ESFP 核心模式加上 T 型表达：它通常围绕活力、现场感和共同体验展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ESFP-T",
+            "body": "ESFP-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 活力、现场感和共同体验 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESFP-T 与 ESFP-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ESFP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ESFP-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Se-Fi-Te-Ni 如何表现",
+            "body": "ESFP 常被解释为以外向感觉 Se 读取现场，以 Fi 校准价值，再由 Te 和 Ni 补足行动与长期方向。 这里的功能语言不是临床机制，而是解释行为的工具。对 ESFP-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：活动、客户体验和现场救火",
+            "body": "在活动、客户体验和现场救火中，ESFP-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：带来温度，同时说清真实边界",
+            "body": "ESFP-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ESFP-T 可能会把 活力、现场感和共同体验 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "活跃不等于肤浅。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ESFP-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ESFP-T 是什么意思？",
+            "answer": "ESFP-T 指 ESFP 核心模式加上 T 型表达，常体现在活力、现场感和共同体验、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ESFP-T 和 ESFP-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ESFP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ESFP-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ESFP-T 的常见优势是什么？",
+            "answer": "常见优势会围绕活力、现场感和共同体验展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ESFP-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ESFP-T 在关系中要注意什么？",
+            "answer": "带来温度，同时说清真实边界，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfp-a",
+            "anchor_text": "ESFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfp-a-vs-esfp-t",
+            "anchor_text": "ESFP-A 与 ESFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/esfp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESFP-T is anchored on 活力、现场感和共同体验.",
+          "Cognitive-function vocabulary: Se-Fi-Te-Ni.",
+          "Primary scenario: 活动、客户体验和现场救火."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/estj-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/estj-a",
+      "path": "/zh/personality/estj-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESTJ-A",
+      "mbti_type": "ESTJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/estj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESTJ-A 人格特点：结构、决策和实际责任 | FermatMind",
+        "description": "深入了解 ESTJ-A 的结构、决策和实际责任、A/T 差异、Te-Si-Ne-Fi 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ESTJ-A 人格特点",
+        "quick_answer": "ESTJ-A 可以理解为 ESTJ 核心模式加上 A 型表达：它通常围绕结构、决策和实际责任展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ESTJ-A",
+            "body": "ESTJ-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 结构、决策和实际责任 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESTJ-A 与 ESTJ-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ESTJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ESTJ-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Te-Si-Ne-Fi 如何表现",
+            "body": "ESTJ 常被解释为以外向思考 Te 组织行动，以 Si 稳定流程，再由 Ne 和 Fi 校准变化与价值。 这里的功能语言不是临床机制，而是解释行为的工具。对 ESTJ-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：运营节奏、角色清晰和质量控制",
+            "body": "在运营节奏、角色清晰和质量控制中，ESTJ-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：在实际解决之外补上情绪确认",
+            "body": "ESTJ-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ESTJ-A 可能会把 结构、决策和实际责任 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "讲结构不等于没感受。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ESTJ-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ESTJ-A 是什么意思？",
+            "answer": "ESTJ-A 指 ESTJ 核心模式加上 A 型表达，常体现在结构、决策和实际责任、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ESTJ-A 和 ESTJ-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ESTJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ESTJ-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ESTJ-A 的常见优势是什么？",
+            "answer": "常见优势会围绕结构、决策和实际责任展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ESTJ-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ESTJ-A 在关系中要注意什么？",
+            "answer": "在实际解决之外补上情绪确认，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estj-t",
+            "anchor_text": "ESTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estj-a-vs-estj-t",
+            "anchor_text": "ESTJ-A 与 ESTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/estj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESTJ-A is anchored on 结构、决策和实际责任.",
+          "Cognitive-function vocabulary: Te-Si-Ne-Fi.",
+          "Primary scenario: 运营节奏、角色清晰和质量控制."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/estj-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/estj-t",
+      "path": "/zh/personality/estj-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESTJ-T",
+      "mbti_type": "ESTJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/estj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESTJ-T 人格特点：结构、决策和实际责任 | FermatMind",
+        "description": "深入了解 ESTJ-T 的结构、决策和实际责任、A/T 差异、Te-Si-Ne-Fi 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ESTJ-T 人格特点",
+        "quick_answer": "ESTJ-T 可以理解为 ESTJ 核心模式加上 T 型表达：它通常围绕结构、决策和实际责任展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ESTJ-T",
+            "body": "ESTJ-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 结构、决策和实际责任 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESTJ-T 与 ESTJ-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ESTJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ESTJ-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Te-Si-Ne-Fi 如何表现",
+            "body": "ESTJ 常被解释为以外向思考 Te 组织行动，以 Si 稳定流程，再由 Ne 和 Fi 校准变化与价值。 这里的功能语言不是临床机制，而是解释行为的工具。对 ESTJ-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：运营节奏、角色清晰和质量控制",
+            "body": "在运营节奏、角色清晰和质量控制中，ESTJ-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：在实际解决之外补上情绪确认",
+            "body": "ESTJ-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ESTJ-T 可能会把 结构、决策和实际责任 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "讲结构不等于没感受。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ESTJ-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ESTJ-T 是什么意思？",
+            "answer": "ESTJ-T 指 ESTJ 核心模式加上 T 型表达，常体现在结构、决策和实际责任、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ESTJ-T 和 ESTJ-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ESTJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ESTJ-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ESTJ-T 的常见优势是什么？",
+            "answer": "常见优势会围绕结构、决策和实际责任展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ESTJ-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ESTJ-T 在关系中要注意什么？",
+            "answer": "在实际解决之外补上情绪确认，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estj-a",
+            "anchor_text": "ESTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estj-a-vs-estj-t",
+            "anchor_text": "ESTJ-A 与 ESTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/estj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESTJ-T is anchored on 结构、决策和实际责任.",
+          "Cognitive-function vocabulary: Te-Si-Ne-Fi.",
+          "Primary scenario: 运营节奏、角色清晰和质量控制."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/estp-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/estp-a",
+      "path": "/zh/personality/estp-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESTP-A",
+      "mbti_type": "ESTP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/estp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESTP-A 人格特点：行动、机会和现场应变 | FermatMind",
+        "description": "深入了解 ESTP-A 的行动、机会和现场应变、A/T 差异、Se-Ti-Fe-Ni 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ESTP-A 人格特点",
+        "quick_answer": "ESTP-A 可以理解为 ESTP 核心模式加上 A 型表达：它通常围绕行动、机会和现场应变展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ESTP-A",
+            "body": "ESTP-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 行动、机会和现场应变 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESTP-A 与 ESTP-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ESTP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ESTP-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Se-Ti-Fe-Ni 如何表现",
+            "body": "ESTP 常被解释为以外向感觉 Se 捕捉现场，以 Ti 快速判断，再由 Fe 和 Ni 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ESTP-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：谈判、销售现场和快速运营恢复",
+            "body": "在谈判、销售现场和快速运营恢复中，ESTP-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：放慢一点，让信任和承诺跟得上行动",
+            "body": "ESTP-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ESTP-A 可能会把 行动、机会和现场应变 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "行动快不等于没思考。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ESTP-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ESTP-A 是什么意思？",
+            "answer": "ESTP-A 指 ESTP 核心模式加上 A 型表达，常体现在行动、机会和现场应变、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ESTP-A 和 ESTP-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ESTP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ESTP-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ESTP-A 的常见优势是什么？",
+            "answer": "常见优势会围绕行动、机会和现场应变展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ESTP-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ESTP-A 在关系中要注意什么？",
+            "answer": "放慢一点，让信任和承诺跟得上行动，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estp-t",
+            "anchor_text": "ESTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estp-a-vs-estp-t",
+            "anchor_text": "ESTP-A 与 ESTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/estp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESTP-A is anchored on 行动、机会和现场应变.",
+          "Cognitive-function vocabulary: Se-Ti-Fe-Ni.",
+          "Primary scenario: 谈判、销售现场和快速运营恢复."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/estp-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/estp-t",
+      "path": "/zh/personality/estp-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESTP-T",
+      "mbti_type": "ESTP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/estp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ESTP-T 人格特点：行动、机会和现场应变 | FermatMind",
+        "description": "深入了解 ESTP-T 的行动、机会和现场应变、A/T 差异、Se-Ti-Fe-Ni 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ESTP-T 人格特点",
+        "quick_answer": "ESTP-T 可以理解为 ESTP 核心模式加上 T 型表达：它通常围绕行动、机会和现场应变展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ESTP-T",
+            "body": "ESTP-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 行动、机会和现场应变 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ESTP-T 与 ESTP-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ESTP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ESTP-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Se-Ti-Fe-Ni 如何表现",
+            "body": "ESTP 常被解释为以外向感觉 Se 捕捉现场，以 Ti 快速判断，再由 Fe 和 Ni 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ESTP-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：谈判、销售现场和快速运营恢复",
+            "body": "在谈判、销售现场和快速运营恢复中，ESTP-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：放慢一点，让信任和承诺跟得上行动",
+            "body": "ESTP-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ESTP-T 可能会把 行动、机会和现场应变 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "行动快不等于没思考。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ESTP-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ESTP-T 是什么意思？",
+            "answer": "ESTP-T 指 ESTP 核心模式加上 T 型表达，常体现在行动、机会和现场应变、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ESTP-T 和 ESTP-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ESTP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ESTP-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ESTP-T 的常见优势是什么？",
+            "answer": "常见优势会围绕行动、机会和现场应变展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ESTP-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ESTP-T 在关系中要注意什么？",
+            "answer": "放慢一点，让信任和承诺跟得上行动，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estp-a",
+            "anchor_text": "ESTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estp-a-vs-estp-t",
+            "anchor_text": "ESTP-A 与 ESTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/estp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ESTP-T is anchored on 行动、机会和现场应变.",
+          "Cognitive-function vocabulary: Se-Ti-Fe-Ni.",
+          "Primary scenario: 谈判、销售现场和快速运营恢复."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/infj-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/infj-a",
+      "path": "/zh/personality/infj-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INFJ-A",
+      "mbti_type": "INFJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/infj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INFJ-A 人格特点：意义感、模式洞察和价值导向 | FermatMind",
+        "description": "深入了解 INFJ-A 的意义感、模式洞察和价值导向、A/T 差异、Ni-Fe-Ti-Se 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "INFJ-A 人格特点",
+        "quick_answer": "INFJ-A 可以理解为 INFJ 核心模式加上 A 型表达：它通常围绕意义感、模式洞察和价值导向展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 INFJ-A",
+            "body": "INFJ-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 意义感、模式洞察和价值导向 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INFJ-A 与 INFJ-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。INFJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，INFJ-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ni-Fe-Ti-Se 如何表现",
+            "body": "INFJ 常被解释为以内向直觉 Ni 收束意义，以外向情感 Fe 读懂关系，再由 Ti 和 Se 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 INFJ-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：使命叙事、辅导和长期人际问题",
+            "body": "在使命叙事、辅导和长期人际问题中，INFJ-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：在失望累积前说清期待",
+            "body": "INFJ-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，INFJ-A 可能会把 意义感、模式洞察和价值导向 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "私下消化不等于暗中评判。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 INFJ-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "INFJ-A 是什么意思？",
+            "answer": "INFJ-A 指 INFJ 核心模式加上 A 型表达，常体现在意义感、模式洞察和价值导向、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "INFJ-A 和 INFJ-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。INFJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "INFJ-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "INFJ-A 的常见优势是什么？",
+            "answer": "常见优势会围绕意义感、模式洞察和价值导向展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "INFJ-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "INFJ-A 在关系中要注意什么？",
+            "answer": "在失望累积前说清期待，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infj-t",
+            "anchor_text": "INFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infj-a-vs-infj-t",
+            "anchor_text": "INFJ-A 与 INFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/infj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INFJ-A is anchored on 意义感、模式洞察和价值导向.",
+          "Cognitive-function vocabulary: Ni-Fe-Ti-Se.",
+          "Primary scenario: 使命叙事、辅导和长期人际问题."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/infj-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/infj-t",
+      "path": "/zh/personality/infj-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INFJ-T",
+      "mbti_type": "INFJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/infj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INFJ-T 人格特点：意义感、模式洞察和价值导向 | FermatMind",
+        "description": "深入了解 INFJ-T 的意义感、模式洞察和价值导向、A/T 差异、Ni-Fe-Ti-Se 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "INFJ-T 人格特点",
+        "quick_answer": "INFJ-T 可以理解为 INFJ 核心模式加上 T 型表达：它通常围绕意义感、模式洞察和价值导向展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 INFJ-T",
+            "body": "INFJ-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 意义感、模式洞察和价值导向 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INFJ-T 与 INFJ-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。INFJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，INFJ-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ni-Fe-Ti-Se 如何表现",
+            "body": "INFJ 常被解释为以内向直觉 Ni 收束意义，以外向情感 Fe 读懂关系，再由 Ti 和 Se 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 INFJ-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：使命叙事、辅导和长期人际问题",
+            "body": "在使命叙事、辅导和长期人际问题中，INFJ-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：在失望累积前说清期待",
+            "body": "INFJ-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，INFJ-T 可能会把 意义感、模式洞察和价值导向 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "私下消化不等于暗中评判。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 INFJ-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "INFJ-T 是什么意思？",
+            "answer": "INFJ-T 指 INFJ 核心模式加上 T 型表达，常体现在意义感、模式洞察和价值导向、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "INFJ-T 和 INFJ-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。INFJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "INFJ-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "INFJ-T 的常见优势是什么？",
+            "answer": "常见优势会围绕意义感、模式洞察和价值导向展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "INFJ-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "INFJ-T 在关系中要注意什么？",
+            "answer": "在失望累积前说清期待，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infj-a",
+            "anchor_text": "INFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infj-a-vs-infj-t",
+            "anchor_text": "INFJ-A 与 INFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/infj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INFJ-T is anchored on 意义感、模式洞察和价值导向.",
+          "Cognitive-function vocabulary: Ni-Fe-Ti-Se.",
+          "Primary scenario: 使命叙事、辅导和长期人际问题."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/infp-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/infp-a",
+      "path": "/zh/personality/infp-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INFP-A",
+      "mbti_type": "INFP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/infp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INFP-A 人格特点：个人意义、价值观和同理想象 | FermatMind",
+        "description": "深入了解 INFP-A 的个人意义、价值观和同理想象、A/T 差异、Fi-Ne-Si-Te 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "INFP-A 人格特点",
+        "quick_answer": "INFP-A 可以理解为 INFP 核心模式加上 A 型表达：它通常围绕个人意义、价值观和同理想象展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 INFP-A",
+            "body": "INFP-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 个人意义、价值观和同理想象 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INFP-A 与 INFP-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。INFP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，INFP-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Fi-Ne-Si-Te 如何表现",
+            "body": "INFP 常被解释为以内在价值 Fi 校准方向，以 Ne 想象可能，再用 Si 和 Te 落地。 这里的功能语言不是临床机制，而是解释行为的工具。对 INFP-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：价值导向创作、倾听支持和叙事设计",
+            "body": "在价值导向创作、倾听支持和叙事设计中，INFP-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：区分深度在乎和没有说出口的期待",
+            "body": "INFP-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，INFP-A 可能会把 个人意义、价值观和同理想象 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "表达柔和不等于立场薄弱。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 INFP-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "INFP-A 是什么意思？",
+            "answer": "INFP-A 指 INFP 核心模式加上 A 型表达，常体现在个人意义、价值观和同理想象、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "INFP-A 和 INFP-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。INFP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "INFP-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "INFP-A 的常见优势是什么？",
+            "answer": "常见优势会围绕个人意义、价值观和同理想象展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "INFP-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "INFP-A 在关系中要注意什么？",
+            "answer": "区分深度在乎和没有说出口的期待，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infp-t",
+            "anchor_text": "INFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infp-a-vs-infp-t",
+            "anchor_text": "INFP-A 与 INFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/infp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INFP-A is anchored on 个人意义、价值观和同理想象.",
+          "Cognitive-function vocabulary: Fi-Ne-Si-Te.",
+          "Primary scenario: 价值导向创作、倾听支持和叙事设计."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/infp-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/infp-t",
+      "path": "/zh/personality/infp-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INFP-T",
+      "mbti_type": "INFP",
+      "variant": "T",
+      "evidence_class": "agent_inventory",
+      "paired_path": "/en/personality/infp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INFP-T 人格特点：个人意义、价值观和同理想象 | FermatMind",
+        "description": "深入了解 INFP-T 的个人意义、价值观和同理想象、A/T 差异、Fi-Ne-Si-Te 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "INFP-T 人格特点",
+        "quick_answer": "INFP-T 可以理解为 INFP 核心模式加上 T 型表达：它通常围绕个人意义、价值观和同理想象展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 INFP-T",
+            "body": "INFP-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 个人意义、价值观和同理想象 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INFP-T 与 INFP-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。INFP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，INFP-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Fi-Ne-Si-Te 如何表现",
+            "body": "INFP 常被解释为以内在价值 Fi 校准方向，以 Ne 想象可能，再用 Si 和 Te 落地。 这里的功能语言不是临床机制，而是解释行为的工具。对 INFP-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：价值导向创作、倾听支持和叙事设计",
+            "body": "在价值导向创作、倾听支持和叙事设计中，INFP-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：区分深度在乎和没有说出口的期待",
+            "body": "INFP-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，INFP-T 可能会把 个人意义、价值观和同理想象 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "表达柔和不等于立场薄弱。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 INFP-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "INFP-T 是什么意思？",
+            "answer": "INFP-T 指 INFP 核心模式加上 T 型表达，常体现在个人意义、价值观和同理想象、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "INFP-T 和 INFP-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。INFP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "INFP-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "INFP-T 的常见优势是什么？",
+            "answer": "常见优势会围绕个人意义、价值观和同理想象展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "INFP-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "INFP-T 在关系中要注意什么？",
+            "answer": "区分深度在乎和没有说出口的期待，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infp-a",
+            "anchor_text": "INFP-A",
+            "reason": "Connect sibling A/T variant pages for same-type comparison.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infp-a-vs-infp-t",
+            "anchor_text": "INFP-A vs INFP-T",
+            "reason": "Connect to the A-vs-T comparison page.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/infp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INFP-T is anchored on 个人意义、价值观和同理想象.",
+          "Cognitive-function vocabulary: Fi-Ne-Si-Te.",
+          "Primary scenario: 价值导向创作、倾听支持和叙事设计."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/intj-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/intj-a",
+      "path": "/zh/personality/intj-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INTJ-A",
+      "mbti_type": "INTJ",
+      "variant": "A",
+      "evidence_class": "agent_inventory",
+      "paired_path": "/en/personality/intj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INTJ-A 人格特点：战略规划、独立标准和长期系统 | FermatMind",
+        "description": "深入了解 INTJ-A 的战略规划、独立标准和长期系统、A/T 差异、Ni-Te-Fi-Se 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "INTJ-A 人格特点",
+        "quick_answer": "INTJ-A 可以理解为 INTJ 核心模式加上 A 型表达：它通常围绕战略规划、独立标准和长期系统展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 INTJ-A",
+            "body": "INTJ-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 战略规划、独立标准和长期系统 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INTJ-A 与 INTJ-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。INTJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，INTJ-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ni-Te-Fi-Se 如何表现",
+            "body": "INTJ 常被解释为以内向直觉 Ni 收束方向，以外向思考 Te 组织执行，再由内在价值 Fi 和现实感知 Se 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 INTJ-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：战略复盘、架构取舍和长期规划",
+            "body": "在战略复盘、架构取舍和长期规划中，INTJ-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：把标准翻译成清晰期待，而不是让别人猜测",
+            "body": "INTJ-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，INTJ-A 可能会把 战略规划、独立标准和长期系统 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "安静不等于轻视别人。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 INTJ-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "INTJ-A 是什么意思？",
+            "answer": "INTJ-A 指 INTJ 核心模式加上 A 型表达，常体现在战略规划、独立标准和长期系统、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "INTJ-A 和 INTJ-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。INTJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "INTJ-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "INTJ-A 的常见优势是什么？",
+            "answer": "常见优势会围绕战略规划、独立标准和长期系统展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "INTJ-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "INTJ-A 在关系中要注意什么？",
+            "answer": "把标准翻译成清晰期待，而不是让别人猜测，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/intj-t",
+            "anchor_text": "INTJ-T",
+            "reason": "Connect sibling A/T variant pages for same-type comparison.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/intj-a-vs-intj-t",
+            "anchor_text": "INTJ-A vs INTJ-T",
+            "reason": "Connect to the A-vs-T comparison page.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/intj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INTJ-A is anchored on 战略规划、独立标准和长期系统.",
+          "Cognitive-function vocabulary: Ni-Te-Fi-Se.",
+          "Primary scenario: 战略复盘、架构取舍和长期规划."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/intj-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/intj-t",
+      "path": "/zh/personality/intj-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INTJ-T",
+      "mbti_type": "INTJ",
+      "variant": "T",
+      "evidence_class": "agent_inventory",
+      "paired_path": "/en/personality/intj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INTJ-T 人格特点：战略规划、独立标准和长期系统 | FermatMind",
+        "description": "深入了解 INTJ-T 的战略规划、独立标准和长期系统、A/T 差异、Ni-Te-Fi-Se 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "INTJ-T 人格特点",
+        "quick_answer": "INTJ-T 可以理解为 INTJ 核心模式加上 T 型表达：它通常围绕战略规划、独立标准和长期系统展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 INTJ-T",
+            "body": "INTJ-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 战略规划、独立标准和长期系统 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INTJ-T 与 INTJ-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。INTJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，INTJ-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ni-Te-Fi-Se 如何表现",
+            "body": "INTJ 常被解释为以内向直觉 Ni 收束方向，以外向思考 Te 组织执行，再由内在价值 Fi 和现实感知 Se 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 INTJ-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：战略复盘、架构取舍和长期规划",
+            "body": "在战略复盘、架构取舍和长期规划中，INTJ-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：把标准翻译成清晰期待，而不是让别人猜测",
+            "body": "INTJ-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，INTJ-T 可能会把 战略规划、独立标准和长期系统 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "安静不等于轻视别人。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 INTJ-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "INTJ-T 是什么意思？",
+            "answer": "INTJ-T 指 INTJ 核心模式加上 T 型表达，常体现在战略规划、独立标准和长期系统、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "INTJ-T 和 INTJ-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。INTJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "INTJ-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "INTJ-T 的常见优势是什么？",
+            "answer": "常见优势会围绕战略规划、独立标准和长期系统展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "INTJ-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "INTJ-T 在关系中要注意什么？",
+            "answer": "把标准翻译成清晰期待，而不是让别人猜测，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/intj-a",
+            "anchor_text": "INTJ-A",
+            "reason": "Connect sibling A/T variant pages for same-type comparison.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/intj-a-vs-intj-t",
+            "anchor_text": "INTJ-A vs INTJ-T",
+            "reason": "Connect to the A-vs-T comparison page.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/intj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INTJ-T is anchored on 战略规划、独立标准和长期系统.",
+          "Cognitive-function vocabulary: Ni-Te-Fi-Se.",
+          "Primary scenario: 战略复盘、架构取舍和长期规划."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/intp-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/intp-t",
+      "path": "/zh/personality/intp-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INTP-T",
+      "mbti_type": "INTP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/intp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "INTP-T 人格特点：分析、建模和独立解题 | FermatMind",
+        "description": "深入了解 INTP-T 的分析、建模和独立解题、A/T 差异、Ti-Ne-Si-Fe 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "INTP-T 人格特点",
+        "quick_answer": "INTP-T 可以理解为 INTP 核心模式加上 T 型表达：它通常围绕分析、建模和独立解题展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 INTP-T",
+            "body": "INTP-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 分析、建模和独立解题 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "INTP-T 与 INTP-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。INTP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，INTP-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ti-Ne-Si-Fe 如何表现",
+            "body": "INTP 常被解释为以内在逻辑 Ti 建模，以可能性探索 Ne 扩展，再用经验 Si 和群体反馈 Fe 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 INTP-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：技术评审、研究框架和复杂问题诊断",
+            "body": "在技术评审、研究框架和复杂问题诊断中，INTP-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：把分析翻译成对方能感受到的关心",
+            "body": "INTP-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，INTP-T 可能会把 分析、建模和独立解题 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "冷静分析不等于没有感受。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 INTP-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "INTP-T 是什么意思？",
+            "answer": "INTP-T 指 INTP 核心模式加上 T 型表达，常体现在分析、建模和独立解题、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "INTP-T 和 INTP-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。INTP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "INTP-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "INTP-T 的常见优势是什么？",
+            "answer": "常见优势会围绕分析、建模和独立解题展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "INTP-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "INTP-T 在关系中要注意什么？",
+            "answer": "把分析翻译成对方能感受到的关心，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/intp-a",
+            "anchor_text": "INTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/intp-a-vs-intp-t",
+            "anchor_text": "INTP-A 与 INTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/intp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "INTP-T is anchored on 分析、建模和独立解题.",
+          "Cognitive-function vocabulary: Ti-Ne-Si-Fe.",
+          "Primary scenario: 技术评审、研究框架和复杂问题诊断."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/isfj-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/isfj-a",
+      "path": "/zh/personality/isfj-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISFJ-A",
+      "mbti_type": "ISFJ",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/isfj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISFJ-A 人格特点：照顾、连续性和可靠支持 | FermatMind",
+        "description": "深入了解 ISFJ-A 的照顾、连续性和可靠支持、A/T 差异、Si-Fe-Ti-Ne 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ISFJ-A 人格特点",
+        "quick_answer": "ISFJ-A 可以理解为 ISFJ 核心模式加上 A 型表达：它通常围绕照顾、连续性和可靠支持展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ISFJ-A",
+            "body": "ISFJ-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 照顾、连续性和可靠支持 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISFJ-A 与 ISFJ-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ISFJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ISFJ-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Si-Fe-Ti-Ne 如何表现",
+            "body": "ISFJ 常被解释为以经验记忆 Si 维持稳定，以 Fe 照顾关系，再由 Ti 和 Ne 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ISFJ-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：服务可靠性、团队支持和细致交接",
+            "body": "在服务可靠性、团队支持和细致交接中，ISFJ-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：学会提出互相支持，而不是默默过度付出",
+            "body": "ISFJ-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ISFJ-A 可能会把 照顾、连续性和可靠支持 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "安静支持不等于没有追求。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ISFJ-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ISFJ-A 是什么意思？",
+            "answer": "ISFJ-A 指 ISFJ 核心模式加上 A 型表达，常体现在照顾、连续性和可靠支持、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ISFJ-A 和 ISFJ-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ISFJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ISFJ-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ISFJ-A 的常见优势是什么？",
+            "answer": "常见优势会围绕照顾、连续性和可靠支持展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ISFJ-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ISFJ-A 在关系中要注意什么？",
+            "answer": "学会提出互相支持，而不是默默过度付出，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfj-t",
+            "anchor_text": "ISFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfj-a-vs-isfj-t",
+            "anchor_text": "ISFJ-A 与 ISFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/isfj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISFJ-A is anchored on 照顾、连续性和可靠支持.",
+          "Cognitive-function vocabulary: Si-Fe-Ti-Ne.",
+          "Primary scenario: 服务可靠性、团队支持和细致交接."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/isfj-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/isfj-t",
+      "path": "/zh/personality/isfj-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISFJ-T",
+      "mbti_type": "ISFJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/isfj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISFJ-T 人格特点：照顾、连续性和可靠支持 | FermatMind",
+        "description": "深入了解 ISFJ-T 的照顾、连续性和可靠支持、A/T 差异、Si-Fe-Ti-Ne 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ISFJ-T 人格特点",
+        "quick_answer": "ISFJ-T 可以理解为 ISFJ 核心模式加上 T 型表达：它通常围绕照顾、连续性和可靠支持展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ISFJ-T",
+            "body": "ISFJ-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 照顾、连续性和可靠支持 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISFJ-T 与 ISFJ-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ISFJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ISFJ-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Si-Fe-Ti-Ne 如何表现",
+            "body": "ISFJ 常被解释为以经验记忆 Si 维持稳定，以 Fe 照顾关系，再由 Ti 和 Ne 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ISFJ-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：服务可靠性、团队支持和细致交接",
+            "body": "在服务可靠性、团队支持和细致交接中，ISFJ-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：学会提出互相支持，而不是默默过度付出",
+            "body": "ISFJ-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ISFJ-T 可能会把 照顾、连续性和可靠支持 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "安静支持不等于没有追求。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ISFJ-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ISFJ-T 是什么意思？",
+            "answer": "ISFJ-T 指 ISFJ 核心模式加上 T 型表达，常体现在照顾、连续性和可靠支持、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ISFJ-T 和 ISFJ-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ISFJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ISFJ-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ISFJ-T 的常见优势是什么？",
+            "answer": "常见优势会围绕照顾、连续性和可靠支持展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ISFJ-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ISFJ-T 在关系中要注意什么？",
+            "answer": "学会提出互相支持，而不是默默过度付出，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfj-a",
+            "anchor_text": "ISFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfj-a-vs-isfj-t",
+            "anchor_text": "ISFJ-A 与 ISFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/isfj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISFJ-T is anchored on 照顾、连续性和可靠支持.",
+          "Cognitive-function vocabulary: Si-Fe-Ti-Ne.",
+          "Primary scenario: 服务可靠性、团队支持和细致交接."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/isfp-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/isfp-a",
+      "path": "/zh/personality/isfp-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISFP-A",
+      "mbti_type": "ISFP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/isfp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISFP-A 人格特点：审美、体验和安静表达 | FermatMind",
+        "description": "深入了解 ISFP-A 的审美、体验和安静表达、A/T 差异、Fi-Se-Ni-Te 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ISFP-A 人格特点",
+        "quick_answer": "ISFP-A 可以理解为 ISFP 核心模式加上 A 型表达：它通常围绕审美、体验和安静表达展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ISFP-A",
+            "body": "ISFP-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 审美、体验和安静表达 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISFP-A 与 ISFP-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ISFP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ISFP-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Fi-Se-Ni-Te 如何表现",
+            "body": "ISFP 常被解释为以内在价值 Fi 校准选择，以 Se 感知体验，再由 Ni 和 Te 落地。 这里的功能语言不是临床机制，而是解释行为的工具。对 ISFP-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：视觉判断、手艺质量和贴近人的体验",
+            "body": "在视觉判断、手艺质量和贴近人的体验中，ISFP-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：在委屈累积前说清偏好和边界",
+            "body": "ISFP-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ISFP-A 可能会把 审美、体验和安静表达 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "安静的审美不等于没有标准。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ISFP-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ISFP-A 是什么意思？",
+            "answer": "ISFP-A 指 ISFP 核心模式加上 A 型表达，常体现在审美、体验和安静表达、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ISFP-A 和 ISFP-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ISFP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ISFP-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ISFP-A 的常见优势是什么？",
+            "answer": "常见优势会围绕审美、体验和安静表达展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ISFP-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ISFP-A 在关系中要注意什么？",
+            "answer": "在委屈累积前说清偏好和边界，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfp-t",
+            "anchor_text": "ISFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfp-a-vs-isfp-t",
+            "anchor_text": "ISFP-A 与 ISFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/isfp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISFP-A is anchored on 审美、体验和安静表达.",
+          "Cognitive-function vocabulary: Fi-Se-Ni-Te.",
+          "Primary scenario: 视觉判断、手艺质量和贴近人的体验."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/isfp-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/isfp-t",
+      "path": "/zh/personality/isfp-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISFP-T",
+      "mbti_type": "ISFP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/isfp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISFP-T 人格特点：审美、体验和安静表达 | FermatMind",
+        "description": "深入了解 ISFP-T 的审美、体验和安静表达、A/T 差异、Fi-Se-Ni-Te 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ISFP-T 人格特点",
+        "quick_answer": "ISFP-T 可以理解为 ISFP 核心模式加上 T 型表达：它通常围绕审美、体验和安静表达展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ISFP-T",
+            "body": "ISFP-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 审美、体验和安静表达 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISFP-T 与 ISFP-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ISFP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ISFP-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Fi-Se-Ni-Te 如何表现",
+            "body": "ISFP 常被解释为以内在价值 Fi 校准选择，以 Se 感知体验，再由 Ni 和 Te 落地。 这里的功能语言不是临床机制，而是解释行为的工具。对 ISFP-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：视觉判断、手艺质量和贴近人的体验",
+            "body": "在视觉判断、手艺质量和贴近人的体验中，ISFP-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：在委屈累积前说清偏好和边界",
+            "body": "ISFP-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ISFP-T 可能会把 审美、体验和安静表达 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "安静的审美不等于没有标准。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ISFP-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ISFP-T 是什么意思？",
+            "answer": "ISFP-T 指 ISFP 核心模式加上 T 型表达，常体现在审美、体验和安静表达、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ISFP-T 和 ISFP-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ISFP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ISFP-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ISFP-T 的常见优势是什么？",
+            "answer": "常见优势会围绕审美、体验和安静表达展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ISFP-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ISFP-T 在关系中要注意什么？",
+            "answer": "在委屈累积前说清偏好和边界，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfp-a",
+            "anchor_text": "ISFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfp-a-vs-isfp-t",
+            "anchor_text": "ISFP-A 与 ISFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/isfp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISFP-T is anchored on 审美、体验和安静表达.",
+          "Cognitive-function vocabulary: Fi-Se-Ni-Te.",
+          "Primary scenario: 视觉判断、手艺质量和贴近人的体验."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/istj-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/istj-a",
+      "path": "/zh/personality/istj-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISTJ-A",
+      "mbti_type": "ISTJ",
+      "variant": "A",
+      "evidence_class": "agent_inventory",
+      "paired_path": "/en/personality/istj-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISTJ-A 人格特点：责任、经验和可靠执行 | FermatMind",
+        "description": "深入了解 ISTJ-A 的责任、经验和可靠执行、A/T 差异、Si-Te-Fi-Ne 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ISTJ-A 人格特点",
+        "quick_answer": "ISTJ-A 可以理解为 ISTJ 核心模式加上 A 型表达：它通常围绕责任、经验和可靠执行展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ISTJ-A",
+            "body": "ISTJ-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 责任、经验和可靠执行 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISTJ-A 与 ISTJ-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ISTJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ISTJ-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Si-Te-Fi-Ne 如何表现",
+            "body": "ISTJ 常被解释为以经验记忆 Si 稳定判断，以 Te 组织执行，再由 Fi 和 Ne 校准边界与新可能。 这里的功能语言不是临床机制，而是解释行为的工具。对 ISTJ-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：流程控制、规范复核和稳定交付",
+            "body": "在流程控制、规范复核和稳定交付中，ISTJ-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：把关心表达出来，而不是只用责任感证明",
+            "body": "ISTJ-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ISTJ-A 可能会把 责任、经验和可靠执行 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "谨慎不等于封闭。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ISTJ-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ISTJ-A 是什么意思？",
+            "answer": "ISTJ-A 指 ISTJ 核心模式加上 A 型表达，常体现在责任、经验和可靠执行、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ISTJ-A 和 ISTJ-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ISTJ-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ISTJ-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ISTJ-A 的常见优势是什么？",
+            "answer": "常见优势会围绕责任、经验和可靠执行展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ISTJ-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ISTJ-A 在关系中要注意什么？",
+            "answer": "把关心表达出来，而不是只用责任感证明，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istj-t",
+            "anchor_text": "ISTJ-T",
+            "reason": "Connect sibling A/T variant pages for same-type comparison.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istj-a-vs-istj-t",
+            "anchor_text": "ISTJ-A vs ISTJ-T",
+            "reason": "Connect to the A-vs-T comparison page.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/istj-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISTJ-A is anchored on 责任、经验和可靠执行.",
+          "Cognitive-function vocabulary: Si-Te-Fi-Ne.",
+          "Primary scenario: 流程控制、规范复核和稳定交付."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/istj-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/istj-t",
+      "path": "/zh/personality/istj-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISTJ-T",
+      "mbti_type": "ISTJ",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/istj-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISTJ-T 人格特点：责任、经验和可靠执行 | FermatMind",
+        "description": "深入了解 ISTJ-T 的责任、经验和可靠执行、A/T 差异、Si-Te-Fi-Ne 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ISTJ-T 人格特点",
+        "quick_answer": "ISTJ-T 可以理解为 ISTJ 核心模式加上 T 型表达：它通常围绕责任、经验和可靠执行展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ISTJ-T",
+            "body": "ISTJ-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 责任、经验和可靠执行 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISTJ-T 与 ISTJ-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ISTJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ISTJ-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Si-Te-Fi-Ne 如何表现",
+            "body": "ISTJ 常被解释为以经验记忆 Si 稳定判断，以 Te 组织执行，再由 Fi 和 Ne 校准边界与新可能。 这里的功能语言不是临床机制，而是解释行为的工具。对 ISTJ-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：流程控制、规范复核和稳定交付",
+            "body": "在流程控制、规范复核和稳定交付中，ISTJ-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：把关心表达出来，而不是只用责任感证明",
+            "body": "ISTJ-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ISTJ-T 可能会把 责任、经验和可靠执行 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "谨慎不等于封闭。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ISTJ-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ISTJ-T 是什么意思？",
+            "answer": "ISTJ-T 指 ISTJ 核心模式加上 T 型表达，常体现在责任、经验和可靠执行、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ISTJ-T 和 ISTJ-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ISTJ-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ISTJ-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ISTJ-T 的常见优势是什么？",
+            "answer": "常见优势会围绕责任、经验和可靠执行展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ISTJ-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ISTJ-T 在关系中要注意什么？",
+            "answer": "把关心表达出来，而不是只用责任感证明，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istj-a",
+            "anchor_text": "ISTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istj-a-vs-istj-t",
+            "anchor_text": "ISTJ-A 与 ISTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/istj-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISTJ-T is anchored on 责任、经验和可靠执行.",
+          "Cognitive-function vocabulary: Si-Te-Fi-Ne.",
+          "Primary scenario: 流程控制、规范复核和稳定交付."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/istp-a:v2",
+      "target_url": "https://fermatmind.com/zh/personality/istp-a",
+      "path": "/zh/personality/istp-a",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISTP-A",
+      "mbti_type": "ISTP",
+      "variant": "A",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/istp-a",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISTP-A 人格特点：动手解题、自主和冷静排障 | FermatMind",
+        "description": "深入了解 ISTP-A 的动手解题、自主和冷静排障、A/T 差异、Ti-Se-Ni-Fe 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ISTP-A 人格特点",
+        "quick_answer": "ISTP-A 可以理解为 ISTP 核心模式加上 A 型表达：它通常围绕动手解题、自主和冷静排障展开，并呈现更稳定的自我确认、反馈后恢复和持续推进。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ISTP-A",
+            "body": "ISTP-A 不是能力排名，也不是固定身份。更稳妥的读法是：在 动手解题、自主和冷静排障 相关场景里，这个人更常用 更稳定的自我确认、反馈后恢复和持续推进 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISTP-A 与 ISTP-T 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ISTP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进，ISTP-T 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更快回到判断和下一步",
+                "turbulent": "更容易反复确认他人评价"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ti-Se-Ni-Fe 如何表现",
+            "body": "ISTP 常被解释为以内在逻辑 Ti 判断机制，以 Se 读取现实，再由 Ni 和 Fe 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ISTP-A 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：故障响应、工具使用和实际系统修复",
+            "body": "在故障响应、工具使用和实际系统修复中，ISTP-A 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：提前说明空间需求，避免被误读为疏离",
+            "body": "ISTP-A 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ISTP-A 可能会把 动手解题、自主和冷静排障 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "独立不等于无法靠近。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ISTP-A 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ISTP-A 是什么意思？",
+            "answer": "ISTP-A 指 ISTP 核心模式加上 A 型表达，常体现在动手解题、自主和冷静排障、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ISTP-A 和 ISTP-T 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ISTP-A 更偏 更稳定的自我确认、反馈后恢复和持续推进。"
+          },
+          {
+            "question": "ISTP-A 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ISTP-A 的常见优势是什么？",
+            "answer": "常见优势会围绕动手解题、自主和冷静排障展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ISTP-A 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ISTP-A 在关系中要注意什么？",
+            "answer": "提前说明空间需求，避免被误读为疏离，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istp-t",
+            "anchor_text": "ISTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istp-a-vs-istp-t",
+            "anchor_text": "ISTP-A 与 ISTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/istp-a",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISTP-A is anchored on 动手解题、自主和冷静排障.",
+          "Cognitive-function vocabulary: Ti-Se-Ni-Fe.",
+          "Primary scenario: 故障响应、工具使用和实际系统修复."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    },
+    {
+      "recommendation_id": "mbti64-remaining-58-competitor-gap:/zh/personality/istp-t:v2",
+      "target_url": "https://fermatmind.com/zh/personality/istp-t",
+      "path": "/zh/personality/istp-t",
+      "framework": "mbti64",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISTP-T",
+      "mbti_type": "ISTP",
+      "variant": "T",
+      "evidence_class": "gsc_pending",
+      "paired_path": "/en/personality/istp-t",
+      "competitor_gap_basis": [
+        "The six completed V2 pages establish the module architecture: A/T table, cognitive-function lens, practical scenarios, common misreads, safe-use boundary and expanded FAQ.",
+        "Competitor scan is used for durable SERP module coverage only; wording is generated independently and validated for copy risk.",
+        "The recommendation remains an untrusted draft until QA, human approval, CMS draft write, promotion readiness and runtime smoke pass."
+      ],
+      "recommendations": {
+        "title": "ISTP-T 人格特点：动手解题、自主和冷静排障 | FermatMind",
+        "description": "深入了解 ISTP-T 的动手解题、自主和冷静排障、A/T 差异、Ti-Se-Ni-Fe 行为机制、工作关系沟通、常见误读和安全使用边界。",
+        "h1": "ISTP-T 人格特点",
+        "quick_answer": "ISTP-T 可以理解为 ISTP 核心模式加上 T 型表达：它通常围绕动手解题、自主和冷静排障展开，并呈现更强的复盘意识、反馈敏感度和压力下校准。这是一种行为偏好和自我调节语言，适合用于自我理解、沟通和成长计划，不适合用来做诊断、筛选或人生结论。",
+        "sections": [
+          {
+            "key": "how_to_read",
+            "title": "先这样理解 ISTP-T",
+            "body": "ISTP-T 不是能力排名，也不是固定身份。更稳妥的读法是：在 动手解题、自主和冷静排障 相关场景里，这个人更常用 更强的复盘意识、反馈敏感度和压力下校准 来处理不确定性、反馈和行动节奏。"
+          },
+          {
+            "key": "at_difference_table",
+            "title": "ISTP-T 与 ISTP-A 对照表",
+            "body": "A/T 差异不是好坏差异，而是压力、反馈和自我确认方式的差异。ISTP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准，ISTP-A 则提供另一种校准节奏。",
+            "comparison_rows": [
+              {
+                "dimension": "反馈后反应",
+                "assertive": "更需要确认反馈是否暴露盲点",
+                "turbulent": "更擅长细致复盘和修正"
+              },
+              {
+                "dimension": "行动节奏",
+                "assertive": "更愿意用可行版本推进",
+                "turbulent": "更愿意继续检查风险和标准"
+              },
+              {
+                "dimension": "成长重点",
+                "assertive": "保留反证入口和他人反馈",
+                "turbulent": "避免把复盘变成停滞"
+              }
+            ]
+          },
+          {
+            "key": "cognitive_function_mechanism",
+            "title": "认知功能机制：Ti-Se-Ni-Fe 如何表现",
+            "body": "ISTP 常被解释为以内在逻辑 Ti 判断机制，以 Se 读取现实，再由 Ni 和 Fe 校准。 这里的功能语言不是临床机制，而是解释行为的工具。对 ISTP-T 来说，关键是看这种功能组合如何影响判断、表达、协作和压力恢复。"
+          },
+          {
+            "key": "work_scenario",
+            "title": "工作场景：故障响应、工具使用和实际系统修复",
+            "body": "在故障响应、工具使用和实际系统修复中，ISTP-T 的优势通常不是某个职业标签，而是处理信息、稳定节奏和推进协作的方式。更成熟的做法是把个人偏好转化成可复盘的行动、清晰的沟通和可交付的下一步。"
+          },
+          {
+            "key": "relationship_communication",
+            "title": "关系与沟通：提前说明空间需求，避免被误读为疏离",
+            "body": "ISTP-T 在关系中容易被误读的地方，往往不是动机，而是表达顺序。更有效的沟通方式是先说明意图，再说明边界，最后确认对方需要倾听、建议还是共同分析。"
+          },
+          {
+            "key": "stress_growth",
+            "title": "压力、盲点与成长",
+            "body": "压力下，ISTP-T 可能会把 动手解题、自主和冷静排障 的优势用得过满：要么过快推进，要么过度复盘。成长不是改变类型，而是增加检查点、反馈入口和可持续节奏。"
+          },
+          {
+            "key": "common_misreads",
+            "title": "常见误读",
+            "body": "独立不等于无法靠近。类型描述的是偏好，不是品格、智商、心理健康或职业价值。健康的 ISTP-T 会把类型当作反思工具，而不是替自己或别人下结论。",
+            "bullets": [
+              "稳定或敏感都不是优劣标签。",
+              "适合的场景来自技能、兴趣、环境和选择，不只来自类型。",
+              "A/T 差异应帮助理解压力和反馈方式，而不是制造等级。"
+            ]
+          },
+          {
+            "key": "how_to_use_not_use",
+            "title": "如何使用这页，以及不该怎么用",
+            "body": "可以用这页做自我观察、沟通复盘和成长计划。不要把它用于心理诊断、招聘筛选、智商判断、关系预测或职业决定。若测评结果和长期行为不一致，应回到具体情境、反馈和真实选择。"
+          }
+        ],
+        "faq": [
+          {
+            "question": "ISTP-T 是什么意思？",
+            "answer": "ISTP-T 指 ISTP 核心模式加上 T 型表达，常体现在动手解题、自主和冷静排障、反馈恢复和自我调节方式上。"
+          },
+          {
+            "question": "ISTP-T 和 ISTP-A 最大差别是什么？",
+            "answer": "差别主要在压力、反馈和自我确认节奏，不是哪一种更好。ISTP-T 更偏 更强的复盘意识、反馈敏感度和压力下校准。"
+          },
+          {
+            "question": "ISTP-T 是否更适合某些职业？",
+            "answer": "它可能提示某些工作偏好，但职业选择还取决于能力、兴趣、训练、机会、团队和价值观。"
+          },
+          {
+            "question": "ISTP-T 的常见优势是什么？",
+            "answer": "常见优势会围绕动手解题、自主和冷静排障展开，但具体表现取决于经验、成熟度和环境。"
+          },
+          {
+            "question": "ISTP-T 的盲点是什么？",
+            "answer": "盲点通常来自过度使用优势：忽略反馈、拖延行动、低估沟通成本或把压力反应当成事实。"
+          },
+          {
+            "question": "ISTP-T 在关系中要注意什么？",
+            "answer": "提前说明空间需求，避免被误读为疏离，同时避免把类型解释当成替对方下结论的理由。"
+          },
+          {
+            "question": "A/T 差异是否有科学诊断意义？",
+            "answer": "没有。这里把 A/T 当作压力和反馈风格语言，不作为临床、招聘或能力判断。"
+          },
+          {
+            "question": "这页和竞品内容有什么不同？",
+            "answer": "这页强调 A/T 对照、认知功能语言、场景化使用和安全边界，并避免复制竞品措辞。"
+          },
+          {
+            "question": "这页是官方 MBTI 说明吗？",
+            "answer": "不是。它是 FermatMind 的公开人格内容解释页，不声明与商标方或其他人格网站有关联。"
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istp-a",
+            "anchor_text": "ISTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istp-a-vs-istp-t",
+            "anchor_text": "ISTP-A 与 ISTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "bilingual_parity_notes": [
+          "Paired counterpart: /en/personality/istp-t",
+          "The paired page keeps the same module architecture but uses locale-native phrasing and examples.",
+          "Chinese headings and examples are localized for native reading, not translated sentence by sentence."
+        ],
+        "claim_boundary_notes": [
+          "No trademark-owner affiliation, certification or official-source claim is made.",
+          "No diagnosis, hiring screen, ability ranking, relationship prediction or fixed career path claim is made.",
+          "A/T is framed as self-regulation and feedback-response language, not superiority or clinical truth."
+        ],
+        "source_ledger_refs": [
+          "competitor_16personalities",
+          "competitor_123test",
+          "competitor_truity",
+          "competitor_personality_junkie",
+          "method_boundary_myers_briggs_safe_use"
+        ],
+        "type_specific_notes": [
+          "ISTP-T is anchored on 动手解题、自主和冷静排障.",
+          "Cognitive-function vocabulary: Ti-Se-Ni-Fe.",
+          "Primary scenario: 故障响应、工具使用和实际系统修复."
+        ]
+      },
+      "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-ARTIFACT-SYNC-01"
+    }
+  ],
+  "safety_boundary": {
+    "cms_write": false,
+    "approval_queue_write": false,
+    "live_promotion": false,
+    "publish_index_search": false,
+    "sitemap_llms_mutation": false,
+    "search_queue_mutation": false,
+    "indexnow_submit": false,
+    "frontend_runtime_change": false,
+    "competitor_text_copied": false
+  },
+  "blockers": [],
+  "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-ARTIFACT-SYNC-01",
+  "package_sha256": "c193b2962516610b7d1feb146dc121e03864671503690a0e19eb72ee20783a37"
+}

--- a/backend/docs/seo/personality/mbti64-remaining-58-competitor-gap-qa-v2-2026-06-28.json
+++ b/backend/docs/seo/personality/mbti64-remaining-58-competitor-gap-qa-v2-2026-06-28.json
@@ -1,0 +1,2927 @@
+{
+  "artifact": "MBTI64-REMAINING-58-COMPETITOR-GAP-QA-V2-01",
+  "generated_at": "2026-06-28T12:00:00.000Z",
+  "input_artifact": "docs/seo/personality/mbti64-remaining-58-competitor-gap-content-expansion-v2-2026-06-28.json",
+  "source_package_sha256": "fddc3f574fefd5fba1f56b773a2b37c366d3bb019d5bb99fcaa33ebbd1eb1cf9",
+  "page_results": [
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfj-t",
+      "path": "/en/personality/enfj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENFJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfp-a",
+      "path": "/en/personality/enfp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENFP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfp-t",
+      "path": "/en/personality/enfp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENFP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entj-a",
+      "path": "/en/personality/entj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENTJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entj-t",
+      "path": "/en/personality/entj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENTJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entp-a",
+      "path": "/en/personality/entp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENTP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entp-t",
+      "path": "/en/personality/entp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ENTP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfj-a",
+      "path": "/en/personality/esfj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESFJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfj-t",
+      "path": "/en/personality/esfj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESFJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfp-t",
+      "path": "/en/personality/esfp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESFP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estj-a",
+      "path": "/en/personality/estj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESTJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estj-t",
+      "path": "/en/personality/estj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESTJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estp-a",
+      "path": "/en/personality/estp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESTP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estp-t",
+      "path": "/en/personality/estp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ESTP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infj-a",
+      "path": "/en/personality/infj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INFJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infj-t",
+      "path": "/en/personality/infj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INFJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infp-a",
+      "path": "/en/personality/infp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INFP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infp-t",
+      "path": "/en/personality/infp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INFP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/intj-a",
+      "path": "/en/personality/intj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INTJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/intj-t",
+      "path": "/en/personality/intj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INTJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/intp-t",
+      "path": "/en/personality/intp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "INTP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfj-a",
+      "path": "/en/personality/isfj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISFJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfj-t",
+      "path": "/en/personality/isfj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISFJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfp-a",
+      "path": "/en/personality/isfp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISFP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfp-t",
+      "path": "/en/personality/isfp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISFP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istj-a",
+      "path": "/en/personality/istj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISTJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istj-t",
+      "path": "/en/personality/istj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISTJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istp-a",
+      "path": "/en/personality/istp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISTP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istp-t",
+      "path": "/en/personality/istp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "type_code": "ISTP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfj-t",
+      "path": "/zh/personality/enfj-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENFJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfp-a",
+      "path": "/zh/personality/enfp-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENFP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfp-t",
+      "path": "/zh/personality/enfp-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENFP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entj-a",
+      "path": "/zh/personality/entj-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENTJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entj-t",
+      "path": "/zh/personality/entj-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENTJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entp-a",
+      "path": "/zh/personality/entp-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENTP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entp-t",
+      "path": "/zh/personality/entp-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ENTP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfj-a",
+      "path": "/zh/personality/esfj-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESFJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfj-t",
+      "path": "/zh/personality/esfj-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESFJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfp-t",
+      "path": "/zh/personality/esfp-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESFP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estj-a",
+      "path": "/zh/personality/estj-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESTJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estj-t",
+      "path": "/zh/personality/estj-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESTJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estp-a",
+      "path": "/zh/personality/estp-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESTP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estp-t",
+      "path": "/zh/personality/estp-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ESTP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infj-a",
+      "path": "/zh/personality/infj-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INFJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infj-t",
+      "path": "/zh/personality/infj-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INFJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infp-a",
+      "path": "/zh/personality/infp-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INFP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infp-t",
+      "path": "/zh/personality/infp-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INFP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/intj-a",
+      "path": "/zh/personality/intj-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INTJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/intj-t",
+      "path": "/zh/personality/intj-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INTJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/intp-t",
+      "path": "/zh/personality/intp-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "INTP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfj-a",
+      "path": "/zh/personality/isfj-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISFJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfj-t",
+      "path": "/zh/personality/isfj-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISFJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfp-a",
+      "path": "/zh/personality/isfp-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISFP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfp-t",
+      "path": "/zh/personality/isfp-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISFP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istj-a",
+      "path": "/zh/personality/istj-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISTJ-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istj-t",
+      "path": "/zh/personality/istj-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISTJ-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istp-a",
+      "path": "/zh/personality/istp-a",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISTP-A",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istp-t",
+      "path": "/zh/personality/istp-t",
+      "locale": "zh",
+      "page_type": "variant",
+      "type_code": "ISTP-T",
+      "section_count": 8,
+      "faq_count": 9,
+      "gates": {
+        "inventory_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "structure_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "trademark_affiliation_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "deterministic_claim_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "clinical_recruiting_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "competitor_copy_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "private_route_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "bilingual_structure_parity_gate": {
+          "status": "pass",
+          "failures": []
+        }
+      },
+      "qa_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+      "blocked_reason": null
+    }
+  ],
+  "summary": {
+    "target_count": 58,
+    "pass_count": 58,
+    "blocked_count": 0,
+    "variant_pages": 58,
+    "comparison_pages": 0,
+    "completed_v2_exclusion_count": 0,
+    "section_count_min": 8,
+    "section_count_max": 8,
+    "faq_count_min": 9,
+    "faq_count_max": 9,
+    "duplicate_signature_group_count": 0
+  },
+  "gate_totals": {
+    "inventory_gate": {
+      "passed": 58,
+      "failed": 0
+    },
+    "structure_gate": {
+      "passed": 58,
+      "failed": 0
+    },
+    "trademark_affiliation_gate": {
+      "passed": 58,
+      "failed": 0
+    },
+    "deterministic_claim_gate": {
+      "passed": 58,
+      "failed": 0
+    },
+    "clinical_recruiting_gate": {
+      "passed": 58,
+      "failed": 0
+    },
+    "competitor_copy_gate": {
+      "passed": 58,
+      "failed": 0
+    },
+    "duplicate_template_gate": {
+      "passed": 58,
+      "failed": 0
+    },
+    "private_route_gate": {
+      "passed": 58,
+      "failed": 0
+    },
+    "bilingual_structure_parity_gate": {
+      "passed": 58,
+      "failed": 0
+    }
+  },
+  "duplicate_template_gate": {
+    "decision": "pass",
+    "duplicate_groups": {
+      "full_duplicate_groups": [],
+      "quick_answer_duplicate_groups": [],
+      "title_duplicate_groups": []
+    }
+  },
+  "safety_boundary": {
+    "artifact_only": true,
+    "cms_write": false,
+    "approval_queue_write": false,
+    "live_promotion": false,
+    "publish_index_search": false,
+    "sitemap_llms_mutation": false,
+    "search_queue_mutation": false,
+    "indexnow_submit": false,
+    "frontend_runtime_change": false,
+    "url_truth_write": false,
+    "production_deploy": false,
+    "external_api_call": false
+  },
+  "blockers": [],
+  "final_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
+  "recommended_next_task": "MBTI64-REMAINING-58-COMPETITOR-GAP-ARTIFACT-SYNC-01",
+  "qa_v2_sha256": "7d8353609d5a0abe1d7a2d68d4b96e06d58def2a05cde87db41a932827dd52da"
+}


### PR DESCRIPTION
## Summary
- Sync the MBTI64 remaining-58 competitor-gap V2 recommendation package into fap-api backend docs.
- Sync the independent QA-V2 artifact so backend approval queue / CMS draft gates can use repo-packaged artifacts.

## Scope
- Artifact sync only.
- No CMS writes, approval queue writes, live promotion, publish/index/search, sitemap/llms mutation, URL Truth, Search Queue, IndexNow, frontend changes, or deploy.

## Validation
- `jq empty backend/docs/seo/personality/mbti64-remaining-58-competitor-gap-content-expansion-v2-2026-06-28.json backend/docs/seo/personality/mbti64-remaining-58-competitor-gap-qa-v2-2026-06-28.json`
- SHA256 verified against fap-web source artifacts:
  - package: `fddc3f574fefd5fba1f56b773a2b37c366d3bb019d5bb99fcaa33ebbd1eb1cf9`
  - QA-V2: `15fe76ce36a78a70803a6120aee4fc0a70041facda280e04c4ad37e6e0c8f7e0`
- Node assertion: 58 package rows, 58 QA rows, QA decision `PASS_READY_FOR_FAP_API_ARTIFACT_SYNC`
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Deferred
- `MBTI64-REMAINING-58-COMPETITOR-GAP-APPROVAL-QUEUE-DRY-RUN-01`
- Any approval queue write, CMS draft, promotion, URL Truth refresh, Search Queue, IndexNow, and production deploy require separate gates/authorization.
