### PR TITLE
fix(report): grant result-page pdf token access

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -890,6 +890,7 @@ class AttemptReadController extends Controller
         $orgId = $this->currentOrgContext()->orgId();
         $attempt = $this->resolveAttemptForAccessRead($request, $orgId, $id);
         $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        $hasResultPagePdfTokenAccess = $this->resolveAttemptForResultPagePdfToken($request, $orgId, (string) $attempt->id) instanceof Attempt;
         $submissionPayload = $this->latestReadableSubmission($request, (string) $attempt->id);
         $resultExists = Result::query()
             ->where('org_id', $orgId)
@@ -1012,6 +1013,21 @@ class AttemptReadController extends Controller
                     (string) ($freeFullReportModeGate['access_source'] ?? 'free_full_report_mode')
                 )
             );
+        }
+        if ($hasResultPagePdfTokenAccess && $scaleCode === 'MBTI' && $resultExists) {
+            $accessState = 'ready';
+            $reportState = 'ready';
+            $pdfState = 'ready';
+            $reasonCode = 'result_page_pdf_token';
+            $payloadJson = array_merge($payloadJson, [
+                'access_level' => ReportAccess::REPORT_ACCESS_FULL,
+                'variant' => ReportAccess::VARIANT_FULL,
+                'unlock_stage' => ReportAccess::UNLOCK_STAGE_FULL,
+                'unlock_source' => ReportAccess::UNLOCK_SOURCE_NONE,
+                'access_source' => 'result_page_pdf_export_token',
+                'paywall_suppressed' => true,
+                'result_page_pdf_export' => true,
+            ]);
         }
 
         if ($repairFailed && $resultExists) {

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -368,11 +368,29 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $result->assertStatus(200);
         $this->assertSame('INTJ-A', $result->json('type_code'));
 
+        $reportAccess = $this->withHeaders([
+            'X-Result-Access-Token' => $token,
+        ])->get("/api/v0.3/attempts/{$attemptId}/report-access?locale=zh-CN");
+
+        $reportAccess->assertStatus(200)
+            ->assertJsonPath('access_state', 'ready')
+            ->assertJsonPath('report_state', 'ready')
+            ->assertJsonPath('pdf_state', 'ready')
+            ->assertJsonPath('reason_code', 'result_page_pdf_token')
+            ->assertJsonPath('access_source', 'result_page_pdf_export_token')
+            ->assertJsonPath('payload.result_page_pdf_export', true);
+
         $wrongAttempt = $this->withHeaders([
             'X-Result-Access-Token' => $token,
         ])->get("/api/v0.3/attempts/{$otherAttemptId}/result?locale=zh-CN");
 
         $wrongAttempt->assertStatus(404);
+
+        $wrongAttemptAccess = $this->withHeaders([
+            'X-Result-Access-Token' => $token,
+        ])->get("/api/v0.3/attempts/{$otherAttemptId}/report-access?locale=zh-CN");
+
+        $wrongAttemptAccess->assertStatus(404);
     }
 
     public function test_public_mbti_result_page_pdf_does_not_fallback_to_mpdf_when_gotenberg_fails(): void


### PR DESCRIPTION
## Summary
- Let valid MBTI result-page PDF export tokens make report-access return ready/pdf-ready for the private print session.
- Keep the existing strict token attempt match; mismatched attempts still 404.
- Add regression coverage so Gotenberg print pages can satisfy the frontend PDF readiness gate.

## Why
Production result-page PDF export was reaching Gotenberg, but the private print page stayed locked in report-access even though the same token could read /report. That prevented window.__FERMAT_PDF_READY__ from becoming true and caused the Gotenberg conversion request to time out.

## Validation
- php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi
- ./vendor/bin/pint --dirty --no-interaction
- git diff --check
- php artisan route:list --path=api/v0.3/attempts --no-ansi | head -n 40

## Deferred
- No frontend change.
- No route change.
- No migration.
- No CMS, DB write, queue, search, indexing, or deploy action in this PR.