### PR TITLE
[codex] MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -24,6 +24,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
     private const NEXT_BATCH_6_OPERATOR_APPROVAL = 'PERSONALITY-AGENT-CMS-DRAFT-NEXT-BATCH-6-WRITE-01';
 
+    private const REMAINING_58_OPERATOR_APPROVAL = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-WRITE-01';
+
     private const WRITE_SAFETY_FLAGS = [
         'draft-only',
         'no-publish',
@@ -42,6 +44,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         {--fresh-query-backed-3 : Restrict planning/write to the fresh 3 query-backed MBTI64 URLs}
         {--fresh-query-backed-5 : Restrict planning/write to the fresh 5 query-backed MBTI64 URLs}
         {--next-batch-6 : Restrict planning/write to the approved 6 next-batch MBTI64 URLs}
+        {--remaining-58 : Restrict planning/write to the approved 58 remaining competitor-gap MBTI64 variant URLs}
         {--agent-batch-size= : Restrict planning/write to an artifact-order batch; only 5 or 10 are allowed}
         {--agent-batch-offset= : Zero-based artifact-order offset for --agent-batch-size; defaults to 0}
         {--json : Emit the full JSON summary}
@@ -139,6 +142,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             (bool) $this->option('fresh-query-backed-3') => self::FRESH_QUERY_BACKED_3_OPERATOR_APPROVAL,
             (bool) $this->option('fresh-query-backed-5') => self::FRESH_QUERY_BACKED_5_OPERATOR_APPROVAL,
             (bool) $this->option('next-batch-6') => self::NEXT_BATCH_6_OPERATOR_APPROVAL,
+            (bool) $this->option('remaining-58') => self::REMAINING_58_OPERATOR_APPROVAL,
             $this->agentBatchRequested() => self::AGENT_BATCH_OPERATOR_APPROVAL,
             default => self::OPERATOR_APPROVAL,
         };
@@ -173,6 +177,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             'fresh_query_backed_3' => (bool) $this->option('fresh-query-backed-3'),
             'fresh_query_backed_5' => (bool) $this->option('fresh-query-backed-5'),
             'next_batch_6' => (bool) $this->option('next-batch-6'),
+            'remaining_58' => (bool) $this->option('remaining-58'),
             'agent_batch_size' => trim((string) $this->option('agent-batch-size')),
             'agent_batch_offset' => trim((string) $this->option('agent-batch-offset')),
             'draft_only' => (bool) $this->option('draft-only'),

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -26,6 +26,10 @@ final class Mbti64CmsProjectionDraftWriter
 
     private const NEXT_BATCH_6_V2_QA_ARTIFACT = 'MBTI64-NEXT-BATCH-6-COMPETITOR-GAP-CONTENT-EXPANSION-V2-QA-01';
 
+    private const REMAINING_58_V2_PACKAGE_ARTIFACT = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01';
+
+    private const REMAINING_58_V2_QA_ARTIFACT = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-QA-01';
+
     private const VISIBLE_QUERY_BACKED_3_URLS = [
         'https://fermatmind.com/en/personality/enfj-a',
         'https://fermatmind.com/zh/personality/intp-a',
@@ -288,6 +292,10 @@ final class Mbti64CmsProjectionDraftWriter
             return $this->validateNextBatch6PackageAndQa($package, $qa);
         }
 
+        if ($this->remaining58Requested($options)) {
+            return $this->validateRemaining58PackageAndQa($package, $qa);
+        }
+
         $errors = [];
         $summary = is_array($package['summary'] ?? null) ? $package['summary'] : [];
         $qaSummary = is_array($qa['summary'] ?? null) ? $qa['summary'] : [];
@@ -429,6 +437,83 @@ final class Mbti64CmsProjectionDraftWriter
     }
 
     /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return list<array<string,string>>
+     */
+    private function validateRemaining58PackageAndQa(array $package, array $qa): array
+    {
+        $errors = [];
+        $qaSummary = is_array($qa['summary'] ?? null) ? $qa['summary'] : [];
+        $recommendationUrls = array_map(
+            static fn (array $item): string => (string) ($item['target_url'] ?? ''),
+            $this->recommendations($package)
+        );
+        $expectedUrls = $this->remaining58Urls();
+        sort($recommendationUrls);
+        sort($expectedUrls);
+
+        if ((string) ($package['artifact'] ?? '') !== self::REMAINING_58_V2_PACKAGE_ARTIFACT) {
+            $errors[] = ['field' => 'artifact', 'code' => 'unsupported_package_artifact', 'message' => 'Unexpected remaining-58 package artifact.'];
+        }
+        if ((string) ($package['status'] ?? '') !== 'pass') {
+            $errors[] = ['field' => 'status', 'code' => 'package_status_not_ready_for_approval_review', 'message' => 'Remaining-58 package must have pass status.'];
+        }
+        if ((string) ($package['final_decision'] ?? '') !== 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW') {
+            $errors[] = ['field' => 'final_decision', 'code' => 'package_not_ready_for_content_expansion_review', 'message' => 'Remaining-58 package must be ready for content expansion review.'];
+        }
+        if (count($this->recommendations($package)) !== 58 || (int) ($package['target_count'] ?? -1) !== 58) {
+            $errors[] = ['field' => 'recommendations', 'code' => 'unexpected_recommendation_count', 'message' => 'Expected exactly 58 remaining recommendations.'];
+        }
+        if ($recommendationUrls !== $expectedUrls) {
+            $errors[] = ['field' => 'recommendations', 'code' => 'remaining_58_url_set_mismatch', 'message' => 'Remaining-58 package must contain exactly the fixed approved URL set.'];
+        }
+        if ($this->countUrlsByPageType($recommendationUrls, 'variant') !== 58
+            || $this->countUrlsByPageType($recommendationUrls, 'comparison') !== 0) {
+            $errors[] = ['field' => 'recommendations', 'code' => 'unexpected_page_type_counts', 'message' => 'Expected 58 variant and 0 comparison recommendations.'];
+        }
+
+        if ((string) ($qa['artifact'] ?? '') !== self::REMAINING_58_V2_QA_ARTIFACT) {
+            $errors[] = ['field' => 'qa.artifact', 'code' => 'unsupported_qa_artifact', 'message' => 'Unexpected remaining-58 QA artifact.'];
+        }
+        if ((string) ($qa['final_decision'] ?? '') !== 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW') {
+            $errors[] = ['field' => 'qa.final_decision', 'code' => 'qa_not_ready_for_content_expansion_review', 'message' => 'Remaining-58 QA must be ready for content expansion review.'];
+        }
+        if ((int) ($qaSummary['target_count'] ?? -1) !== 58
+            || (int) ($qaSummary['pass_count'] ?? -1) !== 58
+            || (int) ($qaSummary['no_go_count'] ?? -1) !== 0
+            || (int) ($qaSummary['variant_pages'] ?? -1) !== 58
+            || (int) ($qaSummary['comparison_pages'] ?? -1) !== 0) {
+            $errors[] = ['field' => 'qa.summary', 'code' => 'qa_summary_not_all_pass', 'message' => 'Remaining-58 QA summary must show 58 variant pass and 0 blocked.'];
+        }
+        if ((array) ($qa['blockers'] ?? []) !== []) {
+            $errors[] = ['field' => 'qa.blockers', 'code' => 'qa_blockers_present', 'message' => 'QA blockers must be empty.'];
+        }
+
+        $qaUrls = array_map(
+            static fn (array $item): string => (string) ($item['target_url'] ?? ''),
+            array_values(array_filter(
+                is_array($qa['page_results'] ?? null) ? $qa['page_results'] : [],
+                static fn (mixed $item): bool => is_array($item)
+            ))
+        );
+        sort($qaUrls);
+        if ($recommendationUrls !== $qaUrls) {
+            $errors[] = ['field' => 'qa.page_results', 'code' => 'qa_url_set_mismatch', 'message' => 'QA page result URLs must match remaining-58 recommendation URLs.'];
+        }
+
+        foreach ($this->qaResultsByUrl($qa) as $url => $result) {
+            $pageDecision = (string) ($result['decision'] ?? ($result['qa_decision'] ?? ''));
+            $blockedReason = trim((string) ($result['blocked_reason'] ?? ''));
+            if ($pageDecision !== 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW' || (array) ($result['blockers'] ?? []) !== [] || $blockedReason !== '') {
+                $errors[] = ['field' => 'qa.page_results.'.$url, 'code' => 'qa_page_not_pass', 'message' => 'Every remaining-58 QA page result must pass content expansion review with no blockers.'];
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
      * @param  list<string>  $urls
      */
     private function countUrlsByPageType(array $urls, string $pageType): int
@@ -481,23 +566,25 @@ final class Mbti64CmsProjectionDraftWriter
         $freshQueryBacked3 = (bool) ($options['fresh_query_backed_3'] ?? false);
         $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
         $nextBatch6 = $this->nextBatch6Requested($options);
+        $remaining58 = $this->remaining58Requested($options);
         $agentBatchRequested = $this->agentBatchRequested($options);
 
         if (($visibleQueryBacked3 ? 1 : 0)
             + ($freshQueryBacked3 ? 1 : 0)
             + ($freshQueryBacked5 ? 1 : 0)
             + ($nextBatch6 ? 1 : 0)
+            + ($remaining58 ? 1 : 0)
             + ($agentBatchRequested ? 1 : 0) > 1) {
             $errors[] = [
                 'field' => 'options',
                 'code' => 'exclusive_subset_modes_required',
-                'message' => 'Only one subset mode can be used: --visible-query-backed-3, --fresh-query-backed-3, --fresh-query-backed-5, --next-batch-6, or agent batch options.',
+                'message' => 'Only one subset mode can be used: --visible-query-backed-3, --fresh-query-backed-3, --fresh-query-backed-5, --next-batch-6, --remaining-58, or agent batch options.',
             ];
 
             return [];
         }
 
-        if (! $visibleQueryBacked3 && ! $freshQueryBacked3 && ! $freshQueryBacked5 && ! $nextBatch6 && ! $agentBatchRequested) {
+        if (! $visibleQueryBacked3 && ! $freshQueryBacked3 && ! $freshQueryBacked5 && ! $nextBatch6 && ! $remaining58 && ! $agentBatchRequested) {
             return $recommendations;
         }
 
@@ -511,6 +598,11 @@ final class Mbti64CmsProjectionDraftWriter
         }
 
         [$expectedUrls, $subsetCode, $subsetLabel] = match (true) {
+            $remaining58 => [
+                $this->remaining58Urls(),
+                'remaining_58_subset_required_urls_missing',
+                'remaining 58',
+            ],
             $nextBatch6 => [
                 self::NEXT_BATCH_6_URLS,
                 'next_batch_6_subset_required_urls_missing',
@@ -567,6 +659,37 @@ final class Mbti64CmsProjectionDraftWriter
     private function nextBatch6Requested(array $options): bool
     {
         return (bool) ($options['next_batch_6'] ?? false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function remaining58Requested(array $options): bool
+    {
+        return (bool) ($options['remaining_58'] ?? false);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function remaining58Urls(): array
+    {
+        $excluded = array_fill_keys(self::NEXT_BATCH_6_URLS, true);
+        $urls = [];
+        foreach (['en', 'zh'] as $prefix) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                foreach (['a', 't'] as $variantCode) {
+                    $url = 'https://fermatmind.com/'.$prefix.'/personality/'.strtolower($typeCode).'-'.$variantCode;
+                    if (! isset($excluded[$url])) {
+                        $urls[] = $url;
+                    }
+                }
+            }
+        }
+
+        sort($urls);
+
+        return $urls;
     }
 
     /**
@@ -768,7 +891,7 @@ final class Mbti64CmsProjectionDraftWriter
      */
     private function agentBatchApprovalGate(array $preparedRows, string $sourceSha256, string $qaSha256, array $options): array
     {
-        if (! $this->agentBatchRequested($options) && ! $this->nextBatch6Requested($options)) {
+        if (! $this->agentBatchRequested($options) && ! $this->nextBatch6Requested($options) && ! $this->remaining58Requested($options)) {
             return [
                 'required_for_write' => false,
                 'ready_for_write' => true,
@@ -1059,6 +1182,7 @@ final class Mbti64CmsProjectionDraftWriter
         $freshQueryBacked3 = (bool) ($options['fresh_query_backed_3'] ?? false);
         $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
         $nextBatch6 = $this->nextBatch6Requested($options);
+        $remaining58 = $this->remaining58Requested($options);
         $agentBatchRequested = $this->agentBatchRequested($options);
         $selectedUrls = array_values(array_map(
             static fn (array $row): string => (string) ($row['url'] ?? ''),
@@ -1111,6 +1235,19 @@ final class Mbti64CmsProjectionDraftWriter
                 'write_allowed_with_strict_approval' => true,
                 'approval_queue_required' => true,
                 'allowed_urls' => self::NEXT_BATCH_6_URLS,
+                'selected_urls' => $selectedUrls,
+                'arbitrary_url_subset_allowed' => false,
+            ];
+        }
+
+        if ($remaining58) {
+            return [
+                'mode' => 'remaining_58',
+                'enabled' => true,
+                'dry_run_only' => false,
+                'write_allowed_with_strict_approval' => true,
+                'approval_queue_required' => true,
+                'allowed_urls' => $this->remaining58Urls(),
                 'selected_urls' => $selectedUrls,
                 'arbitrary_url_subset_allowed' => false,
             ];

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -793,6 +793,183 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         }
     }
 
+    public function test_remaining_fifty_eight_v2_dry_run_accepts_competitor_gap_artifact_and_approved_queue_without_writes(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 58, 0);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--remaining-58' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(58, $payload['row_count']);
+        $this->assertSame(58, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(58, $payload['would_create_revision_count']);
+        $this->assertSame('remaining_58', $payload['subset']['mode']);
+        $this->assertTrue($payload['subset']['approval_queue_required']);
+        $this->assertFalse($payload['subset']['arbitrary_url_subset_allowed']);
+        $this->assertTrue($payload['approval_queue']['ready_for_write']);
+        $this->assertSame(58, $payload['approval_queue']['approved_count']);
+
+        $plannedUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($plannedUrls);
+        $expectedUrls = $this->remainingFiftyEightUrls();
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $plannedUrls);
+        $this->assertSame($expectedUrls, array_values($this->sortedStrings((array) $payload['subset']['allowed_urls'])));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_remaining_fifty_eight_write_requires_remaining_fifty_eight_approval_token(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 58, 0);
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--remaining-58'] = true;
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString(
+            '--operator-approved=MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-WRITE-01 is required',
+            (string) ($payload['errors'][0]['message'] ?? '')
+        );
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_remaining_fifty_eight_write_without_approved_queue_rows_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--remaining-58'] = true;
+        $options['--operator-approved'] = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(58, $payload['row_count']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['approval_queue']['approved_count']);
+        $this->assertSame(58, $payload['approval_queue']['missing_count']);
+        $this->assertContains('agent_batch_approval_required', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_remaining_fifty_eight_write_creates_only_approved_variant_draft_revisions(): void
+    {
+        $targets = $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 58, 0);
+        $profileBefore = $this->profileLiveState($targets['en|ENFJ']);
+        $variantBefore = $this->variantLiveState($targets['en|ENFJ-T']);
+        $surfaceCountsBefore = $this->liveSurfaceCounts();
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--remaining-58'] = true;
+        $options['--operator-approved'] = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(58, $payload['row_count']);
+        $this->assertSame(58, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(58, $payload['created_revision_count']);
+        $this->assertSame('remaining_58', $payload['subset']['mode']);
+        $this->assertTrue($payload['approval_queue']['ready_for_write']);
+        $this->assertSame(58, $payload['approval_queue']['approved_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(58, PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['en|ENFJ']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['en|ENFJ-T']));
+        $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        foreach (PersonalityProfileVariantRevision::query()->get() as $revision) {
+            $this->assertProjectionSnapshot(
+                $revision->snapshot_json,
+                'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01',
+                'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW',
+                9
+            );
+        }
+    }
+
+    public function test_remaining_fifty_eight_fails_closed_when_handoff_contains_arbitrary_url(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $package['recommendations'][0] = $this->recommendation('/en/personality/enfj-a');
+        $package['recommendations'][0]['recommendation_id'] = 'mbti64-remaining-58-competitor-gap:/en/personality/enfj-a:v2';
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--remaining-58' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('remaining_58_url_set_mismatch', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertContains('remaining_58_subset_required_urls_missing', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
     public function test_next_batch_six_write_with_partial_approval_fails_closed_without_revisions(): void
     {
         $this->seedAllTargets();
@@ -1817,6 +1994,150 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
             ],
             'recommended_next_task' => 'MBTI64-NEXT-BATCH-6-COMPETITOR-GAP-CONTENT-EXPANSION-V2-APPROVAL-QUEUE-WRITE-01',
         ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function remainingFiftyEightV2Package(): array
+    {
+        $recommendations = [];
+        foreach ($this->remainingFiftyEightUrls() as $url) {
+            $path = (string) (parse_url($url, PHP_URL_PATH) ?: '');
+            $recommendation = $this->recommendation($path);
+            $locale = str_starts_with($path, '/zh/') ? 'zh' : 'en';
+            $recommended = $recommendation['recommendations'];
+            $recommendation['recommendation_id'] = 'mbti64-remaining-58-competitor-gap:'.$path.':v2';
+            $recommendation['locale'] = $locale;
+            $recommendation['type_code'] = strtoupper(basename($path));
+            $recommendation['evidence_class'] = 'gsc_pending';
+            $recommendation['competitor_gap_basis'] = ['fixture competitor gap'];
+            $recommendation['recommendations'] = [
+                'title' => (string) ($recommended['title']['recommended'] ?? ''),
+                'description' => (string) ($recommended['description']['recommended'] ?? ''),
+                'h1' => (string) ($recommended['h1']['recommended'] ?? ''),
+                'quick_answer' => (string) ($recommended['quick_answer']['recommended'] ?? ''),
+                'sections' => array_map(
+                    static fn (int $index): array => [
+                        'key' => 'section_'.$index,
+                        'title' => 'Fixture remaining section '.$index,
+                        'body' => 'Fixture remaining expanded section body '.$index.'.',
+                    ],
+                    range(1, 8)
+                ),
+                'faq' => array_map(
+                    static fn (int $index): array => [
+                        'question' => 'Fixture remaining question '.$index.'?',
+                        'answer' => 'Fixture remaining answer '.$index.' for safe content expansion.',
+                    ],
+                    range(1, 9)
+                ),
+                'internal_links' => (array) ($recommended['internal_links'] ?? []),
+                'bilingual_parity_notes' => ['paired counterpart fixture'],
+                'claim_boundary_notes' => ['no official MBTI affiliation fixture'],
+            ];
+            $recommendations[] = $recommendation;
+        }
+
+        return [
+            'artifact' => 'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01',
+            'generated_at' => '2026-06-28T12:00:00Z',
+            'status' => 'pass',
+            'target_count' => 58,
+            'final_decision' => 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW',
+            'recommendations' => $recommendations,
+            'safety_boundary' => [
+                'cms_write' => false,
+                'approval_queue_write' => false,
+                'live_promotion' => false,
+                'publish_index_search' => false,
+                'sitemap_llms_mutation' => false,
+            ],
+            'recommended_next_task' => 'MBTI64-REMAINING-58-COMPETITOR-GAP-APPROVAL-QUEUE-DRY-RUN-01',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $package
+     * @return array<string,mixed>
+     */
+    private function remainingFiftyEightV2Qa(?array $package = null): array
+    {
+        $package ??= $this->remainingFiftyEightV2Package();
+        $pageResults = [];
+        foreach ((array) ($package['recommendations'] ?? []) as $recommendation) {
+            if (! is_array($recommendation)) {
+                continue;
+            }
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            $path = (string) (parse_url($targetUrl, PHP_URL_PATH) ?: '');
+            $pageResults[] = [
+                'target_url' => $targetUrl,
+                'path' => $path,
+                'locale' => str_starts_with($path, '/zh/') ? 'zh' : 'en',
+                'page_type' => 'variant',
+                'type_code' => strtoupper(basename($path)),
+                'section_count' => 8,
+                'faq_count' => 9,
+                'private_route_hits' => [],
+                'qa_decision' => 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW',
+                'blocked_reason' => null,
+                'gates' => [
+                    'target_scope' => 'pass',
+                    'schema_shape' => 'pass',
+                    'at_difference_table' => 'pass',
+                    'cognitive_function_mechanism' => 'pass',
+                    'work_relationship_communication' => 'pass',
+                    'safe_use_boundary' => 'pass',
+                    'trademark_claim_boundary' => 'pass',
+                    'deterministic_claim_boundary' => 'pass',
+                    'private_route_boundary' => 'pass',
+                    'competitor_copy_boundary' => 'pass',
+                    'bilingual_parity' => 'pass',
+                    'duplicate_template_risk' => 'pass_with_monitoring',
+                ],
+            ];
+        }
+
+        return [
+            'artifact' => 'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-QA-01',
+            'generated_at' => '2026-06-28T12:00:00Z',
+            'input_artifact' => 'docs/seo/personality/mbti64-remaining-58-competitor-gap-content-expansion-v2-2026-06-28.json',
+            'summary' => [
+                'target_count' => 58,
+                'pass_count' => 58,
+                'no_go_count' => 0,
+                'variant_pages' => 58,
+                'comparison_pages' => 0,
+            ],
+            'page_results' => $pageResults,
+            'blockers' => [],
+            'final_decision' => 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW',
+            'recommended_next_task' => 'MBTI64-REMAINING-58-COMPETITOR-GAP-APPROVAL-QUEUE-WRITE-01',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function remainingFiftyEightUrls(): array
+    {
+        $excluded = array_fill_keys(self::NEXT_BATCH_6_URLS, true);
+        $urls = [];
+        foreach (['en', 'zh'] as $prefix) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                foreach (['a', 't'] as $variantCode) {
+                    $url = 'https://fermatmind.com/'.$prefix.'/personality/'.strtolower($typeCode).'-'.$variantCode;
+                    if (! isset($excluded[$url])) {
+                        $urls[] = $url;
+                    }
+                }
+            }
+        }
+
+        sort($urls);
+
+        return $urls;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds `--remaining-58` support to `personality:mbti64-cms-projection-draft` for the MBTI64 remaining-58 competitor-gap V2 package.
- Validates the exact remaining-58 URL set: 58 MBTI64 variant pages, 0 comparison pages, excluding the six already-completed V2 pages.
- Requires approval queue readiness for the selected 58 rows and a separate remaining-58 write approval token before any write.
- Keeps arbitrary subsets fail-closed and preserves existing full-88, visible-3, fresh-3, fresh-5, next-batch-6, and agent-batch flows.

## Why
The production dry-run for `MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-DRY-RUN-01` could not plan the approved remaining-58 V2 package because the draft writer only recognized older package contracts. This patch adds a fixed, explicit contract for that package without opening arbitrary URL selection.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check origin/main...HEAD`

Note: `ci_verify_mbti.sh` regenerates Big Five compiled content-pack files locally; those generated out-of-scope changes were restored before push.

## Intentionally deferred
- No production deploy.
- No production dry-run/write.
- No CMS live promotion, publish, index/search, sitemap/llms, Search Queue, URL Truth, frontend, or external API mutation.
- Next runtime gate after deploy is `MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-DRY-RUN-02` using `--remaining-58`.

## Repository rule impact
Backend CMS draft command/service contract only. No new content authority surface is introduced; backend remains the authority for CMS draft writes and all runtime gates remain separately approval-bound.
