### PR TITLE
[codex] MBTI64-REMAINING-58-COMPETITOR-GAP-PROMOTE-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
@@ -29,6 +29,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
         {--visible-query-backed-3 : Restrict agent projection promotion planning/write to the approved 3 query-backed visible MBTI64 URLs}
         {--fresh-query-backed-5 : Restrict agent projection promotion planning/write to the fresh 5 query-backed MBTI64 URLs}
         {--next-batch-6 : Restrict agent projection promotion planning/write to the approved next-batch 6 MBTI64 URLs}
+        {--remaining-58 : Restrict agent projection promotion planning/write to the approved 58 remaining competitor-gap MBTI64 variant URLs}
         {--json : Emit the full JSON summary}
         {--output= : Optional path to write the JSON summary}
         {--promote-live-content : Required for --write; confirms live CMS content promotion intent}
@@ -141,6 +142,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
             'visible_query_backed_3' => (bool) $this->option('visible-query-backed-3'),
             'fresh_query_backed_5' => (bool) $this->option('fresh-query-backed-5'),
             'next_batch_6' => (bool) $this->option('next-batch-6'),
+            'remaining_58' => (bool) $this->option('remaining-58'),
         ];
     }
 

--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -30,6 +30,8 @@ final class Mbti64CmsRevisionPromotionService
 
     private const NEXT_BATCH_6_V2_PACKAGE_ARTIFACT = 'MBTI64-NEXT-BATCH-6-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01';
 
+    private const REMAINING_58_V2_PACKAGE_ARTIFACT = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01';
+
     private const VISIBLE_QUERY_BACKED_3_URLS = [
         'https://fermatmind.com/en/personality/enfj-a',
         'https://fermatmind.com/zh/personality/intp-a',
@@ -208,7 +210,11 @@ final class Mbti64CmsRevisionPromotionService
         $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
         $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
         $nextBatch6 = (bool) ($options['next_batch_6'] ?? false);
-        $subsetModeCount = ($visibleQueryBacked3 ? 1 : 0) + ($freshQueryBacked5 ? 1 : 0) + ($nextBatch6 ? 1 : 0);
+        $remaining58 = (bool) ($options['remaining_58'] ?? false);
+        $subsetModeCount = ($visibleQueryBacked3 ? 1 : 0)
+            + ($freshQueryBacked5 ? 1 : 0)
+            + ($nextBatch6 ? 1 : 0)
+            + ($remaining58 ? 1 : 0);
         if ($subsetModeCount > 1) {
             $errors[] = [
                 'field' => 'options',
@@ -221,6 +227,7 @@ final class Mbti64CmsRevisionPromotionService
             $visibleQueryBacked3 => self::VISIBLE_QUERY_BACKED_3_URLS,
             $freshQueryBacked5 => self::FRESH_QUERY_BACKED_5_URLS,
             $nextBatch6 => self::NEXT_BATCH_6_URLS,
+            $remaining58 => $this->remaining58Urls(),
             default => [],
         };
         $contractRecommendations = $subsetUrls !== []
@@ -229,6 +236,8 @@ final class Mbti64CmsRevisionPromotionService
 
         if ($nextBatch6) {
             $this->validateNextBatch6ContractPackage($package, $recommendations, $errors);
+        } elseif ($remaining58) {
+            $this->validateRemaining58ContractPackage($package, $recommendations, $errors);
         } else {
             if ((string) ($package['artifact'] ?? '') !== self::AGENT_PROJECTION_ARTIFACT) {
                 $errors[] = ['field' => 'artifact', 'code' => 'unsupported_package_artifact', 'message' => 'Unexpected MBTI64 agent projection artifact.'];
@@ -265,6 +274,13 @@ final class Mbti64CmsRevisionPromotionService
                 'field' => 'recommendations',
                 'code' => 'next_batch_6_subset_incomplete',
                 'message' => 'Expected exactly the 6 approved next-batch MBTI64 recommendations.',
+            ];
+        }
+        if ($remaining58 && count($contractRecommendations) !== 58) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'remaining_58_subset_incomplete',
+                'message' => 'Expected exactly the 58 approved remaining competitor-gap MBTI64 variant recommendations.',
             ];
         }
 
@@ -307,6 +323,7 @@ final class Mbti64CmsRevisionPromotionService
                     $visibleQueryBacked3 => 'visible_query_backed_3',
                     $freshQueryBacked5 => 'fresh_query_backed_5',
                     $nextBatch6 => 'next_batch_6',
+                    $remaining58 => 'remaining_58',
                     default => 'full_agent_projection_88',
                 },
                 'enabled' => $subsetUrls !== [],
@@ -403,6 +420,92 @@ final class Mbti64CmsRevisionPromotionService
                 'message' => 'Next-batch-6 package must contain exactly the fixed approved URL set.',
             ];
         }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $recommendations
+     * @param  list<array<string,string>>  $errors
+     */
+    private function validateRemaining58ContractPackage(array $package, array $recommendations, array &$errors): void
+    {
+        $summary = is_array($package['summary'] ?? null) ? $package['summary'] : [];
+        $actualUrls = array_map(
+            static fn (array $recommendation): string => (string) ($recommendation['target_url'] ?? ''),
+            $recommendations
+        );
+        $expectedUrls = $this->remaining58Urls();
+        sort($actualUrls);
+        sort($expectedUrls);
+
+        if ((string) ($package['artifact'] ?? '') !== self::REMAINING_58_V2_PACKAGE_ARTIFACT) {
+            $errors[] = [
+                'field' => 'artifact',
+                'code' => 'unsupported_remaining_58_package_artifact',
+                'message' => 'Unexpected MBTI64 remaining-58 competitor-gap artifact.',
+            ];
+        }
+        if ((string) ($package['status'] ?? '') !== 'pass') {
+            $errors[] = [
+                'field' => 'status',
+                'code' => 'remaining_58_package_status_not_pass',
+                'message' => 'Remaining-58 package must have pass status before promotion planning.',
+            ];
+        }
+        if ((string) ($package['final_decision'] ?? '') !== 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW') {
+            $errors[] = [
+                'field' => 'final_decision',
+                'code' => 'remaining_58_package_final_decision_not_ready',
+                'message' => 'Remaining-58 package must be ready for content expansion review before promotion planning.',
+            ];
+        }
+        if (count($recommendations) !== 58 || (int) ($package['target_count'] ?? -1) !== 58) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'unexpected_remaining_58_recommendation_count',
+                'message' => 'Expected exactly 58 remaining MBTI64 recommendations.',
+            ];
+        }
+
+        $variantPages = (int) ($summary['variant_pages'] ?? -1);
+        $comparisonPages = (int) ($summary['comparison_pages'] ?? -1);
+        if ($variantPages !== 58 || $comparisonPages !== 0) {
+            $errors[] = [
+                'field' => 'summary',
+                'code' => 'unexpected_remaining_58_page_type_counts',
+                'message' => 'Expected 58 variant and 0 comparison recommendations for remaining-58.',
+            ];
+        }
+        if ($actualUrls !== $expectedUrls) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'remaining_58_url_set_mismatch',
+                'message' => 'Remaining-58 package must contain exactly the fixed approved URL set.',
+            ];
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function remaining58Urls(): array
+    {
+        $urls = [];
+        foreach (['en', 'zh'] as $prefix) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                foreach (['a', 't'] as $variant) {
+                    $urls[] = 'https://fermatmind.com/'.$prefix.'/personality/'.strtolower($typeCode).'-'.$variant;
+                }
+            }
+        }
+
+        $excluded = self::NEXT_BATCH_6_URLS;
+        $remaining = array_values(array_filter(
+            $urls,
+            static fn (string $url): bool => ! in_array($url, $excluded, true)
+        ));
+        sort($remaining);
+
+        return $remaining;
     }
 
     /**

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -40,6 +40,8 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         'https://fermatmind.com/zh/personality/enfj-a',
     ];
 
+    private const REMAINING_58_EXCLUDED_URLS = self::NEXT_BATCH_6_URLS;
+
     public function test_dry_run_lists_eight_latest_revisions_without_live_writes(): void
     {
         $this->seedTargets();
@@ -410,6 +412,38 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
+    public function test_dry_run_supports_fixed_remaining_fifty_eight_v2_expansion_subset_without_live_writes(): void
+    {
+        $this->seedProjectionTargets();
+        $packagePath = $this->writePackage($this->remainingFiftyEightV2Package());
+        $this->createNextBatchSixDraftRevisions($packagePath);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--remaining-58' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertSame('remaining_58', $payload['contract']['subset']['mode']);
+        $this->assertFalse($payload['contract']['subset']['arbitrary_url_subset_allowed']);
+        $this->assertSame($this->remainingFiftyEightUrls(), $payload['contract']['subset']['allowed_urls']);
+        $this->assertSame(58, $payload['row_count']);
+        $this->assertSame(58, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(58, $payload['would_promote_count']);
+        $this->assertSame($this->remainingFiftyEightUrls(), array_column($payload['rows'], 'url'));
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
     public function test_write_promotes_eighty_eight_agent_projection_revisions_without_index_search_side_effects(): void
     {
         $targets = $this->seedProjectionTargets();
@@ -591,6 +625,43 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             ->first());
     }
 
+    public function test_write_promotes_only_fixed_remaining_fifty_eight_v2_expansion_subset(): void
+    {
+        $targets = $this->seedProjectionTargets();
+        $packagePath = $this->writePackage($this->remainingFiftyEightV2Package());
+        $this->createNextBatchSixDraftRevisions($packagePath);
+        $options = $this->promoteWriteOptions($packagePath);
+        $options['--remaining-58'] = true;
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['write']);
+        $this->assertSame('remaining_58', $payload['contract']['subset']['mode']);
+        $this->assertSame(58, $payload['row_count']);
+        $this->assertSame(58, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(58, $payload['promoted_count']);
+        $this->assertSame(58, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->where('section_key', 'mbti64_comparison_a_vs_t')->count());
+
+        foreach ($this->remainingFiftyEightUrls() as $url) {
+            $key = $this->targetKeyForUrl($url);
+            PersonalityProfileVariantSeoMeta::query()
+                ->where('personality_profile_variant_id', (int) $targets[$key]->id)
+                ->firstOrFail();
+        }
+
+        foreach (self::REMAINING_58_EXCLUDED_URLS as $url) {
+            $key = $this->targetKeyForUrl($url);
+            $this->assertNull(PersonalityProfileVariantSeoMeta::query()
+                ->where('personality_profile_variant_id', (int) $targets[$key]->id)
+                ->first());
+        }
+    }
+
     public function test_visible_query_backed_three_subset_is_idempotent_after_write(): void
     {
         $this->seedProjectionTargets();
@@ -759,6 +830,38 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
+    public function test_remaining_fifty_eight_subset_fails_closed_when_fixed_url_is_missing_or_extra_url_is_present(): void
+    {
+        $this->seedProjectionTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $package['recommendations'][0]['target_url'] = 'https://fermatmind.com/en/personality/enfj-a';
+        $package['target_count'] = 58;
+
+        $packagePath = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--remaining-58' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('remaining_58_url_set_mismatch', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertContains('remaining_58_subset_incomplete', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
     public function test_agent_projection_subset_modes_are_mutually_exclusive(): void
     {
         $this->seedProjectionTargets();
@@ -771,6 +874,7 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             '--visible-query-backed-3' => true,
             '--fresh-query-backed-5' => true,
             '--next-batch-6' => true,
+            '--remaining-58' => true,
             '--json' => true,
         ]);
 
@@ -1281,6 +1385,107 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             'warnings' => [],
             'recommended_next_task' => 'MBTI64-NEXT-BATCH-6-COMPETITOR-GAP-CONTENT-EXPANSION-V2-CMS-DRAFT-WRITE-01',
         ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function remainingFiftyEightV2Package(): array
+    {
+        $recommendations = [];
+        foreach ($this->remainingFiftyEightUrls() as $url) {
+            $path = (string) (parse_url($url, PHP_URL_PATH) ?: '');
+            $recommendation = $this->projectionRecommendation($path);
+            $nested = is_array($recommendation['recommendations'] ?? null) ? $recommendation['recommendations'] : [];
+            $recommendation['recommendations'] = [
+                'title' => (string) ($nested['title']['recommended'] ?? ''),
+                'description' => (string) ($nested['description']['recommended'] ?? ''),
+                'h1' => (string) ($nested['h1']['recommended'] ?? ''),
+                'quick_answer' => (string) ($nested['quick_answer']['recommended'] ?? ''),
+                'sections' => array_map(
+                    static fn (int $index): array => [
+                        'h2' => 'Remaining 58 section '.$index.' for '.basename($path),
+                        'body' => 'Expanded remaining-58 evidence-aware copy '.$index.' for '.$path.'.',
+                    ],
+                    range(1, 8)
+                ),
+                'faq' => array_map(
+                    static fn (int $index): array => [
+                        'question' => 'Remaining 58 question '.$index.' for '.basename($path).'?',
+                        'answer' => 'Remaining 58 safe answer '.$index.' for '.$path.'.',
+                    ],
+                    range(1, 9)
+                ),
+                'internal_links' => $nested['internal_links'] ?? [],
+                'differentiation_notes' => ['Remaining-58 competitor-gap differentiation note for '.$path.'.'],
+                'a_t_difference_module' => [
+                    'summary' => 'A/T difference module for '.$path.'.',
+                    'rows' => [
+                        ['dimension' => 'stress response', 'a_side' => 'steadier recovery', 't_side' => 'more self-monitoring'],
+                    ],
+                ],
+                'cognitive_function_mechanism' => 'Mechanism copy for '.$path.'.',
+                'common_misreads' => ['Do not read this profile as a deterministic career or IQ label.'],
+            ];
+            $recommendation['qa_status'] = 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW';
+            $recommendations[] = $recommendation;
+        }
+
+        return [
+            'artifact' => 'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01',
+            'generated_at' => '2026-06-28T00:00:00Z',
+            'status' => 'pass',
+            'final_decision' => 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW',
+            'target_count' => 58,
+            'summary' => [
+                'target_count' => 58,
+                'variant_pages' => 58,
+                'comparison_pages' => 0,
+                'completed_v2_exclusion_count' => 0,
+                'section_count_min' => 8,
+                'section_count_max' => 8,
+                'faq_count_min' => 9,
+                'faq_count_max' => 9,
+            ],
+            'recommendations' => $recommendations,
+            'blockers' => [],
+            'warnings' => [],
+            'recommended_next_task' => 'MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-DRY-RUN-01',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function remainingFiftyEightUrls(): array
+    {
+        $urls = [];
+        foreach (['en', 'zh'] as $prefix) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                foreach (['a', 't'] as $variant) {
+                    $urls[] = 'https://fermatmind.com/'.$prefix.'/personality/'.strtolower($typeCode).'-'.$variant;
+                }
+            }
+        }
+
+        $remaining = array_values(array_filter(
+            $urls,
+            static fn (string $url): bool => ! in_array($url, self::REMAINING_58_EXCLUDED_URLS, true)
+        ));
+        sort($remaining);
+
+        return $remaining;
+    }
+
+    private function targetKeyForUrl(string $url): string
+    {
+        $path = (string) (parse_url($url, PHP_URL_PATH) ?: '');
+        $this->assertMatchesRegularExpression('#^/(?<prefix>en|zh)/personality/(?<type>[a-z]{4})-(?<variant>a|t)$#i', $path);
+        preg_match('#^/(?<prefix>en|zh)/personality/(?<type>[a-z]{4})-(?<variant>a|t)$#i', $path, $matches);
+        $locale = $matches['prefix'] === 'zh' ? 'zh-CN' : 'en';
+        $runtimeTypeCode = strtoupper((string) $matches['type']).'-'.strtoupper((string) $matches['variant']);
+
+        return $locale.'|'.$runtimeTypeCode;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds fixed `--remaining-58` support to `personality:mbti64-cms-revision-promote`.
- Accepts only `MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01` with `status=pass`, `final_decision=PASS_READY_FOR_CONTENT_EXPANSION_REVIEW`, `target_count=58`, `variant_pages=58`, and `comparison_pages=0`.
- Restricts promotion planning/write to exactly the 58 remaining MBTI64 A/T variant URLs, excluding the six completed next-batch V2 URLs.
- Keeps arbitrary subsets and multi-subset combinations fail-closed.

## Why
`MBTI64-REMAINING-58-COMPETITOR-GAP-PROMOTE-DRY-RUN-01` failed closed because the promotion command only recognized the older full-88/next-batch contracts. This PR adds the missing fixed remaining-58 contract without changing CMS write authorization, publish, indexing, sitemap/llms, Search Queue, or external-call behavior.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

Note: `ci_verify_mbti.sh` regenerated Big Five compiled content-pack files locally; those generated out-of-scope changes were restored before commit.

## Intentionally deferred
- No production deploy.
- No production promotion dry-run/write.
- No CMS live promotion, publish, index/search, sitemap/llms, Search Queue, URL Truth, frontend, or external API mutation.
- Next runtime step after deploy is rerunning `MBTI64-REMAINING-58-COMPETITOR-GAP-PROMOTE-DRY-RUN-01` with `--remaining-58`.

## Repository rule impact
Backend CMS promotion command/service contract only. No new content authority surface is introduced; backend remains the authority for controlled CMS promotion and all runtime gates remain separately approval-bound.
