### PR TITLE
[codex] MBTI64 remaining-58 promotion count contract repair

### DIFF
--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -468,6 +468,19 @@ final class Mbti64CmsRevisionPromotionService
 
         $variantPages = (int) ($summary['variant_pages'] ?? -1);
         $comparisonPages = (int) ($summary['comparison_pages'] ?? -1);
+        if (! array_key_exists('variant_pages', $summary) || ! array_key_exists('comparison_pages', $summary)) {
+            $variantPages = 0;
+            $comparisonPages = 0;
+            foreach ($recommendations as $recommendation) {
+                $identity = $this->identityForRecommendation($recommendation);
+                if (($identity['page_type'] ?? null) === 'variant') {
+                    $variantPages++;
+                }
+                if (($identity['page_type'] ?? null) === 'comparison') {
+                    $comparisonPages++;
+                }
+            }
+        }
         if ($variantPages !== 58 || $comparisonPages !== 0) {
             $errors[] = [
                 'field' => 'summary',

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -444,6 +444,39 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
+    public function test_remaining_fifty_eight_v2_subset_derives_page_type_counts_when_summary_is_absent(): void
+    {
+        $this->seedProjectionTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        unset($package['summary']);
+        $packagePath = $this->writePackage($package);
+        $this->createNextBatchSixDraftRevisions($packagePath);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--remaining-58' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('remaining_58', $payload['contract']['subset']['mode']);
+        $this->assertSame(58, $payload['contract']['row_count']);
+        $this->assertSame(58, $payload['contract']['variant_row_count']);
+        $this->assertSame(0, $payload['contract']['comparison_row_count']);
+        $this->assertSame(58, $payload['row_count']);
+        $this->assertSame(58, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(58, $payload['would_promote_count']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame([], $payload['errors']);
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
     public function test_write_promotes_eighty_eight_agent_projection_revisions_without_index_search_side_effects(): void
     {
         $targets = $this->seedProjectionTargets();


### PR DESCRIPTION
## What changed
- Derive remaining-58 MBTI64 promotion variant/comparison counts from recommendation identities when package summary counts are absent.
- Added focused coverage for a remaining-58 dry-run package without a summary block.

## Why
Production remaining-58 promotion dry-run failed closed with `unexpected_remaining_58_page_type_counts` because the live package lacks `summary.variant_pages` / `summary.comparison_pages`, even though the recommendations are the correct fixed 58 variant URLs.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred
- No production deploy.
- No production promotion dry-run.
- No CMS live promotion/write.
- No publish/index/search/sitemap/llms mutation.
- No Search Queue or external search API action.

## Repository rule impact
Backend promotion contract repair only. CMS/public API remains the authority; no frontend or local editorial fallback is introduced.