### PR TITLE
MBTI-MAIN-FREE-SERP-TDK-01: seo(mbti): align main free-test TDK authority

### DIFF
--- a/backend/database/seeders/ScaleRegistrySeeder.php
+++ b/backend/database/seeders/ScaleRegistrySeeder.php
@@ -89,8 +89,8 @@ final class ScaleRegistrySeeder extends Seeder
                     'og_image_url' => 'https://api.fermatmind.com/static/share/mbti_square_600x600.png',
                 ],
                 'zh' => [
-                    'title' => 'MBTI 性格测试（16型人格测试）',
-                    'description' => '通过结构化测评了解你的 MBTI 类型、偏好强度与沟通协作方式。',
+                    'title' => '免费 MBTI 测试：16 型人格完整结果',
+                    'description' => '免费完成 MBTI 人格测试，查看 16 型人格结果、偏好维度与后续探索建议。结果用于自我了解，不作诊断或职业保证。',
                     'og_image_url' => 'https://api.fermatmind.com/static/share/mbti_square_600x600.png',
                 ],
             ],

--- a/backend/tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php
+++ b/backend/tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class ScalesLookupSeoMetadataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+    }
+
+    public function test_mbti_zh_lookup_uses_conservative_free_test_metadata(): void
+    {
+        $this->getJson('/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh')
+            ->assertOk()
+            ->assertJsonPath('seo_title', '免费 MBTI 测试：16 型人格完整结果')
+            ->assertJsonPath(
+                'seo_description',
+                '免费完成 MBTI 人格测试，查看 16 型人格结果、偏好维度与后续探索建议。结果用于自我了解，不作诊断或职业保证。'
+            );
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -10273,7 +10273,7 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2309",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "FA30-API-03: Add Batch 2 readback and review ledger authority",
     "train_scope": "fa30_batch2_backend_readback_review_ledger",
     "transitions": [
@@ -64883,6 +64883,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to MBTI lookup metadata authority in ScaleRegistrySeeder, focused V0.3 lookup metadata coverage, and authorized docs/codex train metadata. No FAQ, body, schema, search, sitemap, llms, CMS production write, deploy, or fap-web files changed."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2520 checks succeeded on head c669c7f9e7242a37df00ac84f6a76fa440185359: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and semgrep sarif non-blocking upload."
       }
     },
     "commit_sha": "44f569449afa97e5a2e39c6dbf21ebdb87ba2c78",
@@ -64914,6 +64918,11 @@
         "at": "2026-06-28T21:35:00+08:00",
         "status": "pr_open",
         "note": "Opened PR #2520 for MBTI main free-test TDK authority."
+      },
+      {
+        "at": "2026-06-28T21:50:02+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2520 and changed files remain within the MBTI main TDK authority scope."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -64836,5 +64836,80 @@
       }
     ],
     "notes": "Part of EQ v2.3 productization train; production deploy/smoke remain separately authorized."
+  },
+  "MBTI-MAIN-FREE-SERP-TDK-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/mbti-main-free-serp-tdk-01",
+    "title": "MBTI-MAIN-FREE-SERP-TDK-01: seo(mbti): align main free-test TDK authority",
+    "train_scope": "mbti_main_lookup_metadata_authority",
+    "status": "local_checks_passed",
+    "depends_on": [],
+    "checks": {
+      "dependency_verification": {
+        "status": "pass",
+        "evidence": "No dependencies for the first MBTI main TDK authority PR."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list",
+        "evidence": "PASS; route table renders successfully and GET api/v0.3/scales/lookup remains registered."
+      },
+      "focused_lookup_metadata_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php --no-ansi",
+        "evidence": "PASS with existing file_get_contents warning; 1 test, 3 assertions. Asserted MBTI zh lookup seo_title and seo_description use conservative free-test metadata."
+      },
+      "mbti_ci": {
+        "status": "pass",
+        "command": "bash backend/scripts/ci_verify_mbti.sh",
+        "evidence": "PASS; full MBTI CI chain exited 0, including verify_mbti, event acceptance, auth/order/security, migration/static/schema gates, OpenAPI, and dependency security gates."
+      },
+      "manifest_yaml_parse": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')\"",
+        "evidence": "PASS; pr-train.yaml parsed successfully."
+      },
+      "state_json_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "evidence": "PASS; pr-train-state.json parsed successfully."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "PASS; no whitespace errors."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to MBTI lookup metadata authority in ScaleRegistrySeeder, focused V0.3 lookup metadata coverage, and authorized docs/codex train metadata. No FAQ, body, schema, search, sitemap, llms, CMS production write, deploy, or fap-web files changed."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit implementation request for MBTI main TDK/FAQ/Schema three PR plan; executing PR1 only because PR2 and PR3 depend on merged predecessors.",
+    "events": [
+      {
+        "at": "2026-06-28T00:00:00+08:00",
+        "status": "implementation_in_progress",
+        "note": "Started MBTI main free-test TDK authority PR from a clean origin/main worktree. Scope excludes FAQ, body, schema, search, sitemap, llms, CMS production writes, deploy, and fap-web."
+      },
+      {
+        "at": "2026-06-28T21:34:33+08:00",
+        "status": "local_checks_passed",
+        "note": "Route list, focused lookup metadata test, full MBTI CI, YAML/JSON parsing, diff check, and scope validation passed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -64843,7 +64843,7 @@
     "branch": "codex/mbti-main-free-serp-tdk-01",
     "title": "MBTI-MAIN-FREE-SERP-TDK-01: seo(mbti): align main free-test TDK authority",
     "train_scope": "mbti_main_lookup_metadata_authority",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [],
     "checks": {
       "dependency_verification": {
@@ -64885,8 +64885,8 @@
         "evidence": "Changed files are limited to MBTI lookup metadata authority in ScaleRegistrySeeder, focused V0.3 lookup metadata coverage, and authorized docs/codex train metadata. No FAQ, body, schema, search, sitemap, llms, CMS production write, deploy, or fap-web files changed."
       }
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "44f569449afa97e5a2e39c6dbf21ebdb87ba2c78",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2520",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -64909,6 +64909,11 @@
         "at": "2026-06-28T21:34:33+08:00",
         "status": "local_checks_passed",
         "note": "Route list, focused lookup metadata test, full MBTI CI, YAML/JSON parsing, diff check, and scope validation passed."
+      },
+      {
+        "at": "2026-06-28T21:35:00+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2520 for MBTI main free-test TDK authority."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -30078,3 +30078,39 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: MBTI-MAIN-FREE-SERP-TDK-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/mbti-main-free-serp-tdk-01
+    title: "MBTI-MAIN-FREE-SERP-TDK-01: seo(mbti): align main free-test TDK authority"
+    train_scope: mbti_main_lookup_metadata_authority
+    status: user_authorized
+    scope:
+      - Align the MBTI main zh lookup SEO title and description with conservative free-test metadata authority.
+      - Preserve the existing /api/v0.3/scales/lookup response shape; only seo_title and seo_description values change.
+      - Add focused lookup coverage for the canonical MBTI zh slug.
+    allowed_paths:
+      - backend/database/seeders/ScaleRegistrySeeder.php
+      - backend/tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify FAQ, content_i18n_json, body copy, schema policy, search submission, sitemap, llms, CMS production data, deployment, or fap-web.
+      - Use risky SERP copy such as 真全免, 无付费墙, 拒绝强制收费, or 2026专业版.
+      - Add new API fields or frontend fallback metadata.
+    validation:
+      - cd backend && php artisan route:list
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: false }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Registered `MBTI-MAIN-FREE-SERP-TDK-01` in the fap-api PR train manifest/state.
- Updated the MBTI main zh lookup SEO title/description in `ScaleRegistrySeeder` to the conservative free-test authority wording.
- Added focused V0.3 lookup coverage for the canonical MBTI zh slug.

## Why
`fap-web` already prioritizes CMS landing surface metadata, but the backend lookup metadata remained generic. This PR aligns the backend lookup authority with the current conservative live SERP surface without high-risk phrases.

## Validation
- `cd backend && php artisan route:list`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"`\n- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`\n- `git diff --check`\n\n## Intentionally deferred\n- No FAQ/body/content_i18n_json changes.\n- No schema strategy/runtime changes.\n- No fap-web changes.\n- No CMS production writes, search submission, sitemap, llms, deploy, or GSC operation.\n\n## Repository rule impact\n- Backend remains the authority for this test lookup SEO metadata.\n- No content ownership or publishing SOP change introduced.