### PR TITLE
MBTI-MAIN-FREE-FAQ-CONTENT-01: seo(mbti): strengthen main free-test visible FAQ authority

### DIFF
--- a/backend/database/seeders/ScaleRegistrySeeder.php
+++ b/backend/database/seeders/ScaleRegistrySeeder.php
@@ -112,7 +112,25 @@ final class ScaleRegistrySeeder extends Seeder
                 enExcerpt: 'Discover the inner drivers that make your personality uniquely yours. Get a full read on your preference patterns and core strengths, plus tailored guidance for career growth and communication.',
                 zhExcerpt: '探索造就你独特个性的内在动力。全面解析你的性格偏好与核心优势，并获取为你量身定制的职业发展与人际沟通指南。',
                 enSeoCopy: 'The MBTI flow is built on Jungian type dimensions and structured preference scoring. It helps users interpret E/I, S/N, T/F, and J/P patterns for communication, planning, and role-fit decisions.',
-                zhSeoCopy: '该 MBTI 测评基于荣格类型维度与结构化偏好评分，帮助你理解 E/I、S/N、T/F、J/P 模式，并用于沟通协作、计划习惯与岗位匹配决策。'
+                zhSeoCopy: '该 MBTI 测评基于荣格类型维度与结构化偏好评分，帮助你理解 E/I、S/N、T/F、J/P 模式，并用于沟通协作、计划习惯与岗位匹配决策。',
+                zhFaq: [
+                    [
+                        'q' => '费马的 MBTI免费测试会收费吗？',
+                        'a' => 'MBTI 主测试可以免费完成，并在提交后查看 16 型人格完整结果、偏好维度和后续探索建议；页面不会把基础结果解读作为付费前置条件。',
+                    ],
+                    [
+                        'q' => '这份 16型人格完整结果/报告包含哪些内容？',
+                        'a' => '结果会展示你的 16 型人格类型，E/I、S/N、T/F、J/P 偏好方向，以及沟通协作、职业探索和自我观察相关的说明。内容用于理解性格倾向，不等同于诊断或职业保证。',
+                    ],
+                    [
+                        'q' => 'MBTI免费测试结果可以作为职业或心理诊断吗？',
+                        'a' => '不可以。MBTI 测试适合做自我了解和讨论起点，不能替代心理诊断、医疗建议或正式职业评估。重要决策应结合更多资料和专业意见。',
+                    ],
+                    [
+                        'q' => '完成测试后还能重新查看或重复测试吗？',
+                        'a' => '可以。你可以在完成后回看自己的结果报告，也可以在状态或作答理解发生变化时重新测试，并把不同结果作为自我观察的参考。',
+                    ],
+                ],
             ),
 
             'is_public' => true,
@@ -735,6 +753,7 @@ final class ScaleRegistrySeeder extends Seeder
         string $zhExcerpt,
         string $enSeoCopy,
         string $zhSeoCopy,
+        ?array $zhFaq = null,
     ): array {
         return [
             'en' => $this->catalogLocaleContent(
@@ -766,6 +785,7 @@ final class ScaleRegistrySeeder extends Seeder
                 rating: $rating,
                 excerpt: $zhExcerpt,
                 seoCopy: $zhSeoCopy,
+                faq: $zhFaq,
             ),
         ];
     }
@@ -787,6 +807,7 @@ final class ScaleRegistrySeeder extends Seeder
         int $rating,
         string $excerpt,
         string $seoCopy,
+        ?array $faq = null,
     ): array {
         $isZh = preg_match('/\p{Han}/u', $title) === 1;
 
@@ -797,7 +818,7 @@ final class ScaleRegistrySeeder extends Seeder
             'when_to_use' => $this->genericWhenToUse($questions, $minutes, $isZh),
             'audience' => $this->genericAudience($questions, $isZh),
             'how_it_works' => $this->genericHowItWorks($questions, $isZh),
-            'faq' => $this->genericFaq($questions, $minutes, $isZh),
+            'faq' => $faq ?? $this->genericFaq($questions, $minutes, $isZh),
             'catalog' => [
                 'cover_image' => 'https://api.fermatmind.com/static/share/mbti_square_600x600.png',
                 'questions_count' => $questions,

--- a/backend/tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php
+++ b/backend/tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php
@@ -30,4 +30,27 @@ final class ScalesLookupSeoMetadataTest extends TestCase
                 '免费完成 MBTI 人格测试，查看 16 型人格结果、偏好维度与后续探索建议。结果用于自我了解，不作诊断或职业保证。'
             );
     }
+
+    public function test_mbti_zh_lookup_uses_free_test_visible_faq_authority(): void
+    {
+        $response = $this->getJson('/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh')
+            ->assertOk();
+
+        $faq = $response->json('content_i18n_json.zh.faq');
+
+        $this->assertIsArray($faq);
+        $this->assertCount(4, $faq);
+        $this->assertSame('费马的 MBTI免费测试会收费吗？', $faq[0]['q'] ?? null);
+        $this->assertSame('这份 16型人格完整结果/报告包含哪些内容？', $faq[1]['q'] ?? null);
+        $this->assertSame('MBTI免费测试结果可以作为职业或心理诊断吗？', $faq[2]['q'] ?? null);
+        $this->assertStringContainsString('页面不会把基础结果解读作为付费前置条件', (string) ($faq[0]['a'] ?? ''));
+        $this->assertStringContainsString('不等同于诊断或职业保证', (string) ($faq[1]['a'] ?? ''));
+        $this->assertStringContainsString('不能替代心理诊断、医疗建议或正式职业评估', (string) ($faq[2]['a'] ?? ''));
+
+        $serializedFaq = json_encode($faq, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('真全免', $serializedFaq);
+        $this->assertStringNotContainsString('无付费墙', $serializedFaq);
+        $this->assertStringNotContainsString('拒绝强制收费', $serializedFaq);
+        $this->assertStringNotContainsString('2026专业版', $serializedFaq);
+    }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65019,7 +65019,7 @@
     "branch": "codex/mbti-main-free-serp-tdk-01",
     "title": "MBTI-MAIN-FREE-SERP-TDK-01: seo(mbti): align main free-test TDK authority",
     "train_scope": "mbti_main_lookup_metadata_authority",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [],
     "checks": {
       "dependency_verification": {
@@ -65068,9 +65068,9 @@
     "commit_sha": "44f569449afa97e5a2e39c6dbf21ebdb87ba2c78",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2520",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-28T13:56:32Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "database_mutation": false,
     "cms_mutation": false,
@@ -65113,7 +65113,7 @@
     "branch": "codex/mbti-main-free-faq-content-01",
     "title": "MBTI-MAIN-FREE-FAQ-CONTENT-01: seo(mbti): strengthen main free-test visible FAQ authority",
     "train_scope": "mbti_main_visible_faq_content_authority",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "MBTI-MAIN-FREE-SERP-TDK-01"
     ],
@@ -65166,8 +65166,8 @@
         "evidence": "Changed files are limited to MBTI visible FAQ authority in ScaleRegistrySeeder, focused V0.3 lookup FAQ coverage, and authorized docs/codex train metadata. No TDK, schema policy/runtime, search, sitemap, llms, CMS production write, deploy, or fap-web files changed."
       }
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "5e849fc355fba45fa22830be54d17a320da5912c",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2525",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -65190,6 +65190,11 @@
         "at": "2026-06-28T22:14:20+08:00",
         "status": "local_checks_passed",
         "note": "Route list, focused lookup FAQ test, curl/readback, full MBTI CI, YAML/JSON parsing, diff check, and scope validation passed."
+      },
+      {
+        "at": "2026-06-28T22:16:20+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2525 for MBTI main visible FAQ authority."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65113,7 +65113,7 @@
     "branch": "codex/mbti-main-free-faq-content-01",
     "title": "MBTI-MAIN-FREE-FAQ-CONTENT-01: seo(mbti): strengthen main free-test visible FAQ authority",
     "train_scope": "mbti_main_visible_faq_content_authority",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "depends_on": [
       "MBTI-MAIN-FREE-SERP-TDK-01"
     ],
@@ -65164,6 +65164,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to MBTI visible FAQ authority in ScaleRegistrySeeder, focused V0.3 lookup FAQ coverage, and authorized docs/codex train metadata. No TDK, schema policy/runtime, search, sitemap, llms, CMS production write, deploy, or fap-web files changed."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2525 checks succeeded on head 335d487e5225f1624f26bf5fcd44d89723c9e510: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and semgrep sarif non-blocking upload."
       }
     },
     "commit_sha": "5e849fc355fba45fa22830be54d17a320da5912c",
@@ -65195,6 +65199,11 @@
         "at": "2026-06-28T22:16:20+08:00",
         "status": "pr_open",
         "note": "Opened PR #2525 for MBTI main visible FAQ authority."
+      },
+      {
+        "at": "2026-06-28T22:25:05+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2525 and changed files remain within the MBTI main visible FAQ authority scope."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -10656,7 +10656,7 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2353",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "FA30-API-10: Add competitor alternatives source-ledger contract",
     "train_scope": "fa30_competitor_alternatives_source_ledger",
     "transitions": [
@@ -65166,8 +65166,8 @@
         "evidence": "Changed files are limited to MBTI visible FAQ authority in ScaleRegistrySeeder, focused V0.3 lookup FAQ coverage, and authorized docs/codex train metadata. No TDK, schema policy/runtime, search, sitemap, llms, CMS production write, deploy, or fap-web files changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "GitHub rejected merge because base branch changed; rebased PR #2525 onto origin/main at 8e427030f and is awaiting fresh checks."
+        "status": "pass",
+        "evidence": "PR #2525 checks succeeded after rebase on head 86e2b196cf2121393ca00be73ce382148e859ebd: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and semgrep sarif non-blocking upload."
       }
     },
     "commit_sha": "ccf256a8523e713e6ef671eea93e5490d8b30eca",
@@ -65209,6 +65209,11 @@
         "at": "2026-06-28T22:34:20+08:00",
         "status": "pr_open",
         "note": "Merge was blocked because base branch changed. Rebased the PR branch onto origin/main 8e427030f; fresh GitHub checks are pending."
+      },
+      {
+        "at": "2026-06-28T22:40:05+08:00",
+        "status": "ready_to_merge",
+        "note": "Fresh GitHub checks passed after rebase and PR #2525 returned to CLEAN merge state."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65113,7 +65113,7 @@
     "branch": "codex/mbti-main-free-faq-content-01",
     "title": "MBTI-MAIN-FREE-FAQ-CONTENT-01: seo(mbti): strengthen main free-test visible FAQ authority",
     "train_scope": "mbti_main_visible_faq_content_authority",
-    "status": "ready_to_merge",
+    "status": "pr_open",
     "depends_on": [
       "MBTI-MAIN-FREE-SERP-TDK-01"
     ],
@@ -65166,11 +65166,11 @@
         "evidence": "Changed files are limited to MBTI visible FAQ authority in ScaleRegistrySeeder, focused V0.3 lookup FAQ coverage, and authorized docs/codex train metadata. No TDK, schema policy/runtime, search, sitemap, llms, CMS production write, deploy, or fap-web files changed."
       },
       "github": {
-        "status": "pass",
-        "evidence": "PR #2525 checks succeeded on head 335d487e5225f1624f26bf5fcd44d89723c9e510: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and semgrep sarif non-blocking upload."
+        "status": "pending",
+        "evidence": "GitHub rejected merge because base branch changed; rebased PR #2525 onto origin/main at 8e427030f and is awaiting fresh checks."
       }
     },
-    "commit_sha": "5e849fc355fba45fa22830be54d17a320da5912c",
+    "commit_sha": "ccf256a8523e713e6ef671eea93e5490d8b30eca",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2525",
     "failure_reason": null,
     "merged_at": null,
@@ -65204,6 +65204,11 @@
         "at": "2026-06-28T22:25:05+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #2525 and changed files remain within the MBTI main visible FAQ authority scope."
+      },
+      {
+        "at": "2026-06-28T22:34:20+08:00",
+        "status": "pr_open",
+        "note": "Merge was blocked because base branch changed. Rebased the PR branch onto origin/main 8e427030f; fresh GitHub checks are pending."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4132,7 +4132,7 @@
         "status": "pass"
       }
     },
-    "commit_sha": null,
+    "commit_sha": "493ec08e582dfb124b8573eddad77cc31d383219",
     "depends_on": [
       "BIG5-CONTROLLED-PILOT-RUNTIME-ACTIVATION-01"
     ],
@@ -10574,7 +10574,7 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2350",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "status": "pr_open",
+    "status": "merged",
     "title": "FA30-API-09: Add RIASEC major graph backend authority contract",
     "train_scope": "fa30_riasec_major_graph_backend_authority",
     "transitions": [
@@ -64604,9 +64604,9 @@
     "commit_sha": "4d03f73a7c67ad386a28cacfc1f6a45897f3d18e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2496",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-28T13:56:32Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "database_mutation": false,
     "cms_mutation": false,
@@ -65099,6 +65099,97 @@
         "at": "2026-06-28T21:50:02+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #2520 and changed files remain within the MBTI main TDK authority scope."
+      },
+      {
+        "at": "2026-06-28T22:03:50+08:00",
+        "status": "merged",
+        "note": "Reconciled during the dependent FAQ content PR: GitHub reports PR #2520 merged, origin/main contains merge commit e4480b9521d6e872dd52a9cc4c6743e4ea232194, remote branch is deleted, and local cleanup was completed manually because scripts/post_merge_cleanup.sh is not present."
+      }
+    ]
+  },
+  "MBTI-MAIN-FREE-FAQ-CONTENT-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/mbti-main-free-faq-content-01",
+    "title": "MBTI-MAIN-FREE-FAQ-CONTENT-01: seo(mbti): strengthen main free-test visible FAQ authority",
+    "train_scope": "mbti_main_visible_faq_content_authority",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "MBTI-MAIN-FREE-SERP-TDK-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User provided explicit implementation plan for the MBTI main TDK/FAQ/Schema three PR sequence and requested continuation to the next PR."
+      },
+      "dependency_verification": {
+        "status": "pass",
+        "evidence": "PR #2520 is merged and origin/main contains merge commit e4480b9521d6e872dd52a9cc4c6743e4ea232194."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list",
+        "evidence": "PASS; route table renders successfully and GET api/v0.3/scales/lookup remains registered."
+      },
+      "focused_lookup_faq_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php --filter mbti_zh_lookup_uses_free_test_visible_faq_authority --no-ansi",
+        "evidence": "PASS with existing file_get_contents warning; 1 test, 13 assertions. Asserted MBTI zh lookup content_i18n_json.zh.faq covers MBTI免费测试, 16型人格完整结果/报告, fee intent, non-diagnostic boundary, and excludes high-risk copy."
+      },
+      "curl_lookup_faq_readback": {
+        "status": "pass",
+        "command": "local sqlite seed + php artisan serve on 127.0.0.1:18317 + curl /api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh",
+        "evidence": "PASS; readback returned 4 FAQ questions including MBTI免费测试 fee intent, 16型人格完整结果/报告, and职业或心理诊断 boundary; forbidden phrases were absent."
+      },
+      "mbti_ci": {
+        "status": "pass",
+        "command": "bash backend/scripts/ci_verify_mbti.sh",
+        "evidence": "PASS; full MBTI CI chain exited 0, including verify_mbti, event acceptance, personality authority gate, auth/order/security, migration/static/schema gates, OpenAPI, and dependency security gates."
+      },
+      "manifest_yaml_parse": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')\"",
+        "evidence": "PASS; pr-train.yaml parsed successfully."
+      },
+      "state_json_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "evidence": "PASS; pr-train-state.json parsed successfully."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "PASS; no whitespace errors."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to MBTI visible FAQ authority in ScaleRegistrySeeder, focused V0.3 lookup FAQ coverage, and authorized docs/codex train metadata. No TDK, schema policy/runtime, search, sitemap, llms, CMS production write, deploy, or fap-web files changed."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-28 explicit implementation request for MBTI main TDK/FAQ/Schema three PR plan; continuing PR2 after PR1 merged.",
+    "events": [
+      {
+        "at": "2026-06-28T22:04:10+08:00",
+        "status": "implementation_in_progress",
+        "note": "Started MBTI main visible FAQ authority PR from a clean origin/main worktree. Scope excludes TDK changes, schema policy/runtime, search, sitemap, llms, CMS production writes, deploy, and fap-web."
+      },
+      {
+        "at": "2026-06-28T22:14:20+08:00",
+        "status": "local_checks_passed",
+        "note": "Route list, focused lookup FAQ test, curl/readback, full MBTI CI, YAML/JSON parsing, diff check, and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -30114,3 +30114,40 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: MBTI-MAIN-FREE-FAQ-CONTENT-01
+    repo: fap-api
+    depends_on: [MBTI-MAIN-FREE-SERP-TDK-01]
+    branch: codex/mbti-main-free-faq-content-01
+    title: "MBTI-MAIN-FREE-FAQ-CONTENT-01: seo(mbti): strengthen main free-test visible FAQ authority"
+    train_scope: mbti_main_visible_faq_content_authority
+    status: user_authorized
+    scope:
+      - Strengthen the MBTI main zh visible FAQ/content authority to naturally cover MBTI免费测试, 16型人格完整结果/报告, 是否收费, and educational/non-diagnostic boundaries.
+      - Preserve the existing /api/v0.3/scales/lookup response shape; only content_i18n_json.zh.faq content changes.
+      - Add focused lookup coverage for canonical MBTI zh FAQ content.
+    allowed_paths:
+      - backend/database/seeders/ScaleRegistrySeeder.php
+      - backend/tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify seo_i18n_json TDK, schema policy/runtime, search submission, sitemap, llms, CMS production data, deployment, or fap-web.
+      - Use keyword stuffing or high-risk SERP copy such as 真全免, 无付费墙, 拒绝强制收费, or 2026专业版.
+      - Add new API fields or frontend fallback content.
+    validation:
+      - cd backend && php artisan route:list
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php --filter mbti_zh_lookup_uses_free_test_visible_faq_authority --no-ansi
+      - curl/readback for /api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh FAQ fields
+      - bash backend/scripts/ci_verify_mbti.sh
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: false }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Updated the MBTI main zh `content_i18n_json.faq` authority in `ScaleRegistrySeeder` with a focused visible FAQ for free-test intent, 16-type complete result/report intent, fee expectations, and educational/non-diagnostic boundaries.
- Kept `/api/v0.3/scales/lookup` response shape unchanged; no new fields were added.
- Added focused lookup coverage asserting the zh FAQ authority and explicitly rejecting high-risk copy.
- Registered `MBTI-MAIN-FREE-FAQ-CONTENT-01` in the PR train manifest/state and reconciled the merged/cleaned dependency state for `MBTI-MAIN-FREE-SERP-TDK-01`.

## Why
The frontend derives visible FAQ and FAQPage JSON-LD from backend content. This PR makes the backend content source authoritative for MBTI free-test FAQ intent before any frontend schema parity/evidence PR.

## Validation
- `cd backend && php artisan route:list`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/ScalesLookupSeoMetadataTest.php --filter mbti_zh_lookup_uses_free_test_visible_faq_authority --no-ansi`
- Local sqlite seed + `php artisan serve` + `curl /api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh` FAQ readback
- `bash backend/scripts/ci_verify_mbti.sh`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- Changed-file scope validation

## Intentionally deferred
- No TDK/metadata changes.
- No schema policy/runtime changes.
- No search submission, sitemap, llms, CMS production write, deploy, or fap-web changes.
- FAQPage visible-vs-JSON-LD parity evidence remains in the later fap-web PR.

## Repository rule impact
Backend remains the content authority for this CMS-backed/test landing content. Frontend fallback content is not introduced.
