### PR TITLE
MBTI64-REMAINING-58-COMPETITOR-GAP-V2-MODULE-PROMOTION-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -1099,9 +1099,7 @@ final class Mbti64CmsProjectionDraftWriter
                         'description' => $this->recommendedFieldText($recommended, 'description'),
                         'h1' => $this->recommendedFieldText($recommended, 'h1'),
                     ],
-                    'content' => [
-                        'quick_answer' => $this->recommendedFieldText($recommended, 'quick_answer'),
-                    ],
+                    'content' => $this->contentFieldsForRecommendation($recommended),
                     'faq' => is_array($recommended['faq'] ?? null) ? array_values((array) $recommended['faq']) : [],
                     'internal_links' => is_array($recommended['internal_links'] ?? null) ? array_values((array) $recommended['internal_links']) : [],
                     'differentiation_notes' => is_array($recommended['differentiation_notes'] ?? null)
@@ -1142,6 +1140,172 @@ final class Mbti64CmsProjectionDraftWriter
         }
 
         return is_string($value) ? $value : '';
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommended
+     * @return array<string,mixed>
+     */
+    private function contentFieldsForRecommendation(array $recommended): array
+    {
+        $content = [
+            'quick_answer' => $this->recommendedFieldText($recommended, 'quick_answer'),
+        ];
+
+        foreach ($this->sectionFieldsForRecommendation($recommended) as $key => $section) {
+            $content[$key] = $section;
+        }
+
+        return $content;
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommended
+     * @return array<string,array<string,mixed>>
+     */
+    private function sectionFieldsForRecommendation(array $recommended): array
+    {
+        $sections = [];
+        foreach (array_values((array) ($recommended['sections'] ?? [])) as $index => $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            $sectionKey = $this->firstClassSectionKey((string) ($section['key'] ?? ''), $index);
+            if ($sectionKey === '' || array_key_exists($sectionKey, $sections)) {
+                continue;
+            }
+
+            $body = $this->sectionBody($section);
+            if ($body === null) {
+                continue;
+            }
+
+            $sections[$sectionKey] = [
+                'title' => $this->sectionTitle($section),
+                'body' => $body,
+                'source_key' => (string) ($section['key'] ?? ''),
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+                'raw' => $section,
+            ];
+        }
+
+        return $sections;
+    }
+
+    private function firstClassSectionKey(string $sourceKey, int $position): string
+    {
+        $normalized = strtolower(trim(preg_replace('/[^a-zA-Z0-9_]+/', '_', $sourceKey) ?? '', '_'));
+        $map = [
+            'how_to_read' => 'meaning',
+            'at_difference_table' => 'a_t_difference',
+            'cognitive_function_mechanism' => 'core_traits',
+            'work_scenario' => 'careers_work_style',
+            'relationship_communication' => 'relationships_communication',
+            'stress_growth' => 'strengths_blind_spots',
+            'common_misreads' => 'common_misreads',
+            'how_to_use_not_use' => 'similar_types',
+        ];
+
+        if (isset($map[$normalized])) {
+            return $map[$normalized];
+        }
+
+        $fallback = [
+            'meaning',
+            'a_t_difference',
+            'core_traits',
+            'careers_work_style',
+            'relationships_communication',
+            'strengths_blind_spots',
+            'common_misreads',
+            'similar_types',
+        ];
+
+        return $fallback[$position] ?? '';
+    }
+
+    /**
+     * @param  array<string,mixed>  $section
+     */
+    private function sectionTitle(array $section): ?string
+    {
+        foreach (['title', 'h2', 'heading'] as $key) {
+            if (isset($section[$key]) && is_string($section[$key]) && trim($section[$key]) !== '') {
+                return trim($section[$key]);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $section
+     */
+    private function sectionBody(array $section): ?string
+    {
+        $parts = [];
+        foreach (['body', 'summary', 'text'] as $key) {
+            if (isset($section[$key]) && is_string($section[$key]) && trim($section[$key]) !== '') {
+                $parts[] = trim($section[$key]);
+                break;
+            }
+        }
+
+        $comparisonRows = is_array($section['comparison_rows'] ?? null) ? array_values((array) $section['comparison_rows']) : [];
+        if ($comparisonRows !== []) {
+            $parts[] = $this->comparisonRowsMarkdown($comparisonRows);
+        }
+
+        $bullets = is_array($section['bullets'] ?? null) ? array_values((array) $section['bullets']) : [];
+        if ($bullets !== []) {
+            $bulletLines = [];
+            foreach ($bullets as $bullet) {
+                if (is_string($bullet) && trim($bullet) !== '') {
+                    $bulletLines[] = '- '.trim($bullet);
+                }
+            }
+            if ($bulletLines !== []) {
+                $parts[] = implode("\n", $bulletLines);
+            }
+        }
+
+        $body = trim(implode("\n\n", array_filter($parts, static fn (string $part): bool => trim($part) !== '')));
+
+        return $body !== '' ? $body : null;
+    }
+
+    /**
+     * @param  list<mixed>  $rows
+     */
+    private function comparisonRowsMarkdown(array $rows): string
+    {
+        $lines = [
+            '| Dimension | Assertive side | Turbulent side |',
+            '| --- | --- | --- |',
+        ];
+
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $dimension = $this->markdownTableCell((string) ($row['dimension'] ?? ''));
+            $assertive = $this->markdownTableCell((string) ($row['assertive'] ?? ($row['a_side'] ?? '')));
+            $turbulent = $this->markdownTableCell((string) ($row['turbulent'] ?? ($row['t_side'] ?? '')));
+            if ($dimension === '' && $assertive === '' && $turbulent === '') {
+                continue;
+            }
+
+            $lines[] = '| '.$dimension.' | '.$assertive.' | '.$turbulent.' |';
+        }
+
+        return count($lines) > 2 ? implode("\n", $lines) : '';
+    }
+
+    private function markdownTableCell(string $value): string
+    {
+        return str_replace('|', '\\|', trim(preg_replace('/\s+/', ' ', $value) ?? ''));
     }
 
     /**

--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -896,7 +896,7 @@ final class Mbti64CmsRevisionPromotionService
                 'payload_json' => [
                     'title' => $this->nullableString($payload['h2'] ?? ($payload['title'] ?? null)),
                     'body' => $body,
-                    'source' => 'mbti64_v2_1_revision_promotion',
+                    'source' => $this->nullableString($payload['source'] ?? null) ?? 'mbti64_v2_1_revision_promotion',
                     'raw' => $payload,
                 ],
                 'sort_order' => $sort,
@@ -1197,13 +1197,68 @@ final class Mbti64CmsRevisionPromotionService
             return null;
         }
 
+        $parts = [];
         foreach (['body', 'summary', 'text', 'answer'] as $key) {
             if (isset($value[$key]) && is_string($value[$key]) && trim($value[$key]) !== '') {
-                return trim($value[$key]);
+                $parts[] = trim($value[$key]);
+                break;
             }
         }
 
-        return null;
+        $comparisonRows = is_array($value['comparison_rows'] ?? null) ? array_values((array) $value['comparison_rows']) : [];
+        if ($comparisonRows !== []) {
+            $parts[] = $this->comparisonRowsMarkdown($comparisonRows);
+        }
+
+        $bullets = is_array($value['bullets'] ?? null) ? array_values((array) $value['bullets']) : [];
+        if ($bullets !== []) {
+            $bulletLines = [];
+            foreach ($bullets as $bullet) {
+                if (is_string($bullet) && trim($bullet) !== '') {
+                    $bulletLines[] = '- '.trim($bullet);
+                }
+            }
+            if ($bulletLines !== []) {
+                $parts[] = implode("\n", $bulletLines);
+            }
+        }
+
+        $body = trim(implode("\n\n", array_filter($parts, static fn (string $part): bool => trim($part) !== '')));
+
+        return $body !== '' ? $body : null;
+    }
+
+    /**
+     * @param  list<mixed>  $rows
+     */
+    private function comparisonRowsMarkdown(array $rows): string
+    {
+        $lines = [
+            '| Dimension | Assertive side | Turbulent side |',
+            '| --- | --- | --- |',
+        ];
+
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $dimension = $this->markdownTableCell((string) ($row['dimension'] ?? ''));
+            $assertive = $this->markdownTableCell((string) ($row['assertive'] ?? ($row['a_side'] ?? '')));
+            $turbulent = $this->markdownTableCell((string) ($row['turbulent'] ?? ($row['t_side'] ?? '')));
+            if ($dimension === '' && $assertive === '' && $turbulent === '') {
+                continue;
+            }
+
+            $lines[] = '| '.$dimension.' | '.$assertive.' | '.$turbulent.' |';
+        }
+
+        return count($lines) > 2 ? implode("\n", $lines) : '';
+    }
+
+    private function markdownTableCell(string $value): string
+    {
+        return str_replace('|', '\\|', trim(preg_replace('/\s+/', ' ', $value) ?? ''));
     }
 
     private function nullableString(mixed $value): ?string

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -622,7 +622,14 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertNotSame('', $firstPayload['first_class_draft_fields']['seo']['title']);
         $this->assertNotSame('', $firstPayload['first_class_draft_fields']['seo']['description']);
         $this->assertNotSame('', $firstPayload['first_class_draft_fields']['seo']['h1']);
-        $this->assertNotSame('', $firstPayload['first_class_draft_fields']['content']['quick_answer']);
+        $content = $firstPayload['first_class_draft_fields']['content'];
+        $this->assertNotSame('', $content['quick_answer']);
+        foreach ($this->expectedV2FirstClassSectionKeys() as $sectionKey) {
+            $this->assertArrayHasKey($sectionKey, $content);
+            $this->assertNotSame('', $content[$sectionKey]['body'] ?? '');
+            $this->assertSame('mbti64_competitor_gap_v2_first_class_section', $content[$sectionKey]['source'] ?? null);
+        }
+        $this->assertStringContainsString('| Dimension | Assertive side | Turbulent side |', (string) ($content['a_t_difference']['body'] ?? ''));
         $this->assertCount(9, $firstPayload['first_class_draft_fields']['faq']);
         $this->assertNotEmpty($firstPayload['first_class_draft_fields']['internal_links']);
         $this->assertSame(0, PersonalityProfileRevision::query()->count());
@@ -838,6 +845,10 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         sort($expectedUrls);
         $this->assertSame($expectedUrls, $plannedUrls);
         $this->assertSame($expectedUrls, array_values($this->sortedStrings((array) $payload['subset']['allowed_urls'])));
+        $firstContent = $payload['rows'][0]['snapshot_preview']['mbti64_agent_projection_draft_v1']['first_class_draft_fields']['content'];
+        foreach ($this->expectedV2FirstClassSectionKeys() as $sectionKey) {
+            $this->assertArrayHasKey($sectionKey, $firstContent);
+        }
         $this->assertSame(0, PersonalityProfileRevision::query()->count());
         $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
     }
@@ -927,6 +938,14 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame($profileBefore, $this->profileLiveState($targets['en|ENFJ']));
         $this->assertSame($variantBefore, $this->variantLiveState($targets['en|ENFJ-T']));
         $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        $firstRevision = PersonalityProfileVariantRevision::query()->firstOrFail();
+        $firstSnapshot = $firstRevision->snapshot_json['mbti64_agent_projection_draft_v1'] ?? [];
+        $firstContent = $firstSnapshot['first_class_draft_fields']['content'] ?? [];
+        foreach ($this->expectedV2FirstClassSectionKeys() as $sectionKey) {
+            $this->assertArrayHasKey($sectionKey, $firstContent);
+        }
+        $this->assertStringContainsString('| Dimension | Assertive side | Turbulent side |', (string) ($firstContent['a_t_difference']['body'] ?? ''));
 
         foreach (PersonalityProfileVariantRevision::query()->get() as $revision) {
             $this->assertProjectionSnapshot(
@@ -1895,14 +1914,7 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
                 'description' => (string) ($recommended['description']['recommended'] ?? ''),
                 'h1' => (string) ($recommended['h1']['recommended'] ?? ''),
                 'quick_answer' => (string) ($recommended['quick_answer']['recommended'] ?? ''),
-                'sections' => array_map(
-                    static fn (int $index): array => [
-                        'key' => 'section_'.$index,
-                        'title' => 'Fixture section '.$index,
-                        'body' => 'Fixture expanded section body '.$index.'.',
-                    ],
-                    range(1, 8)
-                ),
+                'sections' => $this->v2SectionsForFixture($path, 'Fixture'),
                 'faq' => array_map(
                     static fn (int $index): array => [
                         'question' => 'Fixture expanded question '.$index.'?',
@@ -1997,6 +2009,79 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
     }
 
     /**
+     * @return list<string>
+     */
+    private function expectedV2FirstClassSectionKeys(): array
+    {
+        return [
+            'meaning',
+            'a_t_difference',
+            'core_traits',
+            'careers_work_style',
+            'relationships_communication',
+            'strengths_blind_spots',
+            'common_misreads',
+            'similar_types',
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function v2SectionsForFixture(string $path, string $prefix): array
+    {
+        return [
+            [
+                'key' => 'how_to_read',
+                'title' => $prefix.' how to read '.basename($path),
+                'body' => $prefix.' how-to-read body for '.$path.'.',
+            ],
+            [
+                'key' => 'at_difference_table',
+                'title' => $prefix.' A/T difference table for '.basename($path),
+                'body' => $prefix.' A/T difference body for '.$path.'.',
+                'comparison_rows' => [
+                    [
+                        'dimension' => 'Feedback rhythm',
+                        'assertive' => 'Uses feedback as a calibration input',
+                        'turbulent' => 'Reviews feedback with more self-monitoring',
+                    ],
+                ],
+            ],
+            [
+                'key' => 'cognitive_function_mechanism',
+                'title' => $prefix.' cognitive mechanism for '.basename($path),
+                'body' => $prefix.' cognitive-function body for '.$path.'.',
+            ],
+            [
+                'key' => 'work_scenario',
+                'title' => $prefix.' work scenario for '.basename($path),
+                'body' => $prefix.' work scenario body for '.$path.'.',
+            ],
+            [
+                'key' => 'relationship_communication',
+                'title' => $prefix.' relationship communication for '.basename($path),
+                'body' => $prefix.' communication body for '.$path.'.',
+            ],
+            [
+                'key' => 'stress_growth',
+                'title' => $prefix.' stress and growth for '.basename($path),
+                'body' => $prefix.' stress-growth body for '.$path.'.',
+            ],
+            [
+                'key' => 'common_misreads',
+                'title' => $prefix.' common misreads for '.basename($path),
+                'body' => $prefix.' common misreads body for '.$path.'.',
+            ],
+            [
+                'key' => 'how_to_use_not_use',
+                'title' => $prefix.' how to use this page for '.basename($path),
+                'body' => $prefix.' safe-use body for '.$path.'.',
+            ],
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function remainingFiftyEightV2Package(): array
@@ -2017,14 +2102,7 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
                 'description' => (string) ($recommended['description']['recommended'] ?? ''),
                 'h1' => (string) ($recommended['h1']['recommended'] ?? ''),
                 'quick_answer' => (string) ($recommended['quick_answer']['recommended'] ?? ''),
-                'sections' => array_map(
-                    static fn (int $index): array => [
-                        'key' => 'section_'.$index,
-                        'title' => 'Fixture remaining section '.$index,
-                        'body' => 'Fixture remaining expanded section body '.$index.'.',
-                    ],
-                    range(1, 8)
-                ),
+                'sections' => $this->v2SectionsForFixture($path, 'Fixture remaining'),
                 'faq' => array_map(
                     static fn (int $index): array => [
                         'question' => 'Fixture remaining question '.$index.'?',

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -643,6 +643,13 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(6, $payload['promoted_count']);
         $this->assertSame(6, PersonalityProfileVariantSeoMeta::query()->count());
         $this->assertSame(0, PersonalityProfileSection::query()->where('section_key', 'mbti64_comparison_a_vs_t')->count());
+        foreach ($this->expectedV2FirstClassSectionKeys() as $sectionKey) {
+            $this->assertSame(6, PersonalityProfileVariantSection::query()->where('section_key', $sectionKey)->count());
+        }
+        $atSection = PersonalityProfileVariantSection::query()
+            ->where('section_key', 'a_t_difference')
+            ->firstOrFail();
+        $this->assertStringContainsString('| Dimension | Assertive side | Turbulent side |', (string) $atSection->body_md);
 
         foreach (['zh-CN|INTP-A', 'en|INTP-A', 'zh-CN|ESFP-A', 'en|ESFP-A', 'en|ENFJ-A', 'zh-CN|ENFJ-A'] as $targetKey) {
             PersonalityProfileVariantSeoMeta::query()
@@ -679,6 +686,14 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(58, $payload['promoted_count']);
         $this->assertSame(58, PersonalityProfileVariantSeoMeta::query()->count());
         $this->assertSame(0, PersonalityProfileSection::query()->where('section_key', 'mbti64_comparison_a_vs_t')->count());
+        foreach ($this->expectedV2FirstClassSectionKeys() as $sectionKey) {
+            $this->assertSame(58, PersonalityProfileVariantSection::query()->where('section_key', $sectionKey)->count());
+        }
+        $atSection = PersonalityProfileVariantSection::query()
+            ->where('section_key', 'a_t_difference')
+            ->firstOrFail();
+        $this->assertStringContainsString('| Dimension | Assertive side | Turbulent side |', (string) $atSection->body_md);
+        $this->assertSame('mbti64_competitor_gap_v2_first_class_section', $atSection->payload_json['source'] ?? null);
 
         foreach ($this->remainingFiftyEightUrls() as $url) {
             $key = $this->targetKeyForUrl($url);
@@ -1373,13 +1388,7 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
                 'description' => (string) ($nested['description']['recommended'] ?? ''),
                 'h1' => (string) ($nested['h1']['recommended'] ?? ''),
                 'quick_answer' => (string) ($nested['quick_answer']['recommended'] ?? ''),
-                'sections' => array_map(
-                    static fn (int $index): array => [
-                        'h2' => 'V2 section '.$index.' for '.basename($path),
-                        'body' => 'Expanded V2 evidence-aware copy '.$index.' for '.$path.'.',
-                    ],
-                    range(1, 8)
-                ),
+                'sections' => $this->v2SectionsForFixture($path, 'V2'),
                 'faq' => array_map(
                     static fn (int $index): array => [
                         'question' => 'V2 question '.$index.' for '.basename($path).'?',
@@ -1435,13 +1444,7 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
                 'description' => (string) ($nested['description']['recommended'] ?? ''),
                 'h1' => (string) ($nested['h1']['recommended'] ?? ''),
                 'quick_answer' => (string) ($nested['quick_answer']['recommended'] ?? ''),
-                'sections' => array_map(
-                    static fn (int $index): array => [
-                        'h2' => 'Remaining 58 section '.$index.' for '.basename($path),
-                        'body' => 'Expanded remaining-58 evidence-aware copy '.$index.' for '.$path.'.',
-                    ],
-                    range(1, 8)
-                ),
+                'sections' => $this->v2SectionsForFixture($path, 'Remaining 58'),
                 'faq' => array_map(
                     static fn (int $index): array => [
                         'question' => 'Remaining 58 question '.$index.' for '.basename($path).'?',
@@ -1712,10 +1715,116 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
                 continue;
             }
 
-            $sections['v2_section_'.((string) ($index + 1))] = $section;
+            $sectionKey = $this->firstClassSectionKey((string) ($section['key'] ?? ''), $index);
+            if ($sectionKey === '') {
+                continue;
+            }
+
+            $sections[$sectionKey] = $section;
         }
 
         return $sections;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function expectedV2FirstClassSectionKeys(): array
+    {
+        return [
+            'meaning',
+            'a_t_difference',
+            'core_traits',
+            'careers_work_style',
+            'relationships_communication',
+            'strengths_blind_spots',
+            'common_misreads',
+            'similar_types',
+        ];
+    }
+
+    private function firstClassSectionKey(string $sourceKey, int $position): string
+    {
+        $map = [
+            'how_to_read' => 'meaning',
+            'at_difference_table' => 'a_t_difference',
+            'cognitive_function_mechanism' => 'core_traits',
+            'work_scenario' => 'careers_work_style',
+            'relationship_communication' => 'relationships_communication',
+            'stress_growth' => 'strengths_blind_spots',
+            'common_misreads' => 'common_misreads',
+            'how_to_use_not_use' => 'similar_types',
+        ];
+        $normalized = strtolower(trim(preg_replace('/[^a-zA-Z0-9_]+/', '_', $sourceKey) ?? '', '_'));
+        if (isset($map[$normalized])) {
+            return $map[$normalized];
+        }
+
+        return $this->expectedV2FirstClassSectionKeys()[$position] ?? '';
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function v2SectionsForFixture(string $path, string $prefix): array
+    {
+        return [
+            [
+                'key' => 'how_to_read',
+                'h2' => $prefix.' how to read '.basename($path),
+                'body' => $prefix.' how-to-read body for '.$path.'.',
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+            ],
+            [
+                'key' => 'at_difference_table',
+                'h2' => $prefix.' A/T difference table for '.basename($path),
+                'body' => $prefix.' A/T difference body for '.$path.'.',
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+                'comparison_rows' => [
+                    [
+                        'dimension' => 'Feedback rhythm',
+                        'assertive' => 'Uses feedback as a calibration input',
+                        'turbulent' => 'Reviews feedback with more self-monitoring',
+                    ],
+                ],
+            ],
+            [
+                'key' => 'cognitive_function_mechanism',
+                'h2' => $prefix.' cognitive mechanism for '.basename($path),
+                'body' => $prefix.' cognitive-function body for '.$path.'.',
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+            ],
+            [
+                'key' => 'work_scenario',
+                'h2' => $prefix.' work scenario for '.basename($path),
+                'body' => $prefix.' work scenario body for '.$path.'.',
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+            ],
+            [
+                'key' => 'relationship_communication',
+                'h2' => $prefix.' relationship communication for '.basename($path),
+                'body' => $prefix.' communication body for '.$path.'.',
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+            ],
+            [
+                'key' => 'stress_growth',
+                'h2' => $prefix.' stress and growth for '.basename($path),
+                'body' => $prefix.' stress-growth body for '.$path.'.',
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+            ],
+            [
+                'key' => 'common_misreads',
+                'h2' => $prefix.' common misreads for '.basename($path),
+                'body' => $prefix.' common misreads body for '.$path.'.',
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+            ],
+            [
+                'key' => 'how_to_use_not_use',
+                'h2' => $prefix.' how to use this page for '.basename($path),
+                'body' => $prefix.' safe-use body for '.$path.'.',
+                'source' => 'mbti64_competitor_gap_v2_first_class_section',
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
## What changed
- Promote MBTI64 V2 recommendation sections from raw audit metadata into first-class CMS draft content fields.
- Teach the MBTI64 revision promotion service to preserve renderable V2 section sources and markdown table/bullet bodies when building live content sections.
- Add focused draft-writer and promotion-command assertions for the V2 section keys, A/T table rendering, and remaining-58/next-batch-6 subset contracts.

## Why
Runtime smoke showed the promoted MBTI64 V2 pages had core title/H1/quick-answer fields, but the 7-9 V2 modules were only stored under raw_row audit metadata and were not rendered as live page sections. This keeps backend CMS/API as the content authority and avoids frontend fallback rendering from raw audit payloads.

## Validation
- php -l backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
- php -l backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
- php -l backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
- php -l backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
- php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

## Deferred
- No production deploy.
- No CMS draft write or live promotion.
- No publish/index/search, sitemap/llms, URL Truth, Search Queue, or external API actions.
- Next runtime step after merge/deploy is to rerun the controlled draft/promotion flow and MBTI64 remaining-58 V2 runtime smoke.

## Repository rule impact
Backend CMS/API remains the authority for personality content. This PR makes V2 modules first-class backend fields for rendering and keeps raw_row as audit-only metadata; it does not introduce frontend editorial fallback content.