### PR TITLE
MBTI64-REMAINING-58-COMPETITOR-GAP-V2-MODULE-DRAFT-REWRITE-POLICY-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -26,6 +26,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
     private const REMAINING_58_OPERATOR_APPROVAL = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-WRITE-01';
 
+    private const REMAINING_58_V2_MODULE_REWRITE_OPERATOR_APPROVAL = 'MBTI64-REMAINING-58-COMPETITOR-GAP-V2-MODULE-DRAFT-REWRITE-01';
+
     private const WRITE_SAFETY_FLAGS = [
         'draft-only',
         'no-publish',
@@ -45,6 +47,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         {--fresh-query-backed-5 : Restrict planning/write to the fresh 5 query-backed MBTI64 URLs}
         {--next-batch-6 : Restrict planning/write to the approved 6 next-batch MBTI64 URLs}
         {--remaining-58 : Restrict planning/write to the approved 58 remaining competitor-gap MBTI64 variant URLs}
+        {--rewrite-existing-v2-modules : For --remaining-58 only, create patched draft revisions when same-hash existing drafts lack first-class V2 module fields}
         {--agent-batch-size= : Restrict planning/write to an artifact-order batch; only 5 or 10 are allowed}
         {--agent-batch-offset= : Zero-based artifact-order offset for --agent-batch-size; defaults to 0}
         {--json : Emit the full JSON summary}
@@ -142,6 +145,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             (bool) $this->option('fresh-query-backed-3') => self::FRESH_QUERY_BACKED_3_OPERATOR_APPROVAL,
             (bool) $this->option('fresh-query-backed-5') => self::FRESH_QUERY_BACKED_5_OPERATOR_APPROVAL,
             (bool) $this->option('next-batch-6') => self::NEXT_BATCH_6_OPERATOR_APPROVAL,
+            (bool) $this->option('remaining-58') && (bool) $this->option('rewrite-existing-v2-modules') => self::REMAINING_58_V2_MODULE_REWRITE_OPERATOR_APPROVAL,
             (bool) $this->option('remaining-58') => self::REMAINING_58_OPERATOR_APPROVAL,
             $this->agentBatchRequested() => self::AGENT_BATCH_OPERATOR_APPROVAL,
             default => self::OPERATOR_APPROVAL,
@@ -178,6 +182,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             'fresh_query_backed_5' => (bool) $this->option('fresh-query-backed-5'),
             'next_batch_6' => (bool) $this->option('next-batch-6'),
             'remaining_58' => (bool) $this->option('remaining-58'),
+            'rewrite_existing_v2_modules' => (bool) $this->option('rewrite-existing-v2-modules'),
             'agent_batch_size' => trim((string) $this->option('agent-batch-size')),
             'agent_batch_offset' => trim((string) $this->option('agent-batch-offset')),
             'draft_only' => (bool) $this->option('draft-only'),

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -113,6 +113,7 @@ final class Mbti64CmsProjectionDraftWriter
         $warnings = array_values(array_filter((array) ($qa['warnings'] ?? []), static fn (mixed $warning): bool => is_string($warning)));
         $qaResultsByUrl = $this->qaResultsByUrl($qa);
         $recommendations = $this->recommendationsForOptions($package, $options, $write, $errors);
+        $rewriteExistingV2Modules = $this->remaining58V2ModuleRewriteRequested($options);
 
         $preparedRows = [];
         foreach ($recommendations as $position => $recommendation) {
@@ -151,6 +152,8 @@ final class Mbti64CmsProjectionDraftWriter
             $existingRevision = is_int($targetId)
                 ? $this->existingRevision($pageType, $targetField, $targetId, $sourceSha256)
                 : null;
+            $existingRevisionHasV2Modules = $existingRevision !== null
+                && $this->revisionHasFirstClassV2Modules($existingRevision);
             $nextRevisionNo = is_int($targetId)
                 ? $this->nextRevisionNo($pageType, $targetField, $targetId)
                 : null;
@@ -174,6 +177,8 @@ final class Mbti64CmsProjectionDraftWriter
                 'recommendation_sha256' => $recommendationSha256,
                 'existing_revision_id' => $existingRevision?->id !== null ? (int) $existingRevision->id : null,
                 'existing_revision_no' => $existingRevision?->revision_no !== null ? (int) $existingRevision->revision_no : null,
+                'existing_revision_has_v2_modules' => $existingRevisionHasV2Modules,
+                'rewrite_existing_v2_modules' => $rewriteExistingV2Modules,
                 'next_revision_no' => $nextRevisionNo,
                 'write_mode' => $write ? 'write_draft_revision' : 'dry_run',
                 'action' => 'pending',
@@ -233,9 +238,12 @@ final class Mbti64CmsProjectionDraftWriter
 
         $created = 0;
         $skippedExisting = 0;
+        $rewrittenExisting = 0;
+        $wouldRewriteExisting = 0;
         if ($write) {
             foreach ($preparedRows as &$preparedRow) {
-                if (($preparedRow['existing_revision_id'] ?? null) !== null) {
+                $hasExistingRevision = ($preparedRow['existing_revision_id'] ?? null) !== null;
+                if ($hasExistingRevision && (! $rewriteExistingV2Modules || (bool) ($preparedRow['existing_revision_has_v2_modules'] ?? false))) {
                     $preparedRow['action'] = 'skipped_existing';
                     $skippedExisting++;
 
@@ -243,22 +251,29 @@ final class Mbti64CmsProjectionDraftWriter
                 }
 
                 $revision = $this->createRevision($preparedRow);
-                $preparedRow['action'] = 'created';
+                $preparedRow['action'] = $hasExistingRevision ? 'rewritten_existing' : 'created';
                 $preparedRow['created_revision_id'] = (int) $revision->id;
                 $preparedRow['created_revision_no'] = (int) $revision->revision_no;
                 $created++;
+                if ($hasExistingRevision) {
+                    $rewrittenExisting++;
+                }
             }
             unset($preparedRow);
         } else {
             foreach ($preparedRows as &$preparedRow) {
-                if (($preparedRow['existing_revision_id'] ?? null) !== null) {
+                $hasExistingRevision = ($preparedRow['existing_revision_id'] ?? null) !== null;
+                if ($hasExistingRevision && (! $rewriteExistingV2Modules || (bool) ($preparedRow['existing_revision_has_v2_modules'] ?? false))) {
                     $preparedRow['action'] = 'would_skip_existing';
                     $skippedExisting++;
 
                     continue;
                 }
 
-                $preparedRow['action'] = 'would_create';
+                $preparedRow['action'] = $hasExistingRevision ? 'would_rewrite_existing' : 'would_create';
+                if ($hasExistingRevision) {
+                    $wouldRewriteExisting++;
+                }
             }
             unset($preparedRow);
         }
@@ -271,6 +286,8 @@ final class Mbti64CmsProjectionDraftWriter
             'comparison_row_count' => $this->countRows($preparedRows, 'comparison'),
             'created_revision_count' => $created,
             'skipped_existing_count' => $skippedExisting,
+            'rewritten_existing_count' => $rewrittenExisting,
+            'would_rewrite_existing_count' => $write ? 0 : $wouldRewriteExisting,
             'would_create_revision_count' => $write ? 0 : count($preparedRows) - $skippedExisting,
             'writes_committed' => $write && $created > 0,
             'subset' => $this->subsetSummary($options, $preparedRows),
@@ -567,7 +584,18 @@ final class Mbti64CmsProjectionDraftWriter
         $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
         $nextBatch6 = $this->nextBatch6Requested($options);
         $remaining58 = $this->remaining58Requested($options);
+        $rewriteExistingV2Modules = $this->remaining58V2ModuleRewriteRequested($options);
         $agentBatchRequested = $this->agentBatchRequested($options);
+
+        if ($rewriteExistingV2Modules && ! $remaining58) {
+            $errors[] = [
+                'field' => 'options.rewrite_existing_v2_modules',
+                'code' => 'rewrite_existing_v2_modules_requires_remaining_58',
+                'message' => '--rewrite-existing-v2-modules is only allowed with --remaining-58.',
+            ];
+
+            return [];
+        }
 
         if (($visibleQueryBacked3 ? 1 : 0)
             + ($freshQueryBacked3 ? 1 : 0)
@@ -667,6 +695,14 @@ final class Mbti64CmsProjectionDraftWriter
     private function remaining58Requested(array $options): bool
     {
         return (bool) ($options['remaining_58'] ?? false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function remaining58V2ModuleRewriteRequested(array $options): bool
+    {
+        return (bool) ($options['rewrite_existing_v2_modules'] ?? false);
     }
 
     /**
@@ -873,6 +909,25 @@ final class Mbti64CmsProjectionDraftWriter
         }
 
         return null;
+    }
+
+    private function revisionHasFirstClassV2Modules(
+        PersonalityProfileRevision|PersonalityProfileVariantRevision $revision,
+    ): bool {
+        $snapshot = is_array($revision->snapshot_json) ? $revision->snapshot_json : [];
+        $content = $snapshot[self::SNAPSHOT_KEY]['first_class_draft_fields']['content'] ?? [];
+        if (! is_array($content)) {
+            return false;
+        }
+
+        foreach ($this->expectedFirstClassV2SectionKeys() as $key) {
+            $section = $content[$key] ?? null;
+            if (! is_array($section) || trim((string) ($section['body'] ?? '')) === '') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function nextRevisionNo(string $pageType, string $targetField, int $targetId): int
@@ -1226,6 +1281,23 @@ final class Mbti64CmsProjectionDraftWriter
     }
 
     /**
+     * @return list<string>
+     */
+    private function expectedFirstClassV2SectionKeys(): array
+    {
+        return [
+            'meaning',
+            'a_t_difference',
+            'core_traits',
+            'careers_work_style',
+            'relationships_communication',
+            'strengths_blind_spots',
+            'common_misreads',
+            'similar_types',
+        ];
+    }
+
+    /**
      * @param  array<string,mixed>  $section
      */
     private function sectionTitle(array $section): ?string
@@ -1332,6 +1404,7 @@ final class Mbti64CmsProjectionDraftWriter
             'sitemap_llms_release_attempted' => false,
             'search_release_attempted' => false,
             'writes_committed' => false,
+            'rewrite_existing_v2_modules' => $this->remaining58V2ModuleRewriteRequested($options),
             'subset' => $this->subsetSummary($options),
         ];
     }
@@ -1411,6 +1484,7 @@ final class Mbti64CmsProjectionDraftWriter
                 'dry_run_only' => false,
                 'write_allowed_with_strict_approval' => true,
                 'approval_queue_required' => true,
+                'rewrite_existing_v2_modules' => $this->remaining58V2ModuleRewriteRequested($options),
                 'allowed_urls' => $this->remaining58Urls(),
                 'selected_urls' => $selectedUrls,
                 'arbitrary_url_subset_allowed' => false,

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -957,6 +957,146 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         }
     }
 
+    public function test_remaining_fifty_eight_rewrite_flag_requires_remaining_subset(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--rewrite-existing-v2-modules' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('rewrite_existing_v2_modules_requires_remaining_58', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_remaining_fifty_eight_rewrite_dry_run_plans_same_hash_legacy_draft_rewrites(): void
+    {
+        $targets = $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 58, 0);
+        $this->seedLegacyRemainingFiftyEightDrafts($package, $packagePath, $targets);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--remaining-58' => true,
+            '--rewrite-existing-v2-modules' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['rewrite_existing_v2_modules']);
+        $this->assertTrue($payload['subset']['rewrite_existing_v2_modules']);
+        $this->assertSame(58, $payload['row_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame(58, $payload['would_create_revision_count']);
+        $this->assertSame(58, $payload['would_rewrite_existing_count']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame('would_rewrite_existing', (string) ($payload['rows'][0]['action'] ?? ''));
+        $this->assertFalse((bool) ($payload['rows'][0]['existing_revision_has_v2_modules'] ?? true));
+        $this->assertSame(58, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_remaining_fifty_eight_rewrite_write_requires_rewrite_approval_token(): void
+    {
+        $targets = $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 58, 0);
+        $this->seedLegacyRemainingFiftyEightDrafts($package, $packagePath, $targets);
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--remaining-58'] = true;
+        $options['--rewrite-existing-v2-modules'] = true;
+        $options['--operator-approved'] = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CMS-DRAFT-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertStringContainsString(
+            '--operator-approved=MBTI64-REMAINING-58-COMPETITOR-GAP-V2-MODULE-DRAFT-REWRITE-01 is required',
+            (string) ($payload['errors'][0]['message'] ?? '')
+        );
+        $this->assertSame(58, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_remaining_fifty_eight_rewrite_write_creates_patched_revisions_and_then_is_idempotent(): void
+    {
+        $targets = $this->seedAllTargets();
+        $package = $this->remainingFiftyEightV2Package();
+        $qa = $this->remainingFiftyEightV2Qa($package);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 58, 0);
+        $this->seedLegacyRemainingFiftyEightDrafts($package, $packagePath, $targets);
+        $profileBefore = $this->profileLiveState($targets['en|ENFJ']);
+        $variantBefore = $this->variantLiveState($targets['en|ENFJ-T']);
+        $surfaceCountsBefore = $this->liveSurfaceCounts();
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--remaining-58'] = true;
+        $options['--rewrite-existing-v2-modules'] = true;
+        $options['--operator-approved'] = 'MBTI64-REMAINING-58-COMPETITOR-GAP-V2-MODULE-DRAFT-REWRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertTrue($payload['rewrite_existing_v2_modules']);
+        $this->assertSame(58, $payload['created_revision_count']);
+        $this->assertSame(58, $payload['rewritten_existing_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame('rewritten_existing', (string) ($payload['rows'][0]['action'] ?? ''));
+        $this->assertSame(116, PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['en|ENFJ']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['en|ENFJ-T']));
+        $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        $patchedRevision = PersonalityProfileVariantRevision::query()
+            ->where('personality_profile_variant_id', (int) $targets['en|ENFJ-T']->id)
+            ->orderByDesc('revision_no')
+            ->firstOrFail();
+        $this->assertSame(2, (int) $patchedRevision->revision_no);
+        $firstContent = $patchedRevision->snapshot_json['mbti64_agent_projection_draft_v1']['first_class_draft_fields']['content'] ?? [];
+        foreach ($this->expectedV2FirstClassSectionKeys() as $sectionKey) {
+            $this->assertArrayHasKey($sectionKey, $firstContent);
+        }
+        $this->assertStringContainsString('| Dimension | Assertive side | Turbulent side |', (string) ($firstContent['a_t_difference']['body'] ?? ''));
+
+        $secondExitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $secondPayload = $this->jsonOutput();
+        $this->assertSame(0, $secondExitCode);
+        $this->assertTrue($secondPayload['ok']);
+        $this->assertFalse($secondPayload['writes_committed']);
+        $this->assertSame(0, $secondPayload['created_revision_count']);
+        $this->assertSame(0, $secondPayload['rewritten_existing_count']);
+        $this->assertSame(58, $secondPayload['skipped_existing_count']);
+        $this->assertTrue((bool) ($secondPayload['rows'][0]['existing_revision_has_v2_modules'] ?? false));
+        $this->assertSame(116, PersonalityProfileVariantRevision::query()->count());
+    }
+
     public function test_remaining_fifty_eight_fails_closed_when_handoff_contains_arbitrary_url(): void
     {
         $this->seedAllTargets();
@@ -2385,6 +2525,62 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
             '--no-search-release' => true,
             '--operator-approved' => 'MBTI64-CMS-PROJECTION-DRAFT-88-01',
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,PersonalityProfile|PersonalityProfileVariant>  $targets
+     */
+    private function seedLegacyRemainingFiftyEightDrafts(array $package, string $packagePath, array $targets): void
+    {
+        $sourceSha256 = hash_file('sha256', $packagePath);
+        foreach ((array) ($package['recommendations'] ?? []) as $recommendation) {
+            $this->assertIsArray($recommendation);
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            $path = (string) (parse_url($targetUrl, PHP_URL_PATH) ?: '');
+            $slug = basename($path);
+            $runtimeTypeCode = strtoupper($slug);
+            $locale = str_starts_with($path, '/zh/') ? 'zh-CN' : 'en';
+            $target = $targets[$locale.'|'.$runtimeTypeCode] ?? null;
+            $this->assertInstanceOf(PersonalityProfileVariant::class, $target);
+
+            PersonalityProfileVariantRevision::query()->create([
+                'personality_profile_variant_id' => (int) $target->id,
+                'revision_no' => 1,
+                'snapshot_json' => [
+                    'mbti64_agent_projection_draft_v1' => [
+                        'source' => [
+                            'artifact' => 'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01',
+                            'source_sha256' => $sourceSha256,
+                            'qa_final_decision' => 'PASS_READY_FOR_CONTENT_EXPANSION_REVIEW',
+                        ],
+                        'identity' => [
+                            'url' => $targetUrl,
+                            'path' => $path,
+                            'locale' => $locale,
+                            'page_type' => 'variant',
+                            'runtime_type_code' => $runtimeTypeCode,
+                        ],
+                        'first_class_draft_fields' => [
+                            'seo' => [
+                                'title' => 'Legacy '.$runtimeTypeCode.' title',
+                                'description' => 'Legacy description.',
+                                'h1' => 'Legacy '.$runtimeTypeCode,
+                            ],
+                            'content' => [
+                                'quick_answer' => 'Legacy quick answer without first-class V2 modules.',
+                            ],
+                            'faq' => [],
+                            'internal_links' => [],
+                        ],
+                        'raw_recommendation' => $recommendation,
+                    ],
+                ],
+                'note' => 'legacy remaining-58 fixture without first-class V2 modules: '.$path,
+                'created_by_admin_user_id' => null,
+                'created_at' => now()->subDay(),
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added an explicit `--rewrite-existing-v2-modules` mode for `personality:mbti64-cms-projection-draft`.
- Scoped the mode to `--remaining-58` only and required the dedicated operator token `MBTI64-REMAINING-58-COMPETITOR-GAP-V2-MODULE-DRAFT-REWRITE-01` for writes.
- Updated the draft writer to rewrite same-source-hash remaining-58 drafts only when existing drafts lack first-class V2 module fields; patched drafts remain draft-only until a later promotion gate.
- Added focused tests for fail-closed scope, dry-run planning, approval-token enforcement, rewrite writes, and idempotency after patched drafts exist.

## Why
Production dry-run showed existing same-hash remaining-58 drafts blocking patched V2 module drafts. This adds a bounded rewrite path without changing live CMS content.

## Validation
- `php -l backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php`
- `php -l backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php`
- `php -l backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php`
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No production deploy.
- No production rewrite/write command execution.
- No live promotion.
- No publish/index/search/sitemap/llms mutation.
- No queue enqueue/approve/submit or external API calls.