### PR TITLE
fix(pdf): return structured result-page export errors

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -2959,7 +2959,7 @@ class AttemptReadController extends Controller
     /**
      * GET /api/v0.3/attempts/{id}/result-page.pdf
      */
-    public function resultPagePdf(Request $request, string $id): Response
+    public function resultPagePdf(Request $request, string $id): Response|JsonResponse
     {
         $orgId = $this->currentOrgContext()->orgId();
         $userId = $this->resolveUserId($request);
@@ -3035,7 +3035,15 @@ class AttemptReadController extends Controller
                 'message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
             ]);
 
-            abort(503, 'result-page PDF export failed.');
+            $requestId = $this->resolvePublicDiagnosticRequestId($request) ?? $traceId;
+
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'RESULT_PAGE_PDF_EXPORT_FAILED',
+                'message' => 'Result-page PDF export is temporarily unavailable. Please retry shortly.',
+                'request_id' => $requestId,
+                'trace_id' => $traceId,
+            ], 503)->withHeaders($this->resultPagePdfFailureHeaders($request, $traceId));
         }
 
         $pdfBinary = (string) ($generated['binary'] ?? '');
@@ -3057,6 +3065,46 @@ class AttemptReadController extends Controller
             'X-Legacy-Mpdf-Fallback' => 'false',
             'X-Gotenberg-Trace' => (string) ($generated['trace_id'] ?? ''),
         ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function resultPagePdfFailureHeaders(Request $request, string $traceId): array
+    {
+        $headers = [
+            'Cache-Control' => 'private, no-store',
+            'X-Report-Scale' => 'MBTI',
+            'X-Report-Pdf-Engine' => ReportPdfDocumentService::RESULT_PAGE_EXPORT_ENGINE,
+            'X-Pdf-Surface' => 'mbti_result_page_export',
+            'X-Pdf-Surface-Version' => ReportPdfDocumentService::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION,
+            'X-Gotenberg-Trace' => $traceId,
+            'Vary' => 'Origin',
+        ];
+
+        $origin = trim((string) $request->headers->get('Origin', ''));
+        if (in_array($origin, ['https://fermatmind.com', 'https://www.fermatmind.com'], true)) {
+            $headers['Access-Control-Allow-Origin'] = $origin;
+        }
+
+        return $headers;
+    }
+
+    private function resolvePublicDiagnosticRequestId(Request $request): ?string
+    {
+        $requestId = trim((string) ($request->attributes->get('request_id') ?? ''));
+        if ($requestId !== '') {
+            return $requestId;
+        }
+
+        foreach (['X-Request-Id', 'X-Request-ID'] as $header) {
+            $requestId = trim((string) $request->headers->get($header, ''));
+            if ($requestId !== '') {
+                return $requestId;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -415,9 +415,24 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf = $this->withHeaders([
             'X-Anon-Id' => $anonId,
             'Authorization' => 'Bearer '.$token,
+            'Origin' => 'https://fermatmind.com',
+            'X-Request-Id' => 'pdf-export-request-1',
         ])->get("/api/v0.3/attempts/{$attemptId}/result-page.pdf");
 
         $pdf->assertStatus(503);
+        $pdf->assertHeader('Access-Control-Allow-Origin', 'https://fermatmind.com');
+        $cacheControl = (string) $pdf->headers->get('Cache-Control');
+        $this->assertStringContainsString('private', $cacheControl);
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $pdf->assertHeader('X-Report-Scale', 'MBTI');
+        $pdf->assertHeader('X-Report-Pdf-Engine', 'gotenberg_chromium');
+        $pdf->assertHeader('X-Pdf-Surface', 'mbti_result_page_export');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_export.v1');
+        $this->assertNotSame('', (string) $pdf->headers->get('X-Gotenberg-Trace'));
+        $pdf->assertJsonPath('ok', false);
+        $pdf->assertJsonPath('error_code', 'RESULT_PAGE_PDF_EXPORT_FAILED');
+        $pdf->assertJsonPath('message', 'Result-page PDF export is temporarily unavailable. Please retry shortly.');
+        $pdf->assertJsonPath('request_id', 'pdf-export-request-1');
         Storage::disk('local')->assertMissing(
             "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_export.v1-gotenberg_chromium-zh-locked-free/report_free.pdf"
         );


### PR DESCRIPTION
## What changed
- Return structured JSON for MBTI result-page PDF export failures instead of an opaque abort response.
- Include a safe error code, request/trace diagnostics, cache policy, PDF surface headers, and production-site CORS visibility on the 503 path.
- Extend the existing result-page PDF parity test to cover the diagnostic 503 contract.

## Why
When Gotenberg/result-print export fails, the frontend currently sees an opaque CORS/network failure. This keeps the successful PDF response unchanged while making failures diagnosable by the browser and operator logs.

## Validation
- `php artisan test --filter=AttemptPublicReportPdfParityTest` (passes; existing warning markers remain)
- `./vendor/bin/pint app/Http/Controllers/API/V0_3/AttemptReadController.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php --test`
- `git diff --check`
- `php artisan route:list --path=api/v0.3/attempts | sed -n "1,120p"`

## Intentionally deferred
- No frontend changes in this PR.
- No CMS, DB, queue, search, indexing, scheduler, or deploy changes.
- Does not alter successful `/result-page.pdf` PDF content, filename, or attachment behavior.