### PR TITLE
chore(iq): add beta standard score train entry

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65285,5 +65285,38 @@
         "note": "Fresh GitHub checks passed after rebase and PR #2525 returned to CLEAN merge state."
       }
     ]
+  },
+  "IQ-BETA-STANDARD-SCORE-1": {
+    "id": "IQ-BETA-STANDARD-SCORE-1",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-beta-standard-score",
+    "title": "feat(iq): add random-baseline beta standard score",
+    "depends_on": [
+      "iq-report-builder-three-dimension-result-schema"
+    ],
+    "status": "planned",
+    "checks": {},
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-29 attached /goal IQ-BETA-STANDARD-SCORE-1 requested backend-owned random-baseline beta_standard_score, explicitly not iq_estimate, not production_normed, no population percentile, no frontend changes, no deploy, and no production DB mutation.",
+    "events": [
+      {
+        "at": "2026-06-29T00:00:00+08:00",
+        "status": "planned",
+        "note": "Initialized PR-train state for backend-only IQ beta standard score implementation. Phase 0 only adds train metadata; runtime implementation follows in codex/iq-beta-standard-score after merge."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -30151,3 +30151,45 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: IQ-BETA-STANDARD-SCORE-1
+    repo: fap-api
+    depends_on:
+      - iq-report-builder-three-dimension-result-schema
+    branch: codex/iq-beta-standard-score
+    title: "feat(iq): add random-baseline beta standard score"
+    train_scope: iq_owner_original_30_launch
+    status: user_authorized
+    scope:
+      - Add a backend-owned beta_standard_score for IQ_OWNER_ORIGINAL_30 using the 500-run random-response baseline as random-noise calibration only.
+      - Keep iq_estimate null unless a real backend norm authority provides it.
+      - Include explicit non-production-norm claim metadata and random baseline fields in IQ result/report payloads.
+      - Add focused tests proving formula mapping, no population percentile, no production_normed claim, no answer leak, and no answer scoring change.
+    allowed_paths:
+      - backend/app/Services/Assessment/**
+      - backend/app/Services/Report/**
+      - backend/tests/**IQ**
+      - backend/tests/**Iq**
+      - docs/audits/iq-result-assets/**
+      - docs/audits/iq/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, frontend files, payment, checkout, orders, webhooks, entitlement grants, item banks, questions, answer keys, SVG assets, backend routes, database migrations, production commands, production DB, CMS, SEO, staging deploy, or production deploy.
+      - Create a production_normed authority, population percentile, general_adult_online norm, official/certified/diagnostic/Mensa claim, or license_verified=true assertion.
+      - Fill iq_estimate from the random simulation mapping.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test <new IQ beta standard score test file>
+      - cd backend && php artisan route:list --no-ansi | rg 'api/v0.3/(scales|attempts|orders|webhooks/payment|results/lookup-by-email)'
+      - bash backend/scripts/ci_verify_mbti.sh
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Adds IQ-BETA-STANDARD-SCORE-1 to the fap-api PR train manifest/state.
- Registers the backend-only random-baseline beta standard score scope.

## Why
- Prepares the scoped implementation PR for beta_standard_score without touching runtime code in this bootstrap PR.

## Validation
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"\n- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null\n- git diff --check\n\n## Deferred\n- Runtime implementation.\n- Frontend rendering.\n- Production deploy or production DB mutation.\n- Item bank, answer key, payment, checkout, order, webhook, and entitlement changes.