### PR TITLE
fix(cms): persist article body visual metadata in draft imports

### DIFF
--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
@@ -885,6 +885,9 @@ final class SeoContentPackageDraftImporter
             'cover_image_width' => (int) ($import['cover_image_width'] ?? $fields['cover_image_width'] ?? $social['width'] ?? 0),
             'cover_image_height' => (int) ($import['cover_image_height'] ?? $fields['cover_image_height'] ?? $social['height'] ?? 0),
             'cover_image_variants' => is_array($import['cover_image_variants'] ?? null) ? $import['cover_image_variants'] : ($fields['cover_image_variants'] ?? []),
+            'body_visual_asset_key' => $this->firstString($import['body_visual_asset_key'] ?? null, $fields['body_visual_asset_key'] ?? null),
+            'body_visual_image_url' => $this->firstString($import['body_visual_image_url'] ?? null, $fields['body_visual_image_url'] ?? null),
+            'body_visual_fallback_authorized' => (bool) ($import['body_visual_fallback_authorized'] ?? $fields['body_visual_fallback_authorized'] ?? false),
             'og_image_url' => $this->firstString($import['og_image_url'] ?? null, $fields['og_image_url'] ?? null, data_get($social, 'og_1200x630_variant.url'), $social['twitter_image_url'] ?? null),
             'twitter_image_url' => $this->firstString($import['twitter_image_url'] ?? null, $fields['twitter_image_url'] ?? null, $social['twitter_image_url'] ?? null),
             'social_image_metadata' => $social,
@@ -1137,6 +1140,9 @@ final class SeoContentPackageDraftImporter
             'revalidation_allowed' => false,
             'cover_media_asset_key' => (string) $item['cover_media_asset_key'],
             'social_image_metadata' => $item['social_image_metadata'],
+            'body_visual_asset_key' => trim((string) ($item['body_visual_asset_key'] ?? '')),
+            'body_visual_image_url' => trim((string) ($item['body_visual_image_url'] ?? '')),
+            'body_visual_fallback_authorized' => (bool) ($item['body_visual_fallback_authorized'] ?? false),
             'body_hash' => hash('sha256', preg_replace("/\r\n?/", "\n", trim((string) $item['body_markdown'])) ?: trim((string) $item['body_markdown'])),
         ];
 

--- a/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
@@ -610,6 +610,40 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         }
     }
 
+    public function test_import_persists_body_visual_metadata_for_public_article_api_rendering(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+
+        $articles = Article::query()
+            ->withoutGlobalScopes()
+            ->orderBy('locale')
+            ->get(['id', 'locale', 'cover_image_variants', 'is_public', 'is_indexable', 'sitemap_eligible', 'llms_eligible']);
+
+        $this->assertCount(2, $articles);
+
+        foreach ($articles as $article) {
+            $metadata = $article->cover_image_variants['editorial_package_v1'] ?? null;
+
+            $this->assertIsArray($metadata);
+            $this->assertSame('article.riasec.explanation.body-visual.v1', $metadata['body_visual_asset_key'] ?? null);
+            $this->assertSame(
+                'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationbodyvisualv1/hero_1600x900.jpg',
+                $metadata['body_visual_image_url'] ?? null
+            );
+            $this->assertFalse($metadata['body_visual_fallback_authorized'] ?? true);
+            $this->assertFalse($article->is_public);
+            $this->assertFalse($article->is_indexable);
+            $this->assertFalse($article->sitemap_eligible);
+            $this->assertFalse($article->llms_eligible);
+        }
+    }
+
     /**
      * @param  array<string,mixed>  $overrides
      * @return array<string,mixed>
@@ -747,6 +781,9 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
             'cover_image_width' => 1672,
             'cover_image_height' => 941,
             'cover_image_variants' => $variants,
+            'body_visual_asset_key' => 'article.riasec.explanation.body-visual.v1',
+            'body_visual_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationbodyvisualv1/hero_1600x900.jpg',
+            'body_visual_fallback_authorized' => false,
             'og_image_url' => $social['og_1200x630_variant']['url'],
             'twitter_image_url' => $social['twitter_image_url'],
             'social_image_metadata' => $social,


### PR DESCRIPTION
## What changed
- Carry `body_visual_asset_key`, `body_visual_image_url`, and `body_visual_fallback_authorized` from Mode C CMS import fields into normalized package items.
- Persist those fields under `cover_image_variants.editorial_package_v1` during draft article import so the public article API can later expose body visuals from backend CMS metadata.
- Added a focused importer regression test that verifies body visual metadata is persisted while imported articles remain draft-only, non-public, non-indexable, and excluded from sitemap/llms.

## Why
The MBTI bilingual SEO article draft import successfully registered Media Library assets, but preview QA showed the body visual metadata was not persisted on the article rows. The frontend public article renderer depends on backend `cover_image_variants.editorial_package_v1.body_visual_*` metadata, so publish/operator approval should remain blocked until this importer path is fixed and the drafts are re-imported after deployment.

## Validation
- `cd backend && ./vendor/bin/pint app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php`
- `cd backend && php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest`
- `cd backend && php artisan route:list > /tmp/fap-api-route-list-seo-body-visual.txt && wc -l /tmp/fap-api-route-list-seo-body-visual.txt`
- `cd backend && php artisan migrate --pretend`
- `cd backend && php artisan articles:import-seo-content-package-draft --package=/Users/rainie/Desktop/GitHub/fap-web/generated/seo-article-mbti-full-report-scenario-20260629-content-qa-00/production-media-library-import-20260629/resolved-package --translation-group-id=tg_mbti_full_report_career_relationship_2026v1 --locales=zh-CN,en --expected-zh-slug=mbti-full-report-career-relationship-communication --expected-en-slug=mbti-full-report-career-relationship-communication --draft-only --no-publish --no-index --no-sitemap --no-llms --schema-hold --hreflang-hold --dry-run --json`
- `git diff --check`

## Deferred intentionally
- Did not mutate production CMS drafts in this PR.
- Did not publish, make indexable, mark sitemap/llms eligible, submit search, enable schema/hreflang, trigger revalidation, or deploy.
- Existing production draft articles 60/61 still need backend deployment plus an explicitly authorized draft re-import/backfill before operator approval can resume.

## Repository rule impact
No content authority change. This keeps backend CMS Article metadata as the authority for article body visuals and does not introduce frontend fallback content.
