### PR TITLE
test(seo): align article draft preview with public API media metadata

### DIFF
--- a/backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php
+++ b/backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php
@@ -62,6 +62,7 @@ final class ArticleDraftPreviewController extends Controller
             'canonicalUrl' => $this->safeCanonicalUrl($seoMeta?->canonical_url),
             'publicUrl' => $this->publicUrl($record),
             'coverImageUrl' => PublicMediaUrlGuard::sanitizeNullableUrl($record->cover_image_url),
+            'bodyVisual' => $this->previewBodyVisual($record),
             'redactionCount' => $redacted['count'],
             'previewContext' => [
                 'is_preview' => true,
@@ -165,6 +166,27 @@ final class ArticleDraftPreviewController extends Controller
         }
 
         return filter_var($url, FILTER_VALIDATE_URL) ? $url : null;
+    }
+
+    /**
+     * @return array{asset_key:string,image_url:string,fallback_authorized:bool}|null
+     */
+    private function previewBodyVisual(Article $article): ?array
+    {
+        $variants = is_array($article->cover_image_variants) ? $article->cover_image_variants : [];
+        $metadata = is_array($variants['editorial_package_v1'] ?? null)
+            ? $variants['editorial_package_v1']
+            : [];
+        $imageUrl = PublicMediaUrlGuard::sanitizeNullableUrl($metadata['body_visual_image_url'] ?? null);
+        if ($imageUrl === null) {
+            return null;
+        }
+
+        return [
+            'asset_key' => trim((string) ($metadata['body_visual_asset_key'] ?? '')),
+            'image_url' => $imageUrl,
+            'fallback_authorized' => (bool) ($metadata['body_visual_fallback_authorized'] ?? false),
+        ];
     }
 
     private function publicUrl(Article $article): ?string

--- a/backend/resources/views/ops/article-draft-preview.blade.php
+++ b/backend/resources/views/ops/article-draft-preview.blade.php
@@ -54,6 +54,20 @@
         .meta, .summary { color: var(--muted); }
         .body { font-size: 18px; }
         .body img { max-width: 100%; border-radius: 18px; }
+        .media-preview {
+            margin: 22px 0;
+        }
+        .media-preview img {
+            display: block;
+            max-width: 100%;
+            border-radius: 18px;
+            border: 1px solid var(--line);
+        }
+        .media-preview figcaption {
+            margin-top: 8px;
+            color: var(--muted);
+            font: 13px/1.45 ui-sans-serif, system-ui, sans-serif;
+        }
         .body code, .field code {
             border-radius: 8px;
             background: #efe7da;
@@ -93,6 +107,13 @@
                     <p><img src="{{ $coverImageUrl }}" alt="{{ $article->cover_image_alt ?: $title }}"></p>
                 @endif
 
+                @if ($bodyVisual)
+                    <figure class="media-preview" data-preview-media="body_visual">
+                        <img src="{{ $bodyVisual['image_url'] }}" alt="Body visual preview for {{ $title }}">
+                        <figcaption>Body visual from public API media metadata.</figcaption>
+                    </figure>
+                @endif
+
                 <section class="body">
                     {!! $bodyHtml !!}
                 </section>
@@ -109,6 +130,9 @@
                     <div class="field"><span>SEO title</span>{{ $seoTitle }}</div>
                     <div class="field"><span>SEO description</span>{{ $seoDescription !== '' ? $seoDescription : 'not set' }}</div>
                     <div class="field"><span>Private URL redactions</span>{{ $redactionCount }}</div>
+                    <div class="field"><span>Body visual asset key</span>{{ $bodyVisual['asset_key'] ?? 'not set' }}</div>
+                    <div class="field"><span>Body visual URL</span>{{ $bodyVisual['image_url'] ?? 'not set' }}</div>
+                    <div class="field"><span>Body visual fallback authorized</span>{{ ($bodyVisual['fallback_authorized'] ?? false) ? 'true' : 'false' }}</div>
                 </div>
 
                 <h2>Hard holds</h2>

--- a/backend/tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
+++ b/backend/tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
@@ -49,6 +49,14 @@ final class ArticleDraftPreviewRouteTest extends TestCase
             ->assertSee('CMS Article Draft Preview')
             ->assertSee('Working Revision Preview Title')
             ->assertSee('Draft preview only')
+            ->assertSee('https://assets.fermatmind.com/storage/media-library/variants/articlepreviewcoverv1/hero_1600x900.jpg', false)
+            ->assertSee('https://assets.fermatmind.com/storage/media-library/variants/articlepreviewbodyvisualv1/hero_1600x900.jpg', false)
+            ->assertSee('data-preview-media="body_visual"', false)
+            ->assertSee('Body visual from public API media metadata.')
+            ->assertSee('Body visual asset key')
+            ->assertSee('article.preview.body-visual.v1')
+            ->assertSee('Body visual fallback authorized')
+            ->assertSee('false')
             ->assertSee('schema_enabled: false')
             ->assertSee('hreflang_enabled: false')
             ->assertSee('revalidation_allowed: false')
@@ -111,6 +119,20 @@ final class ArticleDraftPreviewRouteTest extends TestCase
             'title' => 'Article Row Draft Title',
             'excerpt' => 'Article row excerpt.',
             'content_md' => 'Article row body.',
+            'cover_image_url' => 'https://assets.fermatmind.com/storage/media-library/variants/articlepreviewcoverv1/hero_1600x900.jpg',
+            'cover_image_alt' => 'Preview cover image',
+            'cover_image_variants' => [
+                'hero' => [
+                    'url' => 'https://assets.fermatmind.com/storage/media-library/variants/articlepreviewcoverv1/hero_1600x900.jpg',
+                    'width' => 1600,
+                    'height' => 900,
+                ],
+                'editorial_package_v1' => [
+                    'body_visual_asset_key' => 'article.preview.body-visual.v1',
+                    'body_visual_image_url' => 'https://assets.fermatmind.com/storage/media-library/variants/articlepreviewbodyvisualv1/hero_1600x900.jpg',
+                    'body_visual_fallback_authorized' => false,
+                ],
+            ],
             'status' => 'draft',
             'is_public' => false,
             'is_indexable' => false,


### PR DESCRIPTION
## What changed
- Read article body visual metadata from `cover_image_variants.editorial_package_v1` in the Ops draft preview controller.
- Render the body visual in the draft preview body area next to the cover preview.
- Surface body visual asset key, URL, and fallback flag in the preview safety sidebar.
- Extend the Ops preview route test to assert both cover and body visual media are present in preview HTML.

## Why
The SEO article release flow needed preview/API parity for public API media metadata so operator QA can verify body visual readiness from the preview page instead of relying on database readback.

## Validation
- `./vendor/bin/pint app/Http/Controllers/Ops/ArticleDraftPreviewController.php tests/Feature/Ops/ArticleDraftPreviewRouteTest.php`
- `php artisan test --filter=ArticleDraftPreviewRouteTest`
- `php artisan route:list`
- `php artisan migrate --pretend`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No CMS draft creation or publication.
- No indexability, sitemap, llms, schema, hreflang, search submission, revalidation, or deploy changes.
- No importer contract hardening or release orchestration command changes; those are separate follow-up PRs.
