### PR TITLE
test(seo): harden Mode C article package import contracts

### DIFF
--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
@@ -122,6 +122,9 @@ final class SeoContentPackageDraftImporter
         if ($expectedTranslationGroupId === '') {
             $errors[] = $this->issue('translation_group_id', 'missing_expected_translation_group_id', '--translation-group-id is required.');
         }
+        if (mb_strlen($expectedTranslationGroupId) > 64) {
+            $errors[] = $this->issue('translation_group_id', 'translation_group_id_too_long', 'translation_group_id must be 64 characters or fewer.');
+        }
         $manifest = [];
         $packageItems = [];
         $guardScans = [
@@ -134,6 +137,7 @@ final class SeoContentPackageDraftImporter
             $guardScans = $this->validatePackageGuardScopes($packageRoot, $errors);
             $locales = $this->validatedLocales($locales, $manifest, $errors);
             $packageItems = $this->buildPackageItems($packageRoot, $manifest, $locales, $expectedTranslationGroupId, $expectedSlugs, $errors, $warnings);
+            $this->validateBilingualPackageParity($packageItems, $locales, $expectedTranslationGroupId, $errors);
             $this->validateJsonFieldSerialization($packageItems, $errors, $warnings);
         }
 
@@ -263,6 +267,7 @@ final class SeoContentPackageDraftImporter
             'sitemap_eligible' => false,
             'llms_eligible' => false,
             'preview_url_candidate' => '/ops/article-preview/'.(int) $article->id,
+            'media_metadata_parity' => $this->mediaMetadataParity($item, $metadata),
         ];
     }
 
@@ -287,6 +292,7 @@ final class SeoContentPackageDraftImporter
             'sitemap_eligible' => false,
             'llms_eligible' => false,
             'preview_url_candidate' => $existing instanceof Article ? '/ops/article-preview/'.(int) $existing->id : null,
+            'media_metadata_parity' => $this->mediaMetadataParity($item, $this->metadata($item)),
         ];
     }
 
@@ -720,6 +726,54 @@ final class SeoContentPackageDraftImporter
     }
 
     /**
+     * @param  list<array<string,mixed>>  $items
+     * @param  list<string>  $locales
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateBilingualPackageParity(
+        array $items,
+        array $locales,
+        string $expectedTranslationGroupId,
+        array &$errors
+    ): void {
+        if ($locales !== ['zh-CN', 'en']) {
+            return;
+        }
+
+        $byLocale = [];
+        foreach ($items as $item) {
+            $locale = (string) ($item['locale'] ?? '');
+            if ($locale !== '') {
+                $byLocale[$locale] = $item;
+            }
+        }
+
+        foreach (['zh-CN', 'en'] as $locale) {
+            if (! isset($byLocale[$locale])) {
+                $errors[] = $this->issue('locales.'.$locale, 'bilingual_locale_missing', 'Bilingual Mode C packages must include both zh-CN and en items.');
+
+                continue;
+            }
+
+            $slug = trim((string) ($byLocale[$locale]['slug'] ?? ''));
+            $canonicalUrl = trim((string) ($byLocale[$locale]['canonical_url'] ?? ''));
+            $expectedCanonicalUrl = ($locale === 'zh-CN' ? '/zh/articles/' : '/en/articles/').$slug;
+            if ($slug === '' || $canonicalUrl !== $expectedCanonicalUrl) {
+                $errors[] = $this->issue($locale.'.canonical_url', 'canonical_slug_mismatch', 'Canonical article route must match the locale slug.');
+            }
+        }
+
+        $translationGroupIds = array_values(array_unique(array_map(
+            static fn (array $item): string => trim((string) ($item['translation_group_id'] ?? '')),
+            $items
+        )));
+
+        if (count($translationGroupIds) !== 1 || $translationGroupIds[0] !== $expectedTranslationGroupId) {
+            $errors[] = $this->issue('translation_group_id', 'bilingual_translation_group_id_mismatch', 'Bilingual package items must share the expected translation_group_id.');
+        }
+    }
+
+    /**
      * @param  list<array<string,mixed>>  $errors
      * @return array<string,mixed>
      */
@@ -929,6 +983,9 @@ final class SeoContentPackageDraftImporter
                 $errors[] = $this->issue($locale.'.'.$field, 'missing_required_field', $field.' is required.');
             }
         }
+        if (mb_strlen((string) ($item['translation_group_id'] ?? '')) > 64) {
+            $errors[] = $this->issue($locale.'.translation_group_id', 'translation_group_id_too_long', 'translation_group_id must be 64 characters or fewer.');
+        }
         $this->validateUtf8ScalarFields($item, $errors);
 
         if (! is_string($item['primary_keyword'] ?? null)) {
@@ -955,6 +1012,12 @@ final class SeoContentPackageDraftImporter
         $this->validateReaderFacingCategory($item, $errors);
         if ((string) $item['cover_media_asset_key'] === '' || (string) $item['cover_image_url'] === '' || (string) $item['og_image_url'] === '') {
             $errors[] = $this->issue($locale.'.social_image_metadata', 'missing_social_image_metadata', 'social image asset, cover URL, and OG URL are required.');
+        }
+        if ((string) $item['cover_media_asset_key'] === '') {
+            $errors[] = $this->issue($locale.'.cover_media_asset_key', 'missing_cover_media_asset_key', 'cover_media_asset_key is required.');
+        }
+        if ((string) $item['body_visual_asset_key'] === '' || (string) $item['body_visual_image_url'] === '') {
+            $errors[] = $this->issue($locale.'.body_visual', 'missing_body_visual_metadata', 'body_visual_asset_key and body_visual_image_url are required.');
         }
         if ((int) $item['cover_image_width'] <= 0 || (int) $item['cover_image_height'] <= 0) {
             $errors[] = $this->issue($locale.'.social_image_metadata', 'missing_social_image_dimensions', 'social image width and height are required.');
@@ -1147,6 +1210,36 @@ final class SeoContentPackageDraftImporter
         ];
 
         return $variants;
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    private function mediaMetadataParity(array $item, array $metadata): array
+    {
+        $editorialPackage = is_array($metadata['editorial_package_v1'] ?? null)
+            ? $metadata['editorial_package_v1']
+            : [];
+
+        $coverMediaAssetKey = (string) ($editorialPackage['cover_media_asset_key'] ?? '');
+        $bodyVisualAssetKey = (string) ($editorialPackage['body_visual_asset_key'] ?? '');
+        $bodyVisualImageUrl = (string) ($editorialPackage['body_visual_image_url'] ?? '');
+        $bodyVisualFallbackAuthorized = (bool) ($editorialPackage['body_visual_fallback_authorized'] ?? false);
+
+        return [
+            'status' => $coverMediaAssetKey === (string) ($item['cover_media_asset_key'] ?? '')
+                && $bodyVisualAssetKey === (string) ($item['body_visual_asset_key'] ?? '')
+                && $bodyVisualImageUrl === (string) ($item['body_visual_image_url'] ?? '')
+                ? 'passed'
+                : 'failed',
+            'metadata_path' => 'cover_image_variants.editorial_package_v1',
+            'cover_media_asset_key' => $coverMediaAssetKey,
+            'body_visual_asset_key' => $bodyVisualAssetKey,
+            'body_visual_image_url' => $bodyVisualImageUrl,
+            'body_visual_fallback_authorized' => $bodyVisualFallbackAuthorized,
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
@@ -41,6 +41,17 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         $this->assertSame('passed', $payload['active_surface_guard_scan']['status']);
         $this->assertSame('passed', $payload['contract_integrity_scan']['status']);
         $this->assertCount(2, $payload['articles']);
+        foreach ($payload['articles'] as $article) {
+            $this->assertSame('passed', $article['media_metadata_parity']['status'] ?? null);
+            $this->assertSame('cover_image_variants.editorial_package_v1', $article['media_metadata_parity']['metadata_path'] ?? null);
+            $this->assertSame('article.riasec.explanation.cover.v1', $article['media_metadata_parity']['cover_media_asset_key'] ?? null);
+            $this->assertSame('article.riasec.explanation.body-visual.v1', $article['media_metadata_parity']['body_visual_asset_key'] ?? null);
+            $this->assertSame(
+                'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationbodyvisualv1/hero_1600x900.jpg',
+                $article['media_metadata_parity']['body_visual_image_url'] ?? null
+            );
+            $this->assertFalse($article['media_metadata_parity']['body_visual_fallback_authorized'] ?? true);
+        }
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
         $this->assertSame(0, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
         $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
@@ -350,6 +361,80 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         $payload = $this->jsonOutput();
         $this->assertSame(1, $exitCode);
         $this->assertErrorCode($payload, 'missing_social_image_metadata');
+        $this->assertErrorCode($payload, 'missing_cover_media_asset_key');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_translation_group_id_longer_than_database_limit(): void
+    {
+        $tooLong = str_repeat('a', 65);
+        $package = $this->writeModeCPackage(static function (array &$files) use ($tooLong): void {
+            $files['manifest.json']['translation_group_id'] = $tooLong;
+
+            foreach ([
+                'cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json',
+                'cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json',
+                'cms/CMS_IMPORT_DRAFT_zh-CN_career-interest-vs-personality-test-differences.json',
+                'cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json',
+            ] as $path) {
+                $files[$path]['translation_group_id'] = $tooLong;
+            }
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--translation-group-id' => $tooLong,
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'translation_group_id_too_long');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_bilingual_canonical_slug_mismatch(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json']['canonical_url'] = '/en/articles/wrong-slug';
+            $files['cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json']['canonical_url'] = '/en/articles/wrong-slug';
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'canonical_slug_mismatch');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_missing_body_visual_metadata(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            foreach ([
+                'cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json',
+                'cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json',
+                'cms/CMS_IMPORT_DRAFT_zh-CN_career-interest-vs-personality-test-differences.json',
+                'cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json',
+            ] as $path) {
+                unset(
+                    $files[$path]['body_visual_asset_key'],
+                    $files[$path]['body_visual_image_url']
+                );
+            }
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'missing_body_visual_metadata');
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
     }
 


### PR DESCRIPTION
## What changed
- Added preflight validation for Mode C package translation_group_id length, bilingual zh-CN/en slug/canonical/translation-group parity, and required cover/body visual media metadata.
- Added dry-run `media_metadata_parity` evidence so package checks show the body visual metadata that will be written to `cover_image_variants.editorial_package_v1`.
- Extended importer tests for valid parity output and rejection of overlong translation groups, canonical mismatches, missing cover asset key, and missing body visual metadata.

## Why
These checks block the failure modes seen in the MBTI article draft import before CMS draft writes happen.

## Validation
- `./vendor/bin/pint app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php`
- `php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest`
- `php artisan route:list`
- `php artisan migrate --pretend`
- `git diff --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No Ops preview changes.
- No CMS draft creation or publication.
- No indexability, sitemap, llms, schema, hreflang, search submission, revalidation, or deploy changes.
- No staged release orchestrator command; that is the next PR.