### PR TITLE
BIG5-RETAKE-WINDOW-LIMIT-DISABLE-01

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -1039,23 +1039,30 @@ class AttemptStartService
      */
     private function resolveBigFiveRetakePolicy(string $dirVersion): array
     {
-        $cooldownHours = 24;
-        $maxAttempts = 3;
+        $cooldownHours = 0;
+        $maxAttempts = 0;
+        $enforcePackPolicy = (bool) config('fap.big5_retake.enforce_pack_policy', false);
+        $retake = [];
 
-        $compiled = $this->bigFivePackLoader->readCompiledJson('policy.compiled.json', $dirVersion);
-        $policy = is_array($compiled['policy'] ?? null) ? $compiled['policy'] : [];
-        $retake = is_array($policy['retake'] ?? null) ? $policy['retake'] : [];
+        if ($enforcePackPolicy) {
+            $cooldownHours = 24;
+            $maxAttempts = 3;
 
-        $contentPathMode = strtolower(trim((string) config('scale_identity.content_path_mode', 'legacy')));
-        $preferRawInV2Mode = in_array($contentPathMode, ['dual_prefer_new', 'v2'], true);
-        if ($retake === [] || $preferRawInV2Mode) {
-            $raw = $this->bigFivePackLoader->readJson(
-                $this->bigFivePackLoader->rawPath('policy.json', $dirVersion)
-            );
-            if (is_array($raw)) {
-                $rawRetake = is_array($raw['retake'] ?? null) ? $raw['retake'] : [];
-                if ($rawRetake !== []) {
-                    $retake = $rawRetake;
+            $compiled = $this->bigFivePackLoader->readCompiledJson('policy.compiled.json', $dirVersion);
+            $policy = is_array($compiled['policy'] ?? null) ? $compiled['policy'] : [];
+            $retake = is_array($policy['retake'] ?? null) ? $policy['retake'] : [];
+
+            $contentPathMode = strtolower(trim((string) config('scale_identity.content_path_mode', 'legacy')));
+            $preferRawInV2Mode = in_array($contentPathMode, ['dual_prefer_new', 'v2'], true);
+            if ($retake === [] || $preferRawInV2Mode) {
+                $raw = $this->bigFivePackLoader->readJson(
+                    $this->bigFivePackLoader->rawPath('policy.json', $dirVersion)
+                );
+                if (is_array($raw)) {
+                    $rawRetake = is_array($raw['retake'] ?? null) ? $raw['retake'] : [];
+                    if ($rawRetake !== []) {
+                        $retake = $rawRetake;
+                    }
                 }
             }
         }
@@ -1065,6 +1072,16 @@ class AttemptStartService
         }
         if (is_numeric($retake['max_attempts_per_30_days'] ?? null)) {
             $maxAttempts = max(0, (int) $retake['max_attempts_per_30_days']);
+        }
+
+        $configuredCooldown = config('fap.big5_retake.cooldown_hours');
+        if (is_numeric($configuredCooldown)) {
+            $cooldownHours = max(0, (int) $configuredCooldown);
+        }
+
+        $configuredMaxAttempts = config('fap.big5_retake.max_attempts_per_30_days');
+        if (is_numeric($configuredMaxAttempts)) {
+            $maxAttempts = max(0, (int) $configuredMaxAttempts);
         }
 
         return [

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -36,6 +36,12 @@ return [
         explode(',', (string) env('FAP_FREE_FULL_REPORT_ASSESSMENTS', 'MBTI,BIG5_OCEAN,RIASEC,IQ_RAVEN,EQ_60,ENNEAGRAM'))
     ))),
 
+    'big5_retake' => [
+        'enforce_pack_policy' => (bool) env('FAP_BIG5_RETAKE_ENFORCE_PACK_POLICY', false),
+        'cooldown_hours' => env('FAP_BIG5_RETAKE_COOLDOWN_HOURS', null),
+        'max_attempts_per_30_days' => env('FAP_BIG5_RETAKE_MAX_ATTEMPTS_PER_30_DAYS', null),
+    ],
+
     'result_email_gate' => [
         'require_binding_for_read' => (bool) env('FAP_RESULT_EMAIL_REQUIRE_BINDING_FOR_READ', false),
         'enabled_scale_codes' => ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM', 'RIASEC'],

--- a/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
+++ b/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Attempts;
 
 use App\Models\Attempt;
+use App\Services\Auth\FmTokenService;
 use App\Services\Attempts\AttemptStartService;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -23,6 +24,10 @@ final class Big5RetakeCooldownTest extends TestCase
     {
         parent::setUp();
 
+        config()->set('fap.big5_retake.enforce_pack_policy', false);
+        config()->set('fap.big5_retake.cooldown_hours', null);
+        config()->set('fap.big5_retake.max_attempts_per_30_days', null);
+
         $this->mappedBig5CanaryPath = base_path('content_packs/BIG5_OCEAN_POLICY_CANARY');
         File::deleteDirectory($this->mappedBig5CanaryPath);
     }
@@ -33,30 +38,34 @@ final class Big5RetakeCooldownTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_big5_retake_cooldown_blocks_recent_restart(): void
+    public function test_big5_90_retake_window_limits_are_disabled_by_default_for_same_anon(): void
     {
         (new ScaleRegistrySeeder)->run();
 
-        $anonId = 'anon_big5_cooldown';
-        $this->createAttempt($anonId, now()->subHours(1), 'big5_120');
+        $anonId = 'anon_big5_90_default_retake_allowed';
+        $this->createAttempt($anonId, now()->subHours(1), 'big5_90');
+        $this->createAttempt($anonId, now()->subDays(2), 'big5_90');
+        $this->createAttempt($anonId, now()->subDays(10), 'big5_90');
+        $this->createAttempt($anonId, now()->subDays(20), 'big5_90');
 
         $response = $this->postJson('/api/v0.3/attempts/start', [
             'scale_code' => 'BIG5_OCEAN',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
             'anon_id' => $anonId,
+            'form_code' => 'big5_90',
         ]);
 
-        $response->assertStatus(429);
-        $response->assertJsonPath('error_code', 'RETAKE_COOLDOWN');
-        $response->assertJsonPath('details.form_code', 'big5_120');
+        $response->assertStatus(200);
+        $response->assertJsonPath('form_code', 'big5_90');
     }
 
-    public function test_big5_retake_limit_blocks_repeated_attempts_in_30_days(): void
+    public function test_big5_120_retake_window_limits_are_disabled_by_default_for_same_anon(): void
     {
         (new ScaleRegistrySeeder)->run();
 
-        $anonId = 'anon_big5_retake_limit';
+        $anonId = 'anon_big5_120_default_retake_allowed';
+        $this->createAttempt($anonId, now()->subHours(1), 'big5_120');
         $this->createAttempt($anonId, now()->subDays(2), 'big5_120');
         $this->createAttempt($anonId, now()->subDays(10), 'big5_120');
         $this->createAttempt($anonId, now()->subDays(20), 'big5_120');
@@ -66,6 +75,76 @@ final class Big5RetakeCooldownTest extends TestCase
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
             'anon_id' => $anonId,
+            'form_code' => 'big5_120',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('form_code', 'big5_120');
+    }
+
+    public function test_big5_retake_window_limits_are_disabled_by_default_for_same_user(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $userId = 2002;
+        $anonId = 'anon_big5_user_default_retake_allowed';
+        $token = $this->issueUserToken((string) $userId, $anonId);
+        $this->createAttempt($anonId, now()->subHours(1), 'big5_90', $userId);
+        $this->createAttempt($anonId, now()->subDays(2), 'big5_90', $userId);
+        $this->createAttempt($anonId, now()->subDays(10), 'big5_90', $userId);
+        $this->createAttempt($anonId, now()->subDays(20), 'big5_90', $userId);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'BIG5_OCEAN',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+            'form_code' => 'big5_90',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('form_code', 'big5_90');
+    }
+
+    public function test_big5_retake_cooldown_can_be_restored_from_pack_policy(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        config()->set('fap.big5_retake.enforce_pack_policy', true);
+
+        $anonId = 'anon_big5_cooldown_restored';
+        $this->createAttempt($anonId, now()->subHours(1), 'big5_120');
+
+        $response = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'BIG5_OCEAN',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+            'form_code' => 'big5_120',
+        ]);
+
+        $response->assertStatus(429);
+        $response->assertJsonPath('error_code', 'RETAKE_COOLDOWN');
+        $response->assertJsonPath('details.form_code', 'big5_120');
+    }
+
+    public function test_big5_retake_limit_can_be_restored_from_pack_policy(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        config()->set('fap.big5_retake.enforce_pack_policy', true);
+
+        $anonId = 'anon_big5_retake_limit_restored';
+        $this->createAttempt($anonId, now()->subDays(2), 'big5_120');
+        $this->createAttempt($anonId, now()->subDays(10), 'big5_120');
+        $this->createAttempt($anonId, now()->subDays(20), 'big5_120');
+
+        $response = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'BIG5_OCEAN',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'anon_id' => $anonId,
+            'form_code' => 'big5_120',
         ]);
 
         $response->assertStatus(429);
@@ -157,6 +236,7 @@ final class Big5RetakeCooldownTest extends TestCase
         (new ScaleRegistrySeeder)->run();
 
         config()->set('scale_identity.content_path_mode', 'v2');
+        config()->set('fap.big5_retake.enforce_pack_policy', true);
         DB::table('content_path_aliases')->updateOrInsert(
             [
                 'scope' => 'backend_content_packs',
@@ -189,7 +269,50 @@ final class Big5RetakeCooldownTest extends TestCase
         $this->assertSame(1, (int) ($policy['max_attempts_per_30_days'] ?? -1));
     }
 
-    private function createAttempt(string $anonId, \DateTimeInterface $startedAt, string $formCode = 'big5_120'): void
+    public function test_big5_retake_policy_can_be_restored_from_runtime_config_overrides(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        config()->set('fap.big5_retake.cooldown_hours', 12);
+        config()->set('fap.big5_retake.max_attempts_per_30_days', 2);
+
+        $service = app(AttemptStartService::class);
+        $method = new \ReflectionMethod($service, 'resolveBigFiveRetakePolicy');
+        $method->setAccessible(true);
+        /** @var array{cooldown_hours:int,max_attempts_per_30_days:int} $policy */
+        $policy = $method->invoke($service, 'v1');
+
+        $this->assertSame(12, (int) ($policy['cooldown_hours'] ?? -1));
+        $this->assertSame(2, (int) ($policy['max_attempts_per_30_days'] ?? -1));
+    }
+
+    private function issueUserToken(string $userId, string $anonId): string
+    {
+        DB::table('users')->insertOrIgnore([
+            'id' => (int) $userId,
+            'name' => 'Big5 Retake User '.$userId,
+            'email' => 'big5-retake-'.$userId.'@example.test',
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $issued = app(FmTokenService::class)->issueForUser($userId, [
+            'provider' => 'test',
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+        ]);
+
+        return (string) ($issued['token'] ?? '');
+    }
+
+    private function createAttempt(
+        string $anonId,
+        \DateTimeInterface $startedAt,
+        string $formCode = 'big5_120',
+        ?int $userId = null
+    ): void
     {
         $normalizedFormCode = strtolower(trim($formCode)) === 'big5_90' ? 'big5_90' : 'big5_120';
         $dirVersion = $normalizedFormCode === 'big5_90' ? 'v1-form-90' : 'v1';
@@ -202,6 +325,7 @@ final class Big5RetakeCooldownTest extends TestCase
             'id' => (string) Str::uuid(),
             'org_id' => 0,
             'anon_id' => $anonId,
+            'user_id' => $userId,
             'scale_code' => 'BIG5_OCEAN',
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',


### PR DESCRIPTION
## Summary
- Disable the Big Five 24-hour cooldown and 30-day retake window by default so public/free full-report users can restart `big5_90` and `big5_120` without hitting `RETAKE_COOLDOWN` or `RETAKE_LIMIT_EXCEEDED`.
- Keep the API-level throttles on `/api/v0.3/attempts/start` and `/api/v0.3/attempts/submit` unchanged.
- Add `fap.big5_retake` config so operators can restore the old pack policy or explicit cooldown/window values later without deleting the code path.

## Why
The live Big Five take flow was blocked for users who had reached the old form-scoped retake policy: 24-hour cooldown or 3 starts in 30 days. The frontend only renders the backend 429 contract; hiding the frontend copy would not let users start a new attempt.

## What changed
- `AttemptStartService::resolveBigFiveRetakePolicy()` now defaults Big Five retake limits to `0/0`.
- Added config keys:
  - `FAP_BIG5_RETAKE_ENFORCE_PACK_POLICY=false` by default.
  - `FAP_BIG5_RETAKE_COOLDOWN_HOURS` optional override.
  - `FAP_BIG5_RETAKE_MAX_ATTEMPTS_PER_30_DAYS` optional override.
- Updated `Big5RetakeCooldownTest` to prove:
  - `big5_90` same anon can restart repeatedly in 30 days.
  - `big5_120` same anon can restart repeatedly in 30 days.
  - logged-in user identity can restart repeatedly in 30 days.
  - the old pack-policy cooldown/window behavior can still be restored by config.

## Validation
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Big5RetakeCooldownTest --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' ./vendor/bin/phpunit --filter=Big5RetakeCooldownTest --display-warnings --colors=never`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RateLimitKeyEndpointsTest --no-ansi`
- `APP_ENV=testing php artisan route:list --path=attempts --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi`
- `git diff --check`

Note: the artisan test runner reports existing fixture `file_get_contents` warnings in these suites, but exits 0. The focused Big Five retake suite also passes cleanly under raw phpunit.

## Intentionally deferred
- No fap-web copy changes.
- No CMS, SEO, search, sitemap, or llms changes.
- No production rollout/import/release gate changes.
- No Big Five result-page content asset changes.
- No manual deploy or server verification.

## Repository rule impact
Backend remains the authority for attempt start policy. Frontend continues to consume backend response contracts and does not add fallback editorial/product copy.
