### PR TITLE
feat(seo): add staged article release gate reporter

### DIFF
--- a/backend/app/Console/Commands/SeoAgentArticleReleaseCommand.php
+++ b/backend/app/Console/Commands/SeoAgentArticleReleaseCommand.php
@@ -1,0 +1,471 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\SeoContentPackage\SeoContentPackageDraftImporter;
+use Illuminate\Console\Command;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Throwable;
+
+final class SeoAgentArticleReleaseCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-article-release-gate-report.v1';
+
+    private const STAGES = [
+        'package-qa',
+        'media-readiness',
+        'cms-draft-dry-run',
+        'preview-qa',
+        'publish-rehearsal',
+        'closeout-readback',
+    ];
+
+    protected $signature = 'seo-agent:article-release
+        {--package= : Path to a Mode C article content package directory}
+        {--translation-group-id= : Expected translation_group_id}
+        {--locales=zh-CN,en : Comma-separated locale list}
+        {--stage=package-qa : Release stage to report}
+        {--dry-run : Generate a no-write gate report}
+        {--json : Emit a JSON gate report}
+        {--expected-zh-slug= : Expected zh-CN article slug}
+        {--expected-en-slug= : Expected en article slug}';
+
+    protected $description = 'No-write staged SEO article release gate reporter for Mode C packages.';
+
+    public function handle(SeoContentPackageDraftImporter $importer): int
+    {
+        $stage = trim((string) $this->option('stage'));
+        if (! in_array($stage, self::STAGES, true)) {
+            return $this->finish($this->failureReport($stage, 'invalid_stage', 'Unsupported stage.'));
+        }
+
+        $packageRoot = $this->packageRoot();
+        if ($packageRoot === null) {
+            return $this->finish($this->failureReport($stage, 'package_unreadable', 'Package directory is required and must be readable.'));
+        }
+
+        $locales = $this->locales();
+        $translationGroupId = trim((string) $this->option('translation-group-id'));
+        $base = $this->baseReport($stage, $packageRoot, $translationGroupId, $locales);
+
+        try {
+            $report = match ($stage) {
+                'package-qa' => $this->packageQaReport($base, $importer, $packageRoot, $translationGroupId, $locales),
+                'media-readiness' => $this->mediaReadinessReport($base, $packageRoot, $locales),
+                'cms-draft-dry-run' => $this->cmsDraftDryRunReport($base, $importer, $packageRoot, $translationGroupId, $locales),
+                'preview-qa' => $this->previewQaReport($base, $importer, $packageRoot, $translationGroupId, $locales),
+                'publish-rehearsal' => $this->publishRehearsalReport($base, $importer, $packageRoot, $translationGroupId, $locales),
+                'closeout-readback' => $this->closeoutReadbackReport($base, $packageRoot),
+            };
+        } catch (Throwable $exception) {
+            $report = $this->failureReport($stage, 'runtime_error', $exception->getMessage(), $base);
+        }
+
+        return $this->finish($report);
+    }
+
+    /**
+     * @param  array<string,mixed>  $base
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    private function packageQaReport(array $base, SeoContentPackageDraftImporter $importer, string $packageRoot, string $translationGroupId, array $locales): array
+    {
+        $requiredDirectories = $this->requiredDirectoryEvidence($packageRoot);
+        $plan = $importer->planFromDirectory($this->importerOptions($packageRoot, $translationGroupId, $locales));
+        $passed = $this->allRequiredDirectoriesPresent($requiredDirectories) && (bool) ($plan['ok'] ?? false);
+
+        return array_replace($base, [
+            'ok' => $passed,
+            'status' => $passed ? 'passed' : 'blocked',
+            'stage_report' => [
+                'required_directories' => $requiredDirectories,
+                'importer_plan' => $this->sanitizedImporterPlan($plan),
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $base
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    private function mediaReadinessReport(array $base, string $packageRoot, array $locales): array
+    {
+        $items = $this->cmsImportDraftItems($packageRoot, $locales);
+        $missing = [];
+        foreach ($items as $item) {
+            foreach (['cover_media_asset_key', 'body_visual_asset_key', 'body_visual_image_url'] as $field) {
+                if (trim((string) ($item[$field] ?? '')) === '') {
+                    $missing[] = [
+                        'locale' => (string) ($item['locale'] ?? ''),
+                        'slug' => (string) ($item['slug'] ?? ''),
+                        'field' => $field,
+                    ];
+                }
+            }
+        }
+
+        $passed = $items !== [] && $missing === [];
+
+        return array_replace($base, [
+            'ok' => $passed,
+            'status' => $passed ? 'passed' : 'blocked',
+            'stage_report' => [
+                'cms_import_draft_count' => count($items),
+                'media_items' => array_map(
+                    static fn (array $item): array => [
+                        'locale' => (string) ($item['locale'] ?? ''),
+                        'slug' => (string) ($item['slug'] ?? ''),
+                        'cover_media_asset_key' => (string) ($item['cover_media_asset_key'] ?? ''),
+                        'body_visual_asset_key' => (string) ($item['body_visual_asset_key'] ?? ''),
+                        'body_visual_image_url' => (string) ($item['body_visual_image_url'] ?? ''),
+                        'body_visual_fallback_authorized' => (bool) ($item['body_visual_fallback_authorized'] ?? false),
+                    ],
+                    $items
+                ),
+                'missing_media_fields' => $missing,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $base
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    private function cmsDraftDryRunReport(array $base, SeoContentPackageDraftImporter $importer, string $packageRoot, string $translationGroupId, array $locales): array
+    {
+        $plan = $importer->planFromDirectory($this->importerOptions($packageRoot, $translationGroupId, $locales));
+        $passed = (bool) ($plan['ok'] ?? false);
+
+        return array_replace($base, [
+            'ok' => $passed,
+            'status' => $passed ? 'passed' : 'blocked',
+            'stage_report' => [
+                'importer_plan' => $this->sanitizedImporterPlan($plan),
+                'body_visual_parity' => array_values(array_map(
+                    static fn (array $article): array => [
+                        'locale' => (string) ($article['locale'] ?? ''),
+                        'slug' => (string) ($article['slug'] ?? ''),
+                        'media_metadata_parity' => $article['media_metadata_parity'] ?? null,
+                    ],
+                    array_filter((array) ($plan['articles'] ?? []), 'is_array')
+                )),
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $base
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    private function previewQaReport(array $base, SeoContentPackageDraftImporter $importer, string $packageRoot, string $translationGroupId, array $locales): array
+    {
+        $plan = $importer->planFromDirectory($this->importerOptions($packageRoot, $translationGroupId, $locales));
+        $articles = array_values(array_filter((array) ($plan['articles'] ?? []), 'is_array'));
+        $previewCandidates = array_values(array_filter(array_map(
+            static fn (array $article): array => [
+                'locale' => (string) ($article['locale'] ?? ''),
+                'slug' => (string) ($article['slug'] ?? ''),
+                'preview_url_candidate' => (string) ($article['preview_url_candidate'] ?? ''),
+                'media_metadata_parity' => $article['media_metadata_parity'] ?? null,
+            ],
+            $articles
+        ), static fn (array $candidate): bool => $candidate['preview_url_candidate'] !== ''));
+        $passed = (bool) ($plan['ok'] ?? false) && $articles !== [] && count($previewCandidates) === count($articles);
+
+        return array_replace($base, [
+            'ok' => $passed,
+            'status' => $passed ? 'passed' : 'blocked_external_draft_required',
+            'external_evidence_required' => [
+                'ops_article_preview_html',
+                'operator_editorial_preview_approval',
+            ],
+            'stage_report' => [
+                'importer_plan' => $this->sanitizedImporterPlan($plan),
+                'preview_candidates' => $previewCandidates,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $base
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    private function publishRehearsalReport(array $base, SeoContentPackageDraftImporter $importer, string $packageRoot, string $translationGroupId, array $locales): array
+    {
+        $plan = $importer->planFromDirectory($this->importerOptions($packageRoot, $translationGroupId, $locales));
+        $passed = (bool) ($plan['ok'] ?? false);
+
+        return array_replace($base, [
+            'ok' => $passed,
+            'status' => $passed ? 'passed' : 'blocked',
+            'external_exact_authorization_required_for_write' => true,
+            'stage_report' => [
+                'importer_plan' => $this->sanitizedImporterPlan($plan),
+                'blocked_write_actions' => [
+                    'cms_publish',
+                    'make_indexable',
+                    'sitemap_or_llms_enablement',
+                    'schema_or_hreflang_enablement',
+                    'search_submission',
+                    'deploy',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $base
+     * @return array<string,mixed>
+     */
+    private function closeoutReadbackReport(array $base, string $packageRoot): array
+    {
+        $items = $this->cmsImportDraftItems($packageRoot, $this->locales());
+
+        return array_replace($base, [
+            'ok' => true,
+            'status' => 'passed',
+            'stage_report' => [
+                'readback_targets' => array_map(
+                    static fn (array $item): array => [
+                        'locale' => (string) ($item['locale'] ?? ''),
+                        'slug' => (string) ($item['slug'] ?? ''),
+                        'canonical_url' => (string) ($item['canonical_url'] ?? ''),
+                    ],
+                    $items
+                ),
+                'external_evidence_required' => [
+                    'public_smoke',
+                    'discoverability_parity',
+                    'url_truth_readback',
+                    'search_channel_queue_readback',
+                ],
+            ],
+        ]);
+    }
+
+    private function packageRoot(): ?string
+    {
+        $path = trim((string) $this->option('package'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_dir($path) && is_readable($path) ? rtrim($path, '/') : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function locales(): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (string $locale): string => trim($locale),
+            explode(',', (string) $this->option('locales'))
+        ), static fn (string $locale): bool => $locale !== ''));
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    private function importerOptions(string $packageRoot, string $translationGroupId, array $locales): array
+    {
+        return [
+            'package' => $packageRoot,
+            'translation_group_id' => $translationGroupId,
+            'locales' => $locales,
+            'dry_run' => true,
+            'json' => true,
+            'draft_only' => true,
+            'no_publish' => true,
+            'no_index' => true,
+            'no_sitemap' => true,
+            'no_llms' => true,
+            'schema_hold' => true,
+            'hreflang_hold' => true,
+            'expected_slugs' => [
+                'zh-CN' => (string) $this->option('expected-zh-slug'),
+                'en' => (string) $this->option('expected-en-slug'),
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    private function baseReport(string $stage, string $packageRoot, string $translationGroupId, array $locales): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'stage' => $stage,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write_allowed' => false,
+            'writes_attempted' => false,
+            'package' => [
+                'path' => $packageRoot,
+                'sha256' => $this->packageSha256($packageRoot),
+            ],
+            'translation_group_id' => $translationGroupId,
+            'locales' => $locales,
+            'supported_stages' => self::STAGES,
+            'negative_guarantees' => [
+                'no_cms_draft_creation',
+                'no_cms_publish',
+                'no_indexability_change',
+                'no_sitemap_or_llms_change',
+                'no_search_submission',
+                'no_schema_or_hreflang_enablement',
+                'no_deploy',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureReport(string $stage, string $code, string $message, ?array $base = null): array
+    {
+        return array_replace($base ?? [
+            'schema_version' => self::SCHEMA_VERSION,
+            'stage' => $stage,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write_allowed' => false,
+            'writes_attempted' => false,
+        ], [
+            'ok' => false,
+            'status' => 'blocked',
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+        ]);
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function requiredDirectoryEvidence(string $packageRoot): array
+    {
+        $directories = ['brief', 'pages', 'cms', 'contracts', 'review', 'codex', 'media', 'observation'];
+        $evidence = [];
+        foreach ($directories as $directory) {
+            $evidence[$directory] = is_dir($packageRoot.'/'.$directory);
+        }
+
+        $evidence['manifest.json'] = is_file($packageRoot.'/manifest.json');
+
+        return $evidence;
+    }
+
+    /**
+     * @param  array<string,bool>  $evidence
+     */
+    private function allRequiredDirectoriesPresent(array $evidence): bool
+    {
+        foreach ($evidence as $present) {
+            if (! $present) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return list<array<string,mixed>>
+     */
+    private function cmsImportDraftItems(string $packageRoot, array $locales): array
+    {
+        $items = [];
+        foreach (glob($packageRoot.'/cms/CMS_IMPORT_DRAFT_*.json') ?: [] as $path) {
+            $decoded = json_decode((string) file_get_contents($path), true);
+            if (! is_array($decoded)) {
+                continue;
+            }
+            if ($locales !== [] && ! in_array((string) ($decoded['locale'] ?? ''), $locales, true)) {
+                continue;
+            }
+            $items[] = $decoded;
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    private function sanitizedImporterPlan(array $plan): array
+    {
+        return [
+            'ok' => (bool) ($plan['ok'] ?? false),
+            'dry_run' => (bool) ($plan['dry_run'] ?? false),
+            'action' => (string) ($plan['action'] ?? ''),
+            'would_write' => (bool) ($plan['would_write'] ?? false),
+            'translation_group_id' => (string) ($plan['translation_group_id'] ?? ''),
+            'article_count' => count((array) ($plan['articles'] ?? [])),
+            'articles' => array_values(array_map(
+                static fn (array $article): array => [
+                    'locale' => (string) ($article['locale'] ?? ''),
+                    'slug' => (string) ($article['slug'] ?? ''),
+                    'action' => (string) ($article['action'] ?? ''),
+                    'preview_url_candidate' => (string) ($article['preview_url_candidate'] ?? ''),
+                    'media_metadata_parity' => $article['media_metadata_parity'] ?? null,
+                ],
+                array_filter((array) ($plan['articles'] ?? []), 'is_array')
+            )),
+            'errors' => array_values(array_filter((array) ($plan['errors'] ?? []), 'is_array')),
+            'warnings' => array_values(array_filter((array) ($plan['warnings'] ?? []), 'is_array')),
+            'active_surface_guard_scan' => $plan['active_surface_guard_scan'] ?? null,
+            'contract_integrity_scan' => $plan['contract_integrity_scan'] ?? null,
+        ];
+    }
+
+    private function packageSha256(string $packageRoot): string
+    {
+        $hashes = [];
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($packageRoot));
+        foreach ($iterator as $file) {
+            if (! $file instanceof SplFileInfo || ! $file->isFile()) {
+                continue;
+            }
+            $relativePath = ltrim(str_replace($packageRoot, '', $file->getPathname()), '/');
+            $hashes[] = $relativePath.':'.(hash_file('sha256', $file->getPathname()) ?: '');
+        }
+        sort($hashes);
+
+        return hash('sha256', implode("\n", $hashes));
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     */
+    private function finish(array $report): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+        } elseif ((bool) ($report['ok'] ?? false)) {
+            $this->info((string) ($report['status'] ?? 'passed'));
+        } else {
+            $this->error((string) ($report['status'] ?? 'blocked'));
+        }
+
+        return (bool) ($report['ok'] ?? false) ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -199,6 +199,7 @@ use App\Console\Commands\SeoAgentArticleCmsPublishCanaryCommand;
 use App\Console\Commands\SeoAgentArticleDraftClaimRiskQaCommand;
 use App\Console\Commands\SeoAgentArticleDraftPreviewRuntimeQaCommand;
 use App\Console\Commands\SeoAgentArticlePostPublishPropagationDryRunCommand;
+use App\Console\Commands\SeoAgentArticleReleaseCommand;
 use App\Console\Commands\SeoAgentAutoRollbackGuardCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoAgentCmsDraftPayloadRepairCanaryCommand;
@@ -457,6 +458,7 @@ class Kernel extends ConsoleKernel
         SeoAgentArticlePostPublishPropagationDryRunCommand::class,
         SeoAgentArticleDraftClaimRiskQaCommand::class,
         SeoAgentArticleDraftPreviewRuntimeQaCommand::class,
+        SeoAgentArticleReleaseCommand::class,
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,

--- a/backend/tests/Feature/Console/SeoAgentArticleReleaseCommandTest.php
+++ b/backend/tests/Feature/Console/SeoAgentArticleReleaseCommandTest.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class SeoAgentArticleReleaseCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TRANSLATION_GROUP_ID = 'tg_article_career_interest_vs_personality_test_2026v1';
+
+    public function test_package_qa_reports_no_write_importer_evidence(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('seo-agent:article-release', $this->commandOptions($package, [
+            '--stage' => 'package-qa',
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('seo-agent-article-release-gate-report.v1', $payload['schema_version']);
+        $this->assertSame('package-qa', $payload['stage']);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('passed', $payload['status']);
+        $this->assertFalse($payload['write_allowed']);
+        $this->assertFalse($payload['writes_attempted']);
+        $this->assertSame('passed', $payload['stage_report']['importer_plan']['active_surface_guard_scan']['status'] ?? null);
+        $this->assertSame('passed', $payload['stage_report']['importer_plan']['contract_integrity_scan']['status'] ?? null);
+        $this->assertSame(2, $payload['stage_report']['importer_plan']['article_count']);
+        $this->assertContains('no_cms_draft_creation', $payload['negative_guarantees']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_media_readiness_reports_cover_and_body_visual_fields(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('seo-agent:article-release', $this->commandOptions($package, [
+            '--stage' => 'media-readiness',
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('media-readiness', $payload['stage']);
+        $this->assertSame('passed', $payload['status']);
+        $this->assertCount(2, $payload['stage_report']['media_items']);
+        foreach ($payload['stage_report']['media_items'] as $item) {
+            $this->assertSame('article.riasec.explanation.cover.v1', $item['cover_media_asset_key']);
+            $this->assertSame('article.riasec.explanation.body-visual.v1', $item['body_visual_asset_key']);
+            $this->assertSame(
+                'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationbodyvisualv1/hero_1600x900.jpg',
+                $item['body_visual_image_url']
+            );
+        }
+    }
+
+    public function test_cms_draft_dry_run_reports_body_visual_parity(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('seo-agent:article-release', $this->commandOptions($package, [
+            '--stage' => 'cms-draft-dry-run',
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('cms-draft-dry-run', $payload['stage']);
+        $this->assertCount(2, $payload['stage_report']['body_visual_parity']);
+        foreach ($payload['stage_report']['body_visual_parity'] as $item) {
+            $this->assertSame('passed', $item['media_metadata_parity']['status'] ?? null);
+            $this->assertSame('cover_image_variants.editorial_package_v1', $item['media_metadata_parity']['metadata_path'] ?? null);
+        }
+    }
+
+    public function test_preview_qa_blocks_until_draft_preview_candidates_exist(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('seo-agent:article-release', $this->commandOptions($package, [
+            '--stage' => 'preview-qa',
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('blocked_external_draft_required', $payload['status']);
+        $this->assertContains('ops_article_preview_html', $payload['external_evidence_required']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_invalid_stage_is_rejected_before_any_write(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('seo-agent:article-release', $this->commandOptions($package, [
+            '--stage' => 'publish-now',
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('invalid_stage', $payload['errors'][0]['code'] ?? null);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function commandOptions(string $package, array $overrides = []): array
+    {
+        return array_replace([
+            '--package' => $package,
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--locales' => 'zh-CN,en',
+            '--expected-zh-slug' => 'career-interest-vs-personality-test-differences',
+            '--expected-en-slug' => 'career-interest-test-vs-personality-test',
+        ], $overrides);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  callable(array<string,mixed>&):void|null  $mutate
+     */
+    private function writeModeCPackage(?callable $mutate = null): string
+    {
+        $root = sys_get_temp_dir().'/fm-seo-agent-release-package-'.Str::random(12);
+        foreach (['brief', 'pages', 'cms', 'contracts', 'review', 'codex', 'media', 'observation'] as $directory) {
+            mkdir($root.'/'.$directory, 0777, true);
+        }
+
+        $files = $this->modeCFiles();
+        if ($mutate !== null) {
+            $mutate($files);
+        }
+
+        foreach ($files as $relativePath => $contents) {
+            $path = $root.'/'.$relativePath;
+            if (! is_dir(dirname($path))) {
+                mkdir(dirname($path), 0777, true);
+            }
+            file_put_contents(
+                $path,
+                is_array($contents)
+                    ? json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+                    : $contents
+            );
+        }
+
+        return $root;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function modeCFiles(): array
+    {
+        $social = [
+            'media_library_asset_key' => 'article.riasec.explanation.cover.v1',
+            'media_library_status' => 'published',
+            'is_public' => true,
+            'cdn_status' => 'verified',
+            'cover_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/hero_1600x900.jpg',
+            'hero_variant' => [
+                'url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/hero_1600x900.jpg',
+                'width' => 1600,
+                'height' => 900,
+            ],
+            'og_1200x630_variant' => [
+                'url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/og_1200x630.jpg',
+                'width' => 1200,
+                'height' => 630,
+            ],
+            'twitter_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/og_1200x630.jpg',
+            'alt_text' => 'Career exploration notes with a RIASEC structure and decision path diagram',
+            'width' => 1672,
+            'height' => 941,
+        ];
+        $variants = [
+            'hero' => ['url' => $social['hero_variant']['url'], 'width' => 1600, 'height' => 900],
+            'og' => ['url' => $social['og_1200x630_variant']['url'], 'width' => 1200, 'height' => 630],
+        ];
+        $baseFields = [
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'status' => 'draft',
+            'publish_allowed' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'category_name' => '职业决策',
+            'category_slug' => 'career-decision-making',
+            'primary_keyword' => 'career interest test vs personality test',
+            'secondary_keywords' => ['Holland Code vs MBTI', 'career assessment vs personality assessment'],
+            'primary_hub_url' => '/tests/holland-career-interest-test-riasec',
+            'secondary_hub_urls' => ['/tests/mbti-personality-test-16-personality-types', '/tests/big-five-personality-test-ocean-model'],
+            'schema_eligibility' => ['article_schema' => 'review_required', 'faq_schema' => false, 'breadcrumb_schema' => 'review_required'],
+            'cover_media_asset_key' => 'article.riasec.explanation.cover.v1',
+            'cover_image_url' => $social['cover_image_url'],
+            'cover_image_alt' => $social['alt_text'],
+            'cover_image_width' => 1672,
+            'cover_image_height' => 941,
+            'cover_image_variants' => $variants,
+            'body_visual_asset_key' => 'article.riasec.explanation.body-visual.v1',
+            'body_visual_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationbodyvisualv1/hero_1600x900.jpg',
+            'body_visual_fallback_authorized' => false,
+            'og_image_url' => $social['og_1200x630_variant']['url'],
+            'twitter_image_url' => $social['twitter_image_url'],
+            'social_image_metadata' => $social,
+        ];
+
+        return [
+            'manifest.json' => [
+                'package_name' => 'career-interest-test-vs-personality-test',
+                'status' => 'draft_only_not_for_publication',
+                'translation_group_id' => self::TRANSLATION_GROUP_ID,
+                'publish_allowed' => false,
+                'schema_generation_allowed' => false,
+                'hreflang_enablement_allowed' => false,
+                'pages' => [
+                    [
+                        'locale' => 'zh-CN',
+                        'title' => '职业兴趣测试与性格测试的区别：选专业、找工作该先做哪个？',
+                        'slug' => 'career-interest-vs-personality-test-differences',
+                        'canonical_url_draft' => '/zh/articles/career-interest-vs-personality-test-differences',
+                        'meta_title_draft' => '职业兴趣测试与性格测试有什么区别？职业规划指南 | FermatMind',
+                        'meta_description_draft' => '找工作应该测 MBTI 还是霍兰德？本文解释职业兴趣测试与性格测试的区别。',
+                        'file' => 'pages/zh-CN-career-interest-vs-personality-test-differences.md',
+                    ],
+                    [
+                        'locale' => 'en',
+                        'title' => 'Career Interest Test vs Personality Test: Which Should You Take First?',
+                        'slug' => 'career-interest-test-vs-personality-test',
+                        'canonical_url_draft' => '/en/articles/career-interest-test-vs-personality-test',
+                        'meta_title_draft' => 'Career Interest Test vs Personality Test: Which Should You Take?',
+                        'meta_description_draft' => 'Learn how Holland Code, MBTI, and Big Five answer different career exploration questions.',
+                        'file' => 'pages/en-career-interest-test-vs-personality-test.md',
+                    ],
+                ],
+            ],
+            'brief/SEO_BRIEF.md' => "# Brief\n",
+            'pages/zh-CN-career-interest-vs-personality-test-differences.md' => $this->markdownPage('zh-CN', '职业兴趣测试与性格测试的区别：选专业、找工作该先做哪个？', 'career-interest-vs-personality-test-differences', '/zh/articles/career-interest-vs-personality-test-differences'),
+            'pages/en-career-interest-test-vs-personality-test.md' => $this->markdownPage('en', 'Career Interest Test vs Personality Test: Which Should You Take First?', 'career-interest-test-vs-personality-test', '/en/articles/career-interest-test-vs-personality-test'),
+            'cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json' => array_replace($baseFields, [
+                'locale' => 'zh-CN',
+                'title' => '职业兴趣测试与性格测试的区别：选专业、找工作该先做哪个？',
+                'slug' => 'career-interest-vs-personality-test-differences',
+                'canonical_url' => '/zh/articles/career-interest-vs-personality-test-differences',
+                'meta_title' => '职业兴趣测试与性格测试有什么区别？职业规划指南 | FermatMind',
+                'meta_description' => '找工作应该测 MBTI 还是霍兰德？本文解释职业兴趣测试与性格测试的区别。',
+            ]),
+            'cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json' => array_replace($baseFields, [
+                'locale' => 'en',
+                'category_name' => 'Career Decision-Making',
+                'title' => 'Career Interest Test vs Personality Test: Which Should You Take First?',
+                'slug' => 'career-interest-test-vs-personality-test',
+                'canonical_url' => '/en/articles/career-interest-test-vs-personality-test',
+                'meta_title' => 'Career Interest Test vs Personality Test: Which Should You Take?',
+                'meta_description' => 'Learn how Holland Code, MBTI, and Big Five answer different career exploration questions.',
+            ]),
+            'cms/CMS_IMPORT_DRAFT_zh-CN_career-interest-vs-personality-test-differences.json' => array_replace($baseFields, [
+                'locale' => 'zh-CN',
+                'title' => '职业兴趣测试与性格测试的区别：选专业、找工作该先做哪个？',
+                'slug' => 'career-interest-vs-personality-test-differences',
+                'canonical_url' => '/zh/articles/career-interest-vs-personality-test-differences',
+                'meta_title' => '职业兴趣测试与性格测试有什么区别？职业规划指南 | FermatMind',
+                'meta_description' => '找工作应该测 MBTI 还是霍兰德？本文解释职业兴趣测试与性格测试的区别。',
+                'body_markdown_file' => 'pages/zh-CN-career-interest-vs-personality-test-differences.md',
+            ]),
+            'cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json' => array_replace($baseFields, [
+                'locale' => 'en',
+                'category_name' => 'Career Decision-Making',
+                'title' => 'Career Interest Test vs Personality Test: Which Should You Take First?',
+                'slug' => 'career-interest-test-vs-personality-test',
+                'canonical_url' => '/en/articles/career-interest-test-vs-personality-test',
+                'meta_title' => 'Career Interest Test vs Personality Test: Which Should You Take?',
+                'meta_description' => 'Learn how Holland Code, MBTI, and Big Five answer different career exploration questions.',
+                'body_markdown_file' => 'pages/en-career-interest-test-vs-personality-test.md',
+            ]),
+            'contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json' => ['routes' => ['/zh/articles/career-interest-vs-personality-test-differences', '/en/articles/career-interest-test-vs-personality-test']],
+            'contracts/ROUTE_ALIAS_CONTRACT.json' => [
+                'known_alias_autofix_allowed' => true,
+                'unknown_alias_requires_operator_input' => true,
+                'known_aliases' => [
+                    '/tests/big-five-personality-test' => '/tests/big-five-personality-test-ocean-model',
+                ],
+            ],
+            'contracts/SOCIAL_IMAGE_METADATA_REQUIREMENTS.json' => ['asset_key' => 'article.riasec.explanation.cover.v1', 'required' => true],
+            'contracts/DYNAMIC_CTA_CONTRACT.json' => [
+                'primary' => '/tests/holland-career-interest-test-riasec',
+                'secondary' => ['/tests/mbti-personality-test-16-personality-types', '/tests/big-five-personality-test-ocean-model'],
+                'allowed_tracking_params' => ['utm_source', 'utm_medium', 'utm_campaign'],
+                'forbidden_tracking_params' => ['result_id', 'order_id', 'payment_id', 'token', 'score', 'user_id', 'report_id'],
+            ],
+            'contracts/INTERNAL_LINK_PLAN.json' => ['links' => ['/tests/holland-career-interest-test-riasec', '/tests/big-five-personality-test-ocean-model']],
+            'contracts/PRIVATE_URL_GUARD.json' => [
+                'forbidden_paths' => ['/result', '/results', '/orders', '/order', '/share', '/pay', '/payment', '/history', '/take'],
+                'forbidden_query_keys' => ['result_id', 'order_id', 'payment_id', 'token', 'score', 'user_id', 'report_id'],
+            ],
+            'review/claim_gate.md' => "claim_gate_status: not_reviewed\n",
+            'review/operator_review.md' => "operator_review_required: true\n",
+            'codex/qa_checklist.md' => "- no publish\n- no index\n",
+            'media/IMAGE_ASSET_MANIFEST.json' => ['assets' => ['article.riasec.explanation.cover.v1', 'article.riasec.explanation.body-visual.v1']],
+            'observation/D1_D7_D14.md' => "# Observation\n",
+        ];
+    }
+
+    private function markdownPage(string $locale, string $title, string $slug, string $canonical): string
+    {
+        return <<<MD
+---
+translation_group_id: {self::TRANSLATION_GROUP_ID}
+locale: {$locale}
+title: {$title}
+slug: {$slug}
+canonical_url_draft: {$canonical}
+primary_keyword: career interest test vs personality test
+secondary_keywords:
+  - Holland Code vs MBTI
+  - career assessment vs personality assessment
+claim_gate_status: not_reviewed
+publish_allowed: false
+sitemap_eligible: false
+llms_eligible: false
+---
+
+## Quick answer
+
+Start with a career-interest test when the question is direction, then use MBTI and Big Five as supporting lenses.
+
+## CTA
+
+[Start RIASEC](/tests/holland-career-interest-test-riasec)
+[Use Big Five](/tests/big-five-personality-test-ocean-model)
+
+## FAQ
+
+### Can a test decide my career?
+
+No. It is only one input.
+MD;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1662,6 +1662,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_article_release_orchestrator_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentArticleReleaseCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentArticleReleaseCommand;',
+            '+        SeoAgentArticleReleaseCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_weekly_readonly_runner_files(): void
     {
         $changed = [
@@ -5100,6 +5114,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentArticleReleaseOrchestratorFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentWeeklyReadonlyRunnerFile($file)) {
                 continue;
             }
@@ -5988,6 +6006,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRunOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentArticleReleaseOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentWeeklyReadonlyRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentWeeklyDraftWriteAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsPublishCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6889,6 +6908,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentRunCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentArticleReleaseOrchestratorFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentArticleReleaseCommand.php',
         ], true);
     }
 
@@ -9363,6 +9389,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentRunCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentArticleReleaseOrchestratorOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentArticleReleaseCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:article-release`, a no-write staged gate reporter for Mode C article release operations.
- Registered the command explicitly in the console kernel.
- Added focused console tests for package QA, media readiness, CMS draft dry-run body visual parity, preview QA blocking, and invalid stage rejection.

## Why
This gives SEO article operations one consistent command surface for stage reports instead of hand-rolled tinker/curl/jq command chains.

## Validation
- `./vendor/bin/pint app/Console/Commands/SeoAgentArticleReleaseCommand.php app/Console/Kernel.php tests/Feature/Console/SeoAgentArticleReleaseCommandTest.php`
- `php artisan test --filter=SeoAgentArticleReleaseCommandTest`
- `php artisan route:list`
- `php artisan migrate --pretend`
- `php artisan list | rg seo-agent:article-release`
- `git diff --check`
- `git diff --cached --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No CMS draft creation, CMS publish, indexability, sitemap, llms, schema, hreflang, search submission, revalidation, or deploy.
- No replacement of existing publish/search commands.
- Preview QA remains evidence/report oriented; actual operator approval and controlled writes still require separate exact authorization.