### PR TITLE
fix(pdf): log normalized Gotenberg result export fields

### DIFF
--- a/backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php
+++ b/backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php
@@ -55,8 +55,7 @@ final class GotenbergChromiumPdfClient
     public function convertUrl(string $printUrl, array $options = [], ?string $gotenbergTrace = null): string
     {
         $baseUrl = $this->validatedBaseUrl();
-        $this->assertPrivateHttpUrl($printUrl, 'print URL');
-        $payloadOptions = $this->normalizeOptions(['url' => $printUrl, ...$options]);
+        $payloadOptions = $this->normalizedUrlFormFieldsForDiagnostics($printUrl, $options);
 
         $request = Http::connectTimeout((int) config('gotenberg.connect_timeout_seconds', 5))
             ->timeout((int) config('gotenberg.timeout_seconds', 60))
@@ -80,6 +79,17 @@ final class GotenbergChromiumPdfClient
         }
 
         return $body;
+    }
+
+    /**
+     * @param  array<string,string|int|float|bool|null>  $options
+     * @return array<string,string>
+     */
+    public function normalizedUrlFormFieldsForDiagnostics(string $printUrl, array $options = []): array
+    {
+        $this->assertPrivateHttpUrl($printUrl, 'print URL');
+
+        return $this->normalizeOptions(['url' => $printUrl, ...$options]);
     }
 
     public function assertPrivateHttpUrl(string $url, string $label = 'URL'): void

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -651,7 +651,8 @@ final class ReportPdfDocumentService
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
         ];
 
-        $this->logMbtiResultPageGotenbergRequest($attempt, $printUrl, $options, $traceId);
+        $wireFormFields = $this->gotenbergChromiumPdfClient->normalizedUrlFormFieldsForDiagnostics($printUrl, $options);
+        $this->logMbtiResultPageGotenbergRequest($attempt, $printUrl, $wireFormFields, $traceId);
 
         try {
             return $this->gotenbergChromiumPdfClient->convertUrl($printUrl, $options, $traceId);
@@ -678,9 +679,9 @@ final class ReportPdfDocumentService
     }
 
     /**
-     * @param  array<string,string|int|float|bool|null>  $options
+     * @param  array<string,string>  $wireFormFields
      */
-    private function logMbtiResultPageGotenbergRequest(Attempt $attempt, string $printUrl, array $options, string $traceId): void
+    private function logMbtiResultPageGotenbergRequest(Attempt $attempt, string $printUrl, array $wireFormFields, string $traceId): void
     {
         $parts = parse_url($printUrl) ?: [];
 
@@ -691,15 +692,15 @@ final class ReportPdfDocumentService
             'engine' => self::RESULT_PAGE_EXPORT_ENGINE,
             'print_url_host' => (string) ($parts['host'] ?? ''),
             'print_url_path' => (string) ($parts['path'] ?? ''),
-            'wait_for_expression' => (string) ($options['waitForExpression'] ?? ''),
-            'wait_for_selector' => (string) ($options['waitForSelector'] ?? ''),
-            'wait_delay' => (string) ($options['waitDelay'] ?? ''),
-            'skip_network_idle_event' => $options['skipNetworkIdleEvent'] ?? null,
-            'skip_network_almost_idle_event' => $options['skipNetworkAlmostIdleEvent'] ?? null,
-            'fail_on_http_status_codes' => (string) ($options['failOnHttpStatusCodes'] ?? ''),
-            'print_background' => $options['printBackground'] ?? null,
-            'prefer_css_page_size' => $options['preferCssPageSize'] ?? null,
-            'emulated_media_type' => (string) ($options['emulatedMediaType'] ?? ''),
+            'wait_for_expression' => (string) ($wireFormFields['waitForExpression'] ?? ''),
+            'wait_for_selector' => (string) ($wireFormFields['waitForSelector'] ?? ''),
+            'wait_delay' => (string) ($wireFormFields['waitDelay'] ?? ''),
+            'skip_network_idle_event' => (string) ($wireFormFields['skipNetworkIdleEvent'] ?? ''),
+            'skip_network_almost_idle_event' => (string) ($wireFormFields['skipNetworkAlmostIdleEvent'] ?? ''),
+            'fail_on_http_status_codes' => (string) ($wireFormFields['failOnHttpStatusCodes'] ?? ''),
+            'print_background' => (string) ($wireFormFields['printBackground'] ?? ''),
+            'prefer_css_page_size' => (string) ($wireFormFields['preferCssPageSize'] ?? ''),
+            'emulated_media_type' => (string) ($wireFormFields['emulatedMediaType'] ?? ''),
             'client_timeout_seconds' => (int) config('gotenberg.timeout_seconds', 60),
             'gotenberg_trace' => $traceId,
         ]);


### PR DESCRIPTION
## What changed
- Normalize the exact Gotenberg URL-conversion form fields before both logging and sending the request.
- Log result-page export diagnostics from the normalized wire payload so skipNetworkIdleEvent, skipNetworkAlmostIdleEvent, failOnHttpStatusCodes, print settings, timeout, and trace reflect the actual request values.

## Why
Production PDF failures need runtime evidence of the real multipart payload, not inferred option values. This keeps the result-page export on the Gotenberg Chromium path and preserves the existing API route and response contract.

## Validation
- php artisan test --filter=AttemptPublicReportPdfParityTest --no-ansi
- ./vendor/bin/pint --dirty --no-interaction
- git diff --check

## Deferred
- No production deploy.
- No frontend changes in this PR.
- No CMS, DB, queue, search, indexing, or mPDF template changes.