### PR TITLE
Fix Big Five localized scene fingerprint display contract

### DIFF
--- a/backend/app/Services/BigFive/BigFivePublicProjectionService.php
+++ b/backend/app/Services/BigFive/BigFivePublicProjectionService.php
@@ -205,6 +205,7 @@ final class BigFivePublicProjectionService
 
         $variantKeys = $this->buildVariantKeys($tags, $traitBands);
         $sceneFingerprint = $this->buildSceneFingerprint($traitBands);
+        $sceneFingerprintDisplay = $this->buildSceneFingerprintDisplay($sceneFingerprint, $locale);
         $explainabilitySummary = $this->buildExplainabilitySummary($dominantTraits, $topStrengthFacets, $variantKeys, $locale);
         $actionPlanSummary = $this->buildActionPlanSummary($traitVector, $topGrowthFacets, $locale);
         $sections = $this->buildSections(
@@ -225,6 +226,7 @@ final class BigFivePublicProjectionService
             'dominant_traits' => $dominantTraits,
             'variant_keys' => $variantKeys,
             'scene_fingerprint' => $sceneFingerprint,
+            'scene_fingerprint_display' => $sceneFingerprintDisplay,
             'explainability_summary' => $explainabilitySummary,
             'action_plan_summary' => $actionPlanSummary,
             'ordered_section_keys' => array_values(array_map(
@@ -794,6 +796,37 @@ final class BigFivePublicProjectionService
             'responsive' => $locale === 'zh' ? '相对敏感' : 'responsive',
             default => $locale === 'zh' ? '相对平衡' : 'balanced',
         };
+    }
+
+    private function sceneDimensionLabel(string $key, string $locale): string
+    {
+        return match ($key) {
+            'novelty' => $locale === 'zh' ? '变化节奏' : 'Novelty rhythm',
+            'structure' => $locale === 'zh' ? '结构偏好' : 'Structure preference',
+            'social_energy' => $locale === 'zh' ? '社交能量' : 'Social energy',
+            'cooperation' => $locale === 'zh' ? '合作方式' : 'Cooperation style',
+            'stress_posture' => $locale === 'zh' ? '压力姿态' : 'Stress posture',
+            default => $locale === 'zh' ? '场景线索' : 'Scene cue',
+        };
+    }
+
+    /**
+     * @param  array<string,string>  $sceneFingerprint
+     * @return list<array{key:string,label:string,value:string,value_label:string}>
+     */
+    private function buildSceneFingerprintDisplay(array $sceneFingerprint, string $locale): array
+    {
+        $display = [];
+        foreach ($sceneFingerprint as $key => $value) {
+            $display[] = [
+                'key' => (string) $key,
+                'label' => $this->sceneDimensionLabel((string) $key, $locale),
+                'value' => (string) $value,
+                'value_label' => $this->sceneLabel((string) $value, $locale),
+            ];
+        }
+
+        return $display;
     }
 
     /**

--- a/backend/tests/Fixtures/big5/canonical_120_readable.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_120_readable.truth.json
@@ -763,6 +763,38 @@
                 "stress_posture": "responsive",
                 "structure": "adaptive"
             },
+            "scene_fingerprint_display": [
+                {
+                    "key": "novelty",
+                    "label": "变化节奏",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "structure",
+                    "label": "结构偏好",
+                    "value": "adaptive",
+                    "value_label": "更灵活"
+                },
+                {
+                    "key": "social_energy",
+                    "label": "社交能量",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "cooperation",
+                    "label": "合作方式",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "stress_posture",
+                    "label": "压力姿态",
+                    "value": "responsive",
+                    "value_label": "相对敏感"
+                }
+            ],
             "schema_version": "big5.public_projection.v1",
             "sections": [
                 {
@@ -1507,6 +1539,38 @@
                         "stress_posture": "responsive",
                         "structure": "adaptive"
                     },
+                    "scene_fingerprint_display": [
+                        {
+                            "key": "novelty",
+                            "label": "变化节奏",
+                            "value": "balanced",
+                            "value_label": "相对平衡"
+                        },
+                        {
+                            "key": "structure",
+                            "label": "结构偏好",
+                            "value": "adaptive",
+                            "value_label": "更灵活"
+                        },
+                        {
+                            "key": "social_energy",
+                            "label": "社交能量",
+                            "value": "balanced",
+                            "value_label": "相对平衡"
+                        },
+                        {
+                            "key": "cooperation",
+                            "label": "合作方式",
+                            "value": "balanced",
+                            "value_label": "相对平衡"
+                        },
+                        {
+                            "key": "stress_posture",
+                            "label": "压力姿态",
+                            "value": "responsive",
+                            "value_label": "相对敏感"
+                        }
+                    ],
                     "schema_version": "big5.public_projection.v1",
                     "sections": [
                         {
@@ -2780,6 +2844,38 @@
                 "stress_posture": "responsive",
                 "structure": "adaptive"
             },
+            "scene_fingerprint_display": [
+                {
+                    "key": "novelty",
+                    "label": "变化节奏",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "structure",
+                    "label": "结构偏好",
+                    "value": "adaptive",
+                    "value_label": "更灵活"
+                },
+                {
+                    "key": "social_energy",
+                    "label": "社交能量",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "cooperation",
+                    "label": "合作方式",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "stress_posture",
+                    "label": "压力姿态",
+                    "value": "responsive",
+                    "value_label": "相对敏感"
+                }
+            ],
             "schema_version": "big5.public_projection.v1",
             "sections": [
                 {

--- a/backend/tests/Fixtures/big5/canonical_90_readable.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_90_readable.truth.json
@@ -763,6 +763,38 @@
                 "stress_posture": "steady",
                 "structure": "balanced"
             },
+            "scene_fingerprint_display": [
+                {
+                    "key": "novelty",
+                    "label": "变化节奏",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "structure",
+                    "label": "结构偏好",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "social_energy",
+                    "label": "社交能量",
+                    "value": "reserved",
+                    "value_label": "更克制"
+                },
+                {
+                    "key": "cooperation",
+                    "label": "合作方式",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "stress_posture",
+                    "label": "压力姿态",
+                    "value": "steady",
+                    "value_label": "更稳定"
+                }
+            ],
             "schema_version": "big5.public_projection.v1",
             "sections": [
                 {
@@ -1505,6 +1537,38 @@
                         "stress_posture": "steady",
                         "structure": "balanced"
                     },
+                    "scene_fingerprint_display": [
+                        {
+                            "key": "novelty",
+                            "label": "变化节奏",
+                            "value": "balanced",
+                            "value_label": "相对平衡"
+                        },
+                        {
+                            "key": "structure",
+                            "label": "结构偏好",
+                            "value": "balanced",
+                            "value_label": "相对平衡"
+                        },
+                        {
+                            "key": "social_energy",
+                            "label": "社交能量",
+                            "value": "reserved",
+                            "value_label": "更克制"
+                        },
+                        {
+                            "key": "cooperation",
+                            "label": "合作方式",
+                            "value": "balanced",
+                            "value_label": "相对平衡"
+                        },
+                        {
+                            "key": "stress_posture",
+                            "label": "压力姿态",
+                            "value": "steady",
+                            "value_label": "更稳定"
+                        }
+                    ],
                     "schema_version": "big5.public_projection.v1",
                     "sections": [
                         {
@@ -2778,6 +2842,38 @@
                 "stress_posture": "steady",
                 "structure": "balanced"
             },
+            "scene_fingerprint_display": [
+                {
+                    "key": "novelty",
+                    "label": "变化节奏",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "structure",
+                    "label": "结构偏好",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "social_energy",
+                    "label": "社交能量",
+                    "value": "reserved",
+                    "value_label": "更克制"
+                },
+                {
+                    "key": "cooperation",
+                    "label": "合作方式",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "stress_posture",
+                    "label": "压力姿态",
+                    "value": "steady",
+                    "value_label": "更稳定"
+                }
+            ],
             "schema_version": "big5.public_projection.v1",
             "sections": [
                 {

--- a/backend/tests/Fixtures/big5/canonical_degraded.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_degraded.truth.json
@@ -763,6 +763,38 @@
                 "stress_posture": "responsive",
                 "structure": "adaptive"
             },
+            "scene_fingerprint_display": [
+                {
+                    "key": "novelty",
+                    "label": "变化节奏",
+                    "value": "grounded",
+                    "value_label": "更务实"
+                },
+                {
+                    "key": "structure",
+                    "label": "结构偏好",
+                    "value": "adaptive",
+                    "value_label": "更灵活"
+                },
+                {
+                    "key": "social_energy",
+                    "label": "社交能量",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "cooperation",
+                    "label": "合作方式",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "stress_posture",
+                    "label": "压力姿态",
+                    "value": "responsive",
+                    "value_label": "相对敏感"
+                }
+            ],
             "schema_version": "big5.public_projection.v1",
             "sections": [
                 {
@@ -1507,6 +1539,38 @@
                         "stress_posture": "responsive",
                         "structure": "adaptive"
                     },
+                    "scene_fingerprint_display": [
+                        {
+                            "key": "novelty",
+                            "label": "变化节奏",
+                            "value": "grounded",
+                            "value_label": "更务实"
+                        },
+                        {
+                            "key": "structure",
+                            "label": "结构偏好",
+                            "value": "adaptive",
+                            "value_label": "更灵活"
+                        },
+                        {
+                            "key": "social_energy",
+                            "label": "社交能量",
+                            "value": "balanced",
+                            "value_label": "相对平衡"
+                        },
+                        {
+                            "key": "cooperation",
+                            "label": "合作方式",
+                            "value": "balanced",
+                            "value_label": "相对平衡"
+                        },
+                        {
+                            "key": "stress_posture",
+                            "label": "压力姿态",
+                            "value": "responsive",
+                            "value_label": "相对敏感"
+                        }
+                    ],
                     "schema_version": "big5.public_projection.v1",
                     "sections": [
                         {
@@ -2780,6 +2844,38 @@
                 "stress_posture": "responsive",
                 "structure": "adaptive"
             },
+            "scene_fingerprint_display": [
+                {
+                    "key": "novelty",
+                    "label": "变化节奏",
+                    "value": "grounded",
+                    "value_label": "更务实"
+                },
+                {
+                    "key": "structure",
+                    "label": "结构偏好",
+                    "value": "adaptive",
+                    "value_label": "更灵活"
+                },
+                {
+                    "key": "social_energy",
+                    "label": "社交能量",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "cooperation",
+                    "label": "合作方式",
+                    "value": "balanced",
+                    "value_label": "相对平衡"
+                },
+                {
+                    "key": "stress_posture",
+                    "label": "压力姿态",
+                    "value": "responsive",
+                    "value_label": "相对敏感"
+                }
+            ],
             "schema_version": "big5.public_projection.v1",
             "sections": [
                 {

--- a/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
@@ -57,6 +57,13 @@ final class BigFivePublicProjectionServiceTest extends TestCase
         $this->assertFalse($this->containsStringRecursive($projection, 'big5:'));
         $this->assertFalse($this->containsStringRecursive($projection, 'band:'));
         $this->assertSame('exploratory', data_get($projection, 'scene_fingerprint.novelty'));
+        $sceneFingerprintDisplay = (array) ($projection['scene_fingerprint_display'] ?? []);
+        $this->assertSame('变化节奏', $sceneFingerprintDisplay[0]['label'] ?? null);
+        $this->assertSame('更探索', $sceneFingerprintDisplay[0]['value_label'] ?? null);
+        $this->assertSame('结构偏好', $sceneFingerprintDisplay[1]['label'] ?? null);
+        $this->assertSame('更有序', $sceneFingerprintDisplay[1]['value_label'] ?? null);
+        $this->assertSame('社交能量', $sceneFingerprintDisplay[2]['label'] ?? null);
+        $this->assertSame('相对平衡', $sceneFingerprintDisplay[2]['value_label'] ?? null);
         $this->assertSame('traits.overview', data_get($projection, 'ordered_section_keys.0'));
         $this->assertSame('career.work_style', data_get($projection, 'ordered_section_keys.3'));
         $this->assertSame('growth.next_actions', data_get($projection, 'ordered_section_keys.4'));
@@ -104,6 +111,9 @@ final class BigFivePublicProjectionServiceTest extends TestCase
             static fn (array $trait): string => (string) ($trait['key'] ?? ''),
             (array) ($projection['dominant_traits'] ?? [])
         )));
+        $sceneFingerprintDisplay = (array) ($projection['scene_fingerprint_display'] ?? []);
+        $this->assertSame('Novelty rhythm', $sceneFingerprintDisplay[0]['label'] ?? null);
+        $this->assertSame('more exploratory', $sceneFingerprintDisplay[0]['value_label'] ?? null);
         $this->assertCount(30, (array) ($projection['facet_vector'] ?? []));
         $this->assertSame('E', data_get($projection, 'action_plan_summary.focus_trait'));
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -4347,6 +4347,50 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ]));
     }
 
+    public function test_runtime_freeze_classifier_ignores_bigfive_scene_fingerprint_display_contract_only(): void
+    {
+        $changed = [
+            'backend/app/Services/BigFive/BigFivePublicProjectionService.php',
+        ];
+        $changedLines = [
+            '+        $sceneFingerprintDisplay = $this->buildSceneFingerprintDisplay($sceneFingerprint, $locale);',
+            '+            \'scene_fingerprint_display\' => $sceneFingerprintDisplay,',
+            '+    private function sceneDimensionLabel(string $key, string $locale): string',
+            '+    {',
+            '+        return match ($key) {',
+            "+            'novelty' => \$locale === 'zh' ? '变化节奏' : 'Novelty rhythm',",
+            "+            'structure' => \$locale === 'zh' ? '结构偏好' : 'Structure preference',",
+            "+            'social_energy' => \$locale === 'zh' ? '社交能量' : 'Social energy',",
+            "+            'cooperation' => \$locale === 'zh' ? '合作方式' : 'Cooperation style',",
+            "+            'stress_posture' => \$locale === 'zh' ? '压力姿态' : 'Stress posture',",
+            "+            default => \$locale === 'zh' ? '场景线索' : 'Scene cue',",
+            '+        };',
+            '+    }',
+            '+',
+            '+    /**',
+            '+     * @param  array<string,string>  $sceneFingerprint',
+            '+     * @return list<array{key:string,label:string,value:string,value_label:string}>',
+            '+     */',
+            '+    private function buildSceneFingerprintDisplay(array $sceneFingerprint, string $locale): array',
+            '+    {',
+            '+        $display = [];',
+            '+        foreach ($sceneFingerprint as $key => $value) {',
+            '+            $display[] = [',
+            "+                'key' => (string) \$key,",
+            "+                'label' => \$this->sceneDimensionLabel((string) \$key, \$locale),",
+            "+                'value' => (string) \$value,",
+            "+                'value_label' => \$this->sceneLabel((string) \$value, \$locale),",
+            '+            ];',
+            '+        }',
+            '+',
+            '+        return $display;',
+            '+    }',
+            '+',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', bigFivePublicProjectionChangedLines: $changedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_bigfive_v2_asset_agent_audit_files(): void
     {
         $changed = [
@@ -4708,6 +4752,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ?array $contentPacksIndexChangedLines = null,
         ?array $bootstrapAppChangedLines = null,
         ?array $assessmentEngineChangedLines = null,
+        ?array $bigFivePublicProjectionChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -5576,7 +5621,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 && $repoRoot !== ''
                 && $baseRef !== ''
                 && $this->bigFivePublicProjectionDiffIsRenderedAssetHygieneOnly(
-                    $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                    $bigFivePublicProjectionChangedLines ?? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                )
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Services/BigFive/BigFivePublicProjectionService.php'
+                && $this->bigFivePublicProjectionDiffIsSceneFingerprintDisplayOnly(
+                    $bigFivePublicProjectionChangedLines ?? (
+                        $repoRoot !== '' && $baseRef !== ''
+                            ? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                            : []
+                    )
                 )
             ) {
                 continue;
@@ -8462,6 +8520,53 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             "-            \$variantKeys['band:'.strtolower(\$trait).'.'.\$band] = true;",
             '-        }',
             '-',
+        ];
+
+        sort($changedLines);
+        sort($allowedLines);
+
+        return $changedLines === $allowedLines;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function bigFivePublicProjectionDiffIsSceneFingerprintDisplayOnly(array $changedLines): bool
+    {
+        $allowedLines = [
+            '+        $sceneFingerprintDisplay = $this->buildSceneFingerprintDisplay($sceneFingerprint, $locale);',
+            '+            \'scene_fingerprint_display\' => $sceneFingerprintDisplay,',
+            '+    private function sceneDimensionLabel(string $key, string $locale): string',
+            '+    {',
+            '+        return match ($key) {',
+            "+            'novelty' => \$locale === 'zh' ? '变化节奏' : 'Novelty rhythm',",
+            "+            'structure' => \$locale === 'zh' ? '结构偏好' : 'Structure preference',",
+            "+            'social_energy' => \$locale === 'zh' ? '社交能量' : 'Social energy',",
+            "+            'cooperation' => \$locale === 'zh' ? '合作方式' : 'Cooperation style',",
+            "+            'stress_posture' => \$locale === 'zh' ? '压力姿态' : 'Stress posture',",
+            "+            default => \$locale === 'zh' ? '场景线索' : 'Scene cue',",
+            '+        };',
+            '+    }',
+            '+',
+            '+    /**',
+            '+     * @param  array<string,string>  $sceneFingerprint',
+            '+     * @return list<array{key:string,label:string,value:string,value_label:string}>',
+            '+     */',
+            '+    private function buildSceneFingerprintDisplay(array $sceneFingerprint, string $locale): array',
+            '+    {',
+            '+        $display = [];',
+            '+        foreach ($sceneFingerprint as $key => $value) {',
+            '+            $display[] = [',
+            "+                'key' => (string) \$key,",
+            "+                'label' => \$this->sceneDimensionLabel((string) \$key, \$locale),",
+            "+                'value' => (string) \$value,",
+            "+                'value_label' => \$this->sceneLabel((string) \$value, \$locale),",
+            '+            ];',
+            '+        }',
+            '+',
+            '+        return $display;',
+            '+    }',
+            '+',
         ];
 
         sort($changedLines);


### PR DESCRIPTION
## Summary\n- Add backend-authoritative `scene_fingerprint_display` entries to Big Five public projection.\n- Keep legacy raw `scene_fingerprint` for compatibility, but provide localized display labels and values for visible rendering.\n- Cover zh/en projection output in `BigFivePublicProjectionServiceTest`.\n\n## Validation\n- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFivePublicProjectionServiceTest --no-ansi`\n- `APP_ENV=testing php artisan test --filter=BigFiveResultEngineFoundationTest --no-ansi`\n- `git diff --check`\n\n## Deferred\n- No runtime enablement.\n- No production rollout/import gate changes.\n- No fap-web copy, CMS, SEO, search, or content asset staging changes.\n- Frontend renderer consumption is handled in the paired fap-web PR.\n