### PR TITLE
SECURITY-103-API-01: harden MBTI result/PDF token entitlement gates

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -891,7 +891,8 @@ class AttemptReadController extends Controller
         $orgId = $this->currentOrgContext()->orgId();
         $attempt = $this->resolveAttemptForAccessRead($request, $orgId, $id);
         $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
-        $hasResultPagePdfTokenAccess = $this->resolveAttemptForResultPagePdfToken($request, $orgId, (string) $attempt->id) instanceof Attempt;
+        $resultPagePdfTokenGrant = $this->resultPagePdfTokenGrantForRequest($request, $orgId, (string) $attempt->id);
+        $hasResultPagePdfTokenAccess = is_array($resultPagePdfTokenGrant);
         $submissionPayload = $this->latestReadableSubmission($request, (string) $attempt->id);
         $resultExists = Result::query()
             ->where('org_id', $orgId)
@@ -1016,18 +1017,23 @@ class AttemptReadController extends Controller
             );
         }
         if ($hasResultPagePdfTokenAccess && $scaleCode === 'MBTI' && $resultExists) {
-            $accessState = 'ready';
+            $tokenVariant = ReportAccess::normalizeVariant((string) ($resultPagePdfTokenGrant['variant'] ?? ReportAccess::VARIANT_FREE));
+            $tokenEntitlement = strtolower(trim((string) ($resultPagePdfTokenGrant['entitlement'] ?? 'locked')));
+            $tokenGrantsFullAccess = $tokenEntitlement === 'unlocked' && $tokenVariant === ReportAccess::VARIANT_FULL;
+            $accessState = $tokenGrantsFullAccess ? 'ready' : 'locked';
             $reportState = 'ready';
-            $pdfState = 'ready';
-            $reasonCode = 'result_page_pdf_token';
+            $pdfState = $tokenGrantsFullAccess ? 'ready' : 'missing';
+            $reasonCode = $tokenGrantsFullAccess ? 'result_page_pdf_token' : 'result_page_pdf_token_locked';
             $payloadJson = array_merge($payloadJson, [
-                'access_level' => ReportAccess::REPORT_ACCESS_FULL,
-                'variant' => ReportAccess::VARIANT_FULL,
-                'unlock_stage' => ReportAccess::UNLOCK_STAGE_FULL,
+                'locked' => ! $tokenGrantsFullAccess,
+                'access_level' => $tokenGrantsFullAccess ? ReportAccess::REPORT_ACCESS_FULL : ReportAccess::REPORT_ACCESS_FREE,
+                'variant' => $tokenGrantsFullAccess ? ReportAccess::VARIANT_FULL : ReportAccess::VARIANT_FREE,
+                'unlock_stage' => $tokenGrantsFullAccess ? ReportAccess::UNLOCK_STAGE_FULL : ReportAccess::UNLOCK_STAGE_LOCKED,
                 'unlock_source' => ReportAccess::UNLOCK_SOURCE_NONE,
                 'access_source' => 'result_page_pdf_export_token',
-                'paywall_suppressed' => true,
+                'paywall_suppressed' => $tokenGrantsFullAccess,
                 'result_page_pdf_export' => true,
+                'result_page_pdf_token_entitlement' => $tokenGrantsFullAccess ? 'unlocked' : 'locked',
             ]);
         }
 
@@ -2506,12 +2512,7 @@ class AttemptReadController extends Controller
 
     private function resolveAttemptForResultPagePdfToken(Request $request, int $orgId, string $attemptId): ?Attempt
     {
-        $token = $this->resultAccessTokenCandidate($request);
-        if ($token === '') {
-            return null;
-        }
-
-        $grant = $this->resultPagePdfTokenService->verifyMbtiResultPageExport($token, $orgId, $attemptId);
+        $grant = $this->resultPagePdfTokenGrantForRequest($request, $orgId, $attemptId);
         if (! is_array($grant)) {
             return null;
         }
@@ -2530,6 +2531,21 @@ class AttemptReadController extends Controller
         }
 
         return $attempt;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function resultPagePdfTokenGrantForRequest(Request $request, int $orgId, string $attemptId): ?array
+    {
+        $token = $this->resultAccessTokenCandidate($request);
+        if ($token === '') {
+            return null;
+        }
+
+        $grant = $this->resultPagePdfTokenService->verifyMbtiResultPageExport($token, $orgId, $attemptId);
+
+        return is_array($grant) ? $grant : null;
     }
 
     private function resultAccessTokenCandidate(Request $request): string

--- a/backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php
+++ b/backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php
@@ -16,6 +16,7 @@ final class ResultPagePdfTokenService
         $payload = [
             'v' => 1,
             'typ' => 'mbti_result_page_pdf',
+            'org_id' => (int) ($attempt->org_id ?? 0),
             'attempt_id' => (string) $attempt->id,
             'user_id' => (string) ($attempt->user_id ?? ''),
             'owner_id' => (string) (($attempt->user_id ?? null) ?: ($attempt->anon_id ?? '')),
@@ -60,6 +61,7 @@ final class ResultPagePdfTokenService
         if (
             (int) ($payload['v'] ?? 0) !== 1
             || (string) ($payload['typ'] ?? '') !== 'mbti_result_page_pdf'
+            || (int) ($payload['org_id'] ?? $orgId) !== max(0, $orgId)
             || (string) ($payload['attempt_id'] ?? '') !== $attemptId
             || (string) ($payload['surface'] ?? '') !== ReportPdfDocumentService::MBTI_RESULT_PAGE_EXPORT_SURFACE_VERSION
             || (string) ($payload['engine'] ?? '') !== ReportPdfDocumentService::RESULT_PAGE_EXPORT_ENGINE
@@ -76,6 +78,37 @@ final class ResultPagePdfTokenService
         if (! $attempt instanceof Attempt || strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== 'MBTI') {
             return null;
         }
+
+        $payloadUserId = trim((string) ($payload['user_id'] ?? ''));
+        $currentUserId = trim((string) ($attempt->user_id ?? ''));
+        if (! hash_equals($currentUserId, $payloadUserId)) {
+            return null;
+        }
+
+        $payloadOwnerId = trim((string) ($payload['owner_id'] ?? ''));
+        $currentOwnerId = $currentUserId !== ''
+            ? $currentUserId
+            : trim((string) ($attempt->anon_id ?? ''));
+        if ($payloadOwnerId === '' || $currentOwnerId === '' || ! hash_equals($currentOwnerId, $payloadOwnerId)) {
+            return null;
+        }
+
+        $entitlement = strtolower(trim((string) ($payload['entitlement'] ?? '')));
+        $variant = $this->normalizeVariant((string) ($payload['variant'] ?? 'free'));
+        if (! in_array($entitlement, ['locked', 'unlocked'], true)) {
+            return null;
+        }
+
+        if ($entitlement === 'unlocked' && $variant !== 'full') {
+            return null;
+        }
+
+        if ($entitlement === 'locked' && $variant !== 'free') {
+            return null;
+        }
+
+        $payload['entitlement'] = $entitlement;
+        $payload['variant'] = $variant;
 
         return $payload;
     }

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -406,6 +406,90 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $wrongAttemptAccess->assertStatus(404);
     }
 
+    public function test_mbti_result_page_pdf_locked_token_does_not_promote_report_access_to_full(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+        config()->set('gotenberg.result_print_token_secret', 'test-result-print-secret');
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_pdf_print_locked_token');
+        $this->createResult($attemptId);
+
+        DB::table('unified_access_projections')->insert([
+            'attempt_id' => $attemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'entitlement_granted',
+            'projection_version' => 1,
+            'actions_json' => json_encode(['report' => true, 'pdf' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_json' => json_encode([
+                'access_level' => 'full',
+                'variant' => 'full',
+                'unlock_stage' => 'full',
+                'has_active_grant' => true,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'produced_at' => now(),
+            'refreshed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $attempt = Attempt::query()->where('id', $attemptId)->firstOrFail();
+        $token = app(ResultPagePdfTokenService::class)->issueForMbtiResultPageExport($attempt, [
+            'locked' => true,
+            'variant' => 'free',
+        ], 'zh');
+
+        $response = $this->withHeaders([
+            'X-Result-Access-Token' => $token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access?locale=zh-CN");
+
+        $response->assertOk()
+            ->assertJsonPath('access_state', 'locked')
+            ->assertJsonPath('report_state', 'ready')
+            ->assertJsonPath('pdf_state', 'missing')
+            ->assertJsonPath('reason_code', 'result_page_pdf_token_locked')
+            ->assertJsonPath('actions.page_href', "/result/{$attemptId}")
+            ->assertJsonPath('actions.pdf_href', null)
+            ->assertJsonPath('access_source', 'result_page_pdf_export_token')
+            ->assertJsonPath('paywall_suppressed', false)
+            ->assertJsonPath('payload.locked', true)
+            ->assertJsonPath('payload.access_level', 'free')
+            ->assertJsonPath('payload.variant', 'free')
+            ->assertJsonPath('payload.unlock_stage', 'locked')
+            ->assertJsonPath('payload.result_page_pdf_export', true)
+            ->assertJsonPath('payload.result_page_pdf_token_entitlement', 'locked');
+    }
+
+    public function test_mbti_result_page_pdf_token_is_rejected_after_attempt_owner_changes(): void
+    {
+        $this->seedScales();
+        config()->set('gotenberg.result_print_token_secret', 'test-result-print-secret');
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_pdf_print_original_owner');
+        $this->createResult($attemptId);
+
+        $attempt = Attempt::query()->where('id', $attemptId)->firstOrFail();
+        $token = app(ResultPagePdfTokenService::class)->issueForMbtiResultPageExport($attempt, [
+            'locked' => false,
+            'variant' => 'full',
+        ], 'zh');
+
+        Attempt::query()
+            ->where('id', $attemptId)
+            ->update(['anon_id' => 'anon_pdf_print_new_owner']);
+
+        $response = $this->withHeaders([
+            'X-Result-Access-Token' => $token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access?locale=zh-CN");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
+    }
+
     public function test_public_mbti_result_page_pdf_does_not_fallback_to_mpdf_when_gotenberg_fails(): void
     {
         $this->seedScales();

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65392,5 +65392,498 @@
         "note": "Inspected failed GitHub verify-bigfive job, moved IqBetaStandardScore into Assessment scope, updated BigFive runtime freeze classifier for the IQ-only helper, and reran focused IQ tests, focused BigFive freeze tests, PHP lint, scoped Pint, route invariant, ci_verify_mbti, metadata parse, and diff check successfully. Generated BIG5 compiled artifacts from ci_verify_mbti were restored before staging."
       }
     ]
+  },
+  "SECURITY-103-API-01": {
+    "id": "SECURITY-103-API-01",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-01-entitlement-gates",
+    "title": "SECURITY-103-API-01: harden MBTI result/PDF token entitlement gates",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": [],
+    "status": "local_checks_passed",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding/updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for SECURITY-103-API-01 through SECURITY-103-API-12 and executing them sequentially."
+      },
+      "base_sync": {
+        "status": "pass",
+        "evidence": "Started isolated worktree from origin/main 69e28b1db607d2296f1698e5301bbe7e600226a2 and git pull --ff-only origin main reported already up to date."
+      },
+      "focused_mbti_pdf_token_boundary": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php --no-ansi",
+        "evidence": "PASS with existing file_get_contents warnings; 10 tests, 132 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS; route list rendered 231 routes including v0.3 attempt report-access/report.pdf/result-page.pdf routes."
+      },
+      "migrate": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-01.sqlite php artisan migrate --force",
+        "evidence": "PASS; all migrations completed against isolated sqlite database."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/Report/Pdf/ResultPagePdfTokenService.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php",
+        "evidence": "PASS; 3 files unchanged by formatter."
+      },
+      "ci_verify_mbti": {
+        "status": "pass",
+        "command": "bash backend/scripts/ci_verify_mbti.sh",
+        "evidence": "PASS; content pack, report, events funnel, Big Five gates, security gates, dependency gate, and webhook/attempt regression gates completed."
+      },
+      "metadata_parse": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && echo 'json ok'",
+        "evidence": "PASS after local check ledger update; output yaml ok and json ok."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "PASS after local check ledger update; no whitespace errors."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "command": "git diff --name-only",
+        "evidence": "PASS after restoring generated BIG5_OCEAN compiled timestamp/hash churn; diff limited to AttemptReadController, ResultPagePdfTokenService, AttemptPublicReportPdfParityTest, pr-train.yaml, and pr-train-state.json."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "implementation_in_progress",
+        "note": "Started SECURITY-103-API-01 from latest origin/main in an isolated worktree; scope is limited to MBTI result/PDF token entitlement and locked/full access gates plus authorized train metadata."
+      },
+      {
+        "at": "2026-06-30T09:02:13+08:00",
+        "status": "local_checks_passed",
+        "note": "Route list, isolated sqlite migrate, focused AttemptPublicReportPdfParityTest, Pint, full ci_verify_mbti, diff check, and scope validation passed for SECURITY-103-API-01."
+      }
+    ]
+  },
+  "SECURITY-103-API-02": {
+    "id": "SECURITY-103-API-02",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-02-scoring-redaction",
+    "title": "SECURITY-103-API-02: harden scoring payload redaction and claim gates",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-01"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-02; execution waits for SECURITY-103-API-01 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-03": {
+    "id": "SECURITY-103-API-03",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-03-identifiers-cache-redaction",
+    "title": "SECURITY-103-API-03: harden public identifiers and cache headers",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-02"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-03; execution waits for SECURITY-103-API-02 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-04": {
+    "id": "SECURITY-103-API-04",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-04-deploy-workflow-hardening",
+    "title": "SECURITY-103-API-04: harden deploy workflow and runner command boundaries",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-03"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-04; execution waits for SECURITY-103-API-03 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-05": {
+    "id": "SECURITY-103-API-05",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-05-import-integrity-hardening",
+    "title": "SECURITY-103-API-05: harden production import integrity gates",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-04"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-05; execution waits for SECURITY-103-API-04 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-06": {
+    "id": "SECURITY-103-API-06",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-06-cms-publish-gates",
+    "title": "SECURITY-103-API-06: harden CMS publish approval and canary gates",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-05"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-06; execution waits for SECURITY-103-API-05 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-07": {
+    "id": "SECURITY-103-API-07",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-07-seo-scanner-export-safety",
+    "title": "SECURITY-103-API-07: harden SEO scanner submission and export safety",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-06"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-07; execution waits for SECURITY-103-API-06 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-08": {
+    "id": "SECURITY-103-API-08",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-08-seo-ops-access-controls",
+    "title": "SECURITY-103-API-08: harden SEO ops preview and access controls",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-07"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-08; execution waits for SECURITY-103-API-07 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-09": {
+    "id": "SECURITY-103-API-09",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-09-ai-career-salary-assets",
+    "title": "SECURITY-103-API-09: harden AI career salary asset exposure",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-08"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-09; execution waits for SECURITY-103-API-08 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-10": {
+    "id": "SECURITY-103-API-10",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-10-dailygiving-order-data",
+    "title": "SECURITY-103-API-10: harden DailyGiving order transaction exposure",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-09"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-10; execution waits for SECURITY-103-API-09 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-11": {
+    "id": "SECURITY-103-API-11",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-11-cache-locale-fail-closed",
+    "title": "SECURITY-103-API-11: harden public cache and locale fail-closed behavior",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-10"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-11; execution waits for SECURITY-103-API-10 merge."
+      }
+    ]
+  },
+  "SECURITY-103-API-12": {
+    "id": "SECURITY-103-API-12",
+    "repo": "fap-api",
+    "base": "origin/main",
+    "branch": "codex/security-103-api-12-docs-secrets-redaction",
+    "title": "SECURITY-103-API-12: redact committed secrets references and track rotation",
+    "train_scope": "security_103_fap_api_audit",
+    "depends_on": ["SECURITY-103-API-11"],
+    "status": "planned",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      }
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "content_authority": "backend",
+    "authorized_by_user": "2026-06-30 attached /goal SECURITY-103 fap-api audit PR train continuous execution request.",
+    "events": [
+      {
+        "at": "2026-06-30T08:55:17+08:00",
+        "status": "planned",
+        "note": "Registered authorized SECURITY-103-API-12; execution waits for SECURITY-103-API-11 merge."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -262,6 +262,451 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: SECURITY-103-API-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/security-103-api-01-entitlement-gates
+    title: "SECURITY-103-API-01: harden MBTI result/PDF token entitlement gates"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden MBTI PDF/result token authorization, entitlement, variant, locked/full access boundaries.
+      - Ensure result-page PDF tokens cannot promote locked/free exports to full report access.
+      - Bind MBTI result-page PDF tokens to the current org, attempt, and attempt owner.
+    allowed_paths:
+      - backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+      - backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php
+      - backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, CMS, SEO runtime, sitemap, llms, production imports, DB migrations, deployment, payment provider behavior, or non-MBTI scoring.
+      - Broaden token privileges beyond the entitlement/variant encoded by the signed token.
+      - Expose exploit-ready token details in PR text.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-01.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php --no-ansi
+      - cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/Report/Pdf/ResultPagePdfTokenService.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+      - bash backend/scripts/ci_verify_mbti.sh
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-02
+    repo: fap-api
+    depends_on: [SECURITY-103-API-01]
+    branch: codex/security-103-api-02-scoring-redaction
+    title: "SECURITY-103-API-02: harden scoring payload redaction and claim gates"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden IQ/EQ/Big Five public payload redaction, answer-key/test-bank leakage, claim gating, and no-consent analytics storage.
+      - Keep scoring semantics and item-bank authority unchanged unless redaction requires a public boundary guard.
+    allowed_paths:
+      - backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+      - backend/app/Services/Assessment/**
+      - backend/app/Services/Iq/**
+      - backend/app/Services/Eq/**
+      - backend/app/Services/BigFive/**
+      - backend/app/Services/Analytics/**
+      - backend/tests/Feature/Security/Security103Api02ScoringPayloadBoundaryTest.php
+      - backend/tests/Unit/Services/Iq/**
+      - backend/tests/Unit/Eq/**
+      - backend/tests/Unit/Services/BigFive/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Change question content, answer keys, scoring algorithms, production norms, payment/order behavior, CMS, SEO runtime, deploy, or fap-web.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-02.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api02ScoringPayloadBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-03
+    repo: fap-api
+    depends_on: [SECURITY-103-API-02]
+    branch: codex/security-103-api-03-identifiers-cache-redaction
+    title: "SECURITY-103-API-03: harden public identifiers and cache headers"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden public cache headers, tenant/attempt identifiers, anonymous production attempt access identifiers, and audit/staging identifier exposure.
+    allowed_paths:
+      - backend/app/Http/Controllers/**
+      - backend/app/Http/Middleware/**
+      - backend/app/Support/Logging/**
+      - backend/app/Services/Attempts/**
+      - backend/app/Services/Report/**
+      - backend/tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Change scoring, CMS publish, SEO runtime, production import, deploy workflows, DB migrations, or fap-web.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-03.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-04
+    repo: fap-api
+    depends_on: [SECURITY-103-API-03]
+    branch: codex/security-103-api-04-deploy-workflow-hardening
+    title: "SECURITY-103-API-04: harden deploy workflow and runner command boundaries"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden production deploy auto-run, workflow dispatch, command injection, hardcoded production activation phrase, and runner plan-scope trust boundaries.
+    allowed_paths:
+      - .github/workflows/**
+      - backend/scripts/**
+      - scripts/**
+      - deploy.php
+      - backend/tests/Feature/Security/Security103Api04DeployWorkflowBoundaryTest.php
+      - backend/tests/Unit/Security/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Run staging deploy, production deploy, server verification, production imports, CMS writes, or frontend changes.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-04.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api04DeployWorkflowBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-05
+    repo: fap-api
+    depends_on: [SECURITY-103-API-04]
+    branch: codex/security-103-api-05-import-integrity-hardening
+    title: "SECURITY-103-API-05: harden production import integrity gates"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden production import downgrade/overwrite risks, ssh-keyscan trust, JSONL after-SHA gates, empty review artifacts, and manifest integrity.
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Services/**/Import/**
+      - backend/app/Services/**/Importer/**
+      - backend/scripts/**
+      - scripts/**
+      - backend/tests/Feature/Security/Security103Api05ImportIntegrityBoundaryTest.php
+      - backend/tests/Feature/Console/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Run production import, staging overwrite, deploy, CMS publish, SEO runtime mutation, or fap-web changes.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-05.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api05ImportIntegrityBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-06
+    repo: fap-api
+    depends_on: [SECURITY-103-API-05]
+    branch: codex/security-103-api-06-cms-publish-gates
+    title: "SECURITY-103-API-06: harden CMS publish approval and canary gates"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden writer/article locks, family/help/repair publish gates, ContentPage review gates, and canary evidence binding.
+    allowed_paths:
+      - backend/app/Console/Commands/**/*Article*
+      - backend/app/Console/Commands/**/*Cms*
+      - backend/app/Services/Cms/**
+      - backend/app/Services/ContentPage/**
+      - backend/app/Http/Controllers/API/V0_5/Internal/**
+      - backend/tests/Feature/Security/Security103Api06CmsPublishGateBoundaryTest.php
+      - backend/tests/Feature/V0_5/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Perform CMS writes, controlled publish, promotion, production import, SEO/search mutation, deploy, DB migrations, or fap-web changes.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-06.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api06CmsPublishGateBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-07
+    repo: fap-api
+    depends_on: [SECURITY-103-API-06]
+    branch: codex/security-103-api-07-seo-scanner-export-safety
+    title: "SECURITY-103-API-07: harden SEO scanner submission and export safety"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden runtime SEO scanner private paths, cross-tenant CMS path export, GSC CSV formula injection, search submit kill switches, and SEO ingest privacy sanitization.
+    allowed_paths:
+      - backend/app/Console/Commands/**/*Seo*
+      - backend/app/Services/Seo/**
+      - backend/app/Services/SeoIntel/**
+      - backend/docs/seo/**
+      - backend/tests/Feature/Security/Security103Api07SeoScannerExportBoundaryTest.php
+      - backend/tests/Feature/SeoIntel/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Submit live URLs, mutate sitemap/llms/canonical/noindex/JSON-LD, run production SEO jobs, deploy, or change fap-web.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-07.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api07SeoScannerExportBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-08
+    repo: fap-api
+    depends_on: [SECURITY-103-API-07]
+    branch: codex/security-103-api-08-seo-ops-access-controls
+    title: "SECURITY-103-API-08: harden SEO ops preview and access controls"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden SEO ops API/TOTP middleware, public preview route host/IP controls, public SEO ops artifacts, and dashboard access boundaries.
+    allowed_paths:
+      - backend/app/Http/Middleware/**
+      - backend/app/Http/Controllers/**/Seo*
+      - backend/app/Services/Seo/**
+      - backend/app/Services/SeoIntel/**
+      - backend/config/**
+      - backend/tests/Feature/Security/Security103Api08SeoOpsAccessBoundaryTest.php
+      - backend/tests/Feature/SeoIntel/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Change production DNS/CDN/security groups, run deploy, expose public dashboards, mutate search/sitemap/llms, or change fap-web.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-08.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api08SeoOpsAccessBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-09
+    repo: fap-api
+    depends_on: [SECURITY-103-API-08]
+    branch: codex/security-103-api-09-ai-career-salary-assets
+    title: "SECURITY-103-API-09: harden AI career salary asset exposure"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden AI impact assets, career/salary previews, public endpoint exposure, import overwrite, and display asset manifest authorization.
+    allowed_paths:
+      - backend/app/Http/Controllers/**/Career/**
+      - backend/app/Services/Career/**
+      - backend/app/Console/Commands/**/*Career*
+      - backend/tests/Feature/Security/Security103Api09CareerAssetBoundaryTest.php
+      - backend/tests/Feature/Career/**
+      - backend/tests/Unit/Services/Career/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Run production imports, overwrite public assets, change sitemap/llms/search submission, deploy, CMS writes, or fap-web.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-09.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api09CareerAssetBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-10
+    repo: fap-api
+    depends_on: [SECURITY-103-API-09]
+    branch: codex/security-103-api-10-dailygiving-order-data
+    title: "SECURITY-103-API-10: harden DailyGiving order transaction exposure"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden DailyGiving proof/raw URLs, non-publishable records, private transaction metadata, and production order details.
+    allowed_paths:
+      - backend/app/Http/Controllers/**/DailyGiving/**
+      - backend/app/Services/DailyGiving/**
+      - backend/app/Services/Commerce/**
+      - backend/app/Http/Controllers/API/V0_3/**/*Order*
+      - backend/tests/Feature/Security/Security103Api10DailyGivingOrderBoundaryTest.php
+      - backend/tests/Feature/Commerce/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Change payment provider contracts, run production writes/imports, publish records, alter public proof approval policy beyond backend gates, deploy, or change fap-web.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-10.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api10DailyGivingOrderBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-11
+    repo: fap-api
+    depends_on: [SECURITY-103-API-10]
+    branch: codex/security-103-api-11-cache-locale-fail-closed
+    title: "SECURITY-103-API-11: harden public cache and locale fail-closed behavior"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Harden warm cache stale public data, public career detail locale poisoning, and LKG/cache republishing of unpublished content.
+    allowed_paths:
+      - backend/app/Services/Career/**
+      - backend/app/Services/**/Cache/**
+      - backend/app/Console/Commands/**/*Warm*
+      - backend/app/Console/Commands/**/*Cache*
+      - backend/tests/Feature/Security/Security103Api11CacheLocaleBoundaryTest.php
+      - backend/tests/Feature/Career/**
+      - backend/tests/Feature/Console/**
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Warm production caches, publish/unpublish content, run production imports, mutate sitemap/llms/search, deploy, or change fap-web.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-11.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api11CacheLocaleBoundaryTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: SECURITY-103-API-12
+    repo: fap-api
+    depends_on: [SECURITY-103-API-11]
+    branch: codex/security-103-api-12-docs-secrets-redaction
+    title: "SECURITY-103-API-12: redact committed secrets references and track rotation"
+    train_scope: security_103_fap_api_audit
+    status: user_authorized
+    scope:
+      - Redact IndexNow/API token/preflight docs leaks, operational infrastructure docs, committed sensitive metadata, and create rotation-tracking follow-up evidence only.
+    allowed_paths:
+      - docs/**
+      - backend/docs/**
+      - 03-env-config/**
+      - generated/pr-train-sidecar-issues/**
+      - backend/tests/Unit/Security/SecurityGuardrailsTest.php
+      - backend/tests/Feature/Security/Security103Api12DocsSecretsRedactionTest.php
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Rotate live secrets, call secret providers, run production deploy/import, mutate CMS/search, or change runtime code outside docs/test guardrails.
+    validation:
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-12.sqlite php artisan migrate --force
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api12DocsSecretsRedactionTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Security/SecurityGuardrailsTest.php --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-ASSET-02
     repo: fap-api
     depends_on: [PR-EQ-ASSET-01]


### PR DESCRIPTION
## Summary
- Register the authorized SECURITY-103 fap-api PR-train entries SECURITY-103-API-01 through SECURITY-103-API-12.
- Harden MBTI result-page PDF export token verification so grants are bound to the current org, attempt owner, entitlement, and report variant.
- Keep locked/free result-page PDF export tokens from promoting `/report-access` to full access while preserving unlocked/full token behavior.

## Validation
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-01.sqlite php artisan migrate --force`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE='':memory:'' php artisan test tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/Report/Pdf/ResultPagePdfTokenService.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`
- `ruby -e "require ''yaml''; YAML.load_file(''docs/codex/pr-train.yaml''); puts ''yaml ok''" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && echo ''json ok''`
- `git diff --check`
- `git diff --cached --check`

## Scope and boundaries
- SECURITY-103-API-01 only; later SECURITY-103 entries remain planned and unimplemented.
- No migrations added.
- No production deploy, staging deploy, CMS write, production import, or database mutation performed.
- Full `backend/scripts/ci_verify_mbti.sh` passed locally; no unrelated failing tests observed.