### PR TITLE
SECURITY-103-API-03: harden public identifiers and cache headers

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -68,6 +68,12 @@ class AttemptReadController extends Controller
 
     private const SENSITIVE_RESULT_READ_SCALES = ['SDS_20', 'CLINICAL_COMBO_68'];
 
+    private const PRIVATE_NO_STORE_HEADERS = [
+        'Cache-Control' => 'private, no-store',
+        'Pragma' => 'no-cache',
+        'Expires' => '0',
+    ];
+
     public function __construct(
         private AttemptSubmissionService $attemptSubmissionService,
         private ReportGatekeeper $reportGatekeeper,
@@ -123,7 +129,7 @@ class AttemptReadController extends Controller
         $status = (int) ($payload['http_status'] ?? 200);
         unset($payload['http_status']);
 
-        return response()->json($payload, $status);
+        return $this->privateNoStoreJson($payload, $status);
     }
 
     /**
@@ -255,7 +261,7 @@ class AttemptReadController extends Controller
                 $responsePayload['mbti_form_v1'] = $mbtiFormSummary;
             }
 
-            return response()->json($responsePayload);
+            return $this->privateNoStoreJson($responsePayload);
         }
 
         $payload = $result->result_json;
@@ -429,7 +435,7 @@ class AttemptReadController extends Controller
             $responsePayload = IqResultPayloadRedactor::redactAnswerKeys($responsePayload);
         }
 
-        return response()->json($responsePayload);
+        return $this->privateNoStoreJson($responsePayload);
     }
 
     /**
@@ -723,7 +729,7 @@ class AttemptReadController extends Controller
             $responsePayload = IqResultPayloadRedactor::redactAnswerKeys($responsePayload);
         }
 
-        return response()->json($responsePayload);
+        return $this->privateNoStoreJson($responsePayload);
     }
 
     /**
@@ -1205,7 +1211,7 @@ class AttemptReadController extends Controller
             'duration_ms' => $durationMs,
         ]);
 
-        return response()->json($responsePayload);
+        return $this->privateNoStoreJson($responsePayload);
     }
 
     /**
@@ -2784,7 +2790,7 @@ class AttemptReadController extends Controller
             $payload['report'] = [];
         }
 
-        return response()->json($payload, 202);
+        return $this->privateNoStoreJson($payload, 202);
     }
 
     private function failedSubmissionResponse(string $attemptId, array $submissionPayload, bool $includeReport): JsonResponse
@@ -2808,7 +2814,7 @@ class AttemptReadController extends Controller
             $payload['report'] = [];
         }
 
-        return response()->json($payload);
+        return $this->privateNoStoreJson($payload);
     }
 
     private function missingResultAfterSubmissionResponse(string $attemptId, array $submissionPayload, bool $includeReport): JsonResponse
@@ -2827,7 +2833,15 @@ class AttemptReadController extends Controller
             $payload['report'] = [];
         }
 
-        return response()->json($payload);
+        return $this->privateNoStoreJson($payload);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function privateNoStoreJson(array $payload, int $status = 200): JsonResponse
+    {
+        return response()->json($payload, $status)->withHeaders(self::PRIVATE_NO_STORE_HEADERS);
     }
 
     private function resolveAttemptId(Result $result, ?Attempt $attempt, string $fallbackAttemptId): string

--- a/backend/app/Http/Controllers/API/V0_3/ShareController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ShareController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\V0_3\GetShareRequest;
 use App\Http\Requests\V0_3\ShareClickRequest;
 use App\Http\Requests\V0_3\ShareViewRequest;
 use App\Services\V0_3\ShareFlowService;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -16,6 +17,12 @@ use Throwable;
 
 class ShareController extends Controller
 {
+    private const PRIVATE_NO_STORE_HEADERS = [
+        'Cache-Control' => 'private, no-store',
+        'Pragma' => 'no-cache',
+        'Expires' => '0',
+    ];
+
     public function __construct(private readonly ShareFlowService $shareFlow) {}
 
     public function click(ShareClickRequest $request, string $shareId): JsonResponse
@@ -30,7 +37,7 @@ class ShareController extends Controller
                 $this->requestMeta($request)
             );
 
-            return response()->json(array_merge(['ok' => true], $result), 200);
+            return $this->privateNoStoreJson(array_merge(['ok' => true], $result));
         } catch (Throwable $e) {
             $this->logShareFlowFailed($request, 'click', $routeShareId, null, $e);
             throw $e;
@@ -43,7 +50,7 @@ class ShareController extends Controller
             $input = array_merge($request->validated(), $this->requestMeta($request));
             $result = $this->shareFlow->getShareLinkForAttempt($id, $input);
 
-            return response()->json(array_merge(['ok' => true], $result), 200);
+            return $this->privateNoStoreJson(array_merge(['ok' => true], $result));
         } catch (Throwable $e) {
             $this->logShareFlowFailed($request, 'get_share', null, $id, $e);
             throw $e;
@@ -55,7 +62,15 @@ class ShareController extends Controller
         $shareId = (string) ($request->validated()['id'] ?? $id);
         $result = $this->shareFlow->getShareView($shareId);
 
-        return response()->json(array_merge(['ok' => true], $result), 200);
+        return $this->privateNoStoreJson(array_merge(['ok' => true], $result));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function privateNoStoreJson(array $payload, int $status = 200): JsonResponse
+    {
+        return response()->json($payload, $status)->withHeaders(self::PRIVATE_NO_STORE_HEADERS);
     }
 
     /**
@@ -84,8 +99,8 @@ class ShareController extends Controller
     ): void {
         Log::error('share_flow_failed', [
             'action' => $action,
-            'share_id' => $shareId,
-            'attempt_id' => $attemptId,
+            'share_fingerprint' => $shareId !== null ? SensitiveDiagnosticRedactor::fingerprint($shareId) : null,
+            'attempt_fingerprint' => $attemptId !== null ? SensitiveDiagnosticRedactor::fingerprint($attemptId) : null,
             'org_id' => $this->resolveOrgId($request),
             'request_id' => $this->resolveRequestId($request),
             'exception' => $e,

--- a/backend/tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php
+++ b/backend/tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+final class Security103Api03IdentifierCacheBoundaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_attempt_read_json_responses_are_private_no_store(): void
+    {
+        $this->seedRuntime();
+
+        $anonId = 'anon_security_103_api_03_attempt_read';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $headers = $this->authHeaders($anonId);
+
+        foreach ([
+            "/api/v0.3/attempts/{$attemptId}/result",
+            "/api/v0.3/attempts/{$attemptId}/report",
+            "/api/v0.3/attempts/{$attemptId}/report-access",
+        ] as $uri) {
+            $response = $this->withHeaders($headers)->getJson($uri);
+
+            $response->assertOk();
+            $this->assertPrivateNoStore($response);
+        }
+    }
+
+    public function test_share_json_responses_are_no_store_and_public_view_omits_private_identifiers(): void
+    {
+        $this->seedRuntime();
+
+        $anonId = 'anon_security_103_api_03_share';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $headers = $this->authHeaders($anonId);
+
+        $ownerShare = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/share");
+        $ownerShare->assertOk();
+        $this->assertPrivateNoStore($ownerShare);
+
+        $shareId = (string) $ownerShare->json('share_id');
+        $this->assertNotSame('', $shareId);
+
+        $publicShare = $this->getJson("/api/v0.3/shares/{$shareId}");
+        $publicShare->assertOk();
+        $this->assertPrivateNoStore($publicShare);
+
+        foreach ([
+            'anon_id',
+            'user_id',
+            'fm_user_id',
+            'fm_token',
+            'private_result_path',
+            'private_report_path',
+            'audit_context',
+            'staging_context',
+        ] as $forbiddenPath) {
+            $publicShare->assertJsonMissingPath($forbiddenPath);
+        }
+    }
+
+    private function seedRuntime(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function authHeaders(string $anonId): array
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return [
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ];
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => ['EI' => 50, 'SN' => 50, 'TF' => 50, 'JP' => 50, 'AT' => 50],
+            'axis_states' => ['EI' => 'clear', 'SN' => 'clear', 'TF' => 'clear', 'JP' => 'clear', 'AT' => 'clear'],
+            'profile_version' => 'mbti32-v2.5',
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'type_code' => 'INTJ-A',
+                'type_name' => '建筑师型',
+                'summary' => 'Public-safe share summary.',
+                'tagline' => '冷静的长期规划者',
+                'rarity' => '约 2%',
+                'keywords' => ['战略', '独立', '前瞻'],
+            ],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function assertPrivateNoStore(TestResponse $response): void
+    {
+        $cacheControl = (string) $response->headers->get('Cache-Control');
+
+        $this->assertStringContainsString('private', $cacheControl);
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $response->assertHeader('Pragma', 'no-cache');
+        $response->assertHeader('Expires', '0');
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -3813,6 +3813,47 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_security_103_api_03_share_identifier_cache_boundary(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/ShareController.php',
+        ];
+        $shareControllerChangedLines = [
+            '+use App\Support\Logging\SensitiveDiagnosticRedactor;',
+            '+    private const PRIVATE_NO_STORE_HEADERS = [',
+            '+        \'Cache-Control\' => \'private, no-store\',',
+            '+        \'Pragma\' => \'no-cache\',',
+            '+        \'Expires\' => \'0\',',
+            '+    ];',
+            '+',
+            "-            return response()->json(array_merge(['ok' => true], \$result), 200);",
+            "+            return \$this->privateNoStoreJson(array_merge(['ok' => true], \$result));",
+            "-            return response()->json(array_merge(['ok' => true], \$result), 200);",
+            "+            return \$this->privateNoStoreJson(array_merge(['ok' => true], \$result));",
+            "-        return response()->json(array_merge(['ok' => true], \$result), 200);",
+            "+        return \$this->privateNoStoreJson(array_merge(['ok' => true], \$result));",
+            '+    }',
+            '+',
+            '+    /**',
+            '+     * @param  array<string,mixed>  $payload',
+            '+     */',
+            '+    private function privateNoStoreJson(array $payload, int $status = 200): JsonResponse',
+            '+    {',
+            '+        return response()->json($payload, $status)->withHeaders(self::PRIVATE_NO_STORE_HEADERS);',
+            "-            'share_id' => \$shareId,",
+            "-            'attempt_id' => \$attemptId,",
+            "+            'share_fingerprint' => \$shareId !== null ? SensitiveDiagnosticRedactor::fingerprint(\$shareId) : null,",
+            "+            'attempt_fingerprint' => \$attemptId !== null ? SensitiveDiagnosticRedactor::fingerprint(\$attemptId) : null,",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            shareControllerChangedLines: $shareControllerChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_surface_builder_changes(): void
     {
         $changed = [
@@ -4753,6 +4794,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ?array $bootstrapAppChangedLines = null,
         ?array $assessmentEngineChangedLines = null,
         ?array $bigFivePublicProjectionChangedLines = null,
+        ?array $shareControllerChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -5361,6 +5403,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isCiAuthBypassHardeningFile($file)) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Http/Controllers/API/V0_3/ShareController.php'
+                && $this->shareControllerDiffIsSecurity103Api03IdentifierCacheBoundaryOnly(
+                    $shareControllerChangedLines ?? (
+                        $repoRoot !== '' && $baseRef !== ''
+                            ? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                            : []
+                    )
+                )
+            ) {
                 continue;
             }
 
@@ -11067,6 +11122,42 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             '+    ], 401)->withHeaders([',
             '+        \'WWW-Authenticate\' => \'Bearer realm="Fermat API", error="invalid_token"\',',
             '+    ]);',
+        ];
+
+        return $changedLines !== [] && array_values($changedLines) === $allowedLines;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function shareControllerDiffIsSecurity103Api03IdentifierCacheBoundaryOnly(array $changedLines): bool
+    {
+        $allowedLines = [
+            '+use App\Support\Logging\SensitiveDiagnosticRedactor;',
+            '+    private const PRIVATE_NO_STORE_HEADERS = [',
+            '+        \'Cache-Control\' => \'private, no-store\',',
+            '+        \'Pragma\' => \'no-cache\',',
+            '+        \'Expires\' => \'0\',',
+            '+    ];',
+            '+',
+            "-            return response()->json(array_merge(['ok' => true], \$result), 200);",
+            "+            return \$this->privateNoStoreJson(array_merge(['ok' => true], \$result));",
+            "-            return response()->json(array_merge(['ok' => true], \$result), 200);",
+            "+            return \$this->privateNoStoreJson(array_merge(['ok' => true], \$result));",
+            "-        return response()->json(array_merge(['ok' => true], \$result), 200);",
+            "+        return \$this->privateNoStoreJson(array_merge(['ok' => true], \$result));",
+            '+    }',
+            '+',
+            '+    /**',
+            '+     * @param  array<string,mixed>  $payload',
+            '+     */',
+            '+    private function privateNoStoreJson(array $payload, int $status = 200): JsonResponse',
+            '+    {',
+            '+        return response()->json($payload, $status)->withHeaders(self::PRIVATE_NO_STORE_HEADERS);',
+            "-            'share_id' => \$shareId,",
+            "-            'attempt_id' => \$attemptId,",
+            "+            'share_fingerprint' => \$shareId !== null ? SensitiveDiagnosticRedactor::fingerprint(\$shareId) : null,",
+            "+            'attempt_fingerprint' => \$attemptId !== null ? SensitiveDiagnosticRedactor::fingerprint(\$attemptId) : null,",
         ];
 
         return $changedLines !== [] && array_values($changedLines) === $allowedLines;

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65606,7 +65606,7 @@
     "title": "SECURITY-103-API-03: harden public identifiers and cache headers",
     "train_scope": "security_103_fap_api_audit",
     "depends_on": ["SECURITY-103-API-02"],
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "checks": {
       "authorization": {
         "status": "pass",
@@ -65680,10 +65680,14 @@
         "status": "pass",
         "command": "git status --short && git diff --name-only && git ls-files --others --exclude-standard",
         "evidence": "PASS after restoring generated BIG5_OCEAN compiled timestamp/hash churn; diff limited to PR03 controllers and focused security test before ledger update."
+      },
+      "github_pr": {
+        "status": "open",
+        "evidence": "Opened https://github.com/fermatmind/fap-api/pull/2558 for SECURITY-103-API-03 after local checks passed."
       }
     },
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2558",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -65706,6 +65710,11 @@
         "at": "2026-06-30T09:55:34+08:00",
         "status": "local_checks_passed",
         "note": "Route list, isolated sqlite migrate, focused SECURITY-103-API-03 tests, share/report contract regressions, Pint, full ci_verify_mbti, diff check, and scope validation passed."
+      },
+      {
+        "at": "2026-06-30T09:57:26+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2558 for SECURITY-103-API-03 after local validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65606,11 +65606,80 @@
     "title": "SECURITY-103-API-03: harden public identifiers and cache headers",
     "train_scope": "security_103_fap_api_audit",
     "depends_on": ["SECURITY-103-API-02"],
-    "status": "planned",
+    "status": "local_checks_passed",
     "checks": {
       "authorization": {
         "status": "pass",
         "evidence": "Authorized by the 2026-06-30 SECURITY-103 attached /goal."
+      },
+      "dependency_security_103_api_02": {
+        "status": "pass",
+        "evidence": "SECURITY-103-API-02 merged and ledger closeout merged into origin/main at 00d160adf5e9a753cce94700e4be5c568d66209e."
+      },
+      "base_sync": {
+        "status": "pass",
+        "command": "git fetch origin main && git rev-parse HEAD && git rev-parse origin/main",
+        "evidence": "HEAD and origin/main both equal 00d160adf5e9a753cce94700e4be5c568d66209e before PR03 commit."
+      },
+      "syntax": {
+        "status": "pass",
+        "command": "php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php && php -l backend/app/Http/Controllers/API/V0_3/ShareController.php && php -l backend/tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php",
+        "evidence": "All touched PHP files reported no syntax errors."
+      },
+      "focused_security_boundary": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php --no-ansi",
+        "evidence": "PASS with existing file_get_contents warnings; 2 tests, 44 assertions."
+      },
+      "share_flow_alignment": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php --no-ansi",
+        "evidence": "PASS with existing file_get_contents warnings; 2 tests, 66 assertions."
+      },
+      "mbti_report_contract_regression": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php --no-ansi",
+        "evidence": "PASS with existing file_get_contents warnings; 2 tests, 630 assertions."
+      },
+      "enneagram_share_summary_contract": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/EnneagramShareSummaryContractTest.php --no-ansi",
+        "evidence": "PASS with existing file_get_contents warning; 1 test, 49 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS; route list rendered 231 routes."
+      },
+      "migrate": {
+        "status": "pass",
+        "command": "rm -f /tmp/fap-api-security-103-api-03.sqlite && cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-03.sqlite php artisan migrate --force",
+        "evidence": "PASS; all migrations completed against an isolated sqlite database."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_3/AttemptReadController.php app/Http/Controllers/API/V0_3/ShareController.php tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php",
+        "evidence": "PASS; 3 touched PHP files already formatted."
+      },
+      "ci_verify_mbti": {
+        "status": "pass",
+        "command": "bash backend/scripts/ci_verify_mbti.sh",
+        "evidence": "PASS; content pack, Big Five, Enneagram, MBTI smoke, events funnel, security, dependency, and webhook/attempt regression gates completed."
+      },
+      "metadata_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "evidence": "PASS before local ledger update; rerun after ledger update before commit."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "PASS before local ledger update; rerun after ledger update before commit."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "command": "git status --short && git diff --name-only && git ls-files --others --exclude-standard",
+        "evidence": "PASS after restoring generated BIG5_OCEAN compiled timestamp/hash churn; diff limited to PR03 controllers and focused security test before ledger update."
       }
     },
     "commit_sha": null,
@@ -65632,6 +65701,11 @@
         "at": "2026-06-30T08:55:17+08:00",
         "status": "planned",
         "note": "Registered authorized SECURITY-103-API-03; execution waits for SECURITY-103-API-02 merge."
+      },
+      {
+        "at": "2026-06-30T09:55:34+08:00",
+        "status": "local_checks_passed",
+        "note": "Route list, isolated sqlite migrate, focused SECURITY-103-API-03 tests, share/report contract regressions, Pint, full ci_verify_mbti, diff check, and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -17726,7 +17726,7 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2362",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "status": "pr_open",
+    "status": "ci_fix_local_checks_passed",
     "title": "IQ-OWNER-30-BACKEND-ASSETS-01: Import owner-original IQ 30 image bank",
     "train_scope": "iq_owner_original_30_launch",
     "transitions": [
@@ -65684,6 +65684,15 @@
       "github_pr": {
         "status": "open",
         "evidence": "Opened https://github.com/fermatmind/fap-api/pull/2558 for SECURITY-103-API-03 after local checks passed."
+      },
+      "github_verify_bigfive_initial": {
+        "status": "fail",
+        "evidence": "Initial PR #2558 verify-bigfive jobs failed in BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff because the runtime freeze classifier did not yet recognize the PR03 ShareController cache/header and diagnostic-fingerprint-only change."
+      },
+      "ci_fix_runtime_freeze_classifier": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_security_103_api_03_share_identifier_cache_boundary --no-ansi && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi",
+        "evidence": "PASS; scoped classifier test and the failed runtime freeze test passed locally after a line-level ShareController allowlist for SECURITY-103-API-03."
       }
     },
     "commit_sha": null,
@@ -65715,6 +65724,11 @@
         "at": "2026-06-30T09:57:26+08:00",
         "status": "pr_open",
         "note": "Opened PR #2558 for SECURITY-103-API-03 after local validation passed."
+      },
+      {
+        "at": "2026-06-30T10:09:21+08:00",
+        "status": "ci_fix_local_checks_passed",
+        "note": "Added a line-level Big Five runtime freeze classifier allowlist for the PR03 ShareController cache/header and diagnostic fingerprint change after initial verify-bigfive failed; focused classifier and runtime-freeze checks plus Pint passed locally."
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Add private `no-store` JSON response headers on v0.3 attempt read/report/report-access and share JSON read surfaces.
- Redact raw attempt/share identifiers from share-flow failure diagnostics by logging fingerprints instead.
- Add focused SECURITY-103-API-03 feature coverage for cache headers and public share identifier redaction.
- Update the PR train state ledger for local validation evidence.

## Validation
- `php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `php -l backend/app/Http/Controllers/API/V0_3/ShareController.php`
- `php -l backend/tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/EnneagramShareSummaryContractTest.php --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `rm -f /tmp/fap-api-security-103-api-03.sqlite && cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-103-api-03.sqlite php artisan migrate --force`
- `cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_3/AttemptReadController.php app/Http/Controllers/API/V0_3/ShareController.php tests/Feature/Security/Security103Api03IdentifierCacheBoundaryTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Boundaries
- No routes, migrations, scoring, CMS publish, SEO runtime, production import, deploy workflow, DB production mutation, or fap-web changes.
- CI-generated BIG5_OCEAN compiled timestamp/hash churn was restored before staging.
- Deploy/runtime impact: API response header and internal diagnostic redaction only; no deploy triggered.
