### PR TITLE
chore(codex): mark SECURITY-103 API-03 merged

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65606,7 +65606,7 @@
     "title": "SECURITY-103-API-03: harden public identifiers and cache headers",
     "train_scope": "security_103_fap_api_audit",
     "depends_on": ["SECURITY-103-API-02"],
-    "status": "pr_open",
+    "status": "merged",
     "checks": {
       "authorization": {
         "status": "pass",


### PR DESCRIPTION
## Summary
- mark SECURITY-103-API-03 train state as merged after PR #2558 and ledger PR #2559 merged
- docs-only one-line status correction

## Tests
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- git diff --check
- git diff --cached --check

## Scope
- docs/codex/pr-train-state.json only
- no runtime code, routes, migrations, CMS writes, deploys, or production mutation