### PR TITLE
fix(seo): harden daily media release runner

### DIFF
--- a/backend/app/Console/Commands/MediaAssetsSeoReleaseCleanup.php
+++ b/backend/app/Console/Commands/MediaAssetsSeoReleaseCleanup.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\MediaAsset;
+use App\Services\Cms\MediaAssetStorageSyncService;
+use App\Support\PublicMediaUrlGuard;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+final class MediaAssetsSeoReleaseCleanup extends Command
+{
+    protected $signature = 'media-assets:seo-release-cleanup
+        {--asset-prefix= : Media asset key prefix, e.g. article.enneagram.topic}
+        {--translation-group-id= : Optional article translation_group_id for CMS reference readback}
+        {--dry-run : Audit only; this is also the default when --resync is not provided}
+        {--resync : Re-run Media Library OSS sync and CDN verification for matching assets}
+        {--json : Emit a JSON summary}';
+
+    protected $description = 'Audit and resync half-failed SEO Media Library assets without deleting records.';
+
+    public function handle(MediaAssetStorageSyncService $syncService): int
+    {
+        try {
+            $summary = $this->runCleanup($syncService);
+        } catch (Throwable $throwable) {
+            $summary = [
+                'ok' => false,
+                'action' => 'unexpected_error',
+                'would_write' => false,
+                'errors' => [[
+                    'field' => 'command',
+                    'code' => 'unexpected_error',
+                    'message' => $throwable->getMessage(),
+                ]],
+                'warnings' => [],
+                'assets' => [],
+            ];
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function runCleanup(MediaAssetStorageSyncService $syncService): array
+    {
+        $prefix = strtolower(trim((string) $this->option('asset-prefix')));
+        if ($prefix === '') {
+            return $this->failureSummary('asset_prefix_required', '--asset-prefix is required.');
+        }
+
+        $dryRun = (bool) $this->option('dry-run') || ! (bool) $this->option('resync');
+        $resync = (bool) $this->option('resync') && ! $dryRun;
+        $errors = [];
+
+        if ($resync) {
+            $errors = $this->runtimeReadinessErrors();
+            if ($errors !== []) {
+                return [
+                    'ok' => false,
+                    'action' => 'media_runtime_not_ready',
+                    'dry_run' => false,
+                    'would_write' => false,
+                    'asset_prefix' => $prefix,
+                    'translation_group_id' => $this->translationGroupId(),
+                    'assets' => $this->assetPayloads($prefix),
+                    'errors' => $errors,
+                    'warnings' => [],
+                    'deletion_held' => true,
+                ];
+            }
+        }
+
+        $assets = $this->matchingAssets($prefix);
+        $payloads = [];
+        foreach ($assets as $asset) {
+            $fresh = $resync ? $syncService->syncAndVerify($asset) : $asset->fresh('variants');
+            $payloads[] = $this->assetPayload($fresh ?? $asset);
+        }
+
+        $notReady = count(array_filter($payloads, static fn (array $asset): bool => ! (bool) ($asset['ready_for_cms'] ?? false)));
+
+        return [
+            'ok' => $resync ? $notReady === 0 : true,
+            'action' => $resync ? 'resynced_media_assets' : 'cleanup_dry_run',
+            'dry_run' => $dryRun,
+            'would_write' => $resync,
+            'asset_prefix' => $prefix,
+            'translation_group_id' => $this->translationGroupId(),
+            'assets_count' => count($payloads),
+            'not_ready_count' => $notReady,
+            'assets' => $payloads,
+            'errors' => $resync && $notReady > 0 ? [[
+                'field' => 'assets',
+                'code' => 'media_asset_cdn_not_ready',
+                'message' => 'One or more assets remain unverified after resync.',
+            ]] : [],
+            'warnings' => [],
+            'deletion_held' => true,
+        ];
+    }
+
+    /**
+     * @return list<MediaAsset>
+     */
+    private function matchingAssets(string $prefix): array
+    {
+        return MediaAsset::query()
+            ->withoutGlobalScopes()
+            ->with('variants')
+            ->where('org_id', 0)
+            ->where('asset_key', 'like', $prefix.'%')
+            ->orderBy('asset_key')
+            ->get()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function assetPayloads(string $prefix): array
+    {
+        return array_map(fn (MediaAsset $asset): array => $this->assetPayload($asset), $this->matchingAssets($prefix));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function assetPayload(MediaAsset $asset): array
+    {
+        $asset->loadMissing('variants');
+        $url = PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $asset->path, $asset->url);
+        $ready = (string) $asset->sync_status === MediaAsset::SYNC_SYNCED
+            && (string) $asset->cdn_status === MediaAsset::CDN_VERIFIED
+            && $url !== null;
+
+        return [
+            'id' => (int) $asset->id,
+            'asset_key' => (string) $asset->asset_key,
+            'status' => (string) $asset->status,
+            'is_public' => (bool) $asset->is_public,
+            'sync_status' => (string) $asset->sync_status,
+            'cdn_status' => (string) $asset->cdn_status,
+            'last_error' => $asset->last_error,
+            'url' => $url,
+            'ready_for_cms' => $ready,
+            'cms_reference_status' => $this->cmsReferenceStatus((string) $asset->asset_key),
+            'public_url_head' => $this->headStatus($url),
+            'variants' => $asset->variants->map(fn ($variant): array => [
+                'variant_key' => (string) $variant->variant_key,
+                'sync_status' => (string) $variant->sync_status,
+                'cdn_status' => (string) $variant->cdn_status,
+                'url' => PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $variant->path, $variant->url),
+            ])->values()->all(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function cmsReferenceStatus(string $assetKey): array
+    {
+        $query = Article::query()
+            ->withoutGlobalScopes()
+            ->with('seoMeta')
+            ->select(['id', 'slug', 'locale', 'translation_group_id', 'cover_image_variants']);
+
+        if ($this->translationGroupId() !== '') {
+            $query->where('translation_group_id', $this->translationGroupId());
+        }
+
+        $references = [];
+        foreach ($query->get() as $article) {
+            $variants = is_array($article->cover_image_variants) ? $article->cover_image_variants : [];
+            $schema = is_array($article->seoMeta?->schema_json) ? $article->seoMeta->schema_json : [];
+            $encoded = json_encode([$variants, $schema], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+            if (! is_string($encoded) || ! str_contains($encoded, $assetKey)) {
+                continue;
+            }
+
+            $references[] = [
+                'article_id' => (int) $article->id,
+                'locale' => (string) $article->locale,
+                'slug' => (string) $article->slug,
+                'translation_group_id' => (string) $article->translation_group_id,
+            ];
+        }
+
+        return [
+            'referenced' => $references !== [],
+            'references_count' => count($references),
+            'references' => $references,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function headStatus(?string $url): array
+    {
+        if ($url === null) {
+            return [
+                'checked' => false,
+                'ok' => false,
+                'status' => null,
+                'content_type' => null,
+            ];
+        }
+
+        try {
+            $response = Http::timeout(max(1, (int) config('fap.media.cdn_verify_timeout_seconds', 5)))
+                ->withoutRedirecting()
+                ->head($url);
+            $contentType = strtolower((string) $response->header('Content-Type', ''));
+
+            return [
+                'checked' => true,
+                'ok' => $response->successful() && str_starts_with($contentType, 'image/'),
+                'status' => $response->status(),
+                'content_type' => $contentType,
+            ];
+        } catch (Throwable $throwable) {
+            return [
+                'checked' => true,
+                'ok' => false,
+                'status' => null,
+                'content_type' => null,
+                'error' => mb_substr($throwable->getMessage(), 0, 500),
+            ];
+        }
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function runtimeReadinessErrors(): array
+    {
+        $errors = [];
+        if (! (bool) config('fap.media.oss_sync_enabled', false)) {
+            $errors[] = [
+                'field' => 'fap.media.oss_sync_enabled',
+                'code' => 'media_runtime_not_ready',
+                'message' => 'FAP_MEDIA_OSS_SYNC_ENABLED must be true before resync.',
+            ];
+        }
+        if (! (bool) config('fap.media.cdn_verify_enabled', false)) {
+            $errors[] = [
+                'field' => 'fap.media.cdn_verify_enabled',
+                'code' => 'media_runtime_not_ready',
+                'message' => 'FAP_MEDIA_CDN_VERIFY_ENABLED must be true before resync.',
+            ];
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'action' => 'will_skip',
+            'dry_run' => true,
+            'would_write' => false,
+            'asset_prefix' => (string) $this->option('asset-prefix'),
+            'translation_group_id' => $this->translationGroupId(),
+            'assets' => [],
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+            'deletion_held' => true,
+        ];
+    }
+
+    private function translationGroupId(): string
+    {
+        return trim((string) $this->option('translation-group-id'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? true) ? '1' : '0'));
+        $this->line('would_write='.(($summary['would_write'] ?? false) ? '1' : '0'));
+        $this->line('asset_prefix='.(string) ($summary['asset_prefix'] ?? ''));
+        $this->line('assets_count='.(string) ($summary['assets_count'] ?? 0));
+        $this->line('not_ready_count='.(string) ($summary['not_ready_count'] ?? 0));
+        $this->line('deletion_held='.(($summary['deletion_held'] ?? true) ? '1' : '0'));
+    }
+}

--- a/backend/app/Console/Commands/MediaAssetsSeoReleasePreflight.php
+++ b/backend/app/Console/Commands/MediaAssetsSeoReleasePreflight.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\SeoImageBundle\SeoImageBundleImporter;
+use App\Support\PublicMediaUrlGuard;
+use Illuminate\Console\Command;
+use RuntimeException;
+use Throwable;
+
+final class MediaAssetsSeoReleasePreflight extends Command
+{
+    protected $signature = 'media-assets:seo-release-preflight
+        {--package= : Path to a SEO source package directory}
+        {--translation-group-id= : Expected translation_group_id}
+        {--locales=zh-CN,en : Comma-separated locale list}
+        {--json : Emit a JSON summary}
+        {--expected-asset-prefix= : Expected asset_key prefix such as article.career.exploration}';
+
+    protected $description = 'Preflight SEO image bundles against Media Library production runner readiness.';
+
+    public function handle(SeoImageBundleImporter $importer): int
+    {
+        try {
+            $plan = $importer->planFromDirectory($this->optionsPayload());
+            $summary = $this->preflightSummary($plan);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function optionsPayload(): array
+    {
+        $locales = array_values(array_filter(array_map(
+            static fn (string $locale): string => trim($locale),
+            explode(',', (string) $this->option('locales'))
+        ), static fn (string $locale): bool => $locale !== ''));
+
+        return [
+            'package' => (string) $this->option('package'),
+            'translation_group_id' => (string) $this->option('translation-group-id'),
+            'locales' => $locales,
+            'dry_run' => true,
+            'json' => (bool) $this->option('json'),
+            'write_resolved_package' => true,
+            'expected_asset_prefix' => (string) $this->option('expected-asset-prefix'),
+            'allow_update_existing' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    private function preflightSummary(array $plan): array
+    {
+        $errors = [];
+        foreach ((array) ($plan['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $errors[] = $error + ['source' => 'manifest'];
+            }
+        }
+
+        foreach ($this->runtimeReadinessErrors() as $error) {
+            $errors[] = $error;
+        }
+
+        $assets = array_values(array_filter((array) ($plan['assets'] ?? []), 'is_array'));
+        $resumeRequired = false;
+        foreach ($assets as $asset) {
+            if ((bool) ($asset['resume_required'] ?? false)) {
+                $resumeRequired = true;
+                $errors[] = [
+                    'field' => 'assets.'.$asset['asset_key'],
+                    'code' => 'existing_asset_not_ready',
+                    'message' => 'Existing Media Library asset is not synced and CDN-verified; resume with --allow-update-existing from the production runner.',
+                ];
+            }
+        }
+
+        $ok = $errors === [];
+        $action = $ok ? 'seo_release_media_ready' : $this->failureAction($errors);
+        $needsAllowUpdateExisting = $resumeRequired || count(array_filter(
+            $assets,
+            static fn (array $asset): bool => ($asset['existing_asset_id'] ?? null) !== null
+        )) > 0;
+
+        return [
+            'ok' => $ok,
+            'dry_run' => true,
+            'action' => $action,
+            'would_write' => false,
+            'package' => $plan['package'] ?? null,
+            'translation_group_id' => $plan['translation_group_id'] ?? null,
+            'runtime' => $this->redactedRuntimeConfig(),
+            'assets_count' => count($assets),
+            'assets' => $assets,
+            'resume_required' => $resumeRequired,
+            'needs_allow_update_existing' => $needsAllowUpdateExisting,
+            'next_command' => $this->nextCommand($needsAllowUpdateExisting),
+            'errors' => $errors,
+            'warnings' => $plan['warnings'] ?? [],
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function runtimeReadinessErrors(): array
+    {
+        $errors = [];
+        if ($this->appEnv() !== 'production') {
+            $errors[] = [
+                'field' => 'app.env',
+                'code' => 'media_runtime_not_ready',
+                'message' => 'SEO Media Library write stages must run from the production runner.',
+            ];
+        }
+
+        if (! (bool) config('fap.media.oss_sync_enabled', false)) {
+            $errors[] = [
+                'field' => 'fap.media.oss_sync_enabled',
+                'code' => 'media_runtime_not_ready',
+                'message' => 'FAP_MEDIA_OSS_SYNC_ENABLED must be true.',
+            ];
+        }
+
+        if (! (bool) config('fap.media.cdn_verify_enabled', false)) {
+            $errors[] = [
+                'field' => 'fap.media.cdn_verify_enabled',
+                'code' => 'media_runtime_not_ready',
+                'message' => 'FAP_MEDIA_CDN_VERIFY_ENABLED must be true.',
+            ];
+        }
+
+        if (PublicMediaUrlGuard::canonicalAssetOrigin() !== PublicMediaUrlGuard::DEFAULT_ASSET_ORIGIN) {
+            $errors[] = [
+                'field' => 'fap.media.asset_origin',
+                'code' => 'media_runtime_not_ready',
+                'message' => 'FAP_MEDIA_ASSET_ORIGIN must be https://assets.fermatmind.com.',
+            ];
+        }
+
+        $disk = trim((string) config('fap.media.oss_disk', ''));
+        if ($disk === '' || config('filesystems.disks.'.$disk) === null) {
+            $errors[] = [
+                'field' => 'fap.media.oss_disk',
+                'code' => 'media_runtime_not_ready',
+                'message' => 'FAP_MEDIA_OSS_DISK must reference a configured filesystem disk.',
+            ];
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function failureAction(array $errors): string
+    {
+        $codes = array_map(static fn (array $error): string => (string) ($error['code'] ?? ''), $errors);
+        if (in_array('media_runtime_not_ready', $codes, true)) {
+            return 'media_runtime_not_ready';
+        }
+        if (in_array('existing_asset_not_ready', $codes, true)) {
+            return 'existing_asset_not_ready';
+        }
+
+        return 'manifest_importer_incompatible';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function redactedRuntimeConfig(): array
+    {
+        $disk = trim((string) config('fap.media.oss_disk', ''));
+
+        return [
+            'app_env' => $this->appEnv(),
+            'asset_origin' => PublicMediaUrlGuard::canonicalAssetOrigin(),
+            'public_storage_prefix' => (string) config('fap.media.public_storage_prefix', ''),
+            'oss_sync_enabled' => (bool) config('fap.media.oss_sync_enabled', false),
+            'oss_disk' => $disk,
+            'oss_disk_configured' => $disk !== '' && config('filesystems.disks.'.$disk) !== null,
+            'oss_key_prefix' => (string) config('fap.media.oss_key_prefix', ''),
+            'cdn_verify_enabled' => (bool) config('fap.media.cdn_verify_enabled', false),
+            'cdn_verify_timeout_seconds' => (int) config('fap.media.cdn_verify_timeout_seconds', 5),
+        ];
+    }
+
+    private function nextCommand(bool $needsAllowUpdateExisting): string
+    {
+        $parts = [
+            'php artisan media-assets:import-seo-image-bundle',
+            '--package='.escapeshellarg((string) $this->option('package')),
+            '--translation-group-id='.escapeshellarg((string) $this->option('translation-group-id')),
+            '--locales='.escapeshellarg((string) $this->option('locales')),
+            '--expected-asset-prefix='.escapeshellarg((string) $this->option('expected-asset-prefix')),
+            '--write-resolved-package',
+            '--json',
+        ];
+
+        if ($needsAllowUpdateExisting) {
+            $parts[] = '--allow-update-existing';
+        }
+
+        return implode(' ', $parts);
+    }
+
+    private function appEnv(): string
+    {
+        return trim((string) config('app.env', app()->environment()));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'dry_run' => true,
+            'action' => $code === 'runtime_error' ? 'manifest_importer_incompatible' : 'will_skip',
+            'would_write' => false,
+            'runtime' => $this->redactedRuntimeConfig(),
+            'assets' => [],
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('assets_count='.(string) ($summary['assets_count'] ?? 0));
+        $this->line('resume_required='.(($summary['resume_required'] ?? false) ? '1' : '0'));
+        $this->line('needs_allow_update_existing='.(($summary['needs_allow_update_existing'] ?? false) ? '1' : '0'));
+        $this->line('next_command='.(string) ($summary['next_command'] ?? ''));
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('preflight_error='.implode(':', [
+                    (string) ($error['field'] ?? 'unknown'),
+                    (string) ($error['code'] ?? 'unknown'),
+                    (string) ($error['message'] ?? ''),
+                ]));
+            }
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -135,6 +135,8 @@ use App\Console\Commands\FapWeeklyReport;
 use App\Console\Commands\MbtiPrewarm;
 use App\Console\Commands\MbtiUpgradeLegacyPartialUnlocks;
 use App\Console\Commands\MediaAssetsImportSeoImageBundle;
+use App\Console\Commands\MediaAssetsSeoReleaseCleanup;
+use App\Console\Commands\MediaAssetsSeoReleasePreflight;
 use App\Console\Commands\MetricsWeeklyValidity;
 use App\Console\Commands\NormsBig5BootstrapBuild;
 use App\Console\Commands\NormsBig5DriftCheck;
@@ -452,6 +454,8 @@ class Kernel extends ConsoleKernel
         ArticleUpdateImageMetadata::class,
         ArticleWeeklySeoObservationExport::class,
         MediaAssetsImportSeoImageBundle::class,
+        MediaAssetsSeoReleaseCleanup::class,
+        MediaAssetsSeoReleasePreflight::class,
         SeoAgentCmsFaqGapScanCommand::class,
         SeoAgentAutoRollbackGuardCommand::class,
         SeoAgentArticleCmsPublishCanaryCommand::class,

--- a/backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php
+++ b/backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php
@@ -22,6 +22,13 @@ final class SeoImageBundleImporter
 
     private const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
+    private const FORMAT_EXTENSION_TO_MIME = [
+        'jpg' => 'image/jpeg',
+        'jpeg' => 'image/jpeg',
+        'png' => 'image/png',
+        'webp' => 'image/webp',
+    ];
+
     private const MAX_BYTES = 10485760;
 
     private const RECOMMENDED_MAX_BYTES = 3145728;
@@ -94,6 +101,13 @@ final class SeoImageBundleImporter
 
         if ($dryRun) {
             return $this->summary(true, true, 'would_import_media_assets', $package, $translationGroupId, $plans, $this->resolvedMetadataFromPlans($plans, $locales, true), [], $warnings);
+        }
+
+        if ($writeResolvedPackage) {
+            $this->validateMediaRuntimeReadyForResolvedPackage($errors);
+            if ($errors !== []) {
+                return $this->summary(false, false, 'media_runtime_not_ready', $package, $translationGroupId, $plans, [], $errors, $warnings);
+            }
         }
 
         $writtenPlans = [];
@@ -175,7 +189,7 @@ final class SeoImageBundleImporter
             $assetKey = strtolower(trim((string) ($row['asset_key'] ?? '')));
             $role = trim((string) ($row['role'] ?? ''));
             $sourceFile = ltrim(trim((string) ($row['source_file'] ?? '')), '/');
-            $altText = trim((string) ($row['alt_text'] ?? ''));
+            $altText = $this->normalizeAltText($row['alt_text'] ?? null);
             $path = $package.'/'.$sourceFile;
 
             if (! preg_match('/^article\.[a-z0-9][a-z0-9.-]*\.v[0-9]+$/', $assetKey)) {
@@ -222,6 +236,7 @@ final class SeoImageBundleImporter
                 'credit' => $this->nullableString($row['credit'] ?? null),
                 'intended_usage' => array_values(array_filter((array) ($row['intended_usage'] ?? []), 'is_string')),
                 'provenance' => is_array($provenance) ? $provenance : [],
+                'alt_text_localized' => is_array($row['alt_text'] ?? null) ? $row['alt_text'] : null,
                 'file' => $fileMeta,
             ];
         }
@@ -307,7 +322,7 @@ final class SeoImageBundleImporter
         }
 
         $allowedFormats = array_values(array_filter(array_map(
-            static fn (mixed $format): string => strtolower(trim((string) $format)),
+            fn (mixed $format): string => $this->normalizeAllowedFormat($format),
             (array) ($row['format_allowed'] ?? [])
         ), static fn (string $format): bool => $format !== ''));
         if ($allowedFormats !== [] && ! in_array((string) ($fileMeta['mime_type'] ?? ''), $allowedFormats, true)) {
@@ -342,6 +357,10 @@ final class SeoImageBundleImporter
         return [
             ...$asset,
             'existing_asset_id' => $existing?->id,
+            'existing_sync_status' => $existing?->sync_status,
+            'existing_cdn_status' => $existing?->cdn_status,
+            'resume_required' => $existing instanceof MediaAsset
+                && ((string) $existing->sync_status !== MediaAsset::SYNC_SYNCED || (string) $existing->cdn_status !== MediaAsset::CDN_VERIFIED),
             'would_create' => ! $existing instanceof MediaAsset,
             'would_update' => $existing instanceof MediaAsset,
             'would_generate_variants' => true,
@@ -408,6 +427,7 @@ final class SeoImageBundleImporter
                     'source_file' => (string) $plan['source_file'],
                     'intended_usage' => $plan['intended_usage'] ?? [],
                     'provenance' => $plan['provenance'] ?? [],
+                    'alt_text_localized' => $plan['alt_text_localized'] ?? null,
                 ],
             ]),
         ]);
@@ -657,6 +677,29 @@ final class SeoImageBundleImporter
     /**
      * @param  list<array<string,mixed>>  $errors
      */
+    private function validateMediaRuntimeReadyForResolvedPackage(array &$errors): void
+    {
+        if (! (bool) config('fap.media.oss_sync_enabled', false)) {
+            $errors[] = $this->issue('fap.media.oss_sync_enabled', 'media_runtime_not_ready', 'FAP_MEDIA_OSS_SYNC_ENABLED must be true before writing a CMS-ready resolved package.');
+        }
+
+        if (! (bool) config('fap.media.cdn_verify_enabled', false)) {
+            $errors[] = $this->issue('fap.media.cdn_verify_enabled', 'media_runtime_not_ready', 'FAP_MEDIA_CDN_VERIFY_ENABLED must be true before writing a CMS-ready resolved package.');
+        }
+
+        $origin = PublicMediaUrlGuard::canonicalAssetOrigin();
+        if ($origin !== PublicMediaUrlGuard::DEFAULT_ASSET_ORIGIN) {
+            $errors[] = $this->issue('fap.media.asset_origin', 'media_runtime_not_ready', 'FAP_MEDIA_ASSET_ORIGIN must be https://assets.fermatmind.com for daily SEO resolved packages.');
+        }
+
+        if (trim((string) config('fap.media.oss_disk', '')) === '') {
+            $errors[] = $this->issue('fap.media.oss_disk', 'media_runtime_not_ready', 'FAP_MEDIA_OSS_DISK must be configured before writing a CMS-ready resolved package.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
     private function assertCanonicalAssetUrl(mixed $url, string $field, array &$errors): void
     {
         $candidate = PublicMediaUrlGuard::sanitizeNullableUrl($url);
@@ -769,6 +812,9 @@ final class SeoImageBundleImporter
             'alt_text' => (string) ($plan['alt_text'] ?? ''),
             'file' => $plan['file'] ?? [],
             'existing_asset_id' => $plan['existing_asset_id'] ?? null,
+            'existing_sync_status' => $plan['existing_sync_status'] ?? null,
+            'existing_cdn_status' => $plan['existing_cdn_status'] ?? null,
+            'resume_required' => (bool) ($plan['resume_required'] ?? false),
             'media_asset_id' => $plan['media_asset_id'] ?? null,
             'would_create' => (bool) ($plan['would_create'] ?? false),
             'would_update' => (bool) ($plan['would_update'] ?? false),
@@ -795,6 +841,41 @@ final class SeoImageBundleImporter
         $trimmed = trim((string) $value);
 
         return $trimmed !== '' ? $trimmed : null;
+    }
+
+    private function normalizeAltText(mixed $value): string
+    {
+        if (is_array($value)) {
+            foreach (['zh-CN', 'zh_cn', 'zh', 'en'] as $localeKey) {
+                $candidate = $this->nullableString($value[$localeKey] ?? null);
+                if ($candidate !== null) {
+                    return $candidate;
+                }
+            }
+
+            foreach ($value as $candidate) {
+                $normalized = $this->nullableString($candidate);
+                if ($normalized !== null) {
+                    return $normalized;
+                }
+            }
+
+            return '';
+        }
+
+        return trim((string) $value);
+    }
+
+    private function normalizeAllowedFormat(mixed $format): string
+    {
+        $normalized = strtolower(trim((string) $format));
+        if ($normalized === '') {
+            return '';
+        }
+
+        $normalized = ltrim($normalized, '.');
+
+        return self::FORMAT_EXTENSION_TO_MIME[$normalized] ?? $normalized;
     }
 
     /**

--- a/backend/tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php
+++ b/backend/tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php
@@ -43,6 +43,118 @@ final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
         $this->assertFalse(Storage::disk('public')->exists('media-library'));
     }
 
+    public function test_manifest_accepts_localized_alt_text_and_extension_format_allowed(): void
+    {
+        Storage::fake('public');
+        $package = $this->writeImageBundlePackage(static function (array &$manifest): void {
+            $manifest['assets'][0]['alt_text'] = [
+                'zh-CN' => '结构化职业决策地图封面图',
+                'en' => 'SEO cover image showing a structured career decision map',
+            ];
+            $manifest['assets'][0]['format_allowed'] = ['png', 'jpg', 'webp'];
+        });
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('结构化职业决策地图封面图', $payload['resolved_metadata']['cover_image_alt']);
+        $this->assertSame('结构化职业决策地图封面图', $payload['assets'][0]['alt_text']);
+    }
+
+    public function test_seo_release_preflight_fails_when_media_runtime_disabled_without_writes(): void
+    {
+        Storage::fake('public');
+        $package = $this->writeImageBundlePackage();
+
+        $exitCode = Artisan::call('media-assets:seo-release-preflight', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('media_runtime_not_ready', $payload['action']);
+        $this->assertFalse($payload['would_write']);
+        $this->assertErrorCode($payload, 'media_runtime_not_ready');
+        $this->assertSame(0, MediaAsset::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, MediaVariant::query()->count());
+        $this->assertArrayNotHasKey('AWS_SECRET_ACCESS_KEY', $payload['runtime']);
+    }
+
+    public function test_seo_release_preflight_passes_with_production_media_runtime(): void
+    {
+        Storage::fake('public');
+        Storage::fake('s3');
+        config([
+            'app.env' => 'production',
+            'fap.media.oss_sync_enabled' => true,
+            'fap.media.oss_disk' => 's3',
+            'fap.media.oss_key_prefix' => 'storage',
+            'fap.media.cdn_verify_enabled' => true,
+        ]);
+        $package = $this->writeImageBundlePackage();
+
+        $exitCode = Artisan::call('media-assets:seo-release-preflight', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('seo_release_media_ready', $payload['action']);
+        $this->assertFalse($payload['would_write']);
+        $this->assertFalse($payload['resume_required']);
+        $this->assertStringContainsString('media-assets:import-seo-image-bundle', $payload['next_command']);
+    }
+
+    public function test_seo_release_preflight_existing_skipped_asset_requires_resume(): void
+    {
+        Storage::fake('public');
+        Storage::fake('s3');
+        config([
+            'app.env' => 'production',
+            'fap.media.oss_sync_enabled' => true,
+            'fap.media.oss_disk' => 's3',
+            'fap.media.oss_key_prefix' => 'storage',
+            'fap.media.cdn_verify_enabled' => true,
+        ]);
+        MediaAsset::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'asset_key' => 'article.daily.seo.cover.v1',
+            'disk' => 'public',
+            'path' => 'media-library/source/old.png',
+            'url' => 'https://assets.fermatmind.com/storage/media-library/source/old.png',
+            'mime_type' => 'image/png',
+            'width' => 1600,
+            'height' => 900,
+            'bytes' => 100,
+            'alt' => 'Old image',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'sync_status' => MediaAsset::SYNC_SKIPPED,
+            'cdn_status' => MediaAsset::CDN_SKIPPED,
+        ]);
+        $package = $this->writeImageBundlePackage();
+
+        $exitCode = Artisan::call('media-assets:seo-release-preflight', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('existing_asset_not_ready', $payload['action']);
+        $this->assertTrue($payload['resume_required']);
+        $this->assertTrue($payload['needs_allow_update_existing']);
+        $this->assertStringContainsString('--allow-update-existing', $payload['next_command']);
+        $this->assertErrorCode($payload, 'existing_asset_not_ready');
+    }
+
     public function test_missing_manifest_fails_when_image_bundle_required(): void
     {
         $package = $this->writeImageBundlePackage();
@@ -202,7 +314,7 @@ final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
         $this->assertNull($payload['resolved_metadata']['cover_image_variants']['hero']['url']);
     }
 
-    public function test_write_resolved_package_fails_when_media_asset_is_not_cdn_ready(): void
+    public function test_write_resolved_package_fails_before_writes_when_media_runtime_is_not_ready(): void
     {
         config(['app.url' => 'https://ops.fermatmind.com']);
         Storage::fake('public');
@@ -218,10 +330,11 @@ final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
         $payload = $this->jsonOutput();
         $this->assertSame(1, $exitCode);
         $this->assertFalse($payload['ok']);
-        $this->assertSame('media_asset_cdn_not_ready', $payload['action']);
-        $this->assertErrorCode($payload, 'media_asset_cdn_not_ready');
+        $this->assertSame('media_runtime_not_ready', $payload['action']);
+        $this->assertErrorCode($payload, 'media_runtime_not_ready');
         $this->assertDirectoryDoesNotExist($output);
-        $this->assertNull($payload['resolved_metadata']['cover_image_url']);
+        $this->assertSame(0, MediaAsset::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, MediaVariant::query()->count());
     }
 
     public function test_write_resolved_package_requires_and_outputs_canonical_assets_origin_urls(): void
@@ -258,6 +371,165 @@ final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
         $draft = json_decode((string) file_get_contents($output.'/cms/CMS_IMPORT_DRAFT_en_demo.json'), true);
         $this->assertStringStartsWith('https://assets.fermatmind.com/storage/media-library/variants/', $draft['cover_image_url']);
         $this->assertStringNotContainsString('ops.fermatmind.com', json_encode($draft, JSON_THROW_ON_ERROR));
+    }
+
+    public function test_write_resolved_package_resumes_existing_asset_with_allow_update_existing(): void
+    {
+        Storage::fake('public');
+        Storage::fake('s3');
+        Http::fake([
+            'assets.fermatmind.com/*' => Http::response('', 200, ['Content-Type' => 'image/jpeg']),
+        ]);
+        config([
+            'fap.media.oss_sync_enabled' => true,
+            'fap.media.oss_disk' => 's3',
+            'fap.media.oss_key_prefix' => 'storage',
+            'fap.media.cdn_verify_enabled' => true,
+        ]);
+        MediaAsset::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'asset_key' => 'article.daily.seo.cover.v1',
+            'disk' => 'public',
+            'path' => 'media-library/source/old.png',
+            'url' => 'https://assets.fermatmind.com/storage/media-library/source/old.png',
+            'mime_type' => 'image/png',
+            'width' => 1600,
+            'height' => 900,
+            'bytes' => 100,
+            'alt' => 'Old image',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'sync_status' => MediaAsset::SYNC_SKIPPED,
+            'cdn_status' => MediaAsset::CDN_SKIPPED,
+        ]);
+        $package = $this->writeImageBundlePackage();
+        $output = sys_get_temp_dir().'/fm-image-bundle-resume-'.Str::random(12);
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--json' => true,
+            '--write-resolved-package' => true,
+            '--resolved-output-dir' => $output,
+            '--allow-update-existing' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame(1, MediaAsset::query()->withoutGlobalScopes()->count());
+
+        $asset = MediaAsset::query()->withoutGlobalScopes()->where('asset_key', 'article.daily.seo.cover.v1')->firstOrFail();
+        $this->assertSame('SEO cover image showing a structured career decision map', (string) $asset->alt);
+        $this->assertSame(MediaAsset::SYNC_SYNCED, (string) $asset->sync_status);
+        $this->assertSame(MediaAsset::CDN_VERIFIED, (string) $asset->cdn_status);
+        $this->assertSame(6, $asset->variants()->count());
+        $this->assertFileExists($output.'/cms/CMS_IMPORT_DRAFT_en_demo.json');
+    }
+
+    public function test_seo_release_cleanup_dry_run_reports_half_failed_assets(): void
+    {
+        Http::fake([
+            'assets.fermatmind.com/*' => Http::response('', 404, ['Content-Type' => 'text/html']),
+        ]);
+        Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'demo',
+            'locale' => 'en',
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'title' => 'Demo',
+            'excerpt' => 'Demo',
+            'content_md' => 'Body',
+            'cover_image_url' => 'https://assets.fermatmind.com/storage/media-library/variants/articledailyseocoverv1/hero_1600x900.jpg',
+            'cover_image_alt' => 'Demo',
+            'cover_image_width' => 1600,
+            'cover_image_height' => 900,
+            'cover_image_variants' => [
+                'editorial_package_v1' => [
+                    'cover_media_asset_key' => 'article.daily.seo.cover.v1',
+                ],
+            ],
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+        MediaAsset::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'asset_key' => 'article.daily.seo.cover.v1',
+            'disk' => 'public',
+            'path' => 'media-library/source/cover.png',
+            'url' => 'https://assets.fermatmind.com/storage/media-library/source/cover.png',
+            'mime_type' => 'image/png',
+            'width' => 1600,
+            'height' => 900,
+            'bytes' => 100,
+            'alt' => 'Demo',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'sync_status' => MediaAsset::SYNC_SKIPPED,
+            'cdn_status' => MediaAsset::CDN_SKIPPED,
+        ]);
+
+        $exitCode = Artisan::call('media-assets:seo-release-cleanup', [
+            '--asset-prefix' => 'article.daily.seo',
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('cleanup_dry_run', $payload['action']);
+        $this->assertTrue($payload['deletion_held']);
+        $this->assertSame(1, $payload['not_ready_count']);
+        $this->assertFalse($payload['assets'][0]['ready_for_cms']);
+        $this->assertTrue($payload['assets'][0]['cms_reference_status']['referenced']);
+    }
+
+    public function test_seo_release_cleanup_resync_moves_half_failed_assets_to_verified(): void
+    {
+        Storage::fake('public');
+        Storage::fake('s3');
+        Http::fake([
+            'assets.fermatmind.com/*' => Http::response('', 200, ['Content-Type' => 'image/jpeg']),
+        ]);
+        config([
+            'fap.media.oss_sync_enabled' => false,
+            'fap.media.cdn_verify_enabled' => false,
+        ]);
+        $package = $this->writeImageBundlePackage();
+
+        $createExitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+        $this->assertSame(0, $createExitCode);
+        $asset = MediaAsset::query()->withoutGlobalScopes()->where('asset_key', 'article.daily.seo.cover.v1')->firstOrFail();
+        $this->assertSame(MediaAsset::SYNC_SKIPPED, (string) $asset->sync_status);
+
+        config([
+            'fap.media.oss_sync_enabled' => true,
+            'fap.media.oss_disk' => 's3',
+            'fap.media.oss_key_prefix' => 'storage',
+            'fap.media.cdn_verify_enabled' => true,
+        ]);
+
+        $exitCode = Artisan::call('media-assets:seo-release-cleanup', [
+            '--asset-prefix' => 'article.daily.seo',
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--resync' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('resynced_media_assets', $payload['action']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame(0, $payload['not_ready_count']);
+        $this->assertTrue($payload['assets'][0]['ready_for_cms']);
+
+        $fresh = MediaAsset::query()->withoutGlobalScopes()->where('asset_key', 'article.daily.seo.cover.v1')->firstOrFail();
+        $this->assertSame(MediaAsset::SYNC_SYNCED, (string) $fresh->sync_status);
+        $this->assertSame(MediaAsset::CDN_VERIFIED, (string) $fresh->cdn_status);
     }
 
     public function test_dry_run_does_not_write_existing_asset_or_storage(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2652,12 +2652,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Console/Commands/MediaAssetsImportSeoImageBundle.php',
+            'backend/app/Console/Commands/MediaAssetsSeoReleaseCleanup.php',
+            'backend/app/Console/Commands/MediaAssetsSeoReleasePreflight.php',
             'backend/app/Console/Kernel.php',
             'backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php',
         ];
         $kernelChangedLines = [
             '+use App\\Console\\Commands\\MediaAssetsImportSeoImageBundle;',
+            '+use App\\Console\\Commands\\MediaAssetsSeoReleaseCleanup;',
+            '+use App\\Console\\Commands\\MediaAssetsSeoReleasePreflight;',
             '+        MediaAssetsImportSeoImageBundle::class,',
+            '+        MediaAssetsSeoReleaseCleanup::class,',
+            '+        MediaAssetsSeoReleasePreflight::class,',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
@@ -6619,7 +6625,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isSeoImageBundleImporterFile(string $file): bool
     {
-        return $file === 'backend/app/Console/Commands/MediaAssetsImportSeoImageBundle.php'
+        return in_array($file, [
+            'backend/app/Console/Commands/MediaAssetsImportSeoImageBundle.php',
+            'backend/app/Console/Commands/MediaAssetsSeoReleaseCleanup.php',
+            'backend/app/Console/Commands/MediaAssetsSeoReleasePreflight.php',
+        ], true)
             || str_starts_with($file, 'backend/app/Services/Cms/SeoImageBundle/');
     }
 
@@ -8974,7 +8984,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\bMediaAssetsImportSeoImageBundle\b/u', $line) !== 1) {
+            if (preg_match('/\b(MediaAssetsImportSeoImageBundle|MediaAssetsSeoReleaseCleanup|MediaAssetsSeoReleasePreflight)\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/runbooks/seo-daily-media-release-runner.md
+++ b/docs/runbooks/seo-daily-media-release-runner.md
@@ -1,0 +1,81 @@
+# SEO Daily Media Release Runner
+
+This runbook hardens the Media Library stage that runs before CMS draft import for daily SEO articles.
+
+## Production Runner Requirements
+
+- Run Media Library write stages only from the production runner.
+- Required media runtime:
+  - `APP_ENV=production`
+  - `FAP_MEDIA_ASSET_ORIGIN=https://assets.fermatmind.com`
+  - `FAP_MEDIA_OSS_SYNC_ENABLED=true`
+  - `FAP_MEDIA_CDN_VERIFY_ENABLED=true`
+  - `FAP_MEDIA_OSS_DISK` points to a configured filesystem disk.
+  - `FAP_MEDIA_OSS_KEY_PREFIX=storage`
+- Keep OSS credentials in the runner environment only. Do not commit secrets, resolved credential values, private URLs, or temporary key files.
+
+## Required Sequence
+
+1. Preflight package, manifest, existing asset state, and production media runtime:
+
+```bash
+php artisan media-assets:seo-release-preflight \
+  --package=/path/to/stage4-package \
+  --translation-group-id=tg_article_example_2026v1 \
+  --locales=zh-CN,en \
+  --expected-asset-prefix=article.example.topic \
+  --json
+```
+
+2. Run importer dry-run:
+
+```bash
+php artisan media-assets:import-seo-image-bundle \
+  --package=/path/to/stage4-package \
+  --translation-group-id=tg_article_example_2026v1 \
+  --locales=zh-CN,en \
+  --expected-asset-prefix=article.example.topic \
+  --dry-run \
+  --write-resolved-package \
+  --json
+```
+
+3. Write/resume Media Library assets and create the resolved CMS-ready package:
+
+```bash
+php artisan media-assets:import-seo-image-bundle \
+  --package=/path/to/stage4-package \
+  --translation-group-id=tg_article_example_2026v1 \
+  --locales=zh-CN,en \
+  --expected-asset-prefix=article.example.topic \
+  --allow-update-existing \
+  --write-resolved-package \
+  --resolved-output-dir=/path/to/resolved-package \
+  --json
+```
+
+4. Continue only after the resolved package contains canonical `https://assets.fermatmind.com/...` image URLs. Then proceed to CMS draft import, preview QA, controlled publish, URL Truth, Search Channel, GSC Request Indexing, and D1/D7/D14 observation.
+
+## Half-Failed Asset Recovery
+
+When an earlier run created MediaAsset rows but CDN/object truth was not ready, audit first:
+
+```bash
+php artisan media-assets:seo-release-cleanup \
+  --asset-prefix=article.example.topic \
+  --translation-group-id=tg_article_example_2026v1 \
+  --dry-run \
+  --json
+```
+
+If the production media runtime is now ready, resync without deleting assets:
+
+```bash
+php artisan media-assets:seo-release-cleanup \
+  --asset-prefix=article.example.topic \
+  --translation-group-id=tg_article_example_2026v1 \
+  --resync \
+  --json
+```
+
+Deletion is intentionally held. Do not delete half-failed assets without a separate reviewed operator approval.


### PR DESCRIPTION
## What changed
- Added `media-assets:seo-release-preflight` for production runner readiness checks before SEO Media Library writes.
- Added `media-assets:seo-release-cleanup` for half-failed SEO asset audit/resync without deletion.
- Hardened `media-assets:import-seo-image-bundle` so `--write-resolved-package` fails before DB/storage writes when OSS/CDN runtime is not ready.
- Made the SEO image importer tolerate localized `alt_text` and extension-style `format_allowed`, and expose existing asset resume state.
- Added a daily SEO media release runner runbook.

## Why
Daily SEO article publication can otherwise create MediaAsset rows before discovering that the production CDN/object truth is not ready. This PR makes that failure happen before writes, and gives operators a safe idempotent resume/resync path.

## Validation
- `./vendor/bin/pint app/Console/Commands/MediaAssetsSeoReleasePreflight.php app/Console/Commands/MediaAssetsSeoReleaseCleanup.php app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php`
- `php artisan test --filter=MediaAssetsImportSeoImageBundleCommandTest`
- `php artisan test --filter=MediaAssetStorageSyncServiceTest`
- `php artisan test --filter=MediaLibraryOssSyncTest`
- `php artisan help media-assets:seo-release-preflight`
- `php artisan help media-assets:seo-release-cleanup`
- `git diff --check`
- `php artisan route:list`
- `php artisan migrate --pretend`
- `bash scripts/ci_verify_mbti.sh`

## Repository rule impact
Backend/CMS remains the authority for article media. This adds backend Media Library operational gates only; it does not add frontend fallback content, publish controls, schema/hreflang behavior, or search submission behavior.

## Intentionally deferred
- No automatic deletion of half-failed assets; deletion remains held for separate reviewed operator approval.
- No schema/hreflang/search-channel changes.
- No production environment secret changes in repo.