### PR TITLE
MBTI64-ZH32-EN32-V8_5-V5-PROMOTION-CONTRACT-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
@@ -30,6 +30,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
         {--fresh-query-backed-5 : Restrict agent projection promotion planning/write to the fresh 5 query-backed MBTI64 URLs}
         {--next-batch-6 : Restrict agent projection promotion planning/write to the approved next-batch 6 MBTI64 URLs}
         {--remaining-58 : Restrict agent projection promotion planning/write to the approved 58 remaining competitor-gap MBTI64 variant URLs}
+        {--v8-5-v5-bilingual-64 : Restrict agent projection promotion planning/write to the fixed 64 MBTI64 V8.5/V5 bilingual variant URLs}
         {--json : Emit the full JSON summary}
         {--output= : Optional path to write the JSON summary}
         {--promote-live-content : Required for --write; confirms live CMS content promotion intent}
@@ -143,6 +144,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
             'fresh_query_backed_5' => (bool) $this->option('fresh-query-backed-5'),
             'next_batch_6' => (bool) $this->option('next-batch-6'),
             'remaining_58' => (bool) $this->option('remaining-58'),
+            'v8_5_v5_bilingual_64' => (bool) $this->option('v8-5-v5-bilingual-64'),
         ];
     }
 

--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -32,6 +32,14 @@ final class Mbti64CmsRevisionPromotionService
 
     private const REMAINING_58_V2_PACKAGE_ARTIFACT = 'MBTI64-REMAINING-58-COMPETITOR-GAP-CONTENT-EXPANSION-V2-01';
 
+    private const V8_5_V5_BILINGUAL_64_ARTIFACT = 'MBTI64-ZH32-EN32-V8_5-V5-BILINGUAL-PACKAGE-QA-01';
+
+    private const V8_5_V5_BILINGUAL_64_PACKAGE_VERSION = 'mbti64_zh32_en32_v8_5_v5_bilingual_v1';
+
+    private const V8_5_V5_BILINGUAL_64_PACKAGE_FILE_SHA256 = 'a0fd058b82ec40940b8c92546c461086d3bfca7a4b0521aeb92e5cc8b0517b67';
+
+    private const V8_5_V5_BILINGUAL_64_EMBEDDED_PACKAGE_SHA256 = '13ec2c55caf2cf7b48650739fabadfb09ec4a02214cb1af99d5e47d8af2499d8';
+
     private const VISIBLE_QUERY_BACKED_3_URLS = [
         'https://fermatmind.com/en/personality/enfj-a',
         'https://fermatmind.com/zh/personality/intp-a',
@@ -86,7 +94,7 @@ final class Mbti64CmsRevisionPromotionService
      */
     private function buildSummary(array $package, string $sourceSha256, bool $write, array $options): array
     {
-        $contract = $this->promotionContract($package, $options);
+        $contract = $this->promotionContract($package, $sourceSha256, $options);
         if (($contract['ok'] ?? false) !== true) {
             return array_merge($this->baseSummary($package, $sourceSha256, $write), [
                 'ok' => false,
@@ -169,10 +177,10 @@ final class Mbti64CmsRevisionPromotionService
      * @param  array<string,mixed>  $package
      * @return array<string,mixed>
      */
-    private function promotionContract(array $package, array $options): array
+    private function promotionContract(array $package, string $sourceSha256, array $options): array
     {
         if ($this->isAgentProjectionPackage($package)) {
-            return $this->agentProjectionContract($package, $options);
+            return $this->agentProjectionContract($package, $sourceSha256, $options);
         }
 
         return $this->planner->plan($package);
@@ -192,7 +200,7 @@ final class Mbti64CmsRevisionPromotionService
      * @param  array<string,mixed>  $package
      * @return array<string,mixed>
      */
-    private function agentProjectionContract(array $package, array $options): array
+    private function agentProjectionContract(array $package, string $sourceSha256, array $options): array
     {
         $errors = [];
         $warnings = [];
@@ -211,10 +219,12 @@ final class Mbti64CmsRevisionPromotionService
         $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
         $nextBatch6 = (bool) ($options['next_batch_6'] ?? false);
         $remaining58 = (bool) ($options['remaining_58'] ?? false);
+        $v85V5Bilingual64 = (bool) ($options['v8_5_v5_bilingual_64'] ?? false);
         $subsetModeCount = ($visibleQueryBacked3 ? 1 : 0)
             + ($freshQueryBacked5 ? 1 : 0)
             + ($nextBatch6 ? 1 : 0)
-            + ($remaining58 ? 1 : 0);
+            + ($remaining58 ? 1 : 0)
+            + ($v85V5Bilingual64 ? 1 : 0);
         if ($subsetModeCount > 1) {
             $errors[] = [
                 'field' => 'options',
@@ -228,6 +238,7 @@ final class Mbti64CmsRevisionPromotionService
             $freshQueryBacked5 => self::FRESH_QUERY_BACKED_5_URLS,
             $nextBatch6 => self::NEXT_BATCH_6_URLS,
             $remaining58 => $this->remaining58Urls(),
+            $v85V5Bilingual64 => $this->v85V5Bilingual64Urls(),
             default => [],
         };
         $contractRecommendations = $subsetUrls !== []
@@ -238,6 +249,8 @@ final class Mbti64CmsRevisionPromotionService
             $this->validateNextBatch6ContractPackage($package, $recommendations, $errors);
         } elseif ($remaining58) {
             $this->validateRemaining58ContractPackage($package, $recommendations, $errors);
+        } elseif ($v85V5Bilingual64) {
+            $this->validateV85V5Bilingual64ContractPackage($package, $sourceSha256, $recommendations, $errors);
         } else {
             if ((string) ($package['artifact'] ?? '') !== self::AGENT_PROJECTION_ARTIFACT) {
                 $errors[] = ['field' => 'artifact', 'code' => 'unsupported_package_artifact', 'message' => 'Unexpected MBTI64 agent projection artifact.'];
@@ -283,6 +296,13 @@ final class Mbti64CmsRevisionPromotionService
                 'message' => 'Expected exactly the 58 approved remaining competitor-gap MBTI64 variant recommendations.',
             ];
         }
+        if ($v85V5Bilingual64 && count($contractRecommendations) !== 64) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'v8_5_v5_bilingual_64_subset_incomplete',
+                'message' => 'Expected exactly the 64 approved MBTI64 V8.5/V5 bilingual variant recommendations.',
+            ];
+        }
 
         $rows = [];
         foreach ($contractRecommendations as $index => $recommendation) {
@@ -324,6 +344,7 @@ final class Mbti64CmsRevisionPromotionService
                     $freshQueryBacked5 => 'fresh_query_backed_5',
                     $nextBatch6 => 'next_batch_6',
                     $remaining58 => 'remaining_58',
+                    $v85V5Bilingual64 => 'v8_5_v5_bilingual_64',
                     default => 'full_agent_projection_88',
                 },
                 'enabled' => $subsetUrls !== [],
@@ -498,6 +519,99 @@ final class Mbti64CmsRevisionPromotionService
     }
 
     /**
+     * @param  list<array<string,mixed>>  $recommendations
+     * @param  list<array<string,string>>  $errors
+     */
+    private function validateV85V5Bilingual64ContractPackage(array $package, string $sourceSha256, array $recommendations, array &$errors): void
+    {
+        $summary = is_array($package['summary'] ?? null) ? $package['summary'] : [];
+        $actualUrls = array_map(
+            static fn (array $recommendation): string => (string) ($recommendation['target_url'] ?? ''),
+            $recommendations
+        );
+        $expectedUrls = $this->v85V5Bilingual64Urls();
+        sort($actualUrls);
+        sort($expectedUrls);
+
+        if ($sourceSha256 !== self::V8_5_V5_BILINGUAL_64_PACKAGE_FILE_SHA256) {
+            $errors[] = [
+                'field' => 'source_sha256',
+                'code' => 'unsupported_v8_5_v5_bilingual_64_package_sha256',
+                'message' => 'Unexpected MBTI64 V8.5/V5 bilingual package file SHA256.',
+            ];
+        }
+        if ((string) ($package['package_sha256'] ?? '') !== self::V8_5_V5_BILINGUAL_64_EMBEDDED_PACKAGE_SHA256) {
+            $errors[] = [
+                'field' => 'package_sha256',
+                'code' => 'unsupported_v8_5_v5_bilingual_64_embedded_sha256',
+                'message' => 'Unexpected MBTI64 V8.5/V5 bilingual embedded package SHA256.',
+            ];
+        }
+        if ((string) ($package['artifact'] ?? '') !== self::V8_5_V5_BILINGUAL_64_ARTIFACT) {
+            $errors[] = [
+                'field' => 'artifact',
+                'code' => 'unsupported_v8_5_v5_bilingual_64_artifact',
+                'message' => 'Unexpected MBTI64 V8.5/V5 bilingual package artifact.',
+            ];
+        }
+        if ((string) ($package['package_version'] ?? '') !== self::V8_5_V5_BILINGUAL_64_PACKAGE_VERSION) {
+            $errors[] = [
+                'field' => 'package_version',
+                'code' => 'unsupported_v8_5_v5_bilingual_64_package_version',
+                'message' => 'Unexpected MBTI64 V8.5/V5 bilingual package version.',
+            ];
+        }
+        if ((string) ($package['status'] ?? '') !== 'pass') {
+            $errors[] = [
+                'field' => 'status',
+                'code' => 'v8_5_v5_bilingual_64_package_status_not_pass',
+                'message' => 'V8.5/V5 bilingual package must have pass status before promotion planning.',
+            ];
+        }
+        if ((string) ($package['framework'] ?? '') !== 'mbti64') {
+            $errors[] = [
+                'field' => 'framework',
+                'code' => 'v8_5_v5_bilingual_64_framework_not_mbti64',
+                'message' => 'V8.5/V5 bilingual package framework must be mbti64.',
+            ];
+        }
+        if ((string) ($package['final_decision'] ?? '') !== 'PASS_READY_FOR_FAP_API_ARTIFACT_SYNC') {
+            $errors[] = [
+                'field' => 'final_decision',
+                'code' => 'v8_5_v5_bilingual_64_final_decision_not_ready',
+                'message' => 'V8.5/V5 bilingual package must be ready for fap-api artifact sync before promotion planning.',
+            ];
+        }
+        if (count($recommendations) !== 64 || (int) ($package['target_count'] ?? -1) !== 64) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'unexpected_v8_5_v5_bilingual_64_recommendation_count',
+                'message' => 'Expected exactly 64 MBTI64 V8.5/V5 bilingual recommendations.',
+            ];
+        }
+        if ((int) ($summary['target_count'] ?? -1) !== 64
+            || (int) ($summary['zh_pages'] ?? -1) !== 32
+            || (int) ($summary['en_pages'] ?? -1) !== 32
+            || (int) ($summary['variant_pages'] ?? -1) !== 64
+            || (int) ($summary['comparison_pages'] ?? -1) !== 0
+            || (int) ($summary['qa_pass_count'] ?? -1) !== 64
+            || (int) ($summary['qa_blocked_count'] ?? -1) !== 0) {
+            $errors[] = [
+                'field' => 'summary',
+                'code' => 'unexpected_v8_5_v5_bilingual_64_summary_counts',
+                'message' => 'Expected 64 pass, 32 zh, 32 en, 64 variant, and 0 comparison recommendations.',
+            ];
+        }
+        if ($actualUrls !== $expectedUrls) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'v8_5_v5_bilingual_64_url_set_mismatch',
+                'message' => 'V8.5/V5 bilingual package must contain exactly the fixed 64 MBTI64 variant URL set.',
+            ];
+        }
+    }
+
+    /**
      * @return list<string>
      */
     private function remaining58Urls(): array
@@ -519,6 +633,24 @@ final class Mbti64CmsRevisionPromotionService
         sort($remaining);
 
         return $remaining;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function v85V5Bilingual64Urls(): array
+    {
+        $urls = [];
+        foreach (['en', 'zh'] as $prefix) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                foreach (['a', 't'] as $variant) {
+                    $urls[] = 'https://fermatmind.com/'.$prefix.'/personality/'.strtolower($typeCode).'-'.$variant;
+                }
+            }
+        }
+        sort($urls);
+
+        return $urls;
     }
 
     /**

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -42,6 +42,8 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
 
     private const REMAINING_58_EXCLUDED_URLS = self::NEXT_BATCH_6_URLS;
 
+    private const V8_5_V5_BILINGUAL_64_PACKAGE_PATH = 'docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-package-2026-07-01.json';
+
     public function test_dry_run_lists_eight_latest_revisions_without_live_writes(): void
     {
         $this->seedTargets();
@@ -477,6 +479,38 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
+    public function test_dry_run_supports_fixed_v8_5_v5_bilingual_sixty_four_subset_without_live_writes(): void
+    {
+        $this->seedProjectionTargets();
+        $packagePath = base_path(self::V8_5_V5_BILINGUAL_64_PACKAGE_PATH);
+        $this->createNextBatchSixDraftRevisions($packagePath);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => self::V8_5_V5_BILINGUAL_64_PACKAGE_PATH,
+            '--dry-run' => true,
+            '--v8-5-v5-bilingual-64' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertSame('v8_5_v5_bilingual_64', $payload['contract']['subset']['mode']);
+        $this->assertFalse($payload['contract']['subset']['arbitrary_url_subset_allowed']);
+        $this->assertSame($this->v85V5Bilingual64Urls(), $payload['contract']['subset']['allowed_urls']);
+        $this->assertSame(64, $payload['row_count']);
+        $this->assertSame(64, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(64, $payload['would_promote_count']);
+        $this->assertSame($this->v85V5Bilingual64Urls(), array_column($payload['rows'], 'url'));
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
     public function test_write_promotes_eighty_eight_agent_projection_revisions_without_index_search_side_effects(): void
     {
         $targets = $this->seedProjectionTargets();
@@ -710,6 +744,56 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         }
     }
 
+    public function test_write_promotes_only_fixed_v8_5_v5_bilingual_sixty_four_subset(): void
+    {
+        $targets = $this->seedProjectionTargets();
+        $packagePath = base_path(self::V8_5_V5_BILINGUAL_64_PACKAGE_PATH);
+        $this->createNextBatchSixDraftRevisions($packagePath);
+        $options = $this->promoteWriteOptions(self::V8_5_V5_BILINGUAL_64_PACKAGE_PATH);
+        $options['--v8-5-v5-bilingual-64'] = true;
+        $profileBefore = $this->profilePublishState($targets['zh-CN|INTJ']);
+        $variantBefore = $this->variantPublishState($targets['zh-CN|INTJ-A']);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame('v8_5_v5_bilingual_64', $payload['contract']['subset']['mode']);
+        $this->assertSame(64, $payload['row_count']);
+        $this->assertSame(64, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(64, $payload['promoted_count']);
+        $this->assertSame(64, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->where('section_key', 'mbti64_comparison_a_vs_t')->count());
+        $this->assertSame($profileBefore, $this->profilePublishState($targets['zh-CN|INTJ']));
+        $this->assertSame($variantBefore, $this->variantPublishState($targets['zh-CN|INTJ-A']));
+
+        foreach ($this->expectedV85V5FirstClassSectionKeys() as $sectionKey) {
+            $this->assertSame(64, PersonalityProfileVariantSection::query()->where('section_key', $sectionKey)->count(), $sectionKey);
+        }
+
+        $seo = PersonalityProfileVariantSeoMeta::query()
+            ->where('personality_profile_variant_id', (int) $targets['zh-CN|INTJ-A']->id)
+            ->firstOrFail();
+        $this->assertSame('INTJ-A 人格：战略思维、独立判断与长期执行', $seo->seo_title);
+        $this->assertSame('/zh/personality/intj-a', $seo->canonical_url);
+        $this->assertSame('index,follow', $seo->robots);
+
+        $section = PersonalityProfileVariantSection::query()
+            ->where('personality_profile_variant_id', (int) $targets['zh-CN|INTJ-A']->id)
+            ->where('section_key', 'meaning')
+            ->firstOrFail();
+        $this->assertStringContainsString('INTJ-A', (string) $section->body_md);
+        $this->assertSame('mbti64_v8_5_v5_first_class_section', $section->payload_json['source'] ?? null);
+        $this->assertSame('core-reading', $section->payload_json['raw']['raw']['id'] ?? null);
+    }
+
     public function test_visible_query_backed_three_subset_is_idempotent_after_write(): void
     {
         $this->seedProjectionTargets();
@@ -910,6 +994,41 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
+    public function test_v8_5_v5_bilingual_sixty_four_subset_fails_closed_when_fixed_url_is_missing_or_extra_url_is_present(): void
+    {
+        $this->seedProjectionTargets();
+        $package = $this->v85V5Bilingual64Package();
+        $package['recommendations'][0]['target_url'] = 'https://fermatmind.com/en/personality/intj-a-vs-intj-t';
+        $package['target_count'] = 64;
+        $packagePath = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--v8-5-v5-bilingual-64' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('unsupported_v8_5_v5_bilingual_64_package_sha256', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertContains('v8_5_v5_bilingual_64_url_set_mismatch', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertContains('v8_5_v5_bilingual_64_subset_incomplete', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
     public function test_agent_projection_subset_modes_are_mutually_exclusive(): void
     {
         $this->seedProjectionTargets();
@@ -923,6 +1042,7 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             '--fresh-query-backed-5' => true,
             '--next-batch-6' => true,
             '--remaining-58' => true,
+            '--v8-5-v5-bilingual-64' => true,
             '--json' => true,
         ]);
 
@@ -1491,6 +1611,22 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
     }
 
     /**
+     * @return array<string,mixed>
+     */
+    private function v85V5Bilingual64Package(): array
+    {
+        $package = json_decode(
+            (string) File::get(base_path(self::V8_5_V5_BILINGUAL_64_PACKAGE_PATH)),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertIsArray($package);
+
+        return $package;
+    }
+
+    /**
      * @return list<string>
      */
     private function remainingFiftyEightUrls(): array
@@ -1511,6 +1647,24 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         sort($remaining);
 
         return $remaining;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function v85V5Bilingual64Urls(): array
+    {
+        $urls = [];
+        foreach (['en', 'zh'] as $prefix) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                foreach (['a', 't'] as $variant) {
+                    $urls[] = 'https://fermatmind.com/'.$prefix.'/personality/'.strtolower($typeCode).'-'.$variant;
+                }
+            }
+        }
+        sort($urls);
+
+        return $urls;
     }
 
     private function targetKeyForUrl(string $url): string
@@ -1675,6 +1829,9 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $recommendations = is_array($recommendation['recommendations'] ?? null)
             ? $recommendation['recommendations']
             : [];
+        if ($recommendations === [] && (string) ($recommendation['package_version'] ?? '') === '') {
+            return $this->v85V5FirstClassFieldsForRecommendation($recommendation, $locale);
+        }
 
         return [
             'url' => (string) ($recommendation['target_url'] ?? ''),
@@ -1691,6 +1848,37 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             'faq' => array_values((array) ($recommendations['faq'] ?? [])),
             'internal_links' => array_values((array) ($recommendations['internal_links'] ?? [])),
             'differentiation_notes' => array_values((array) ($recommendations['differentiation_notes'] ?? [])),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array<string,mixed>
+     */
+    private function v85V5FirstClassFieldsForRecommendation(array $recommendation, string $locale): array
+    {
+        $seo = is_array($recommendation['seo'] ?? null) ? $recommendation['seo'] : [];
+        $geoSummary = is_array($recommendation['geo_summary'] ?? null) ? $recommendation['geo_summary'] : [];
+        $aiBlock = is_array($geoSummary['ai_search_answer_block'] ?? null) ? $geoSummary['ai_search_answer_block'] : [];
+
+        return [
+            'url' => (string) ($recommendation['target_url'] ?? ''),
+            'locale' => $locale,
+            'page_type' => 'variant',
+            'seo' => [
+                'title' => (string) ($seo['title'] ?? ''),
+                'description' => (string) ($seo['description'] ?? ''),
+                'h1' => (string) ($recommendation['h1'] ?? ''),
+            ],
+            'content' => [
+                'quick_answer' => (string) ($geoSummary['direct_answer'] ?? ($aiBlock['what_is'] ?? '')),
+            ] + $this->v85V5SectionFieldsForRecommendation($recommendation),
+            'faq' => array_values((array) ($recommendation['faq'] ?? [])),
+            'internal_links' => array_values((array) ($recommendation['internal_links'] ?? [])),
+            'differentiation_notes' => array_filter([
+                (string) ($recommendation['core_tension'] ?? ''),
+                (string) ((is_array($recommendation['reader_experience'] ?? null) ? $recommendation['reader_experience'] : [])['structure_model'] ?? ''),
+            ]),
         ];
     }
 
@@ -1741,6 +1929,112 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             'common_misreads',
             'similar_types',
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function expectedV85V5FirstClassSectionKeys(): array
+    {
+        return [
+            'meaning',
+            'a_t_difference',
+            'core_traits',
+            'careers_work_style',
+            'relationships_communication',
+            'strengths_blind_spots',
+            'similar_types',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array<string,mixed>
+     */
+    private function v85V5SectionFieldsForRecommendation(array $recommendation): array
+    {
+        $sections = [];
+        foreach (array_values((array) ($recommendation['modules'] ?? [])) as $index => $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            $sectionKey = $this->v85V5FirstClassSectionKey((string) ($section['id'] ?? ($section['key'] ?? '')), $index);
+            if ($sectionKey === '') {
+                continue;
+            }
+
+            $body = $this->v85V5ModuleBody($section);
+            if ($body === '') {
+                continue;
+            }
+
+            $sections[$sectionKey] = [
+                'title' => (string) ($section['title'] ?? ''),
+                'body' => $body,
+                'source_key' => (string) ($section['id'] ?? ($section['key'] ?? '')),
+                'source' => 'mbti64_v8_5_v5_first_class_section',
+                'raw' => $section,
+            ];
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string,mixed>  $section
+     */
+    private function v85V5ModuleBody(array $section): string
+    {
+        $parts = [];
+        if (isset($section['insight']) && is_string($section['insight']) && trim($section['insight']) !== '') {
+            $parts[] = trim($section['insight']);
+        }
+
+        $paragraphs = is_array($section['paragraphs'] ?? null) ? array_values((array) $section['paragraphs']) : [];
+        $paragraphLines = [];
+        foreach ($paragraphs as $paragraph) {
+            if (is_string($paragraph) && trim($paragraph) !== '') {
+                $paragraphLines[] = trim($paragraph);
+            }
+        }
+        if ($paragraphLines !== []) {
+            $parts[] = implode("\n\n", $paragraphLines);
+        }
+
+        return trim(implode("\n\n", $parts));
+    }
+
+    private function v85V5FirstClassSectionKey(string $sourceKey, int $position): string
+    {
+        $map = [
+            'core_reading' => 'meaning',
+            'logic_evidence_judgment' => 'core_traits',
+            'independence_decision_control' => 'a_t_difference',
+            'will_standards_long_termism' => 'strengths_blind_spots',
+            'curiosity_revision' => 'core_traits',
+            'emotional_blind_spots_pressure_feedback' => 'strengths_blind_spots',
+            'social_friction_feedback_relationships' => 'relationships_communication',
+            'work_career_scenarios' => 'careers_work_style',
+            'relationships_intimacy' => 'relationships_communication',
+            'faq_usage_boundary' => 'similar_types',
+            'core_reading' => 'meaning',
+            'rational_standard' => 'core_traits',
+            'independence_control' => 'a_t_difference',
+            'willpower_ambition' => 'strengths_blind_spots',
+            'curiosity_revision' => 'core_traits',
+            'emotional_blindspot' => 'strengths_blind_spots',
+            'social_friction' => 'relationships_communication',
+            'career_workflow' => 'careers_work_style',
+            'relationships' => 'relationships_communication',
+            'faq_boundary' => 'similar_types',
+        ];
+        $normalized = strtolower(trim(preg_replace('/[^a-zA-Z0-9_]+/', '_', $sourceKey) ?? '', '_'));
+        if (isset($map[$normalized])) {
+            return $map[$normalized];
+        }
+
+        return $this->expectedV85V5FirstClassSectionKeys()[$position] ?? '';
     }
 
     private function firstClassSectionKey(string $sourceKey, int $position): string


### PR DESCRIPTION
## What changed
- Added `--v8-5-v5-bilingual-64` to `personality:mbti64-cms-revision-promote`.
- Locked the promotion contract to the fixed 64 MBTI64 V8.5/V5 bilingual package and package hashes.
- Validates 64 variant URLs, 32 zh / 32 en, 0 comparison pages, 64 QA pass, exact URL set, and fixed artifact/version before planning promotion.
- Added focused dry-run, write, fail-closed URL/hash, and mutual-exclusion test coverage.

## Why
The V8.5/V5 bilingual package needs a backend-authoritative promotion contract after CMS draft creation. This keeps promotion fail-closed to the fixed 64 public MBTI A/T variant URLs and does not introduce publish, index, sitemap, llms, or search side effects.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --filter="v8_5|agent_projection_subset_modes" --display-warnings`
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

Local PHPUnit emitted expected clean-worktree `.env` warnings because the temp backend worktree does not contain `.env`; tests passed.

## Intentionally deferred
- No production deploy.
- No CMS draft write.
- No live promotion.
- No publish/index/search.
- No sitemap/llms mutation.
- No URL Truth/Search Queue/IndexNow actions.

## Repository rule impact
Backend CMS remains the content and promotion authority. This PR adds only a fixed backend promotion contract for an already-synced package and does not add frontend editorial fallback or production mutations.
