### PR TITLE
test(seo): enable article schema gate policy for release closeout

### DIFF
--- a/backend/app/Services/Cms/ArticleReleaseCloseoutService.php
+++ b/backend/app/Services/Cms/ArticleReleaseCloseoutService.php
@@ -15,6 +15,10 @@ use Illuminate\Support\Facades\Schema;
 
 final class ArticleReleaseCloseoutService
 {
+    public function __construct(
+        private readonly ArticleSeoService $articleSeoService,
+    ) {}
+
     /**
      * Closeout audits historical Media Library article references that are already
      * public-rendered. Keep this narrower than the general API media sanitizer.
@@ -475,6 +479,10 @@ final class ArticleReleaseCloseoutService
         $hasNoHreflangPolicy = is_array($hreflang)
             && ($hreflang['enabled'] ?? null) === false
             && ($hreflang['policy'] ?? null) === 'no_hreflang';
+        $hasReciprocalHreflangPolicy = is_array($hreflang)
+            && ($hreflang['enabled'] ?? null) === true
+            && ($hreflang['policy'] ?? null) === 'reciprocal_counterparts_verified';
+        $hasGeneratedFaqPage = $faqSchemaEnabled && in_array('FAQPage', $this->generatedJsonLdTypes($article), true);
 
         if (! $schemaHold && ! $articleSchemaEnabled) {
             $issues[] = $this->issue('schema.article_schema_enabled', 'article_schema_not_enabled', 'Article schema gate is not enabled.');
@@ -482,26 +490,76 @@ final class ArticleReleaseCloseoutService
         if (! $schemaHold && ! $breadcrumbSchemaEnabled) {
             $issues[] = $this->issue('schema.breadcrumb_schema_enabled', 'breadcrumb_schema_not_enabled', 'Breadcrumb schema gate is not enabled.');
         }
-        if ($faqSchemaEnabled) {
-            $issues[] = $this->issue('schema.faq_schema_enabled', 'faq_schema_not_held', 'FAQ schema should remain held unless explicitly reviewed.');
+        if ($faqSchemaEnabled && ! $hasGeneratedFaqPage) {
+            $issues[] = $this->issue('schema.faq_schema_enabled', 'faq_schema_enabled_without_faqpage', 'FAQ schema gate is enabled but generated JSON-LD has no FAQPage.');
         }
-        if (! $hreflangHold && ! $hasNoHreflangPolicy) {
+        if (! $hreflangHold && ! $hasNoHreflangPolicy && ! $hasReciprocalHreflangPolicy) {
             $issues[] = $this->issue('hreflang_gate_v1', 'hreflang_policy_missing', 'Hreflang gate must be enabled reciprocally or record no_hreflang policy.');
         }
 
         return [
             'ok' => $issues === [],
-            'schema_state' => $schemaHold ? 'held' : 'enabled_required',
-            'hreflang_state' => $hreflangHold ? 'held' : 'policy_required',
+            'schema_state' => $schemaHold ? 'held' : ($articleSchemaEnabled && $breadcrumbSchemaEnabled ? 'enabled' : 'enabled_required'),
+            'faq_schema_state' => $faqSchemaEnabled ? ($hasGeneratedFaqPage ? 'enabled' : 'enabled_without_faqpage') : 'held',
+            'hreflang_state' => $hreflangHold ? 'held' : ($hasReciprocalHreflangPolicy ? 'enabled' : ($hasNoHreflangPolicy ? 'no_hreflang_policy' : 'policy_required')),
             'schema_hold' => $schemaHold,
             'hreflang_hold' => $hreflangHold,
             'article_schema_enabled' => $articleSchemaEnabled,
             'breadcrumb_schema_enabled' => $breadcrumbSchemaEnabled,
             'faq_schema_enabled' => $faqSchemaEnabled,
+            'faqpage_generated' => $hasGeneratedFaqPage,
             'hreflang_no_hreflang_policy_recorded' => $hasNoHreflangPolicy,
+            'hreflang_reciprocal_policy_recorded' => $hasReciprocalHreflangPolicy,
             'hreflang_gate_v1' => $hreflang,
             'issues' => $issues,
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function generatedJsonLdTypes(Article $article): array
+    {
+        return $this->jsonLdTypes($this->articleSeoService->generateJsonLd(
+            $article,
+            $article->publishedRevision,
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $jsonLd
+     * @return list<string>
+     */
+    private function jsonLdTypes(array $jsonLd): array
+    {
+        $types = [];
+        $stack = [$jsonLd];
+
+        while ($stack !== []) {
+            $node = array_pop($stack);
+            if (! is_array($node)) {
+                continue;
+            }
+
+            $type = $node['@type'] ?? null;
+            if (is_string($type) && $type !== '') {
+                $types[] = $type;
+            } elseif (is_array($type)) {
+                foreach ($type as $value) {
+                    if (is_string($value) && $value !== '') {
+                        $types[] = $value;
+                    }
+                }
+            }
+
+            foreach ($node as $value) {
+                if (is_array($value)) {
+                    $stack[] = $value;
+                }
+            }
+        }
+
+        return array_values(array_unique($types));
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php
@@ -108,6 +108,130 @@ final class ArticleReleaseCloseoutCommandTest extends TestCase
         $this->assertErrorCodeMissing($payload, 'hreflang_policy_missing');
     }
 
+    public function test_closeout_accepts_reciprocal_hreflang_gate_policy(): void
+    {
+        $article = $this->createReleasedArticle();
+        $article->seoMeta?->forceFill([
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => true,
+                        'policy' => 'reciprocal_counterparts_verified',
+                        'verified_by' => 'articles:seo-gate-rollout',
+                        'verified_at' => '2026-07-01T04:00:00Z',
+                    ],
+                ],
+            ],
+        ])->save();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('enabled', data_get($payload, 'checks.schema_hreflang.schema_state'));
+        $this->assertSame('enabled', data_get($payload, 'checks.schema_hreflang.hreflang_state'));
+        $this->assertTrue(data_get($payload, 'checks.schema_hreflang.hreflang_reciprocal_policy_recorded'));
+        $this->assertFalse(data_get($payload, 'checks.schema_hreflang.hreflang_no_hreflang_policy_recorded'));
+        $this->assertErrorCodeMissing($payload, 'hreflang_policy_missing');
+    }
+
+    public function test_closeout_accepts_faq_schema_when_generated_jsonld_contains_faqpage(): void
+    {
+        $article = $this->createReleasedArticle();
+        $article->seoMeta?->forceFill([
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => true,
+                    'answer_surface_policy' => 'editor_supplied',
+                    'answer_surface_visibility' => 'visible',
+                    'answer_surface_v1' => [
+                        'faq_items' => [
+                            [
+                                'question' => '霍兰德测试能直接决定专业吗？',
+                                'answer' => '不能。它只能帮助识别兴趣倾向，仍需结合学校政策、课程和个人条件判断。',
+                            ],
+                        ],
+                    ],
+                    'hreflang_gate_v1' => [
+                        'enabled' => false,
+                        'policy' => 'no_hreflang',
+                        'reason' => 'no_direct_english_counterpart_approved',
+                    ],
+                ],
+            ],
+        ])->save();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('enabled', data_get($payload, 'checks.schema_hreflang.schema_state'));
+        $this->assertSame('enabled', data_get($payload, 'checks.schema_hreflang.faq_schema_state'));
+        $this->assertTrue(data_get($payload, 'checks.schema_hreflang.faq_schema_enabled'));
+        $this->assertTrue(data_get($payload, 'checks.schema_hreflang.faqpage_generated'));
+        $this->assertErrorCodeMissing($payload, 'faq_schema_enabled_without_faqpage');
+        $this->assertErrorCodeMissing($payload, 'faq_schema_not_held');
+    }
+
+    public function test_closeout_blocks_faq_schema_when_generated_jsonld_has_no_faqpage(): void
+    {
+        $article = $this->createReleasedArticle();
+        $article->seoMeta?->forceFill([
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => true,
+                    'hreflang_gate_v1' => [
+                        'enabled' => false,
+                        'policy' => 'no_hreflang',
+                        'reason' => 'no_direct_english_counterpart_approved',
+                    ],
+                ],
+            ],
+        ])->save();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('BLOCKED_OPERATOR_INPUT', $payload['decision']);
+        $this->assertSame('enabled_without_faqpage', data_get($payload, 'checks.schema_hreflang.faq_schema_state'));
+        $this->assertFalse(data_get($payload, 'checks.schema_hreflang.faqpage_generated'));
+        $this->assertErrorCode($payload, 'faq_schema_enabled_without_faqpage');
+    }
+
     public function test_missing_search_queue_blocks_search_closeout(): void
     {
         $article = $this->createReleasedArticle();


### PR DESCRIPTION
## What changed
- Updated article release closeout schema/hreflang policy so enabled Article + Breadcrumb gates can complete closeout.
- Allows FAQ schema closeout only when generated JSON-LD currently contains FAQPage.
- Allows reciprocal hreflang gate policy while preserving schema/hreflang hold and no_hreflang compatibility.
- Added focused closeout tests for reciprocal hreflang, FAQPage pass, and FAQ missing blocked states.

## Why
Daily bilingual article releases need schema and hreflang to be independent release gates instead of permanent closeout holds, while keeping old held content compatible and keeping articles:seo-gate-rollout as the write authority.

## Validation
- php artisan test --filter=ArticleSeoGateRolloutCommandTest
- php artisan test --filter=ArticleReleaseCloseoutCommandTest
- php artisan route:list
- git diff --check

## Intentionally deferred
- No CMS content writes.
- No importer default schema/hreflang enablement.
- No URL Truth, Search Channel, GSC, sitemap/llms, revalidation, deploy, or production writes.