### PR TITLE
MBTI-PDF-RESULT-SNAPSHOT-PARITY-REALIGN-08: bump snapshot PDF surface to v4

### DIFF
--- a/backend/app/Http/Middleware/NormalizeApiErrorContract.php
+++ b/backend/app/Http/Middleware/NormalizeApiErrorContract.php
@@ -56,7 +56,7 @@ final class NormalizeApiErrorContract
     private function isResultPagePdfDiagnostic(array $payload): bool
     {
         $surface = trim((string) ($payload['surface'] ?? ''));
-        if (in_array($surface, ['mbti.result_page_export.v1', 'mbti.result_page_export.v2', 'mbti.result_page_snapshot.v3'], true)) {
+        if (in_array($surface, ['mbti.result_page_export.v1', 'mbti.result_page_export.v2', 'mbti.result_page_snapshot.v4'], true)) {
             return true;
         }
 

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -20,7 +20,7 @@ final class ReportPdfDocumentService
 
     public const MBTI_RESULT_PAGE_SNAPSHOT_SURFACE = 'mbti_result_page_snapshot';
 
-    public const MBTI_RESULT_PAGE_SNAPSHOT_SURFACE_VERSION = 'mbti.result_page_snapshot.v3';
+    public const MBTI_RESULT_PAGE_SNAPSHOT_SURFACE_VERSION = 'mbti.result_page_snapshot.v4';
 
     public const RESULT_PAGE_EXPORT_ENGINE = 'gotenberg_chromium';
 

--- a/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php
@@ -308,7 +308,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf->assertHeader('Content-Type', 'application/pdf');
         $pdf->assertHeader('X-Report-Pdf-Engine', 'gotenberg_chromium');
         $pdf->assertHeader('X-Pdf-Surface', 'mbti_result_page_snapshot');
-        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_snapshot.v3');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_snapshot.v4');
         $pdf->assertHeader('X-Pdf-Artifact-Cache', 'MISS');
         $pdf->assertHeader('X-Legacy-Mpdf-Fallback', 'false');
         $this->assertNotSame('', (string) $pdf->headers->get('X-Gotenberg-Trace'));
@@ -339,7 +339,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $this->assertStringStartsWith("mbti-result-page-pdf-{$attemptId}-", $trace);
         $this->assertSame("/zh/result/{$attemptId}/print", (string) parse_url($printUrl, PHP_URL_PATH));
         $this->assertStringContainsString('pdf=1', $printUrl);
-        $this->assertStringContainsString('surface=mbti.result_page_snapshot.v3', $printUrl);
+        $this->assertStringContainsString('surface=mbti.result_page_snapshot.v4', $printUrl);
         $this->assertStringContainsString('pdf_token=', $printUrl);
         $this->assertStringContainsString('result_access_token=', $printUrl);
         $this->assertSame('window.__FERMAT_PDF_READY__ === true', $payload['waitForExpression'] ?? null);
@@ -352,7 +352,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $this->assertArrayNotHasKey('failOnConsoleExceptions', $payload);
 
         Storage::disk('local')->assertExists(
-            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_snapshot.v3-gotenberg_chromium-zh-locked-free/report_free.pdf"
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_snapshot.v4-gotenberg_chromium-zh-locked-free/report_free.pdf"
         );
     }
 
@@ -525,7 +525,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf->assertHeader('X-Report-Scale', 'MBTI');
         $pdf->assertHeader('X-Report-Pdf-Engine', 'gotenberg_chromium');
         $pdf->assertHeader('X-Pdf-Surface', 'mbti_result_page_snapshot');
-        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_snapshot.v3');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_snapshot.v4');
         $pdf->assertHeader('X-Legacy-Mpdf-Fallback', 'false');
         $pdf->assertHeader('X-Pdf-Error-Stage', 'gotenberg.convert_url');
         $this->assertStringContainsString('X-Gotenberg-Trace', (string) $pdf->headers->get('Access-Control-Expose-Headers'));
@@ -534,12 +534,12 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf->assertJsonPath('code', 'PDF_GENERATION_TIMEOUT');
         $pdf->assertJsonPath('error_code', 'PDF_GENERATION_TIMEOUT');
         $pdf->assertJsonPath('engine', 'gotenberg_chromium');
-        $pdf->assertJsonPath('surface', 'mbti.result_page_snapshot.v3');
+        $pdf->assertJsonPath('surface', 'mbti.result_page_snapshot.v4');
         $pdf->assertJsonPath('message', 'PDF generation timed out');
         $pdf->assertJsonPath('request_id', 'pdf-export-request-1');
         $this->assertSame($pdf->headers->get('X-Gotenberg-Trace'), $pdf->json('trace'));
         Storage::disk('local')->assertMissing(
-            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_snapshot.v3-gotenberg_chromium-zh-locked-free/report_free.pdf"
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_snapshot.v4-gotenberg_chromium-zh-locked-free/report_free.pdf"
         );
     }
 
@@ -570,6 +570,10 @@ final class AttemptPublicReportPdfParityTest extends TestCase
             "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_export.v2-gotenberg_chromium-zh-locked-free/report_free.pdf",
             '%PDF-1.4 old v2 result-page export artifact'
         );
+        Storage::disk('local')->put(
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_snapshot.v3-gotenberg_chromium-zh-locked-free/report_free.pdf",
+            '%PDF-1.4 old v3 summary snapshot artifact'
+        );
 
         Http::fake([
             'gotenberg:3000/forms/chromium/convert/url' => Http::response('%PDF-1.4 new chromium export', 200, [
@@ -588,6 +592,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $this->assertStringNotContainsString('old mPDF artifact', (string) $pdf->getContent());
         $this->assertStringNotContainsString('old result-page export artifact', (string) $pdf->getContent());
         $this->assertStringNotContainsString('old v2 result-page export artifact', (string) $pdf->getContent());
+        $this->assertStringNotContainsString('old v3 summary snapshot artifact', (string) $pdf->getContent());
     }
 
     public function test_public_mbti_result_page_pdf_cache_hit_preserves_engine_headers(): void
@@ -606,7 +611,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $this->createResult($attemptId);
 
         Storage::disk('local')->put(
-            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_snapshot.v3-gotenberg_chromium-zh-locked-free/report_free.pdf",
+            "artifacts/pdf/MBTI/{$attemptId}/nohash-mbti.result_page_snapshot.v4-gotenberg_chromium-zh-locked-free/report_free.pdf",
             '%PDF-1.4 cached chromium export'
         );
 
@@ -620,7 +625,7 @@ final class AttemptPublicReportPdfParityTest extends TestCase
         $pdf->assertStatus(200);
         $pdf->assertHeader('X-Report-Pdf-Engine', 'gotenberg_chromium');
         $pdf->assertHeader('X-Pdf-Surface', 'mbti_result_page_snapshot');
-        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_snapshot.v3');
+        $pdf->assertHeader('X-Pdf-Surface-Version', 'mbti.result_page_snapshot.v4');
         $pdf->assertHeader('X-Pdf-Artifact-Cache', 'HIT');
         $pdf->assertHeader('X-Legacy-Mpdf-Fallback', 'false');
         $this->assertStringContainsString('cached chromium export', (string) $pdf->getContent());


### PR DESCRIPTION
## What changed
- Bumped backend MBTI result-page snapshot surface headers/cache identity to `mbti.result_page_snapshot.v4`.
- Updated API error normalization to recognize the v4 result-page snapshot surface.
- Updated focused PDF parity tests to expect v4 and verify old v3 artifacts are not reused.

## Why
The previous v3 surface has been semantically polluted by summary-shell artifacts. v4 provides a clean cache and contract boundary for the corrected result-page snapshot rendering path.

## Validation
- `php artisan test --filter=AttemptPublicReportPdfParityTest`
- `vendor/bin/pint --dirty`
- `git diff --check`

## Intentionally deferred
- No deployment or server configuration changes.
- No production artifact/cache cleanup.
- No CMS, DB, queue, search, or indexing changes.
- No mPDF fallback changes.
