### PR TITLE
MBTI64-ZH32-V8_5-DUPLICATE-PARAGRAPH-ARTIFACT-SYNC-01: sync repaired bilingual package

### DIFF
--- a/backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php
+++ b/backend/app/Console/Commands/PersonalityAgentPostPromotionSearchGateCommand.php
@@ -21,9 +21,9 @@ final class PersonalityAgentPostPromotionSearchGateCommand extends Command
 
     private const V8_5_V5_BILINGUAL_64_PACKAGE_VERSION = 'mbti64_zh32_en32_v8_5_v5_bilingual_v1';
 
-    private const V8_5_V5_BILINGUAL_64_PACKAGE_FILE_SHA256 = 'a0fd058b82ec40940b8c92546c461086d3bfca7a4b0521aeb92e5cc8b0517b67';
+    private const V8_5_V5_BILINGUAL_64_PACKAGE_FILE_SHA256 = '38e1e325c8ed38c2181d8ce01d315b12c161690691dcc699605ecc186d72f286';
 
-    private const V8_5_V5_BILINGUAL_64_EMBEDDED_PACKAGE_SHA256 = '13ec2c55caf2cf7b48650739fabadfb09ec4a02214cb1af99d5e47d8af2499d8';
+    private const V8_5_V5_BILINGUAL_64_EMBEDDED_PACKAGE_SHA256 = '937842c2a152f5943f641470f030cb88d08e318df5cfb40d24d6449d6999d8ad';
 
     private const SURFACE_PATHS = [
         'sitemap' => '/sitemap.xml',

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -34,13 +34,13 @@ final class Mbti64CmsProjectionDraftWriter
 
     private const V8_5_V5_BILINGUAL_64_PACKAGE_VERSION = 'mbti64_zh32_en32_v8_5_v5_bilingual_v1';
 
-    private const V8_5_V5_BILINGUAL_64_PACKAGE_FILE_SHA256 = 'a0fd058b82ec40940b8c92546c461086d3bfca7a4b0521aeb92e5cc8b0517b67';
+    private const V8_5_V5_BILINGUAL_64_PACKAGE_FILE_SHA256 = '38e1e325c8ed38c2181d8ce01d315b12c161690691dcc699605ecc186d72f286';
 
-    private const V8_5_V5_BILINGUAL_64_EMBEDDED_PACKAGE_SHA256 = '13ec2c55caf2cf7b48650739fabadfb09ec4a02214cb1af99d5e47d8af2499d8';
+    private const V8_5_V5_BILINGUAL_64_EMBEDDED_PACKAGE_SHA256 = '937842c2a152f5943f641470f030cb88d08e318df5cfb40d24d6449d6999d8ad';
 
-    private const V8_5_V5_BILINGUAL_64_QA_FILE_SHA256 = 'a6757d87af71db28815446269eb3a6c5ab9e1fbe0a3176191f1ebc25be2933b4';
+    private const V8_5_V5_BILINGUAL_64_QA_FILE_SHA256 = 'f0afbfcdb795050764951b2d1c08779b65bdc7f96cb2482ffba7fc957db398b7';
 
-    private const V8_5_V5_BILINGUAL_64_EMBEDDED_QA_SHA256 = 'd433814924c172e88ad0a52bda665ddee1ea1d6bbe8c6bb9be46a47367baaf1a';
+    private const V8_5_V5_BILINGUAL_64_EMBEDDED_QA_SHA256 = '9246f6f2644c218b6b5e4d678a2364b558a21bf2ee7d1d2cf96ef43fe21d6011';
 
     private const VISIBLE_QUERY_BACKED_3_URLS = [
         'https://fermatmind.com/en/personality/enfj-a',

--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -36,9 +36,9 @@ final class Mbti64CmsRevisionPromotionService
 
     private const V8_5_V5_BILINGUAL_64_PACKAGE_VERSION = 'mbti64_zh32_en32_v8_5_v5_bilingual_v1';
 
-    private const V8_5_V5_BILINGUAL_64_PACKAGE_FILE_SHA256 = 'a0fd058b82ec40940b8c92546c461086d3bfca7a4b0521aeb92e5cc8b0517b67';
+    private const V8_5_V5_BILINGUAL_64_PACKAGE_FILE_SHA256 = '38e1e325c8ed38c2181d8ce01d315b12c161690691dcc699605ecc186d72f286';
 
-    private const V8_5_V5_BILINGUAL_64_EMBEDDED_PACKAGE_SHA256 = '13ec2c55caf2cf7b48650739fabadfb09ec4a02214cb1af99d5e47d8af2499d8';
+    private const V8_5_V5_BILINGUAL_64_EMBEDDED_PACKAGE_SHA256 = '937842c2a152f5943f641470f030cb88d08e318df5cfb40d24d6449d6999d8ad';
 
     private const VISIBLE_QUERY_BACKED_3_URLS = [
         'https://fermatmind.com/en/personality/enfj-a',

--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
@@ -14,13 +14,13 @@ final class PersonalityAgentApprovalQueueWriter
 
     private const MBTI64_V85_V5_PACKAGE_VERSION = 'mbti64_zh32_en32_v8_5_v5_bilingual_v1';
 
-    private const MBTI64_V85_V5_PACKAGE_FILE_SHA256 = 'a0fd058b82ec40940b8c92546c461086d3bfca7a4b0521aeb92e5cc8b0517b67';
+    private const MBTI64_V85_V5_PACKAGE_FILE_SHA256 = '38e1e325c8ed38c2181d8ce01d315b12c161690691dcc699605ecc186d72f286';
 
-    private const MBTI64_V85_V5_QA_FILE_SHA256 = 'a6757d87af71db28815446269eb3a6c5ab9e1fbe0a3176191f1ebc25be2933b4';
+    private const MBTI64_V85_V5_QA_FILE_SHA256 = 'f0afbfcdb795050764951b2d1c08779b65bdc7f96cb2482ffba7fc957db398b7';
 
-    private const MBTI64_V85_V5_PACKAGE_SHA256 = '13ec2c55caf2cf7b48650739fabadfb09ec4a02214cb1af99d5e47d8af2499d8';
+    private const MBTI64_V85_V5_PACKAGE_SHA256 = '937842c2a152f5943f641470f030cb88d08e318df5cfb40d24d6449d6999d8ad';
 
-    private const MBTI64_V85_V5_QA_SHA256 = 'd433814924c172e88ad0a52bda665ddee1ea1d6bbe8c6bb9be46a47367baaf1a';
+    private const MBTI64_V85_V5_QA_SHA256 = '9246f6f2644c218b6b5e4d678a2364b558a21bf2ee7d1d2cf96ef43fe21d6011';
 
     private const MBTI64_TYPES = [
         'enfj',

--- a/backend/docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-package-2026-07-01.md
+++ b/backend/docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-package-2026-07-01.md
@@ -1,0 +1,26 @@
+# MBTI64 ZH32/EN32 V8.5/V5 Bilingual Package
+
+- Artifact: `MBTI64-ZH32-EN32-V8_5-V5-BILINGUAL-PACKAGE-QA-01`
+- Generated: `2026-07-01T12:00:00.000Z`
+- Final decision: `PASS_READY_FOR_FAP_API_ARTIFACT_SYNC`
+- Target count: 64
+- zh pages: 32
+- en pages: 32
+- Variant pages: 64
+- Comparison pages: 0
+- Package SHA256: `937842c2a152f5943f641470f030cb88d08e318df5cfb40d24d6449d6999d8ad`
+
+## Scope Boundary
+
+This artifact is package/QA handoff only. It does not write CMS, approval queue, URL Truth, Search Queue, sitemap, llms, or frontend runtime.
+
+## Next Task
+
+`MBTI64-ZH32-EN32-V8_5-V5-ARTIFACT-SYNC-01`
+
+## QA Summary
+
+- QA decision: `PASS_READY_FOR_FAP_API_ARTIFACT_SYNC`
+- Pass count: 64
+- Blocked count: 0
+- Blockers: none

--- a/backend/docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-qa-2026-07-01.json
+++ b/backend/docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-qa-2026-07-01.json
@@ -2,7 +2,7 @@
   "artifact": "MBTI64-ZH32-EN32-V8_5-V5-BILINGUAL-PACKAGE-QA-01",
   "generated_at": "2026-07-01T12:00:00.000Z",
   "input_artifact": "docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-package-2026-07-01.json",
-  "input_package_sha256": "13ec2c55caf2cf7b48650739fabadfb09ec4a02214cb1af99d5e47d8af2499d8",
+  "input_package_sha256": "937842c2a152f5943f641470f030cb88d08e318df5cfb40d24d6449d6999d8ad",
   "final_decision": "PASS_READY_FOR_FAP_API_ARTIFACT_SYNC",
   "recommended_next_task": "MBTI64-ZH32-EN32-V8_5-V5-ARTIFACT-SYNC-01",
   "summary": {
@@ -70,6 +70,10 @@
       "passed": 64,
       "failed": 0
     },
+    "exact_paragraph_duplicate_gate": {
+      "passed": 64,
+      "failed": 0
+    },
     "private_route_gate": {
       "passed": 64,
       "failed": 0
@@ -118,6 +122,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -174,6 +182,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -224,6 +236,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -280,6 +296,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -330,6 +350,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -386,6 +410,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -436,6 +464,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -492,6 +524,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -542,6 +578,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -598,6 +638,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -648,6 +692,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -704,6 +752,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -754,6 +806,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -810,6 +866,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -860,6 +920,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -916,6 +980,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -966,6 +1034,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1022,6 +1094,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1072,6 +1148,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1128,6 +1208,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1178,6 +1262,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1234,6 +1322,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1284,6 +1376,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1340,6 +1436,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1390,6 +1490,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1446,6 +1550,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1496,6 +1604,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1552,6 +1664,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1602,6 +1718,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1658,6 +1778,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1708,6 +1832,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1764,6 +1892,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1814,6 +1946,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1870,6 +2006,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -1920,6 +2060,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -1976,6 +2120,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2026,6 +2174,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2082,6 +2234,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2132,6 +2288,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2188,6 +2348,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2238,6 +2402,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2294,6 +2462,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2344,6 +2516,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2400,6 +2576,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2450,6 +2630,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2506,6 +2690,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2556,6 +2744,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2612,6 +2804,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2662,6 +2858,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2718,6 +2918,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2768,6 +2972,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2824,6 +3032,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2874,6 +3086,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -2930,6 +3146,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -2980,6 +3200,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -3036,6 +3260,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -3086,6 +3314,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -3142,6 +3374,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -3192,6 +3428,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -3248,6 +3488,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -3298,6 +3542,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -3354,6 +3602,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -3404,6 +3656,10 @@
           "failures": []
         },
         "duplicate_template_gate": {
+          "status": "pass",
+          "failures": []
+        },
+        "exact_paragraph_duplicate_gate": {
           "status": "pass",
           "failures": []
         },
@@ -3460,6 +3716,10 @@
           "status": "pass",
           "failures": []
         },
+        "exact_paragraph_duplicate_gate": {
+          "status": "pass",
+          "failures": []
+        },
         "private_route_gate": {
           "status": "pass",
           "failures": []
@@ -3484,5 +3744,5 @@
     "external_api_call": false
   },
   "blockers": [],
-  "qa_sha256": "d433814924c172e88ad0a52bda665ddee1ea1d6bbe8c6bb9be46a47367baaf1a"
+  "qa_sha256": "9246f6f2644c218b6b5e4d678a2364b558a21bf2ee7d1d2cf96ef43fe21d6011"
 }

--- a/backend/docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-qa-2026-07-01.md
+++ b/backend/docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-qa-2026-07-01.md
@@ -1,0 +1,37 @@
+# MBTI64 ZH32/EN32 V8.5/V5 Bilingual QA
+
+- Artifact: `MBTI64-ZH32-EN32-V8_5-V5-BILINGUAL-PACKAGE-QA-01`
+- Generated: `2026-07-01T12:00:00.000Z`
+- Final decision: `PASS_READY_FOR_FAP_API_ARTIFACT_SYNC`
+- Target count: 64
+- Pass count: 64
+- Blocked count: 0
+
+## Gate Totals
+
+| Gate | Passed | Failed |
+|---|---:|---:|
+| inventory_gate | 64 | 0 |
+| field_completeness_gate | 64 | 0 |
+| module_depth_gate | 64 | 0 |
+| bilingual_alignment_gate | 64 | 0 |
+| trademark_affiliation_gate | 64 | 0 |
+| deterministic_claim_gate | 64 | 0 |
+| clinical_recruiting_gate | 64 | 0 |
+| duplicate_template_gate | 64 | 0 |
+| exact_paragraph_duplicate_gate | 64 | 0 |
+| private_route_gate | 64 | 0 |
+
+## Safety Boundary
+
+- CMS write: false
+- Approval queue write: false
+- Live promotion: false
+- Publish/index/search: false
+- Sitemap/llms mutation: false
+- URL Truth write: false
+- Production deploy: false
+
+## Next Task
+
+`MBTI64-ZH32-EN32-V8_5-V5-ARTIFACT-SYNC-01`

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
@@ -228,8 +228,8 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
         $this->assertSame('pass', $payload['status']);
         $this->assertSame('mbti64', $payload['framework']);
         $this->assertSame('PASS_READY_FOR_FAP_API_ARTIFACT_SYNC', $payload['qa_final_decision']);
-        $this->assertSame('a0fd058b82ec40940b8c92546c461086d3bfca7a4b0521aeb92e5cc8b0517b67', $payload['source_package_sha256']);
-        $this->assertSame('a6757d87af71db28815446269eb3a6c5ab9e1fbe0a3176191f1ebc25be2933b4', $payload['qa_sha256']);
+        $this->assertSame('38e1e325c8ed38c2181d8ce01d315b12c161690691dcc699605ecc186d72f286', $payload['source_package_sha256']);
+        $this->assertSame('f0afbfcdb795050764951b2d1c08779b65bdc7f96cb2482ffba7fc957db398b7', $payload['qa_sha256']);
         $this->assertTrue($payload['dry_run']);
         $this->assertFalse($payload['write']);
         $this->assertFalse($payload['writes_attempted']);


### PR DESCRIPTION
## What changed
- Synced the repaired MBTI64 zh32/en32 V8.5/V5 bilingual package and QA artifacts into backend authority docs.
- Updated the fixed package/QA file and embedded SHA locks used by approval queue, CMS draft, promotion, and post-promotion search gate contracts.
- Updated the focused approval queue assertion to the repaired artifact file hashes.

## Why
The repaired fap-web package removes exact paragraph duplicates from zh32 while preserving the fixed 64-page V8.5/V5 contract. Backend commands are hash-locked, so fap-api must carry the repaired artifacts and matching hash locks before production approval queue / draft rewrite / promotion rewrite gates can run.

## Validation
- `jq empty backend/docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-package-2026-07-01.json backend/docs/seo/personality/mbti64-zh32-en32-v8-5-v5-bilingual-qa-2026-07-01.json`
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php tests/Feature/SeoIntel/PersonalityAgentPostPromotionSearchGateCommandTest.php --display-warnings`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred
- No production deploy.
- No approval queue write/approve.
- No CMS draft write.
- No live promotion.
- No publish/index/search/sitemap/llms mutation.

## Repository rule impact
This preserves backend/CMS authority for public personality content. No frontend fallback or runtime content authority change is introduced.