### PR TITLE
deploy: allow backend config changes through auto deploy guard

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -105,7 +105,6 @@ jobs:
               /^backend\/scripts\/deploy\//,
               /^backend\/scripts\/.*(deploy|release|import|publish|search|sitemap|llms|queue)/i,
               /^backend\/database\//,
-              /^backend\/config\//,
               /^backend\/content_assets\//,
               /^content_packages\//,
               /^backend\/docs\/seo\//,

--- a/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
+++ b/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
@@ -54,6 +54,18 @@ final class DeployStorageAndDatabaseConfigTest extends TestCase
         $this->assertStringNotContainsString('mktemp /etc/nginx/sites-enabled', $source);
     }
 
+    #[Test]
+    public function production_auto_deploy_policy_allows_backend_config_changes_but_keeps_hard_risk_paths(): void
+    {
+        $source = $this->readRepoFile('.github/workflows/deploy-production.yml');
+
+        $this->assertStringNotContainsString('/^backend\\/config\\//', $source);
+        $this->assertStringContainsString('/^backend\\/database\\//', $source);
+        $this->assertStringContainsString('/^\\.github\\/workflows\\//', $source);
+        $this->assertStringContainsString('/(^|\\/)\\.env($|\\.|-)/', $source);
+        $this->assertStringContainsString('/(^|\\/).*secret.*$/i', $source);
+    }
+
     private function readRepoFile(string $relativePath): string
     {
         $path = dirname(__DIR__, 3).'/'.$relativePath;


### PR DESCRIPTION
## What changed
- Removed `backend/config/**` from the production auto-deploy policy guard risky path list.
- Added an SRE contract test proving backend config paths are no longer blocked while hard-risk paths still remain guarded.

## Why
Recent backend runtime changes that only touch config, such as `backend/config/gotenberg.php`, should be eligible for automatic production deploy after CI. The guard still blocks workflow, database, script deploy/release/import, content asset, CMS/search/sitemap/llms/service, env, and secret paths.

## Validation
- `php artisan test tests/Sre/DeployStorageAndDatabaseConfigTest.php`
- `./vendor/bin/pint --dirty`
- `git diff --check`

## Deferred
- No deployment triggered manually.
- No server env, DB/CMS, cache, queue, content import, sitemap/llms/SEO runtime, or production data change.

## Note
This PR itself modifies `.github/workflows/deploy-production.yml`, so it is expected to remain subject to the manual deploy path for this one workflow-policy change.