### PR TITLE
MBTI64-ZH32-EN32-V8_5-V5-RUNTIME-DUPLICATE-SECTION-SUPPRESSION-02

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -29,13 +29,22 @@ class PersonalityController extends Controller
     private const MBTI64_V85_SECTION_PREFIX = 'v8_5_';
 
     private const MBTI64_V85_DUPLICATE_LEGACY_SECTION_KEYS = [
+        'quick_answer',
         'meaning',
         'a_t_difference',
         'core_traits',
         'careers_work_style',
         'relationships_communication',
         'strengths_blind_spots',
+        'common_misreads',
         'similar_types',
+        'faq',
+    ];
+
+    private const MBTI64_V85_DUPLICATE_LEGACY_SECTION_PREFIXES = [
+        'career.',
+        'growth.',
+        'relationships.',
     ];
 
     use RespondsWithNotFound;
@@ -1636,7 +1645,15 @@ class PersonalityController extends Controller
         }
 
         if ($this->hasV85FirstClassSections($sections->keys()->all())) {
-            foreach (self::MBTI64_V85_DUPLICATE_LEGACY_SECTION_KEYS as $sectionKey) {
+            foreach ($sections->keys()->all() as $sectionKey) {
+                if (! is_string($sectionKey)) {
+                    continue;
+                }
+
+                if (! $this->shouldSuppressV85DuplicateSection($sectionKey)) {
+                    continue;
+                }
+
                 $sections->forget($sectionKey);
             }
         }
@@ -1657,6 +1674,21 @@ class PersonalityController extends Controller
     {
         foreach ($sectionKeys as $sectionKey) {
             if (str_starts_with((string) $sectionKey, self::MBTI64_V85_SECTION_PREFIX)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function shouldSuppressV85DuplicateSection(string $sectionKey): bool
+    {
+        if (in_array($sectionKey, self::MBTI64_V85_DUPLICATE_LEGACY_SECTION_KEYS, true)) {
+            return true;
+        }
+
+        foreach (self::MBTI64_V85_DUPLICATE_LEGACY_SECTION_PREFIXES as $prefix) {
+            if (str_starts_with($sectionKey, $prefix)) {
                 return true;
             }
         }

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -836,6 +836,19 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         foreach ($this->expectedV85V5FirstClassSectionKeys() as $legacySectionKey) {
             $this->assertNotContains($legacySectionKey, $sectionKeys, $legacySectionKey);
         }
+        foreach ($this->expectedV85V5SuppressedPublicSectionKeys() as $legacySectionKey) {
+            $this->assertNotContains($legacySectionKey, $sectionKeys, $legacySectionKey);
+        }
+        foreach ($sectionKeys as $sectionKey) {
+            $this->assertFalse(str_starts_with($sectionKey, 'career.'), $sectionKey);
+            $this->assertFalse(str_starts_with($sectionKey, 'growth.'), $sectionKey);
+            $this->assertFalse(str_starts_with($sectionKey, 'relationships.'), $sectionKey);
+        }
+
+        $this->assertContains('related_content', $sectionKeys);
+        $this->assertContains('mbti64_promotion_metadata', $sectionKeys);
+        $this->assertNoExactDuplicateVisibleApiParagraphs((array) ($detail['sections'] ?? []));
+
         $apiModule = collect((array) ($detail['sections'] ?? []))
             ->firstWhere('section_key', 'v8_5_module_01_core_reading');
         $this->assertIsArray($apiModule);
@@ -2021,6 +2034,48 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             'strengths_blind_spots',
             'similar_types',
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function expectedV85V5SuppressedPublicSectionKeys(): array
+    {
+        return [
+            'quick_answer',
+            'common_misreads',
+            'faq',
+        ];
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $sections
+     */
+    private function assertNoExactDuplicateVisibleApiParagraphs(array $sections): void
+    {
+        $seen = [];
+        foreach ($sections as $section) {
+            $sectionKey = (string) ($section['section_key'] ?? '');
+            $body = (string) ($section['body_md'] ?? '');
+            foreach (preg_split('/\R{2,}/u', $body) ?: [] as $index => $paragraph) {
+                $normalized = trim((string) preg_replace('/\s+/u', ' ', $paragraph));
+                if (mb_strlen($normalized) < 18) {
+                    continue;
+                }
+
+                $this->assertArrayNotHasKey(
+                    $normalized,
+                    $seen,
+                    sprintf(
+                        'Duplicate visible API paragraph in %s[%d]; first seen at %s.',
+                        $sectionKey,
+                        $index,
+                        $seen[$normalized] ?? 'unknown'
+                    )
+                );
+                $seen[$normalized] = sprintf('%s[%d]', $sectionKey, $index);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Extend the V8.5/V5 public API suppression boundary when `v8_5_*` first-class sections are present.
- Hide duplicate legacy reader-path sections for `career.*`, `growth.*`, `relationships.*`, plus `quick_answer`, `common_misreads`, and `faq`.
- Keep `related_content` and `mbti64_promotion_metadata` available for necessary navigation/metadata use.
- Add focused test coverage that the public detail response keeps V8.5 sections, suppresses the duplicated legacy groups, and has no exact duplicate visible API paragraphs.

## Why
The duplicate-paragraph repair package is live, but runtime still exposed duplicate legacy sections beside the V8.5/V5 first-class modules. This PR keeps backend CMS/content authority unchanged and only fixes public API response shaping for the V8.5/V5 runtime path.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
  - Passed: 33 warnings from missing temporary `.env` in the clean worktree, exit code 0.
- `bash backend/scripts/ci_verify_mbti.sh`
  - Passed.
- `git diff --check`
  - Passed.

## Intentionally deferred
- No production deploy in this PR.
- No CMS writes, promotion, publish, sitemap/llms mutation, URL Truth, Search Queue, IndexNow, or external search submission.
- Runtime acceptance remains the post-deploy read-only smoke: `MBTI64-ZH32-V8_5-DUPLICATE-PARAGRAPH-RUNTIME-SMOKE-01`.

## Repository rule impact
Backend public API response shaping only. CMS/backend remains the content authority; this PR does not introduce frontend fallback content or change publishing/search ownership.
