### PR TITLE
feat(seo): ingest article release closeout evidence files

### DIFF
--- a/backend/app/Console/Commands/ArticleReleaseCloseout.php
+++ b/backend/app/Console/Commands/ArticleReleaseCloseout.php
@@ -13,6 +13,8 @@ final class ArticleReleaseCloseout extends Command
         {--article-id= : Exact article id to inspect}
         {--expected-slug= : Expected article slug lock}
         {--public-smoke-json= : Optional JSON file produced by the public article smoke verifier}
+        {--gsc-manual-json= : Optional JSON file recording manual GSC Request Indexing evidence}
+        {--observation-json= : Optional JSON file recording D1/D7/D14 observation readiness}
         {--json : Emit JSON}';
 
     protected $description = 'Read-only closeout report for one released article across CMS, discoverability, URL Truth, and Search Channel state.';
@@ -21,8 +23,10 @@ final class ArticleReleaseCloseout extends Command
     {
         $articleId = (int) $this->option('article-id');
         $expectedSlug = trim((string) $this->option('expected-slug'));
-        $publicSmoke = $this->publicSmokePayload((string) $this->option('public-smoke-json'));
-        $payload = $closeout->inspect($articleId, $expectedSlug, $publicSmoke);
+        $publicSmoke = $this->evidencePayload((string) $this->option('public-smoke-json'), 'PUBLIC_SMOKE_EVIDENCE');
+        $gscManual = $this->evidencePayload((string) $this->option('gsc-manual-json'), 'GSC_MANUAL_EVIDENCE');
+        $observation = $this->evidencePayload((string) $this->option('observation-json'), 'OBSERVATION_EVIDENCE');
+        $payload = $closeout->inspect($articleId, $expectedSlug, $publicSmoke, $gscManual, $observation);
 
         if ((bool) $this->option('json')) {
             $this->line((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
@@ -38,7 +42,7 @@ final class ArticleReleaseCloseout extends Command
     /**
      * @return array<string,mixed>|null
      */
-    private function publicSmokePayload(string $path): ?array
+    private function evidencePayload(string $path, string $label): ?array
     {
         $path = trim($path);
         if ($path === '') {
@@ -48,7 +52,7 @@ final class ArticleReleaseCloseout extends Command
         if (! is_file($path)) {
             return [
                 'ok' => false,
-                'decision' => 'PUBLIC_SMOKE_EVIDENCE_FILE_MISSING',
+                'decision' => $label.'_FILE_MISSING',
                 'path' => $path,
             ];
         }
@@ -57,7 +61,7 @@ final class ArticleReleaseCloseout extends Command
         if (! is_array($decoded)) {
             return [
                 'ok' => false,
-                'decision' => 'PUBLIC_SMOKE_EVIDENCE_JSON_INVALID',
+                'decision' => $label.'_JSON_INVALID',
                 'path' => $path,
             ];
         }

--- a/backend/app/Services/Cms/ArticleReleaseCloseoutService.php
+++ b/backend/app/Services/Cms/ArticleReleaseCloseoutService.php
@@ -45,9 +45,17 @@ final class ArticleReleaseCloseoutService
 
     /**
      * @param  array<string,mixed>|null  $publicSmoke
+     * @param  array<string,mixed>|null  $gscManual
+     * @param  array<string,mixed>|null  $observation
      * @return array<string,mixed>
      */
-    public function inspect(int $articleId, string $expectedSlug, ?array $publicSmoke = null): array
+    public function inspect(
+        int $articleId,
+        string $expectedSlug,
+        ?array $publicSmoke = null,
+        ?array $gscManual = null,
+        ?array $observation = null,
+    ): array
     {
         $errors = [];
 
@@ -70,6 +78,8 @@ final class ArticleReleaseCloseoutService
                 checks: [],
                 errors: $errors,
                 publicSmoke: $publicSmoke,
+                gscManual: $gscManual,
+                observation: $observation,
             );
         }
 
@@ -85,8 +95,8 @@ final class ArticleReleaseCloseoutService
             'search_channel' => $this->searchChannelCheck($canonicalUrl),
             'schema_hreflang' => $this->schemaHreflangCheck($article),
             'public_html_smoke' => $this->publicSmokeCheck($publicSmoke),
-            'gsc_manual' => $this->manualCheck('operator_record_required'),
-            'observation' => $this->manualCheck('d1_d7_d14_queue_record_required'),
+            'gsc_manual' => $this->gscManualCheck($gscManual, $canonicalUrl),
+            'observation' => $this->observationCheck($observation),
         ];
 
         return $this->summary(
@@ -97,6 +107,8 @@ final class ArticleReleaseCloseoutService
             checks: $checks,
             errors: $errors,
             publicSmoke: $publicSmoke,
+            gscManual: $gscManual,
+            observation: $observation,
         );
     }
 
@@ -603,6 +615,85 @@ final class ArticleReleaseCloseoutService
     }
 
     /**
+     * @param  array<string,mixed>|null  $gscManual
+     * @return array<string,mixed>
+     */
+    private function gscManualCheck(?array $gscManual, ?string $canonicalUrl): array
+    {
+        if ($gscManual === null) {
+            return $this->manualCheck('operator_record_required');
+        }
+
+        $issues = [];
+        $status = strtolower((string) ($gscManual['status'] ?? ''));
+        $okFlag = $gscManual['ok'] ?? null;
+        $statusOk = $status === 'success' || $okFlag === true;
+        if (! $statusOk) {
+            $issues[] = $this->issue('gsc_manual.status', 'gsc_manual_status_not_success', 'GSC manual indexing evidence must have status=success.');
+        }
+
+        $matched = false;
+        $matchedHasConfirmation = false;
+        foreach ($this->evidenceUrlRecords($gscManual) as $record) {
+            $url = $this->evidenceRecordUrl($record);
+            if ($url !== $canonicalUrl) {
+                continue;
+            }
+
+            $matched = true;
+            $matchedHasConfirmation = $this->evidenceRecordHasConfirmation($record);
+        }
+
+        if (! $matched) {
+            $issues[] = $this->issue('gsc_manual.urls', 'gsc_manual_url_mismatch', 'GSC manual indexing evidence must include the article canonical URL.', [
+                'canonical_url' => $canonicalUrl,
+            ]);
+        } elseif (! $matchedHasConfirmation) {
+            $issues[] = $this->issue('gsc_manual.urls.confirmation', 'gsc_manual_confirmation_missing', 'GSC manual indexing evidence must include request indexing confirmation for the canonical URL.', [
+                'canonical_url' => $canonicalUrl,
+            ]);
+        }
+
+        return [
+            'ok' => $issues === [],
+            'state' => $issues === [] ? 'requested' : 'failed',
+            'canonical_url' => $canonicalUrl,
+            'status' => $status,
+            'issues' => $issues,
+            'evidence' => $gscManual,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $observation
+     * @return array<string,mixed>
+     */
+    private function observationCheck(?array $observation): array
+    {
+        if ($observation === null) {
+            return $this->manualCheck('d1_d7_d14_queue_record_required');
+        }
+
+        $status = strtolower((string) ($observation['status'] ?? ''));
+        $hasChecklist = is_array($observation['checklist'] ?? null)
+            || is_array($observation['d1_d7_d14_checklist'] ?? null)
+            || is_array($observation['observation_windows'] ?? null)
+            || is_array($observation['queue_record'] ?? null);
+        $acceptedStatus = in_array($status, ['recorded', 'pending_window', 'scheduled', 'success'], true);
+        $ok = $acceptedStatus || $hasChecklist;
+        $issues = $ok ? [] : [
+            $this->issue('observation', 'observation_evidence_invalid', 'Observation evidence must record a D1/D7/D14 checklist, queue record, or pending observation window.'),
+        ];
+
+        return [
+            'ok' => $ok,
+            'state' => $ok ? ($acceptedStatus ? $status : 'pending_window') : 'failed',
+            'issues' => $issues,
+            'evidence' => $observation,
+        ];
+    }
+
+    /**
      * @param  array<string,mixed>|null  $publicSmoke
      * @param  list<array<string,mixed>>  $errors
      * @param  array<string,mixed>  $checks
@@ -616,6 +707,8 @@ final class ArticleReleaseCloseoutService
         array $checks,
         array $errors,
         ?array $publicSmoke,
+        ?array $gscManual,
+        ?array $observation,
     ): array {
         $issues = $errors;
         foreach ($checks as $check) {
@@ -645,8 +738,8 @@ final class ArticleReleaseCloseoutService
             'issues' => $issues,
             'remaining_operator_inputs' => [
                 'public_html_smoke' => $publicSmoke === null ? 'not_provided_use_fap_web_smoke_verifier' : 'provided',
-                'gsc_manual_request_indexing' => 'operator_record_required',
-                'd1_d7_d14_observation' => 'schedule_or_record_after_release',
+                'gsc_manual_request_indexing' => (($checks['gsc_manual']['ok'] ?? null) === true ? 'provided' : ($gscManual === null ? 'operator_record_required' : 'provided_but_invalid')),
+                'd1_d7_d14_observation' => (($checks['observation']['ok'] ?? null) === true ? 'recorded_or_pending_window' : ($observation === null ? 'schedule_or_record_after_release' : 'provided_but_invalid')),
             ],
             'allowed_decisions' => [
                 self::COMPLETE_SEARCH_OBSERVATION_PENDING,
@@ -656,6 +749,56 @@ final class ArticleReleaseCloseoutService
                 self::BLOCKED_OPERATOR_INPUT,
             ],
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $evidence
+     * @return list<mixed>
+     */
+    private function evidenceUrlRecords(array $evidence): array
+    {
+        foreach (['urls', 'target_urls', 'url_results', 'requested_urls'] as $key) {
+            if (is_array($evidence[$key] ?? null)) {
+                return array_values($evidence[$key]);
+            }
+        }
+
+        return [];
+    }
+
+    private function evidenceRecordUrl(mixed $record): string
+    {
+        if (is_string($record)) {
+            return $record;
+        }
+
+        if (! is_array($record)) {
+            return '';
+        }
+
+        foreach (['canonical_url', 'url', 'target_url'] as $key) {
+            $value = $record[$key] ?? null;
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    private function evidenceRecordHasConfirmation(mixed $record): bool
+    {
+        if (! is_array($record)) {
+            return false;
+        }
+
+        foreach (['request_indexing_confirmation', 'request_indexing_result', 'confirmation', 'confirmed_at'] as $key) {
+            if (trim((string) ($record[$key] ?? '')) !== '') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php
@@ -274,6 +274,152 @@ final class ArticleReleaseCloseoutCommandTest extends TestCase
         $this->assertErrorCode($payload, 'category_not_reader_facing_zh');
     }
 
+    public function test_closeout_accepts_valid_gsc_manual_request_indexing_evidence(): void
+    {
+        $article = $this->createReleasedArticle();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+        $gscPath = $this->writeEvidenceJson([
+            'runtime' => 'gsc_manual_request_indexing',
+            'status' => 'success',
+            'urls' => [
+                [
+                    'canonical_url' => $canonicalUrl,
+                    'request_indexing_confirmation' => 'URL was added to the priority crawl queue.',
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--gsc-manual-json' => $gscPath,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue(data_get($payload, 'checks.gsc_manual.ok'));
+        $this->assertSame('requested', data_get($payload, 'checks.gsc_manual.state'));
+        $this->assertSame('provided', data_get($payload, 'remaining_operator_inputs.gsc_manual_request_indexing'));
+        $this->assertErrorCodeMissing($payload, 'gsc_manual_url_mismatch');
+    }
+
+    public function test_closeout_blocks_gsc_manual_evidence_url_mismatch(): void
+    {
+        $article = $this->createReleasedArticle();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+        $gscPath = $this->writeEvidenceJson([
+            'runtime' => 'gsc_manual_request_indexing',
+            'status' => 'success',
+            'urls' => [
+                [
+                    'canonical_url' => 'https://fermatmind.com/zh/articles/wrong-url',
+                    'request_indexing_confirmation' => 'URL was added to the priority crawl queue.',
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--gsc-manual-json' => $gscPath,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('BLOCKED_OPERATOR_INPUT', $payload['decision']);
+        $this->assertFalse(data_get($payload, 'checks.gsc_manual.ok'));
+        $this->assertSame('provided_but_invalid', data_get($payload, 'remaining_operator_inputs.gsc_manual_request_indexing'));
+        $this->assertErrorCode($payload, 'gsc_manual_url_mismatch');
+    }
+
+    public function test_closeout_records_observation_evidence_as_pending_window(): void
+    {
+        $article = $this->createReleasedArticle();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+        $observationPath = $this->writeEvidenceJson([
+            'status' => 'pending_window',
+            'd1_d7_d14_checklist' => [
+                'd1' => ['indexing', 'impressions', 'clicks'],
+                'd7' => ['queries', 'ctr', 'average_position'],
+                'd14' => ['cta_click', 'start_test', 'title_or_faq_followup'],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--observation-json' => $observationPath,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue(data_get($payload, 'checks.observation.ok'));
+        $this->assertSame('pending_window', data_get($payload, 'checks.observation.state'));
+        $this->assertSame('recorded_or_pending_window', data_get($payload, 'remaining_operator_inputs.d1_d7_d14_observation'));
+    }
+
+    public function test_closeout_merges_public_smoke_gsc_and_observation_evidence(): void
+    {
+        $article = $this->createReleasedArticle();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+        $publicSmokePath = $this->writeEvidenceJson([
+            'ok' => true,
+            'decision' => 'PUBLIC_ARTICLE_RELEASE_SMOKE_PASSED',
+            'url' => $canonicalUrl,
+        ]);
+        $gscPath = $this->writeEvidenceJson([
+            'status' => 'success',
+            'urls' => [
+                [
+                    'url' => $canonicalUrl,
+                    'confirmation' => 'Request indexing clicked and accepted.',
+                ],
+            ],
+        ]);
+        $observationPath = $this->writeEvidenceJson([
+            'status' => 'recorded',
+            'checklist' => [
+                'd1' => 'scheduled',
+                'd7' => 'scheduled',
+                'd14' => 'scheduled',
+            ],
+        ]);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--public-smoke-json' => $publicSmokePath,
+            '--gsc-manual-json' => $gscPath,
+            '--observation-json' => $observationPath,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('ARTICLE_RELEASE_COMPLETE_SEARCH_OBSERVATION_PENDING', $payload['decision']);
+        $this->assertSame('passed', data_get($payload, 'checks.public_html_smoke.state'));
+        $this->assertSame('requested', data_get($payload, 'checks.gsc_manual.state'));
+        $this->assertSame('recorded', data_get($payload, 'checks.observation.state'));
+        $this->assertSame('provided', data_get($payload, 'remaining_operator_inputs.public_html_smoke'));
+        $this->assertSame('provided', data_get($payload, 'remaining_operator_inputs.gsc_manual_request_indexing'));
+        $this->assertSame('recorded_or_pending_window', data_get($payload, 'remaining_operator_inputs.d1_d7_d14_observation'));
+    }
+
     public function test_slug_lock_mismatch_blocks_discoverability(): void
     {
         $this->createReleasedArticle();
@@ -508,6 +654,21 @@ final class ArticleReleaseCloseoutCommandTest extends TestCase
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function writeEvidenceJson(array $payload): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'article-closeout-evidence-');
+        $this->assertIsString($path);
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->beforeApplicationDestroyed(static function () use ($path): void {
+            @unlink($path);
+        });
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added `--gsc-manual-json` and `--observation-json` inputs to `articles:release-closeout`.
- Taught closeout to validate GSC Request Indexing evidence against the article canonical URL and confirmation record.
- Taught closeout to record D1/D7/D14 observation evidence as recorded or pending-window instead of always requiring operator remarks.
- Added focused command coverage for valid GSC evidence, URL mismatch blocking, observation evidence, and merged public-smoke/GSC/observation closeout.

## Why
Daily SEO article releases already produce evidence files, but closeout could not ingest GSC/manual-indexing or observation artifacts. This makes the release report reflect completed work instead of relying on manual notes.

## Validation
- `php artisan test --filter=ArticleReleaseCloseoutCommandTest`
- `php artisan route:list`
- `git diff --check`

## Intentionally deferred
- No CMS content changes.
- No article publish/discoverability/search writes.
- No schema/hreflang production data changes.
- No deploy.
