### PR TITLE
fix(seo): clear article SEO hold flags when gates are enabled

### DIFF
--- a/backend/app/Services/Cms/ArticleSeoGateRollout.php
+++ b/backend/app/Services/Cms/ArticleSeoGateRollout.php
@@ -325,9 +325,11 @@ final class ArticleSeoGateRollout
 
         if ((bool) ($options['enable_article_schema'] ?? false)) {
             $package['article_schema_enabled'] = true;
+            unset($package['schema_hold']);
         }
         if ((bool) ($options['enable_breadcrumb_schema'] ?? false)) {
             $package['breadcrumb_schema_enabled'] = true;
+            unset($package['schema_hold']);
         }
         if ((bool) ($options['enable_faq_schema'] ?? false)) {
             $package['faq_schema_enabled'] = true;
@@ -336,6 +338,7 @@ final class ArticleSeoGateRollout
         }
 
         if ((bool) ($options['enable_hreflang'] ?? false)) {
+            unset($package['hreflang_hold']);
             $package['hreflang_gate_v1'] = [
                 'enabled' => true,
                 'policy' => 'reciprocal_counterparts_verified',
@@ -343,6 +346,7 @@ final class ArticleSeoGateRollout
                 'verified_at' => now()->toIso8601String(),
             ];
         } elseif ((bool) ($options['no_hreflang_policy'] ?? false)) {
+            unset($package['hreflang_hold']);
             $package['hreflang_gate_v1'] = [
                 'enabled' => false,
                 'policy' => 'no_hreflang',
@@ -386,6 +390,8 @@ final class ArticleSeoGateRollout
             'robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
             'schema_json_sha256' => $seoMeta instanceof ArticleSeoMeta ? hash('sha256', (string) json_encode($seoMeta->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)) : null,
             'schema_gates' => [
+                'schema_hold' => $package['schema_hold'] ?? null,
+                'hreflang_hold' => $package['hreflang_hold'] ?? null,
                 'article_schema_enabled' => $package['article_schema_enabled'] ?? null,
                 'breadcrumb_schema_enabled' => $package['breadcrumb_schema_enabled'] ?? null,
                 'faq_schema_enabled' => $package['faq_schema_enabled'] ?? null,
@@ -411,9 +417,11 @@ final class ArticleSeoGateRollout
 
         if ((bool) ($options['enable_article_schema'] ?? false)) {
             $snapshot['schema_gates']['article_schema_enabled'] = true;
+            $snapshot['schema_gates']['schema_hold'] = null;
         }
         if ((bool) ($options['enable_breadcrumb_schema'] ?? false)) {
             $snapshot['schema_gates']['breadcrumb_schema_enabled'] = true;
+            $snapshot['schema_gates']['schema_hold'] = null;
         }
         if ((bool) ($options['enable_faq_schema'] ?? false)) {
             $snapshot['schema_gates']['faq_schema_enabled'] = true;
@@ -429,11 +437,13 @@ final class ArticleSeoGateRollout
             ));
         }
         if ((bool) ($options['enable_hreflang'] ?? false)) {
+            $snapshot['schema_gates']['hreflang_hold'] = null;
             $snapshot['schema_gates']['hreflang_gate_v1'] = [
                 'enabled' => true,
                 'policy' => 'reciprocal_counterparts_verified',
             ];
         } elseif ((bool) ($options['no_hreflang_policy'] ?? false)) {
+            $snapshot['schema_gates']['hreflang_hold'] = null;
             $snapshot['schema_gates']['hreflang_gate_v1'] = [
                 'enabled' => false,
                 'policy' => 'no_hreflang',

--- a/backend/tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php
@@ -35,6 +35,8 @@ final class ArticleSeoGateRolloutCommandTest extends TestCase
         $this->createSeoMeta($article, [
             'schema_json' => [
                 'editorial_package_v1' => [
+                    'schema_hold' => true,
+                    'hreflang_hold' => true,
                     'article_schema_enabled' => false,
                     'breadcrumb_schema_enabled' => false,
                     'faq_schema_enabled' => false,
@@ -60,6 +62,10 @@ final class ArticleSeoGateRolloutCommandTest extends TestCase
         $this->assertTrue($payload['ok']);
         $this->assertTrue($payload['dry_run']);
         $this->assertTrue($payload['would_write']);
+        $this->assertTrue((bool) data_get($payload, 'before.0.schema_gates.schema_hold'));
+        $this->assertTrue((bool) data_get($payload, 'before.0.schema_gates.hreflang_hold'));
+        $this->assertNull(data_get($payload, 'after.0.schema_gates.schema_hold'));
+        $this->assertNull(data_get($payload, 'after.0.schema_gates.hreflang_hold'));
         $this->assertFalse((bool) data_get($payload, 'before.0.schema_gates.article_schema_enabled'));
         $this->assertTrue((bool) data_get($payload, 'after.0.schema_gates.article_schema_enabled'));
         $this->assertTrue((bool) data_get($payload, 'after.0.schema_gates.breadcrumb_schema_enabled'));
@@ -67,6 +73,8 @@ final class ArticleSeoGateRolloutCommandTest extends TestCase
         $this->assertSame('no_hreflang', data_get($payload, 'after.0.schema_gates.hreflang_gate_v1.policy'));
 
         $fresh = ArticleSeoMeta::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->firstOrFail();
+        $this->assertTrue((bool) data_get($fresh->schema_json, 'editorial_package_v1.schema_hold'));
+        $this->assertTrue((bool) data_get($fresh->schema_json, 'editorial_package_v1.hreflang_hold'));
         $this->assertFalse((bool) data_get($fresh->schema_json, 'editorial_package_v1.article_schema_enabled'));
         $this->assertSame(0, AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_seo_gate_rollout')->count());
     }
@@ -84,7 +92,11 @@ final class ArticleSeoGateRolloutCommandTest extends TestCase
         $this->createSeoMeta($article, [
             'schema_json' => [
                 'editorial_package_v1' => [
+                    'schema_hold' => true,
+                    'hreflang_hold' => true,
                     'article_schema_enabled' => false,
+                    'breadcrumb_schema_enabled' => false,
+                    'faq_schema_enabled' => false,
                 ],
             ],
         ]);
@@ -96,6 +108,9 @@ final class ArticleSeoGateRolloutCommandTest extends TestCase
             '--translation-group-id' => 'unknown_until_cms_import',
             '--expected-slugs' => 'iq-test-score-and-limits-explained',
             '--set-translation-group-id' => 'tg_article_iq_test_score_and_limits_explained_2026v1',
+            '--enable-article-schema' => true,
+            '--enable-breadcrumb-schema' => true,
+            '--hold-faq-schema' => true,
             '--no-hreflang-policy' => true,
             '--execute' => true,
             '--json' => true,
@@ -116,6 +131,11 @@ final class ArticleSeoGateRolloutCommandTest extends TestCase
         $this->assertSame('tg_article_iq_test_score_and_limits_explained_2026v1', (string) $fresh->translation_group_id);
         $this->assertSame($contentMd, (string) $fresh->content_md);
         $this->assertSame($revisionCount, ArticleTranslationRevision::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->count());
+        $this->assertNull(data_get($fresh->seoMeta?->schema_json, 'editorial_package_v1.schema_hold'));
+        $this->assertNull(data_get($fresh->seoMeta?->schema_json, 'editorial_package_v1.hreflang_hold'));
+        $this->assertTrue((bool) data_get($fresh->seoMeta?->schema_json, 'editorial_package_v1.article_schema_enabled'));
+        $this->assertTrue((bool) data_get($fresh->seoMeta?->schema_json, 'editorial_package_v1.breadcrumb_schema_enabled'));
+        $this->assertFalse((bool) data_get($fresh->seoMeta?->schema_json, 'editorial_package_v1.faq_schema_enabled'));
         $this->assertSame('no_hreflang', data_get($fresh->seoMeta?->schema_json, 'editorial_package_v1.hreflang_gate_v1.policy'));
 
         $audit = AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_seo_gate_rollout')->first();


### PR DESCRIPTION
## What changed
- Clears legacy `editorial_package_v1.schema_hold` when `articles:seo-gate-rollout` enables Article or Breadcrumb schema gates.
- Clears legacy `editorial_package_v1.hreflang_hold` when the rollout records either reciprocal hreflang or an explicit no-hreflang policy.
- Extends rollout command coverage so dry-run shows planned hold-flag clearing while DB state remains unchanged, and execute verifies content/revision safety.

## Why
Article 72/73 showed the enabled gate flags could be written while old hold flags remained, causing `articles:release-closeout` to report `schema_state=held` / `hreflang_state=held` even though public JSON-LD and hreflang were valid.

## Validation
- `php artisan test --filter=ArticleSeoGateRolloutCommandTest`
- `php artisan test --filter=ArticleReleaseCloseoutCommandTest`
- `php artisan route:list --no-ansi`
- `git diff --check`

## Intentionally deferred
- No CMS content changes.
- No publish action.
- No search submission.
- No sitemap or llms mutation.
- No content-release revalidation.
- No deploy.

## Repository rule impact
Article SEO gate state remains backend/CMS-authoritative. This PR only fixes the backend gate metadata transition used by release closeout; it does not introduce a new content surface or frontend fallback.
