### PR TITLE
test(enneagram): enforce result-page scientific boundary checks

### DIFF
--- a/backend/app/Services/Enneagram/Registry/RegistryValidator.php
+++ b/backend/app/Services/Enneagram/Registry/RegistryValidator.php
@@ -78,6 +78,60 @@ final class RegistryValidator
     ];
 
     /**
+     * @var list<array{category:string,pattern:string}>
+     */
+    private const UNSUPPORTED_TEXT_BOUNDARY_PATTERNS = [
+        [
+            'category' => 'pseudo_validity',
+            'pattern' => '/(?:准确率|命中率)(?:达到|高达|为|超过|不低于)\\s*\\d/u',
+        ],
+        [
+            'category' => 'pseudo_validity',
+            'pattern' => '/(?:通过|具备|拥有|达到).{0,12}(?:外部效度验证|效度验证|临床验证|科学验证)/u',
+        ],
+        [
+            'category' => 'pseudo_validity',
+            'pattern' => '/(?:科学|研究|数据|模型).{0,8}(?:证明|证实).{0,18}(?:你是|用户是|此人是|人格|类型)/u',
+        ],
+        [
+            'category' => 'diagnostic_use',
+            'pattern' => '/(?:可用于|可以用于|能够用于|用于|用来|作为|适合).{0,16}(?:临床诊断|临床判断|心理治疗建议|医学判断|医学状态|诊断结论)/u',
+        ],
+        [
+            'category' => 'hiring_use',
+            'pattern' => '/(?:可用于|可以用于|能够用于|用于|用来|作为|适合|支持).{0,18}(?:招聘筛选|招聘|候选人筛选|录用|淘汰|筛掉)/u',
+        ],
+        [
+            'category' => 'hiring_use',
+            'pattern' => '/(?:录用|淘汰|筛掉).{0,16}(?:候选人|应聘者|员工)/u',
+        ],
+        [
+            'category' => 'health_level_hard_judgement',
+            'pattern' => '/(?:判定|判断|确定|证明|说明|锁定).{0,16}(?:健康层级|高健康层级|低健康层级|发展阶段)/u',
+        ],
+        [
+            'category' => 'health_level_hard_judgement',
+            'pattern' => '/(?:处于|属于|就是).{0,10}(?:高健康层级|低健康层级|低发展阶段|高发展阶段)/u',
+        ],
+        [
+            'category' => 'high_certainty',
+            'pattern' => '/(?:一定|必然|总是|永远).{0,16}(?:会|是|导致|代表|意味着|说明)/u',
+        ],
+        [
+            'category' => 'high_certainty',
+            'pattern' => '/(?:你|用户|此人|该结果).{0,10}(?:就是|必然是|一定是|确定是|证明是).{0,12}(?:[1-9]号|这种人格|这个类型|核心类型)/u',
+        ],
+        [
+            'category' => 'high_certainty',
+            'pattern' => '/(?:证明|证实|确定).{0,8}(?:你|用户|此人).{0,8}(?:就是|必然是|一定是|属于).{0,12}(?:[1-9]号|这种人格|这个类型|核心类型)/u',
+        ],
+        [
+            'category' => 'wing_subtype_arrow_hard_judgement',
+            'pattern' => '/(?:翼型|子类型|箭头|本能).{0,14}(?:判定|确定|锁定|硬判)/u',
+        ],
+    ];
+
+    /**
      * @var array<string,string>
      */
     private const REQUIRED_REGISTRIES = [
@@ -203,6 +257,7 @@ final class RegistryValidator
             $errors = array_merge($errors, $this->validateUiCopyRegistry((array) ($registries['enneagram_ui_copy_registry'] ?? [])));
             $errors = array_merge($errors, $this->validateSampleReportRegistry((array) ($registries['enneagram_sample_report_registry'] ?? [])));
             $errors = array_merge($errors, $this->validateTechnicalNoteRegistry((array) ($registries['enneagram_technical_note_registry'] ?? [])));
+            $errors = array_merge($errors, $this->validateRegistryTextBoundaries($registries));
         }
 
         return $errors;
@@ -834,5 +889,78 @@ final class RegistryValidator
         }
 
         return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $registries
+     * @return list<string>
+     */
+    private function validateRegistryTextBoundaries(array $registries): array
+    {
+        $errors = [];
+        foreach ($registries as $registryKey => $payload) {
+            $this->scanTextValue($errors, (string) $registryKey, $payload);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function scanTextValue(array &$errors, string $path, mixed $value): void
+    {
+        if (is_string($value)) {
+            $this->validateTextBoundaryValue($errors, $path, $value);
+
+            return;
+        }
+
+        if (! is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $key => $child) {
+            $childPath = $path.'.'.(is_int($key) ? (string) $key : (string) $key);
+            $this->scanTextValue($errors, $childPath, $child);
+        }
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function validateTextBoundaryValue(array &$errors, string $path, string $value): void
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return;
+        }
+
+        foreach (self::UNSUPPORTED_TEXT_BOUNDARY_PATTERNS as $rule) {
+            if (preg_match($rule['pattern'], $value, $matches, PREG_OFFSET_CAPTURE) !== 1) {
+                continue;
+            }
+
+            $matched = (string) ($matches[0][0] ?? '');
+            $offset = (int) ($matches[0][1] ?? 0);
+            if ($matched === '' || $this->isNegatedBoundaryContext($value, $offset, $matched)) {
+                continue;
+            }
+
+            $errors[] = sprintf(
+                'Registry text boundary violation at %s: %s claim "%s"',
+                $path,
+                $rule['category'],
+                $matched
+            );
+        }
+    }
+
+    private function isNegatedBoundaryContext(string $value, int $offset, string $matched): bool
+    {
+        $prefix = substr($value, max(0, $offset - 18), min(18, $offset));
+        $context = $prefix.$matched;
+
+        return preg_match('/(?:不(?:用于|用来|能|可|应|是|会|把|一定)|不能(?:推出|说明|证明|判定|解释)|不得|不可|非|无法|避免|禁止)/u', $context) === 1;
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -475,6 +475,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_registry_validator_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Enneagram/Registry/RegistryValidator.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_big_five_public_profile_agent_draft_writer_files(): void
     {
         $changed = [
@@ -4900,6 +4909,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramRegistryValidatorFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageRegistryContentAssetFile($file)) {
                 continue;
             }
@@ -7714,6 +7727,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isEnneagramResultPageRegistryContentAssetFile(string $file): bool
     {
         return preg_match('#^backend/content_packs/ENNEAGRAM/v2/registry/[a-z_]+_registry\\.json$#', $file) === 1;
+    }
+
+    private function isEnneagramRegistryValidatorFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Enneagram/Registry/RegistryValidator.php';
     }
 
     private function isEnneagramPhase8bCandidateAssetReconciliationFile(string $file): bool

--- a/backend/tests/Unit/Services/Content/EnneagramRegistryPackLoadTest.php
+++ b/backend/tests/Unit/Services/Content/EnneagramRegistryPackLoadTest.php
@@ -40,6 +40,27 @@ final class EnneagramRegistryPackLoadTest extends TestCase
         $this->assertSame([], $errors);
     }
 
+    public function test_registry_validator_rejects_unsupported_scientific_boundary_claims(): void
+    {
+        $loader = app(EnneagramPackLoader::class);
+        $pack = $loader->loadRegistryPack();
+
+        data_set($pack, 'registries.enneagram_method_registry.entries.0.copy', '本测试可用于临床诊断，并可作为心理治疗建议。');
+        data_set($pack, 'registries.enneagram_pair_registry.entries.0.short_compare_copy', '本结果可以用于招聘筛选候选人，并支持录用决定。');
+        data_set($pack, 'registries.enneagram_state_registry.entries.0.disclaimer', '系统可以判定高健康层级，并锁定发展阶段。');
+        data_set($pack, 'registries.enneagram_technical_note_registry.entries.0.body', '本测试准确率达到 95%，已经通过外部效度验证。');
+        data_set($pack, 'registries.enneagram_ui_copy_registry.entries.instant_summary.clear.body', '该结果证明你就是这个核心类型。');
+
+        $errors = app(RegistryValidator::class)->validate($pack);
+        $joined = implode("\n", $errors);
+
+        $this->assertStringContainsString('diagnostic_use', $joined);
+        $this->assertStringContainsString('hiring_use', $joined);
+        $this->assertStringContainsString('health_level_hard_judgement', $joined);
+        $this->assertStringContainsString('pseudo_validity', $joined);
+        $this->assertStringContainsString('high_certainty', $joined);
+    }
+
     public function test_registry_release_hash_is_stable(): void
     {
         $loader = app(EnneagramPackLoader::class);

--- a/backend/tests/Unit/Services/Content/EnneagramTypeRegistryCoverageTest.php
+++ b/backend/tests/Unit/Services/Content/EnneagramTypeRegistryCoverageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Services\Content;
 
 use App\Services\Content\EnneagramPackLoader;
+use App\Services\Enneagram\Registry\RegistryValidator;
 use Tests\TestCase;
 
 final class EnneagramTypeRegistryCoverageTest extends TestCase
@@ -96,6 +97,20 @@ final class EnneagramTypeRegistryCoverageTest extends TestCase
                 $this->assertNotSame('', trim((string) data_get($entry, 'growth_pack.state_spectrum_copy.'.$stateKey, '')), sprintf('type %s missing growth_pack.state_spectrum_copy.%s', (string) ($entry['type_id'] ?? ''), $stateKey));
             }
         }
+    }
+
+    public function test_type_registry_boundary_scan_rejects_high_certainty_type_claims(): void
+    {
+        $loader = app(EnneagramPackLoader::class);
+        $pack = $loader->loadRegistryPack();
+
+        data_set($pack, 'registries.enneagram_type_registry.entries.0.hero_summary', '数据证明你就是 1 号核心类型，测试准确率达到 99%。');
+
+        $errors = app(RegistryValidator::class)->validate($pack);
+        $joined = implode("\n", $errors);
+
+        $this->assertStringContainsString('high_certainty', $joined);
+        $this->assertStringContainsString('pseudo_validity', $joined);
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added full ENNEAGRAM registry text boundary scanning in `RegistryValidator`.
- The scan blocks unsupported scientific-boundary claims across all registry text values, including pseudo-validity, diagnostic use, hiring use, health-level hard judgement, high-certainty type assertions, and wing/subtype/arrow hard judgement.
- Added regression coverage that mutates registry payloads to prove these categories fail validation while the current real registry still passes.
- Added a narrow BigFive runtime-freeze classifier regression so Enneagram `RegistryValidator.php` changes are not incorrectly treated as BigFive runtime drift.

## Why
- PR-1 repaired the backend result-page registry content assets.
- PR-2 makes the validator enforce the scientific boundaries so the same unsupported claim patterns cannot return in future registry edits.
- The CI-only BigFive guard update fixes the observed `verify-bigfive` failure for this Enneagram validator-only scope.

## Validation
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_enneagram_registry_validator_changes --no-ansi`
- `jq empty content_packs/ENNEAGRAM/v2/registry/*.json`
- `php artisan test --filter=EnneagramTypeRegistryCoverageTest --no-ansi`
- `php artisan test --filter=EnneagramRegistryPackLoadTest --no-ansi`
- `php artisan test --filter=EnneagramReportComposerV2Test --no-ansi`
- `php artisan test --filter=Enneagram --no-ansi`
- `git diff --check`

## Intentionally deferred
- No registry JSON/content changes in this PR.
- No routes, migrations, frontend, deployment, registry release activation, or production smoke.
- Online sync still requires backend deploy plus registry source/activation checks after both PRs are merged.

## Repository rule impact
- Backend registry remains the result-page content authority.
- This PR adds validation around that authority layer and introduces no frontend or CMS fallback content.