### PR TITLE
RIASEC-CONTENT-SCIENCE-00 establish RIASEC content science boundary lint

### DIFF
--- a/backend/docs/riasec/content-science-boundary-lint-v1.json
+++ b/backend/docs/riasec/content-science-boundary-lint-v1.json
@@ -1,0 +1,223 @@
+{
+  "schema_version": "riasec.content_science_boundary_lint.v1",
+  "scale_code": "RIASEC",
+  "content_authority": "backend_content_assets",
+  "review_mode": "codex_science_editorial_self_review",
+  "runtime_behavior": {
+    "frontend_fallback_allowed": false,
+    "cms_write_allowed": false,
+    "production_import_allowed": false,
+    "production_deploy_allowed": false
+  },
+  "reference_basis": [
+    {
+      "source_id": "holland_riasec_theory",
+      "use": "Treat Holland/RIASEC as vocational interest and person-environment exploration language, not diagnosis, ability proof, hiring suitability, or deterministic career matching."
+    },
+    {
+      "source_id": "onet_interest_profiler",
+      "use": "Keep results framed around work activities users may like and occupations they may explore; do not present occupations as matches, rankings, or recommendations."
+    },
+    {
+      "source_id": "onet_vocational_interests_update",
+      "use": "Ground thickening in illustrative work activities and occupational task language rather than personality labels or outcome promises."
+    },
+    {
+      "source_id": "vocational_interest_fit_research",
+      "use": "Interest fit may support exploration and hypothesis generation, but it must not be written as success, performance, admission, hiring, salary, or qualification prediction."
+    }
+  ],
+  "required_boundaries": [
+    "interest_evidence_only",
+    "not_personality_identity",
+    "not_ability_or_skill_measure",
+    "not_career_recommendation",
+    "not_job_fit",
+    "not_success_prediction",
+    "not_hiring_or_screening_use",
+    "examples_not_matches",
+    "no_60q_140q_raw_delta",
+    "140q_contextual_not_more_accurate",
+    "feedback_does_not_mutate_measured_result",
+    "missing_content_fails_closed",
+    "frontend_fallback_forbidden"
+  ],
+  "positive_claims_forbidden": [
+    "best_career",
+    "career_match",
+    "occupation_ranking",
+    "job_fit",
+    "fit_score",
+    "success_prediction",
+    "salary_prediction",
+    "admission_or_hiring_suitability",
+    "qualification_judgment",
+    "ability_or_skill_inference",
+    "personality_identity",
+    "diagnostic_claim",
+    "140q_more_accurate",
+    "60q_wrong_or_overridden",
+    "raw_score_delta",
+    "feedback_changes_scores",
+    "cms_or_frontend_runtime_authority"
+  ],
+  "copy_quality_rules": [
+    "Prefer concrete work activities, tradeoffs, validation questions, and small experiments over labels.",
+    "Use zh-CN that sounds like professional career counseling, not machine-generated motivational prose.",
+    "Do not thicken by repeating the same boundary paragraph in every section.",
+    "When a section is already dense, improve structure and specificity before adding length.",
+    "Keep occupation names as examples that illuminate activity signals; never turn them into recommendations."
+  ],
+  "sections": [
+    {
+      "section_key": "hero_activity_chain",
+      "primary_assets": ["content_assets/riasec/top3_code_chain_strategy_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php", "app/Services/Riasec/RiasecPublicProjectionService.php"],
+      "risk": "top3 ordering can read like an identity label",
+      "repair_goal": "frame the top3 as an activity chain and exploration order, not ability or career conclusion"
+    },
+    {
+      "section_key": "six_dimension_map",
+      "primary_assets": ["content_assets/riasec/profile_shape_copy_v1.zh-CN.json", "content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json"],
+      "service_files": ["app/Services/Riasec/RiasecReportModuleSelector.php", "app/Services/Riasec/RiasecPublicProjectionService.php"],
+      "risk": "high or flat bars can be overread as absolute strength or ability",
+      "repair_goal": "explain relative shape, flatness, near ties, and reading strength"
+    },
+    {
+      "section_key": "pair_blend",
+      "primary_assets": ["content_assets/riasec/pair_blend_15_pairs_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecReportModuleSelector.php", "app/Services/Riasec/RiasecPublicProjectionService.php"],
+      "risk": "module visibility can expose strong combination copy when a cautious view is safer",
+      "repair_goal": "align visible/collapsed behavior with quality and profile-shape risk"
+    },
+    {
+      "section_key": "activity_explorer",
+      "primary_assets": ["content_assets/riasec/activity_task_examples_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecActivityExplorerService.php"],
+      "risk": "activity examples can become repetitive, generic, or recommendation-like",
+      "repair_goal": "make activities concrete, observable, low-risk, and non-deterministic"
+    },
+    {
+      "section_key": "occupation_examples",
+      "primary_assets": ["content_assets/riasec/occupation_examples_boundary_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecActivityExplorerService.php"],
+      "risk": "occupation examples are the highest-risk surface for career recommendation and job-fit claims",
+      "repair_goal": "keep occupations as examples-only bridges from activity signals"
+    },
+    {
+      "section_key": "140q_cta",
+      "primary_assets": ["content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php"],
+      "risk": "140Q can be misread as more accurate or as a repair for 60Q",
+      "repair_goal": "describe 140Q as a contextual detail layer that does not override 60Q"
+    },
+    {
+      "section_key": "140q_context_cards",
+      "primary_assets": ["content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php", "app/Services/Riasec/RiasecPublicProjectionService.php"],
+      "risk": "task, environment, and role cards can be over-generalized",
+      "repair_goal": "make work-daily context specific without comparing raw scores or concluding occupations"
+    },
+    {
+      "section_key": "share_card",
+      "primary_assets": ["content_assets/riasec/share_pdf_history_v1.zh-CN.json", "content_assets/riasec/share_pdf_history_v1.en.json"],
+      "service_files": ["app/Services/Riasec/RiasecLifecycleCopyService.php"],
+      "risk": "public share copy can leak private context or overstate the result",
+      "repair_goal": "keep share copy minimal, public-safe, and free of score or identity claims"
+    },
+    {
+      "section_key": "pdf",
+      "primary_assets": ["content_assets/riasec/share_pdf_history_v1.zh-CN.json", "content_assets/riasec/share_pdf_history_v1.en.json"],
+      "service_files": ["app/Services/Report/RiasecReportComposer.php", "app/Services/Riasec/RiasecLifecycleCopyService.php"],
+      "risk": "PDF can become too dense or repeat boundaries without adding decision value",
+      "repair_goal": "compress repeated boundary copy while preserving scientific limits"
+    },
+    {
+      "section_key": "history",
+      "primary_assets": ["content_assets/riasec/share_pdf_history_v1.zh-CN.json", "content_assets/riasec/share_pdf_history_v1.en.json"],
+      "service_files": ["app/Services/Riasec/RiasecLifecycleCopyService.php"],
+      "risk": "history can imply stable personality identity instead of a snapshot",
+      "repair_goal": "show snapshot and exploration history without stable identity claims"
+    },
+    {
+      "section_key": "feedback_overlay",
+      "primary_assets": ["content_assets/riasec/feedback_action_lab_v1.zh-CN.jsonl", "content_assets/riasec/next_exploration_nodes_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php"],
+      "risk": "feedback can be mistaken as changing scores or Holland code",
+      "repair_goal": "make feedback affect only exploration actions and never measured results"
+    },
+    {
+      "section_key": "dimension_deep_copy",
+      "primary_assets": ["content_assets/riasec/dimension_deep_copy_v1.zh-CN.r3.json"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php"],
+      "risk": "single dimensions can sound like personality or ability profiles",
+      "repair_goal": "anchor every dimension in interest activities, costs, misreads, and validation"
+    },
+    {
+      "section_key": "pair_blend_copy",
+      "primary_assets": ["content_assets/riasec/pair_blend_15_pairs_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php"],
+      "risk": "pair labels can create identity labels",
+      "repair_goal": "de-label pair copy and thicken tension, cost, and validation"
+    },
+    {
+      "section_key": "140q_layer_copy",
+      "primary_assets": ["content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php"],
+      "risk": "layer copy can drift between task, environment, role, and CTA meanings",
+      "repair_goal": "make the three 140Q layers consistent and boundary-safe"
+    },
+    {
+      "section_key": "quality_copy",
+      "primary_assets": ["content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php", "app/Services/Riasec/RiasecQualityRuleContract.php"],
+      "risk": "low-quality copy can blame the user or upsell 140Q",
+      "repair_goal": "explain cautious reading, retake guidance, and hidden strong modules"
+    },
+    {
+      "section_key": "structural_difference_copy",
+      "primary_assets": ["content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php", "app/Services/Riasec/RiasecPublicProjectionService.php"],
+      "risk": "60Q and 140Q differences can be read as better or worse results",
+      "repair_goal": "describe emphasis differences without raw-score comparison or override"
+    },
+    {
+      "section_key": "aspirations_copy",
+      "primary_assets": ["content_assets/riasec/aspirations_calibration_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php"],
+      "risk": "aspiration copy can override measured interest signals",
+      "repair_goal": "turn aspirations into reality-check questions and small experiments"
+    },
+    {
+      "section_key": "feedback_response_copy",
+      "primary_assets": ["content_assets/riasec/disagree_path_v1.zh-CN.jsonl"],
+      "service_files": ["app/Services/Riasec/RiasecDeepCopySlotRegistry.php"],
+      "risk": "disagree copy can imply report correction or score mutation",
+      "repair_goal": "give next steps while preserving snapshot, share, PDF, and measured code"
+    }
+  ],
+  "asset_inventory": [
+    "content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl",
+    "content_assets/riasec/activity_task_examples_v1.zh-CN.jsonl",
+    "content_assets/riasec/aspirations_calibration_v1.zh-CN.jsonl",
+    "content_assets/riasec/dimension_deep_copy_v1.zh-CN.r3.json",
+    "content_assets/riasec/disagree_path_v1.zh-CN.jsonl",
+    "content_assets/riasec/faq_v1.en.json",
+    "content_assets/riasec/faq_v1.zh-CN.json",
+    "content_assets/riasec/feedback_action_lab_v1.zh-CN.jsonl",
+    "content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json",
+    "content_assets/riasec/near_tie_alternate_code_copy_v1.zh-CN.json",
+    "content_assets/riasec/next_exploration_nodes_v1.zh-CN.jsonl",
+    "content_assets/riasec/occupation_examples_boundary_v1.zh-CN.jsonl",
+    "content_assets/riasec/pair_blend_15_pairs_v1.zh-CN.jsonl",
+    "content_assets/riasec/professional_method_boundary_v1.en.json",
+    "content_assets/riasec/professional_method_boundary_v1.zh-CN.json",
+    "content_assets/riasec/profile_shape_copy_v1.zh-CN.json",
+    "content_assets/riasec/share_pdf_history_v1.en.json",
+    "content_assets/riasec/share_pdf_history_v1.zh-CN.json",
+    "content_assets/riasec/technical_note_user_summary_v1.en.json",
+    "content_assets/riasec/technical_note_user_summary_v1.zh-CN.json",
+    "content_assets/riasec/top3_code_chain_strategy_v1.zh-CN.jsonl",
+    "content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json"
+  ]
+}

--- a/backend/docs/riasec/content-science-boundary-lint-v1.md
+++ b/backend/docs/riasec/content-science-boundary-lint-v1.md
@@ -1,0 +1,36 @@
+# RIASEC Content Science Boundary Lint V1
+
+Task: `RIASEC-CONTENT-SCIENCE-00`
+
+This document defines the baseline review contract for the RIASEC/Holland result-page content repair train.
+
+## Scope
+
+This PR establishes lintable scientific and editorial boundaries. It does not rewrite runtime content, import CMS data, change production state, or modify frontend public editorial copy.
+
+## Review Principles
+
+- RIASEC results describe vocational interests and work-activity exploration signals.
+- Results must not be written as ability, skill, diagnosis, hiring suitability, admission suitability, salary, or success prediction.
+- Occupation names may illustrate work activities, but they are not matches, rankings, recommendations, or fit scores.
+- 140Q may add task, environment, and role-context detail. It must not be framed as more accurate than 60Q or as overriding 60Q.
+- Feedback, disagreement, and aspirations may guide exploration actions. They must not mutate scores, Holland code, report snapshot, share payload, PDF, or history payload.
+- If an asset is missing or unsafe, the backend should omit the section fail-closed. The frontend must not supply fallback public content.
+
+## PR Train Usage
+
+Every later `RIASEC-CONTENT-*` PR should use `content-science-boundary-lint-v1.json` as the baseline. A section PR should:
+
+1. Keep the section inside its own PR scope.
+2. Repair scientific claims before style.
+3. Remove AI-like repetition, generic encouragement, and deterministic labels.
+4. Add specificity through activities, tradeoffs, validation questions, and realistic next steps.
+5. Run the section-focused tests plus the baseline lint test.
+
+## Non-Goals
+
+- No CMS write.
+- No production import.
+- No manual deploy.
+- No production deploy.
+- No sitemap, llms, canonical, noindex, JSON-LD, SEO runtime, permission, secret, or DB migration change.

--- a/backend/tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use Tests\TestCase;
+
+final class RiasecContentScienceBoundaryLintTest extends TestCase
+{
+    /** @var list<string> */
+    private const REQUIRED_SECTIONS = [
+        'hero_activity_chain',
+        'six_dimension_map',
+        'pair_blend',
+        'activity_explorer',
+        'occupation_examples',
+        '140q_cta',
+        '140q_context_cards',
+        'share_card',
+        'pdf',
+        'history',
+        'feedback_overlay',
+        'dimension_deep_copy',
+        'pair_blend_copy',
+        '140q_layer_copy',
+        'quality_copy',
+        'structural_difference_copy',
+        'aspirations_copy',
+        'feedback_response_copy',
+    ];
+
+    /** @var list<string> */
+    private const REQUIRED_BOUNDARIES = [
+        'interest_evidence_only',
+        'not_personality_identity',
+        'not_ability_or_skill_measure',
+        'not_career_recommendation',
+        'not_job_fit',
+        'not_success_prediction',
+        'not_hiring_or_screening_use',
+        'examples_not_matches',
+        'no_60q_140q_raw_delta',
+        '140q_contextual_not_more_accurate',
+        'feedback_does_not_mutate_measured_result',
+        'missing_content_fails_closed',
+        'frontend_fallback_forbidden',
+    ];
+
+    /** @var array<string,string> */
+    private const POSITIVE_HIGH_RISK_PATTERNS = [
+        'best_career' => '/最佳职业|最适合的职业|推荐职业|职业推荐/u',
+        'job_fit' => '/岗位匹配|职业匹配|岗位胜任|匹配度|适合度/u',
+        'success_prediction' => '/成功概率|职业成功|保证成功|一定成功/u',
+        'deterministic_identity' => '/天生适合|你就是|最终答案|注定/u',
+        'form_override' => '/140Q\s*更准确|140题更准确|推翻\s*60Q|60Q错了|60题错了/iu',
+    ];
+
+    public function test_science_boundary_registry_covers_all_authorized_sections(): void
+    {
+        $registry = $this->registry();
+
+        $this->assertSame('riasec.content_science_boundary_lint.v1', $registry['schema_version']);
+        $this->assertSame('RIASEC', $registry['scale_code']);
+        $this->assertSame('backend_content_assets', $registry['content_authority']);
+        $this->assertFalse(data_get($registry, 'runtime_behavior.frontend_fallback_allowed'));
+        $this->assertFalse(data_get($registry, 'runtime_behavior.cms_write_allowed'));
+        $this->assertFalse(data_get($registry, 'runtime_behavior.production_import_allowed'));
+        $this->assertFalse(data_get($registry, 'runtime_behavior.production_deploy_allowed'));
+
+        $sections = array_column((array) $registry['sections'], 'section_key');
+        sort($sections);
+
+        $expected = self::REQUIRED_SECTIONS;
+        sort($expected);
+
+        $this->assertSame($expected, $sections);
+    }
+
+    public function test_science_boundary_registry_declares_required_boundaries_and_forbidden_claims(): void
+    {
+        $registry = $this->registry();
+
+        foreach (self::REQUIRED_BOUNDARIES as $boundary) {
+            $this->assertContains($boundary, $registry['required_boundaries']);
+        }
+
+        foreach ([
+            'career_match',
+            'job_fit',
+            'success_prediction',
+            'ability_or_skill_inference',
+            'personality_identity',
+            '140q_more_accurate',
+            'feedback_changes_scores',
+            'cms_or_frontend_runtime_authority',
+        ] as $claim) {
+            $this->assertContains($claim, $registry['positive_claims_forbidden']);
+        }
+    }
+
+    public function test_science_boundary_registry_maps_current_top_level_assets(): void
+    {
+        $registry = $this->registry();
+        $listedAssets = (array) $registry['asset_inventory'];
+
+        foreach ($this->topLevelRiasecAssets() as $asset) {
+            $this->assertContains($asset, $listedAssets, "{$asset} must be explicitly mapped before section repair");
+        }
+
+        foreach ((array) $registry['sections'] as $section) {
+            $this->assertNotEmpty($section['primary_assets'], $section['section_key'].' must name source assets');
+            $this->assertNotEmpty($section['service_files'], $section['section_key'].' must name backend service files');
+            $this->assertNotEmpty($section['risk'], $section['section_key'].' must record the risk being repaired');
+            $this->assertNotEmpty($section['repair_goal'], $section['section_key'].' must record the repair goal');
+        }
+    }
+
+    public function test_positive_claim_matcher_distinguishes_negated_boundaries_from_positive_claims(): void
+    {
+        $this->assertFalse($this->containsPositiveHighRiskClaim(
+            '140Q 更具体地观察任务、环境和角色责任，不推翻 60Q，也不比较不同表单原始分。',
+            self::POSITIVE_HIGH_RISK_PATTERNS['form_override'],
+        ));
+        $this->assertFalse($this->containsPositiveHighRiskClaim(
+            '这不是岗位胜任依据，也不输出职业推荐。',
+            self::POSITIVE_HIGH_RISK_PATTERNS['job_fit'],
+        ));
+        $this->assertTrue($this->containsPositiveHighRiskClaim(
+            '这个结果说明你岗位胜任，职业匹配度很高。',
+            self::POSITIVE_HIGH_RISK_PATTERNS['job_fit'],
+        ));
+        $this->assertTrue($this->containsPositiveHighRiskClaim(
+            '140Q 更准确，会推翻 60Q。',
+            self::POSITIVE_HIGH_RISK_PATTERNS['form_override'],
+        ));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function registry(): array
+    {
+        $path = base_path('docs/riasec/content-science-boundary-lint-v1.json');
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function topLevelRiasecAssets(): array
+    {
+        $base = base_path('content_assets/riasec');
+        $assets = [];
+
+        foreach (glob($base.'/*.{json,jsonl}', GLOB_BRACE) ?: [] as $path) {
+            $assets[] = 'content_assets/riasec/'.basename($path);
+        }
+
+        sort($assets);
+
+        return $assets;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function assetRecords(string $relativePath): array
+    {
+        $path = base_path($relativePath);
+        $this->assertFileExists($path);
+
+        if (str_ends_with($path, '.jsonl')) {
+            $records = [];
+            foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+                $decoded = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                $this->assertIsArray($decoded);
+                $records[] = $decoded;
+            }
+
+            return $records;
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return [$decoded];
+    }
+
+    private function containsPositiveHighRiskClaim(string $text, string $pattern): bool
+    {
+        if (preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE) < 1) {
+            return false;
+        }
+
+        foreach ($matches[0] as [$match, $offset]) {
+            if (! $this->isNegatedBoundaryMention($text, (string) $match, (int) $offset)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isNegatedBoundaryMention(string $text, string $match, int $offset): bool
+    {
+        $prefix = mb_substr(substr($text, 0, $offset), -14);
+        $window = $prefix.$match;
+
+        foreach (['不', '不是', '不能', '不得', '不可', '不应', '不要', '不会', '不代表', '不作为', '不等于', '非'] as $negation) {
+            if (str_contains($window, $negation)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -63745,7 +63745,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-30T09:37:12+08:00",
+  "updated_at": "2026-07-02T16:21:59Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",
@@ -67033,6 +67033,862 @@
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-SCIENCE-00": {
+    "id": "RIASEC-CONTENT-SCIENCE-00",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-science-00",
+    "title": "RIASEC-CONTENT-SCIENCE-00 establish RIASEC content science boundary lint",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [],
+    "status": "pr_opened",
+    "commit_sha": "60d9808ff7ec926321ecb7cb8f8a0f8d981183d5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2601",
+    "checks": {
+      "phpunit": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "4 tests, 133 assertions"
+      },
+      "pint": {
+        "command": "cd backend && vendor/bin/pint --test tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php",
+        "status": "passed"
+      },
+      "manifest_yaml_parse": {
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+        "status": "passed"
+      },
+      "state_json_parse": {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed"
+      },
+      "boundary_registry_json_parse": {
+        "command": "python3 -m json.tool backend/docs/riasec/content-science-boundary-lint-v1.json >/dev/null",
+        "status": "passed"
+      },
+      "diff_check": {
+        "command": "git diff --check",
+        "status": "passed"
+      },
+      "scope_validation": {
+        "command": "git diff --name-only && git ls-files --others --exclude-standard; compare against SCIENCE-00 allowed paths",
+        "status": "passed",
+        "summary": "Only 5 SCIENCE-00 allowed paths changed."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/docs/riasec/content-science-boundary-lint-v1.json",
+        "backend/docs/riasec/content-science-boundary-lint-v1.md",
+        "backend/tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php",
+        "docs/codex/pr-train-state.json",
+        "docs/codex/pr-train.yaml"
+      ]
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "in_progress",
+        "note": "User authorized full RIASEC content science repair train; started first scoped PR from latest origin/main in isolated worktree."
+      },
+      {
+        "at": "2026-07-02T16:14:09Z",
+        "from": "in_progress",
+        "to": "local_validation_passed",
+        "note": "SCIENCE-00 local checks passed and changed files stayed within allowed scope."
+      },
+      {
+        "at": "2026-07-02T16:15:43Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2601 after local validation and scope validation passed."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-HERO-01": {
+    "id": "RIASEC-CONTENT-HERO-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-hero-01",
+    "title": "RIASEC-CONTENT-HERO-01 optimize RIASEC hero activity chain content",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-DIMMAP-01": {
+    "id": "RIASEC-CONTENT-DIMMAP-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-dimmap-01",
+    "title": "RIASEC-CONTENT-DIMMAP-01 optimize RIASEC six-dimension map interpretation",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-PAIRMODULE-01": {
+    "id": "RIASEC-CONTENT-PAIRMODULE-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-pairmodule-01",
+    "title": "RIASEC-CONTENT-PAIRMODULE-01 govern RIASEC pair blend module visibility",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-ACTIVITY-01": {
+    "id": "RIASEC-CONTENT-ACTIVITY-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-activity-01",
+    "title": "RIASEC-CONTENT-ACTIVITY-01 repair RIASEC activity explorer content assets",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-ACTIVITY-02": {
+    "id": "RIASEC-CONTENT-ACTIVITY-02",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-activity-02",
+    "title": "RIASEC-CONTENT-ACTIVITY-02 harden RIASEC activity explorer selection",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-ACTIVITY-01"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-OCC-01": {
+    "id": "RIASEC-CONTENT-OCC-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-occ-01",
+    "title": "RIASEC-CONTENT-OCC-01 repair RIASEC occupation example boundaries",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-OCC-02": {
+    "id": "RIASEC-CONTENT-OCC-02",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-occ-02",
+    "title": "RIASEC-CONTENT-OCC-02 harden RIASEC occupation example projection",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-OCC-01"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-140CTA-01": {
+    "id": "RIASEC-CONTENT-140CTA-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-140cta-01",
+    "title": "RIASEC-CONTENT-140CTA-01 repair RIASEC 60Q and 140Q CTA boundaries",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-140CTX-01": {
+    "id": "RIASEC-CONTENT-140CTX-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-140ctx-01",
+    "title": "RIASEC-CONTENT-140CTX-01 repair RIASEC 140Q context card assets",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-140CTA-01"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-140CTX-02": {
+    "id": "RIASEC-CONTENT-140CTX-02",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-140ctx-02",
+    "title": "RIASEC-CONTENT-140CTX-02 harden RIASEC 140Q structural selection",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-140CTX-01"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-SHARE-01": {
+    "id": "RIASEC-CONTENT-SHARE-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-share-01",
+    "title": "RIASEC-CONTENT-SHARE-01 repair RIASEC public share card copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-PDF-01": {
+    "id": "RIASEC-CONTENT-PDF-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-pdf-01",
+    "title": "RIASEC-CONTENT-PDF-01 repair RIASEC PDF density and boundaries",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-HISTORY-01": {
+    "id": "RIASEC-CONTENT-HISTORY-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-history-01",
+    "title": "RIASEC-CONTENT-HISTORY-01 repair RIASEC history summary boundaries",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-FEEDBACK-01": {
+    "id": "RIASEC-CONTENT-FEEDBACK-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-feedback-01",
+    "title": "RIASEC-CONTENT-FEEDBACK-01 repair RIASEC feedback overlay copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-FEEDBACK-02": {
+    "id": "RIASEC-CONTENT-FEEDBACK-02",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-feedback-02",
+    "title": "RIASEC-CONTENT-FEEDBACK-02 repair RIASEC next exploration nodes",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-FEEDBACK-01"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-DIMDEEP-01": {
+    "id": "RIASEC-CONTENT-DIMDEEP-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-dimdeep-01",
+    "title": "RIASEC-CONTENT-DIMDEEP-01 repair RIASEC dimension deep copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-PAIRDEEP-01": {
+    "id": "RIASEC-CONTENT-PAIRDEEP-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-pairdeep-01",
+    "title": "RIASEC-CONTENT-PAIRDEEP-01 repair RIASEC pair blend deep copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-140LAYER-01": {
+    "id": "RIASEC-CONTENT-140LAYER-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-140layer-01",
+    "title": "RIASEC-CONTENT-140LAYER-01 repair RIASEC 140Q layer copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-140CTA-01",
+      "RIASEC-CONTENT-140CTX-02"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-QUALITY-01": {
+    "id": "RIASEC-CONTENT-QUALITY-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-quality-01",
+    "title": "RIASEC-CONTENT-QUALITY-01 repair RIASEC quality boundary copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-STRUCT-01": {
+    "id": "RIASEC-CONTENT-STRUCT-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-struct-01",
+    "title": "RIASEC-CONTENT-STRUCT-01 repair RIASEC structural difference copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-140LAYER-01"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-ASPIRATION-01": {
+    "id": "RIASEC-CONTENT-ASPIRATION-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-aspiration-01",
+    "title": "RIASEC-CONTENT-ASPIRATION-01 repair RIASEC aspirations copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-DISAGREE-01": {
+    "id": "RIASEC-CONTENT-DISAGREE-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-disagree-01",
+    "title": "RIASEC-CONTENT-DISAGREE-01 repair RIASEC disagree path copy",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      }
+    ]
+  },
+  "RIASEC-CONTENT-FINALQA-01": {
+    "id": "RIASEC-CONTENT-FINALQA-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-finalqa-01",
+    "title": "RIASEC-CONTENT-FINALQA-01 revalidate all RIASEC content sections",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-HERO-01",
+      "RIASEC-CONTENT-DIMMAP-01",
+      "RIASEC-CONTENT-PAIRMODULE-01",
+      "RIASEC-CONTENT-ACTIVITY-02",
+      "RIASEC-CONTENT-OCC-02",
+      "RIASEC-CONTENT-140LAYER-01",
+      "RIASEC-CONTENT-QUALITY-01",
+      "RIASEC-CONTENT-STRUCT-01",
+      "RIASEC-CONTENT-ASPIRATION-01",
+      "RIASEC-CONTENT-DISAGREE-01",
+      "RIASEC-CONTENT-PDF-01",
+      "RIASEC-CONTENT-SHARE-01",
+      "RIASEC-CONTENT-HISTORY-01",
+      "RIASEC-CONTENT-FEEDBACK-02",
+      "RIASEC-CONTENT-DIMDEEP-01",
+      "RIASEC-CONTENT-PAIRDEEP-01"
+    ],
+    "status": "authorized_pending_start",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -63745,7 +63745,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-02T16:21:59Z",
+  "updated_at": "2026-07-02T16:22:20Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -31621,3 +31621,963 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: RIASEC-CONTENT-SCIENCE-00
+    repo: fap-api
+    depends_on: []
+    branch: codex/riasec-content-science-00
+    title: "RIASEC-CONTENT-SCIENCE-00 establish RIASEC content science boundary lint"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Register the RIASEC content science repair PR train.
+      - Add a backend-owned science boundary registry for the 18 RIASEC result content sections.
+      - Add a focused lint test proving section coverage, asset mapping, and high-risk positive-claim blocking.
+    allowed_paths:
+      - backend/docs/riasec/content-science-boundary-lint-v1.*
+      - backend/tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -m json.tool backend/docs/riasec/content-science-boundary-lint-v1.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-HERO-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-hero-01
+    title: "RIASEC-CONTENT-HERO-01 optimize RIASEC hero activity chain content"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair hero_activity_chain content so top3 is an activity chain and exploration order, not identity or ability conclusion.
+    allowed_paths:
+      - backend/content_assets/riasec/top3_code_chain_strategy_v1.zh-CN.jsonl
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/app/Services/Riasec/RiasecPublicProjectionService.php
+      - backend/tests/Unit/Services/Riasec/**
+      - backend/tests/Feature/V0_3/Riasec*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-DIMMAP-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-dimmap-01
+    title: "RIASEC-CONTENT-DIMMAP-01 optimize RIASEC six-dimension map interpretation"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair six_dimension_map interpretation for high scores, flat profiles, near ties, and ability-boundary risks.
+    allowed_paths:
+      - backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json
+      - backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json
+      - backend/app/Services/Riasec/RiasecReportModuleSelector.php
+      - backend/app/Services/Riasec/RiasecPublicProjectionService.php
+      - backend/tests/Unit/Services/Riasec/**
+      - backend/tests/Feature/V0_3/Riasec*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-PAIRMODULE-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-pairmodule-01
+    title: "RIASEC-CONTENT-PAIRMODULE-01 govern RIASEC pair blend module visibility"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Align pair_blend module visibility with quality/profile risk and content-safety boundaries.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecReportModuleSelector.php
+      - backend/app/Services/Riasec/RiasecPublicProjectionService.php
+      - backend/tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php
+      - backend/tests/Unit/Services/Riasec/**Pair**
+      - backend/tests/Feature/V0_3/Riasec*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-ACTIVITY-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-activity-01
+    title: "RIASEC-CONTENT-ACTIVITY-01 repair RIASEC activity explorer content assets"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair 360 activity/task examples for scientific correctness, specificity, low-risk validation, and non-recommendation language.
+    allowed_paths:
+      - backend/content_assets/riasec/activity_task_examples_v1.zh-CN.jsonl
+      - backend/tests/Unit/Services/Riasec/RiasecActivityTaskExamplesPreflightTest.php
+      - backend/tests/Fixtures/Riasec/activity_task_examples_v1.zh-CN.jsonl
+      - backend/docs/riasec/activity-task-examples-pack-05-preflight.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-ACTIVITY-02
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-ACTIVITY-01
+    branch: codex/riasec-content-activity-02
+    title: "RIASEC-CONTENT-ACTIVITY-02 harden RIASEC activity explorer selection"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair activity explorer selection, dedupe, ordering, and fail-closed behavior so examples are not recommendations.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecActivityExplorerService.php
+      - backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecActivityTaskExamplesPreflightTest.php
+      - backend/tests/Feature/V0_3/Riasec*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-OCC-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-occ-01
+    title: "RIASEC-CONTENT-OCC-01 repair RIASEC occupation example boundaries"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair 360 occupation examples so occupations remain examples-only activity bridges without fit, rank, or recommendation claims.
+    allowed_paths:
+      - backend/content_assets/riasec/occupation_examples_boundary_v1.zh-CN.jsonl
+      - backend/tests/Unit/Services/Riasec/RiasecOccupationExamplesPreflightTest.php
+      - backend/tests/Fixtures/Riasec/occupation_examples_boundary_v1.zh-CN.jsonl
+      - backend/docs/riasec/occupation-examples-pack-06-preflight.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-OCC-02
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-OCC-01
+    branch: codex/riasec-content-occ-02
+    title: "RIASEC-CONTENT-OCC-02 harden RIASEC occupation example projection"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Harden occupation example projection and public surfaces against ranking, fit score, success, qualification, and share/PDF leakage.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecActivityExplorerService.php
+      - backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecOccupationExamplesPreflightTest.php
+      - backend/tests/Feature/V0_3/Riasec*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-140CTA-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-140cta-01
+    title: "RIASEC-CONTENT-140CTA-01 repair RIASEC 60Q and 140Q CTA boundaries"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair 140q_cta copy so 140Q is contextual detail, not more accurate or a 60Q repair.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/Riasec140qLayerAssetRegistryTest.php
+      - backend/content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-140CTX-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-140CTA-01
+    branch: codex/riasec-content-140ctx-01
+    title: "RIASEC-CONTENT-140CTX-01 repair RIASEC 140Q context card assets"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair 140Q task, environment, and role assets for realistic work-daily context without occupational conclusions.
+    allowed_paths:
+      - backend/content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl
+      - backend/tests/Unit/Services/Riasec/Riasec140qLayerAssetRegistryTest.php
+      - backend/tests/Fixtures/Riasec/**140q**
+      - backend/docs/riasec/**140q**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-140CTX-02
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-140CTX-01
+    branch: codex/riasec-content-140ctx-02
+    title: "RIASEC-CONTENT-140CTX-02 harden RIASEC 140Q structural selection"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Harden 140Q context card projection and cross-form structural difference selection so raw scores are never compared.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecPublicProjectionService.php
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php
+      - backend/tests/Feature/V0_3/Riasec*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-SHARE-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-share-01
+    title: "RIASEC-CONTENT-SHARE-01 repair RIASEC public share card copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair share_card copy to be minimal, public-safe, and free of score, identity, private context, or outcome claims.
+    allowed_paths:
+      - backend/content_assets/riasec/share_pdf_history_v1.*.json
+      - backend/app/Services/Riasec/RiasecLifecycleCopyService.php
+      - backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
+      - backend/tests/Feature/V0_3/*Share*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-PDF-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-pdf-01
+    title: "RIASEC-CONTENT-PDF-01 repair RIASEC PDF density and boundaries"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair PDF lifecycle copy density and boundary wording without changing PDF runtime or deployment.
+    allowed_paths:
+      - backend/content_assets/riasec/share_pdf_history_v1.*.json
+      - backend/app/Services/Riasec/RiasecLifecycleCopyService.php
+      - backend/app/Services/Report/RiasecReportComposer.php
+      - backend/tests/Feature/V0_3/*Pdf*
+      - backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-HISTORY-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-history-01
+    title: "RIASEC-CONTENT-HISTORY-01 repair RIASEC history summary boundaries"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair history copy so it reads as a snapshot and exploration record, not a stable personality identity.
+    allowed_paths:
+      - backend/content_assets/riasec/share_pdf_history_v1.*.json
+      - backend/app/Services/Riasec/RiasecLifecycleCopyService.php
+      - backend/tests/Feature/V0_3/*History*
+      - backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-FEEDBACK-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-feedback-01
+    title: "RIASEC-CONTENT-FEEDBACK-01 repair RIASEC feedback overlay copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair feedback action lab content so feedback only guides exploration and never mutates score or code.
+    allowed_paths:
+      - backend/content_assets/riasec/feedback_action_lab_v1.zh-CN.jsonl
+      - backend/app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php
+      - backend/tests/Unit/Services/Riasec/RiasecFeedbackActionLabPreflightTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-FEEDBACK-02
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-FEEDBACK-01
+    branch: codex/riasec-content-feedback-02
+    title: "RIASEC-CONTENT-FEEDBACK-02 repair RIASEC next exploration nodes"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair next exploration nodes as small experiments and observation questions, not recommendations.
+    allowed_paths:
+      - backend/content_assets/riasec/next_exploration_nodes_v1.zh-CN.jsonl
+      - backend/app/Services/Riasec/RiasecExplorationFeedbackOverlayService.php
+      - backend/tests/Unit/Services/Riasec/RiasecExplorationFeedbackOverlayServiceTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecFeedbackActionLabPreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-DIMDEEP-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-dimdeep-01
+    title: "RIASEC-CONTENT-DIMDEEP-01 repair RIASEC dimension deep copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair dimension_deep_copy so each dimension stays grounded in interest activities, costs, misreads, and validation.
+    allowed_paths:
+      - backend/content_assets/riasec/dimension_deep_copy_v1.zh-CN.r3.json
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/tests/Unit/Services/Riasec/RiasecDeepCopySlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-PAIRDEEP-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-pairdeep-01
+    title: "RIASEC-CONTENT-PAIRDEEP-01 repair RIASEC pair blend deep copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair 15 pair_blend_copy rows to reduce identity labels and thicken tension, cost, and validation.
+    allowed_paths:
+      - backend/content_assets/riasec/pair_blend_15_pairs_v1.zh-CN.jsonl
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/tests/Unit/Services/Riasec/RiasecPairBlendAssetPreflightTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecPairBlendSlotRegistryTest.php
+      - backend/tests/Fixtures/Riasec/pair_blend_15_pairs_v7_3_preflight.jsonl
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-140LAYER-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-140CTA-01
+      - RIASEC-CONTENT-140CTX-02
+    branch: codex/riasec-content-140layer-01
+    title: "RIASEC-CONTENT-140LAYER-01 repair RIASEC 140Q layer copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair 140q_layer_copy consistency across task, environment, role, agreement, tension, unavailable, CTA, and low-quality states.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl
+      - backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/Riasec140qLayerAssetRegistryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-QUALITY-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-quality-01
+    title: "RIASEC-CONTENT-QUALITY-01 repair RIASEC quality boundary copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair quality_copy so low-quality and cautious states never blame users, upsell 140Q, or make strong conclusions.
+    allowed_paths:
+      - backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/app/Services/Riasec/RiasecQualityRuleContract.php
+      - backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-STRUCT-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-140LAYER-01
+    branch: codex/riasec-content-struct-01
+    title: "RIASEC-CONTENT-STRUCT-01 repair RIASEC structural difference copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair structural_difference_copy so 60Q/140Q differences are emphasis differences, not correctness or raw-score comparisons.
+    allowed_paths:
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/app/Services/Riasec/RiasecPublicProjectionService.php
+      - backend/tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-ASPIRATION-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-aspiration-01
+    title: "RIASEC-CONTENT-ASPIRATION-01 repair RIASEC aspirations copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair aspirations_copy so aspirations generate validation questions and never override measured results.
+    allowed_paths:
+      - backend/content_assets/riasec/aspirations_calibration_v1.zh-CN.jsonl
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/tests/Unit/Services/Riasec/RiasecAspirationsDisagreeAssetPreflightTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-DISAGREE-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-SCIENCE-00
+    branch: codex/riasec-content-disagree-01
+    title: "RIASEC-CONTENT-DISAGREE-01 repair RIASEC disagree path copy"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Repair feedback_response_copy so disagreement gives next steps but never changes score, code, snapshot, share, or PDF.
+    allowed_paths:
+      - backend/content_assets/riasec/disagree_path_v1.zh-CN.jsonl
+      - backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+      - backend/tests/Unit/Services/Riasec/RiasecAspirationsDisagreeAssetPreflightTest.php
+      - backend/tests/Unit/Services/Riasec/RiasecAspirationsDisagreeSlotRegistryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+
+  - id: RIASEC-CONTENT-FINALQA-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-CONTENT-HERO-01
+      - RIASEC-CONTENT-DIMMAP-01
+      - RIASEC-CONTENT-PAIRMODULE-01
+      - RIASEC-CONTENT-ACTIVITY-02
+      - RIASEC-CONTENT-OCC-02
+      - RIASEC-CONTENT-140LAYER-01
+      - RIASEC-CONTENT-QUALITY-01
+      - RIASEC-CONTENT-STRUCT-01
+      - RIASEC-CONTENT-ASPIRATION-01
+      - RIASEC-CONTENT-DISAGREE-01
+      - RIASEC-CONTENT-PDF-01
+      - RIASEC-CONTENT-SHARE-01
+      - RIASEC-CONTENT-HISTORY-01
+      - RIASEC-CONTENT-FEEDBACK-02
+      - RIASEC-CONTENT-DIMDEEP-01
+      - RIASEC-CONTENT-PAIRDEEP-01
+    branch: codex/riasec-content-finalqa-01
+    title: "RIASEC-CONTENT-FINALQA-01 revalidate all RIASEC content sections"
+    train_scope: riasec_result_content_science_repair
+    status: user_authorized
+    stop_if_changed_files_outside_scope: true
+    scope:
+      - Run full RIASEC content lint, dedupe, rendered evidence, PDF/share/history review, and final sidecar closeout for all 18 sections.
+    allowed_paths:
+      - backend/content_assets/riasec/**
+      - backend/app/Services/Riasec/**
+      - backend/app/Services/Report/RiasecReportComposer.php
+      - backend/tests/Unit/Services/Riasec/**
+      - backend/tests/Feature/V0_3/Riasec*
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web public editorial content or add frontend fallback copy.
+      - Run CMS writes, production import, database migration, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, permission or secret changes.
+      - Wait for staging deploy, trigger manual deploy, verify server deployment, or run production deploy.
+      - Combine adjacent RIASEC-CONTENT scopes or repair future PR scopes early.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Registered the authorized RIASEC result content science repair PR train in `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json`.
- Added backend-owned RIASEC science boundary lint registry for the 18 result content sections.
- Added a focused PHPUnit lint test covering section coverage, asset inventory mapping, required boundaries, forbidden positive claims, and negation-aware high-risk claim matching.

## Why
RIASEC result content repair needs a fixed scientific boundary before section-level rewrites begin. This PR establishes the baseline: RIASEC output is interest evidence for exploration, not personality identity, ability measurement, career recommendation, job-fit ranking, success prediction, hiring signal, or 60Q/140Q superiority claim.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php --no-ansi --display-warnings`
- `cd backend && vendor/bin/pint --test tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool backend/docs/riasec/content-science-boundary-lint-v1.json >/dev/null`
- `git diff --check`

## Scope validation
Changed files stayed within SCIENCE-00 allowed paths:
- `backend/docs/riasec/content-science-boundary-lint-v1.json`
- `backend/docs/riasec/content-science-boundary-lint-v1.md`
- `backend/tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php`
- `docs/codex/pr-train.yaml`
- `docs/codex/pr-train-state.json`

## Intentionally deferred
- No section content rewriting in this PR; those are split into the follow-up RIASEC-CONTENT-* scopes.
- No CMS write, production import, DB migration, SEO runtime, sitemap, llms, canonical/noindex/JSON-LD, server deploy, staging wait, or production deploy.
- No fap-web public editorial content changes.

## Repository rule impact
RIASEC remains backend-content-authoritative. This PR adds a backend science-boundary lint baseline and PR-train metadata only; it does not create frontend fallback content or change runtime publishing authority.
