### PR TITLE
feat(personality): add A/T comparison list authority API

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -204,6 +204,84 @@ class PersonalityController extends Controller
         ]);
     }
 
+    public function comparisonIndex(Request $request): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $paginator = $this->personalityProfileService->listPublicProfileVariants(
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+            1,
+            100,
+        );
+        $variantsByBase = [];
+
+        foreach ($paginator->items() as $variant) {
+            if (! $variant instanceof PersonalityProfileVariant) {
+                continue;
+            }
+
+            $profile = $variant->profile;
+            if (! $profile instanceof PersonalityProfile || ! $this->isMbtiProfile($profile)) {
+                continue;
+            }
+
+            $baseTypeCode = strtoupper((string) ($variant->canonical_type_code ?: $profile->type_code));
+            $variantCode = strtoupper((string) $variant->variant_code);
+            if (! in_array($baseTypeCode, PersonalityProfile::BASE_TYPE_CODES, true) || ! in_array($variantCode, ['A', 'T'], true)) {
+                continue;
+            }
+
+            $variantsByBase[$baseTypeCode] ??= [
+                'profile' => $profile,
+                'variants' => [],
+            ];
+            $variantsByBase[$baseTypeCode]['variants'][strtolower($variantCode)] = $variant;
+        }
+
+        $items = [];
+        foreach (PersonalityProfile::BASE_TYPE_CODES as $baseTypeCode) {
+            $entry = $variantsByBase[$baseTypeCode] ?? null;
+            $profile = $entry['profile'] ?? null;
+            $variants = is_array($entry['variants'] ?? null) ? $entry['variants'] : [];
+            if (! $profile instanceof PersonalityProfile
+                || ! ($variants['a'] ?? null) instanceof PersonalityProfileVariant
+                || ! ($variants['t'] ?? null) instanceof PersonalityProfileVariant
+            ) {
+                continue;
+            }
+
+            $items[] = $this->comparisonListItemPayload($baseTypeCode, $validated['locale'], $profile);
+        }
+
+        $projection = [
+            'comparison_list_contract_version' => 'mbti.comparison_list.v1',
+            'locale' => $validated['locale'],
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'groups' => [
+                [
+                    'key' => 'at_comparisons',
+                    'comparison_type' => 'mbti_at_comparison',
+                    'title' => $validated['locale'] === 'zh-CN' ? 'A/T 人格差异' : 'A/T personality differences',
+                    'description' => $validated['locale'] === 'zh-CN'
+                        ? '同一 16 型人格核心下，比较 A 与 T 在压力反馈、自我确认和行动节奏上的差异。'
+                        : 'Compare A and T variants within the same 16-type personality core across stress feedback, self-confirmation, and action rhythm.',
+                    'items' => $items,
+                ],
+            ],
+        ];
+
+        return response()->json([
+            'ok' => true,
+            'comparison_list_public_projection_v1' => $projection,
+            'at_comparisons' => $items,
+        ]);
+    }
+
     public function comparison(Request $request, string $comparison): JsonResponse
     {
         $validated = $this->validateReadQuery($request);
@@ -333,6 +411,32 @@ class PersonalityController extends Controller
             .'/'.$this->frontendLocaleSegment($locale)
             .'/personality/'
             .$this->comparisonSlug($baseTypeCode);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function comparisonListItemPayload(string $baseTypeCode, string $locale, PersonalityProfile $profile): array
+    {
+        $comparisonOverlay = $this->mbti64PromotedComparisonOverlay($profile);
+        $meta = $this->comparisonMeta($baseTypeCode, $locale, $comparisonOverlay);
+        $slug = $this->comparisonSlug($baseTypeCode);
+
+        return [
+            'slug' => $slug,
+            'comparison_type' => 'mbti_at_comparison',
+            'base_type_code' => $baseTypeCode,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'locale' => $locale,
+            'public_route_type' => 'at-comparison',
+            'title' => (string) ($meta['title'] ?? ($baseTypeCode.'-A vs '.$baseTypeCode.'-T')),
+            'description' => (string) ($meta['description'] ?? ''),
+            'public_url' => $meta['canonical'] ?? $this->comparisonCanonicalUrl($baseTypeCode, $locale),
+            'canonical_url' => $meta['canonical'] ?? $this->comparisonCanonicalUrl($baseTypeCode, $locale),
+            'is_public' => (bool) $profile->is_public,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'status' => (string) $profile->status,
+        ];
     }
 
     /**

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -4314,6 +4314,23 @@
                 ]
             }
         },
+        "/api/v0.5/personality/comparisons": {
+            "get": {
+                "operationId": "get_api_v0_5_personality_comparisons",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@comparisonIndex",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/personality/comparisons/{comparison}": {
             "get": {
                 "operationId": "get_api_v0_5_personality_comparisons_comparison_",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -646,10 +646,14 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/personality-content-assets/{framework}/{entityType}/{code}', [PersonalityPublicContentAssetController::class, 'showByCode']);
     Route::get('/personality-content-assets/{framework}/{slug}', [PersonalityPublicContentAssetController::class, 'show']);
     Route::get('/personality', [PersonalityController::class, 'index']);
+    Route::get('/personality/comparisons', [PersonalityController::class, 'comparisonIndex']);
     Route::get('/personality/comparisons/{comparison}', [PersonalityController::class, 'comparison']);
-    Route::get('/personality/{type}/desktop-clone', [PersonalityDesktopCloneController::class, 'show']);
-    Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);
-    Route::get('/personality/{type}', [PersonalityController::class, 'show']);
+    Route::get('/personality/{type}/desktop-clone', [PersonalityDesktopCloneController::class, 'show'])
+        ->where('type', '[A-Za-z]{4}(?:-[AaTt])?');
+    Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo'])
+        ->where('type', '[A-Za-z]{4}(?:-[AaTt])?');
+    Route::get('/personality/{type}', [PersonalityController::class, 'show'])
+        ->where('type', '[A-Za-z]{4}(?:-[AaTt])?');
     Route::get('/topics', [TopicController::class, 'index']);
     Route::get('/topics/{slug}/seo', [TopicController::class, 'seo']);
     Route::get('/topics/{slug}', [TopicController::class, 'show']);

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -612,6 +612,116 @@ final class PersonalityPublicApiTest extends TestCase
         );
     }
 
+    public function test_personality_comparison_index_returns_backend_authoritative_at_list_only(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $intj = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'type_name' => 'Architect',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($intj, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect Assertive',
+        ]);
+        $this->createVariant($intj, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'type_name' => 'Architect Turbulent',
+        ]);
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $intj->id,
+            'section_key' => 'mbti64_comparison_a_vs_t',
+            'title' => 'INTJ-A vs INTJ-T',
+            'render_variant' => 'rich_text',
+            'body_md' => 'INTJ A/T comparison draft.',
+            'payload_json' => [
+                'seo' => [
+                    'seo_title' => 'INTJ-A vs INTJ-T: Key Differences',
+                    'h1' => 'INTJ-A vs INTJ-T: Key Differences',
+                    'quick_answer_summary' => 'Compare INTJ-A and INTJ-T by confidence, stress feedback, and self-correction.',
+                ],
+                'content' => [
+                    'quick_answer' => 'Compare INTJ-A and INTJ-T by confidence, stress feedback, and self-correction.',
+                ],
+            ],
+            'sort_order' => 920,
+            'is_enabled' => true,
+        ]);
+
+        $intp = $this->createProfile([
+            'type_code' => 'INTP',
+            'slug' => 'intp',
+            'locale' => 'en',
+            'title' => 'INTP Personality Type',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($intp, [
+            'canonical_type_code' => 'INTP',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTP-A',
+        ]);
+
+        $entp = $this->createProfile([
+            'type_code' => 'ENTP',
+            'slug' => 'entp',
+            'locale' => 'en',
+            'title' => 'ENTP Personality Type',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($entp, [
+            'canonical_type_code' => 'ENTP',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'ENTP-A',
+        ]);
+        $this->createVariant($entp, [
+            'canonical_type_code' => 'ENTP',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'ENTP-T',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality/comparisons?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('comparison_list_public_projection_v1.comparison_list_contract_version', 'mbti.comparison_list.v1')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.0.key', 'at_comparisons')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.0.comparison_type', 'mbti_at_comparison')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.0.items.0.slug', 'intj-a-vs-intj-t')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.0.items.0.title', 'INTJ-A vs INTJ-T: Key Differences')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.0.items.0.base_type_code', 'INTJ')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.0.items.0.public_url', 'https://fermatmind.com/en/personality/intj-a-vs-intj-t')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.0.items.0.is_public', true)
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.0.items.0.is_indexable', true)
+            ->assertJsonPath('at_comparisons.0.slug', 'intj-a-vs-intj-t');
+
+        self::assertCount(1, (array) data_get($response->json(), 'comparison_list_public_projection_v1.groups.0.items'));
+        self::assertStringNotContainsString('intp-a-vs-intp-t', (string) $response->getContent());
+        self::assertStringNotContainsString('entp-a-vs-entp-t', (string) $response->getContent());
+        self::assertStringNotContainsString('intj-vs-intp', (string) $response->getContent());
+        self::assertStringNotContainsString('/result', (string) $response->getContent());
+        self::assertStringNotContainsString('token', (string) $response->getContent());
+    }
+
     public function test_personality_comparison_endpoint_returns_backend_authoritative_at_pair(): void
     {
         config(['app.frontend_url' => 'https://www.fermatmind.com']);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -268,7 +268,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/routes/api.php',
         ];
         $routeChangedLines = [
+            "+    Route::get('/personality/comparisons', [PersonalityController::class, 'comparisonIndex']);",
             "+    Route::get('/personality/comparisons/{comparison}', [PersonalityController::class, 'comparison']);",
+            "-    Route::get('/personality/{type}/desktop-clone', [PersonalityDesktopCloneController::class, 'show']);",
+            "+    Route::get('/personality/{type}/desktop-clone', [PersonalityDesktopCloneController::class, 'show'])",
+            "+        ->where('type', '[A-Za-z]{4}(?:-[AaTt])?');",
+            "-    Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);",
+            "+    Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo'])",
+            "+        ->where('type', '[A-Za-z]{4}(?:-[AaTt])?');",
+            "-    Route::get('/personality/{type}', [PersonalityController::class, 'show']);",
+            "+    Route::get('/personality/{type}', [PersonalityController::class, 'show'])",
+            "+        ->where('type', '[A-Za-z]{4}(?:-[AaTt])?');",
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
@@ -10926,7 +10936,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         }
 
         $allowedLines = [
+            "+    Route::get('/personality/comparisons', [PersonalityController::class, 'comparisonIndex']);",
             "+    Route::get('/personality/comparisons/{comparison}', [PersonalityController::class, 'comparison']);",
+            "-    Route::get('/personality/{type}/desktop-clone', [PersonalityDesktopCloneController::class, 'show']);",
+            "+    Route::get('/personality/{type}/desktop-clone', [PersonalityDesktopCloneController::class, 'show'])",
+            "+        ->where('type', '[A-Za-z]{4}(?:-[AaTt])?');",
+            "-    Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);",
+            "+    Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo'])",
+            "-    Route::get('/personality/{type}', [PersonalityController::class, 'show']);",
+            "+    Route::get('/personality/{type}', [PersonalityController::class, 'show'])",
         ];
 
         foreach ($changedLines as $line) {


### PR DESCRIPTION
## What changed
- Added a backend-authoritative public A/T comparison list endpoint at /api/v0.5/personality/comparisons.
- The endpoint groups only complete published MBTI A/T pairs and emits a stable mbti.comparison_list.v1 projection plus an at_comparisons alias for frontend consumption.
- Added route constraints for personality type routes so reserved collection paths such as /personality/comparisons do not drift into the type detail route.
- Updated the OpenAPI snapshot for the new public route.
- Added focused feature coverage for complete pairs, incomplete pairs, draft/private profiles, cross-type exclusion, and no result/token leakage.

## Why
Personality navigation and homepage modules need a backend public list authority for the existing 16 A/T comparison pages before fap-web can render the module without local editorial fallback.

## Validation
- php artisan test --filter=PersonalityPublicApiTest --no-ansi
- php artisan test tests/Feature/OpenApiDiffTest.php --no-ansi
- php artisan route:list --path=api/v0.5/personality/comparisons --no-ansi
- ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php tests/Feature/V0_5/PersonalityPublicApiTest.php docs/contracts/openapi.snapshot.json
- git diff --check

## Intentionally deferred
- Cross-type comparison authority/readmodel and public APIs.
- Frontend personality menu/homepage integration.
- CMS writes/imports/publishing.
- sitemap, llms.txt, JSON-LD, canonical, noindex, and search submission.
- Staging or production deployment.