### PR TITLE
RIASEC-CONTENT-DIMMAP-01 optimize RIASEC six-dimension map interpretation

### DIFF
--- a/backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json
+++ b/backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json
@@ -1,45 +1,45 @@
 {
   "asset_id": "profile_shape_copy_v1.zh-CN",
-  "asset_status": "content_review_v7_3_final_preflight_candidate",
+  "asset_status": "content_review_science_boundary_repair_v1",
   "locale": "zh-CN",
   "scale_code": "RIASEC",
-  "review_status": "content_review_v7_3_final_preflight_candidate",
+  "review_status": "content_review_science_boundary_repair_v1",
   "target_review_status_after_owner_signoff": "owner_signoff_required_before_runtime_import_after_owner_signoff",
   "profile_shapes": [
     {
       "shape": "clear_code",
-      "title": "主线索清楚",
-      "summary": "你可以先从三字母活动线索组合进入结果，但不要把它读成固定身份。第二、第三维决定了这条活动线索组合如何落地。",
+      "title": "主线索相对清楚",
+      "summary": "六维分布显示一个相对更靠前的兴趣入口。可以先从三字母顺序进入结果，但仍要把第二、第三维当作补充观察线索；这不是固定身份、能力结论或职业结论。",
       "module_policy": "show_standard_chain_and_pair_blends"
     },
     {
       "shape": "blended_code",
-      "title": "混合型结果",
-      "summary": "前两到三条兴趣线索都在参与结果。建议重点看 pair blend 和 Top3 chain，而不是只看第一个字母。",
+      "title": "多条线索共同参与",
+      "summary": "前两到三条兴趣线索都值得阅读。建议先看 Top2 与 Top3 的活动差异，再用小任务观察哪类活动更想继续；不要只用第一个字母概括整个结果。",
       "module_policy": "show_pair_blend_first"
     },
     {
       "shape": "broad_profile",
-      "title": "广谱兴趣",
-      "summary": "多个维度接近时，系统不应强行给出单一路径。先用活动和小实验收窄：哪些任务让你更想继续，哪些只是看起来有吸引力。",
+      "title": "兴趣分布较宽",
+      "summary": "多个维度接近时，结果更像一张待验证的兴趣地图，而不是单一路径。先用活动和小实验收窄：哪些任务让你更想继续，哪些只是看起来有吸引力。",
       "module_policy": "hide_strong_code_claims"
     },
     {
       "shape": "near_tie",
-      "title": "近似并列",
-      "summary": "字母顺序只是本次排序，不是身份高低。请同时阅读 alternate code 的组合解释，并用 1–2 个真实任务观察。",
+      "title": "前几项接近",
+      "summary": "字母顺序只是本次分数的阅读顺序，不是身份等级、能力排序或最终答案。请同时阅读 alternate code 的组合解释，并用 1-2 个真实任务观察。",
       "module_policy": "show_alternate_code_boundary"
     },
     {
       "shape": "low_quality",
       "title": "谨慎阅读",
-      "summary": "这次结果不适合输出强结论。页面应先保护用户：弱化三字码、隐藏职业例子、建议重测或仅看六维。",
+      "summary": "这次结果不适合输出强解释。页面应先保护用户：弱化三字码、隐藏职业例子、建议重测或仅看六维相对分布。",
       "module_policy": "show_minimal_dimension_only"
     },
     {
       "shape": "low_clarity",
-      "title": "低清晰度",
-      "summary": "结果并非无效，但主线不够清楚。更适合看候选活动，而不是马上形成方向判断。",
+      "title": "主线不够集中",
+      "summary": "结果并非无效，但六维差距不足以支持强阅读。更适合先看候选活动和观察问题，而不是马上形成方向判断。",
       "module_policy": "show_candidate_activities"
     }
   ],
@@ -75,5 +75,5 @@
   ],
   "frontend_fallback_allowed": false,
   "fallback_behavior": "omit_module",
-  "v5_editorial_note": "Profile-shape copy reviewed for clear, blended, broad, near-tie, and low-quality reading without identity framing."
+  "v5_editorial_note": "Profile-shape copy repaired for relative distribution, flat/near-tie boundaries, and no identity, ability, or career-outcome framing."
 }

--- a/backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json
+++ b/backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json
@@ -1,38 +1,38 @@
 {
   "asset_id": "top_code_confidence_copy_v1.zh-CN",
-  "asset_status": "content_review_v7_3_final_preflight_candidate",
+  "asset_status": "content_review_science_boundary_repair_v1",
   "locale": "zh-CN",
   "scale_code": "RIASEC",
-  "review_status": "content_review_v7_3_final_preflight_candidate",
+  "review_status": "content_review_science_boundary_repair_v1",
   "target_review_status_after_owner_signoff": "owner_signoff_required_before_runtime_import_after_owner_signoff",
   "states": [
     {
       "state": "high_confidence",
-      "label": "主线索清楚",
-      "copy": "第一维与后续维度差距较明显，可以把三字码作为本次兴趣探索入口；仍需同时阅读第二、第三维，因为它们决定活动线索组合如何展开。"
+      "label": "阅读力度较高",
+      "copy": "第一维与后续维度差距较明显，说明本次结果的阅读力度较高，并有一个较清楚的阅读入口。可以先按三字码阅读，但仍要用第二、第三维补充任务条件；这不是准确率、能力判断或职业前景判断。"
     },
     {
       "state": "moderate_confidence",
       "label": "可正常阅读",
-      "copy": "主线索可读，但不是单一结论。建议先看 Top2 组合，再看 Top3 活动线索组合。"
+      "copy": "主线索可读，但不应被写成单一结论。建议先看 Top2 组合，再看 Top3 活动线索，把差距当作阅读力度而不是能力高低。"
     },
     {
       "state": "near_tie",
       "label": "近似并列",
-      "copy": "前两维或前三维接近时，不要急着固定一个字母顺序。把它读成几条活动线索的接近竞争，并用小实验观察。"
+      "copy": "前两维或前三维接近时，不要急着固定一个字母顺序。把它读成几条兴趣线索都值得观察，并用小实验比较具体活动，而不是比较谁更强。"
     },
     {
       "state": "broad_profile",
       "label": "兴趣较广",
-      "copy": "多个维度都较接近时，页面应少强调单一 Code，更多展示可观察活动与低风险选择。"
+      "copy": "多个维度都较接近时，应少强调单一 Code，更多展示可观察活动与低风险选择。平坦分布只说明线索分散，不说明结果无效或用户能力不足。"
     },
     {
       "state": "low_clarity",
       "label": "谨慎阅读",
-      "copy": "本次结果更适合当作初步线索。建议先看六维分布，不输出强活动线索组合。"
+      "copy": "本次结果更适合当作初步线索。建议先看六维相对分布，不输出强活动线索组合，也不把低清晰度解释成作答者的问题。"
     }
   ],
-  "user_visible_boundary": "结果阅读力度只说明本次兴趣线索是否集中、接近或需要谨慎阅读；它不是准确率、职业前景或能力判断。",
+  "user_visible_boundary": "结果阅读力度只说明本次兴趣线索相对集中、接近或需要谨慎阅读；它不是准确率、职业前景、能力判断或稳定人格结论。",
   "required_boundaries": [
     "interest_evidence_only",
     "not_personality_identity",

--- a/backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php
@@ -84,6 +84,38 @@ final class RiasecLowQualityCopySlotRegistryTest extends TestCase
         $this->assertStringNotContainsString('你其实是另一个 Code', $nearTie['summary']);
     }
 
+    public function test_profile_shape_and_confidence_copy_frame_dimension_map_as_relative_reading(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slots = $registry->interpretationStateCopySlots();
+
+        foreach (['clear_code', 'blended_code', 'broad_profile', 'near_tie', 'low_quality', 'low_clarity'] as $shape) {
+            $slot = $slots['profile_shape_copy:'.$shape] ?? null;
+            $this->assertIsArray($slot, $shape.' profile shape copy should exist.');
+            $copy = (string) ($slot['summary'] ?? '');
+
+            $this->assertMatchesRegularExpression('/相对|接近|分布|差距|阅读顺序|观察/u', $copy);
+            $this->assertStringNotContainsString('决定了', $copy);
+            $this->assertStringNotContainsString('能力强弱', $copy);
+            $this->assertStringNotContainsString('职业方向结论', $copy);
+            $this->assertStringNotContainsString('最终排序', $copy);
+        }
+
+        foreach (['high_confidence', 'moderate_confidence', 'near_tie', 'broad_profile', 'low_clarity'] as $state) {
+            $slot = $slots['top_code_confidence_copy:'.$state] ?? null;
+            $this->assertIsArray($slot, $state.' confidence copy should exist.');
+            $copy = (string) ($slot['summary'] ?? '');
+
+            $this->assertMatchesRegularExpression('/阅读力度|相对|接近|分散|初步线索|观察/u', $copy);
+            $this->assertStringNotContainsString('成功概率', $copy);
+            $this->assertStringNotContainsString('更准确', $copy);
+            $this->assertStringNotContainsString('职业匹配', $copy);
+            $this->assertStringNotContainsString('岗位匹配', $copy);
+            $this->assertStringNotContainsString('能力证明', $copy);
+            $this->assertStringNotContainsString('身份标签', $copy);
+        }
+    }
+
     public function test_low_quality_downgrade_policy_hides_strong_modules(): void
     {
         $policy = (new RiasecDeepCopySlotRegistry)->lowQualityModuleDowngradePolicy();

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6,9 +6,7 @@
     "branch": "codex/ennea-rp-01-instant-summary",
     "title": "ENNEA-RP-01: fix(enneagram): repair instant summary content asset",
     "train_scope": "enneagram_result_page_content_asset_repair",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "status": "pr_open_rebased_local_validation_passed",
     "commit_sha": "da6f8b075b228fdf69d6b16343d8e261bd085ca7",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2600",
@@ -110,9 +108,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ],
+      "outside_scope_files": [],
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json",
         "backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php",
@@ -180,9 +176,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -222,9 +216,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -266,9 +258,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -310,9 +300,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -354,9 +342,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -397,9 +383,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -439,9 +423,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -483,9 +465,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -525,9 +505,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -567,9 +545,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -609,9 +585,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -652,9 +626,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -696,9 +668,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -740,9 +710,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -783,9 +751,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -825,9 +791,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -867,9 +831,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -909,9 +871,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -951,9 +911,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -993,9 +951,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1037,9 +993,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1079,9 +1033,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1122,9 +1074,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1165,9 +1115,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1207,9 +1155,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1250,9 +1196,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1293,9 +1237,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1335,9 +1277,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1378,9 +1318,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1420,9 +1358,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1462,9 +1398,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1505,9 +1439,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1548,9 +1480,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1590,9 +1520,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1632,9 +1560,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1674,9 +1600,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1717,9 +1641,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1760,9 +1682,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1804,9 +1724,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1846,9 +1764,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1889,9 +1805,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -1933,9 +1847,7 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "outside_scope_files": []
     },
     "events": [
       {
@@ -65691,7 +65603,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-02T16:36:25Z",
+  "updated_at": "2026-07-02T16:50:24Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",
@@ -69163,8 +69075,8 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "pr_opened",
-    "commit_sha": "7e5a2042dac39c1b02bb5031b626e7320099582b",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "455ddfc3344d1d3d4448e889b82a129d8c9802e1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2606",
     "checks": {
       "phpunit_riasec_unit_subset": {
@@ -69189,23 +69101,32 @@
       "manifest_state_parse_and_diff_check": {
         "command": "ruby YAML parse; python JSON parse; git diff --check",
         "status": "passed"
+      },
+      "github_required_checks": {
+        "status": "passed",
+        "summary": "hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-mbti-legacy, verify-mbti-v2, verify-bigfive all passed before squash merge."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T16:45:08Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
         "backend/content_assets/riasec/top3_code_chain_strategy_v1.zh-CN.jsonl",
         "backend/tests/Unit/Services/Riasec/RiasecTop3ChainSlotRegistryTest.php",
         "docs/codex/pr-train-state.json"
-      ]
+      ],
+      "origin_main_contains_merge_commit": true,
+      "local_main_synced": true,
+      "local_main_equals_origin_main": true,
+      "task_branch_deleted_local": true,
+      "task_branch_deleted_remote": true
     },
     "transitions": [
       {
@@ -69225,8 +69146,15 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2606 after HERO-01 local validation and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T16:50:24Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2606 merged; origin/main contains merge commit; local main synced; task branches cleaned. Recorded during DIMMAP-01 ledger reconciliation."
       }
-    ]
+    ],
+    "merge_commit_sha": "198be548e180187cea760bb602ea0c6d486d28ce"
   },
   "RIASEC-CONTENT-DIMMAP-01": {
     "id": "RIASEC-CONTENT-DIMMAP-01",
@@ -69238,19 +69166,48 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "authorized_pending_start",
+    "status": "local_validation_passed",
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "165 tests, 95268 assertions"
+      },
+      "phpunit_dimmap_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "22 tests, 1388 assertions"
+      },
+      "pint": {
+        "command": "cd backend && vendor/bin/pint --test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php",
+        "status": "passed"
+      },
+      "asset_preflight": {
+        "command": "parse profile_shape_copy and top_code_confidence_copy JSON; reject high-risk dimension-map terms",
+        "status": "passed"
+      },
+      "manifest_state_parse_and_diff_check": {
+        "command": "ruby YAML parse; python JSON parse; git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json",
+        "backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json",
+        "backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -69258,6 +69215,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T16:50:24Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Implemented DIMMAP-01 six-dimension map copy repair; local RIASEC unit subset and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65603,7 +65603,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-02T16:50:24Z",
+  "updated_at": "2026-07-02T16:51:28Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",
@@ -69166,9 +69166,9 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "a7c42ce32cb52fed088fa0732c6dbf918c3232c6",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2607",
     "checks": {
       "phpunit_riasec_unit_subset": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
@@ -69221,6 +69221,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Implemented DIMMAP-01 six-dimension map copy repair; local RIASEC unit subset and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T16:51:28Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2607 after DIMMAP-01 local validation and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Repaired profile-shape and top-code-confidence copy so six-dimension bars are framed as relative interest distribution and reading strength.
- Replaced over-strong terms around `决定`, ability strength, final ordering, and career direction with cautious language about relative shape, near ties, broad profiles, and low clarity.
- Added regression coverage for profile-shape and confidence copy to prevent accuracy, identity, ability, career-fit, and outcome overclaims.
- Reconciled HERO-01 merge/cleanup truth in the PR train state ledger.

## Why
The six-dimension map can be overread as absolute strength, ability level, or stable identity. DIMMAP-01 keeps it as a relative interest snapshot: concentrated, blended, flat, near-tie, or low-clarity reading guidance.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecInterpretationRuleContractTest.php tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php --no-ansi --display-warnings`
- `cd backend && vendor/bin/pint --test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php`
- JSON asset preflight for profile-shape and confidence copy high-risk terms
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Scope validation
Changed files stayed within DIMMAP-01 allowed paths:
- `backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json`
- `backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json`
- `backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php`
- `docs/codex/pr-train-state.json`

## Intentionally deferred
- No pair module, activity explorer, occupation examples, 140Q, share/PDF/history, feedback, quality, aspiration, disagree, or final QA repairs in this PR.
- No CMS write, production import, DB migration, SEO runtime, sitemap, llms, canonical/noindex/JSON-LD, server deploy, staging wait, or production deploy.
- No fap-web public editorial content changes.

## Repository rule impact
RIASEC remains backend-content-authoritative. This PR changes backend RIASEC content assets, backend tests, and PR-train state only; it adds no frontend fallback content and changes no publishing authority.
