### PR TITLE
RIASEC-CONTENT-PAIRMODULE-01 govern RIASEC pair blend module visibility

### DIFF
--- a/backend/app/Services/Riasec/RiasecReportModuleSelector.php
+++ b/backend/app/Services/Riasec/RiasecReportModuleSelector.php
@@ -59,7 +59,7 @@ final class RiasecReportModuleSelector
         return [
             'hero_activity_chain' => $this->module('hero_activity_chain', 'visible', 'standard_reading_available'),
             'six_dimension_map' => $this->module('six_dimension_map', 'visible', 'dimension_overview_available'),
-            'pair_blend' => $this->module('pair_blend', 'visible', 'combination_reading_available'),
+            'pair_blend' => $this->module('pair_blend', 'visible', 'clear_or_blended_pair_context_available', 'pair_blend_is_context_not_fit_or_ranking'),
             'activity_explorer' => $this->module('activity_explorer', 'visible', 'examples_only_activity_explorer_available'),
             'occupation_examples' => $this->module('occupation_examples', 'collapsed', 'examples_only_not_registry_match'),
             '140q_cta' => $this->module('140q_cta', $formCode === 'riasec_140' ? 'hidden' : 'visible', 'contextual_form_optional_not_more_accurate'),
@@ -78,7 +78,7 @@ final class RiasecReportModuleSelector
     private function applyLowQuality(array $modules): array
     {
         foreach (['hero_activity_chain', 'pair_blend', 'activity_explorer', 'occupation_examples', '140q_cta', '140q_context_cards'] as $key) {
-            $modules[$key] = $this->module($key, 'hidden', 'low_quality_hides_strong_modules');
+            $modules[$key] = $this->module($key, 'hidden', 'low_quality_hides_strong_modules', 'hide_when_result_quality_cannot_support_pair_reading');
         }
         $modules['six_dimension_map'] = $this->module('six_dimension_map', 'visible', 'low_quality_overview_only');
         $modules['share_card'] = $this->module('share_card', 'collapsed', 'low_quality_no_strong_public_share');
@@ -94,7 +94,7 @@ final class RiasecReportModuleSelector
     private function applyCaution(array $modules): array
     {
         foreach (['pair_blend', 'occupation_examples', '140q_cta'] as $key) {
-            $modules[$key] = $this->module($key, 'collapsed', 'caution_softens_interpretation');
+            $modules[$key] = $this->module($key, 'collapsed', 'caution_requires_boundary_first', 'collapsed_pair_copy_must_read_as_activity_context');
         }
 
         return $modules;
@@ -107,6 +107,7 @@ final class RiasecReportModuleSelector
     private function applyBroadProfile(array $modules): array
     {
         $modules['hero_activity_chain'] = $this->module('hero_activity_chain', 'hidden', 'broad_profile_activity_filter_first');
+        $modules['pair_blend'] = $this->module('pair_blend', 'collapsed', 'broad_profile_pair_blend_secondary_after_dimension_map', 'broad_profile_needs_dimension_map_before_pair_reading');
         $modules['occupation_examples'] = $this->module('occupation_examples', 'hidden', 'broad_profile_no_single_chain_examples');
 
         return $modules;
@@ -119,7 +120,7 @@ final class RiasecReportModuleSelector
     private function applyNearTie(array $modules): array
     {
         $modules['hero_activity_chain'] = $this->module('hero_activity_chain', 'collapsed', 'near_tie_candidate_chains_first');
-        $modules['pair_blend'] = $this->module('pair_blend', 'visible', 'near_tie_pair_blend_required');
+        $modules['pair_blend'] = $this->module('pair_blend', 'visible', 'near_tie_pair_blend_explains_candidate_pairs_without_identity', 'pair_blend_is_candidate_reading_not_final_order');
 
         return $modules;
     }
@@ -131,20 +132,22 @@ final class RiasecReportModuleSelector
     private function applyLowClarity(array $modules): array
     {
         $modules['hero_activity_chain'] = $this->module('hero_activity_chain', 'collapsed', 'low_clarity_cautious_overview');
+        $modules['pair_blend'] = $this->module('pair_blend', 'collapsed', 'low_clarity_pair_blend_secondary_after_dimension_map', 'collapsed_pair_copy_must_read_as_activity_context');
         $modules['occupation_examples'] = $this->module('occupation_examples', 'hidden', 'low_clarity_hides_strong_examples');
 
         return $modules;
     }
 
     /**
-     * @return array{key:string,visibility:string,reason:string}
+     * @return array{key:string,visibility:string,reason:string,risk_boundary:string}
      */
-    private function module(string $key, string $visibility, string $reason): array
+    private function module(string $key, string $visibility, string $reason, string $riskBoundary = 'module_visibility_backend_owned_no_frontend_inference'): array
     {
         return [
             'key' => $key,
             'visibility' => $visibility,
             'reason' => $reason,
+            'risk_boundary' => $riskBoundary,
         ];
     }
 }

--- a/backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php
@@ -213,11 +213,17 @@ final class RiasecFullContentFixtureMatrixTest extends TestCase
 
         $broad = $selector->build($this->projectionContext('normal', 'broad_profile', 'riasec_60'));
         $this->assertSame('hidden', $this->moduleVisibility($broad, 'hero_activity_chain'));
+        $this->assertSame('collapsed', $this->moduleVisibility($broad, 'pair_blend'));
         $this->assertSame('hidden', $this->moduleVisibility($broad, 'occupation_examples'));
 
         $nearTie = $selector->build($this->projectionContext('normal', 'near_tie', 'riasec_60'));
         $this->assertSame('collapsed', $this->moduleVisibility($nearTie, 'hero_activity_chain'));
         $this->assertSame('visible', $this->moduleVisibility($nearTie, 'pair_blend'));
+
+        $lowClarity = $selector->build($this->projectionContext('normal', 'low_clarity', 'riasec_60'));
+        $this->assertSame('collapsed', $this->moduleVisibility($lowClarity, 'hero_activity_chain'));
+        $this->assertSame('collapsed', $this->moduleVisibility($lowClarity, 'pair_blend'));
+        $this->assertSame('hidden', $this->moduleVisibility($lowClarity, 'occupation_examples'));
 
         $lowQuality = $selector->build($this->projectionContext('low_quality', 'low_quality', 'riasec_60'));
         $this->assertSame('hidden', $this->moduleVisibility($lowQuality, 'pair_blend'));

--- a/backend/tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php
@@ -20,6 +20,9 @@ final class RiasecReportModuleSelectorTest extends TestCase
         $this->assertSame('riasec.module_visibility_policy.v1', $policy['schema_version']);
         $this->assertSame(RiasecReportModuleSelector::POLICY_ID, $policy['policy_id']);
         $this->assertSame('visible', $this->moduleVisibility($policy, 'hero_activity_chain'));
+        $this->assertSame('visible', $this->moduleVisibility($policy, 'pair_blend'));
+        $this->assertSame('clear_or_blended_pair_context_available', $this->moduleReason($policy, 'pair_blend'));
+        $this->assertSame('pair_blend_is_context_not_fit_or_ranking', $this->moduleRiskBoundary($policy, 'pair_blend'));
         $this->assertSame('visible', $this->moduleVisibility($policy, 'activity_explorer'));
         $this->assertSame('collapsed', $this->moduleVisibility($policy, 'occupation_examples'));
         $this->assertSame('visible', $this->moduleVisibility($policy, '140q_cta'));
@@ -55,7 +58,50 @@ final class RiasecReportModuleSelectorTest extends TestCase
         $this->assertSame('collapsed', $this->moduleVisibility($policy, 'hero_activity_chain'));
         $this->assertSame('visible', $this->moduleVisibility($policy, 'pair_blend'));
         $this->assertSame('near_tie_candidate_chains_first', $this->moduleReason($policy, 'hero_activity_chain'));
+        $this->assertSame('near_tie_pair_blend_explains_candidate_pairs_without_identity', $this->moduleReason($policy, 'pair_blend'));
+        $this->assertSame('pair_blend_is_candidate_reading_not_final_order', $this->moduleRiskBoundary($policy, 'pair_blend'));
         $this->assertNoForbiddenClaims($policy);
+    }
+
+    public function test_pair_blend_collapses_when_profile_shape_or_quality_needs_caution(): void
+    {
+        $selector = new RiasecReportModuleSelector;
+
+        $caution = $selector->build($this->projection(
+            qualityState: 'caution',
+            profileShape: 'clear_code',
+            formCode: 'riasec_60',
+        ));
+        $this->assertSame('collapsed', $this->moduleVisibility($caution, 'pair_blend'));
+        $this->assertSame('caution_requires_boundary_first', $this->moduleReason($caution, 'pair_blend'));
+
+        $broad = $selector->build($this->projection(
+            qualityState: 'normal',
+            profileShape: 'broad_profile',
+            formCode: 'riasec_60',
+        ));
+        $this->assertSame('collapsed', $this->moduleVisibility($broad, 'pair_blend'));
+        $this->assertSame('broad_profile_pair_blend_secondary_after_dimension_map', $this->moduleReason($broad, 'pair_blend'));
+
+        $lowClarity = $selector->build($this->projection(
+            qualityState: 'normal',
+            profileShape: 'low_clarity',
+            formCode: 'riasec_60',
+        ));
+        $this->assertSame('collapsed', $this->moduleVisibility($lowClarity, 'pair_blend'));
+        $this->assertSame('low_clarity_pair_blend_secondary_after_dimension_map', $this->moduleReason($lowClarity, 'pair_blend'));
+
+        $lowQuality = $selector->build($this->projection(
+            qualityState: 'low_quality',
+            profileShape: 'low_quality',
+            formCode: 'riasec_60',
+        ));
+        $this->assertSame('hidden', $this->moduleVisibility($lowQuality, 'pair_blend'));
+        $this->assertSame('hide_when_result_quality_cannot_support_pair_reading', $this->moduleRiskBoundary($lowQuality, 'pair_blend'));
+        $this->assertNoForbiddenClaims($caution);
+        $this->assertNoForbiddenClaims($broad);
+        $this->assertNoForbiddenClaims($lowClarity);
+        $this->assertNoForbiddenClaims($lowQuality);
     }
 
     /**
@@ -84,6 +130,14 @@ final class RiasecReportModuleSelectorTest extends TestCase
     private function moduleReason(array $policy, string $key): string
     {
         return (string) ($this->module($policy, $key)['reason'] ?? '');
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     */
+    private function moduleRiskBoundary(array $policy, string $key): string
+    {
+        return (string) ($this->module($policy, $key)['risk_boundary'] ?? '');
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65603,7 +65603,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-02T16:51:28Z",
+  "updated_at": "2026-07-02T17:00:55Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",
@@ -69166,8 +69166,8 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "pr_opened",
-    "commit_sha": "a7c42ce32cb52fed088fa0732c6dbf918c3232c6",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "88f9005c2b54826255036204ce4be4fda80ab2dd",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2607",
     "checks": {
       "phpunit_riasec_unit_subset": {
@@ -69191,23 +69191,32 @@
       "manifest_state_parse_and_diff_check": {
         "command": "ruby YAML parse; python JSON parse; git diff --check",
         "status": "passed"
+      },
+      "github_required_checks": {
+        "status": "passed",
+        "summary": "hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-mbti-legacy, verify-mbti-v2, verify-bigfive all passed before squash merge."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T16:57:12Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/content_assets/riasec/profile_shape_copy_v1.zh-CN.json",
         "backend/content_assets/riasec/top_code_confidence_copy_v1.zh-CN.json",
         "backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php",
         "docs/codex/pr-train-state.json"
-      ]
+      ],
+      "origin_main_contains_merge_commit": true,
+      "local_main_synced": true,
+      "local_main_equals_origin_main": true,
+      "task_branch_deleted_local": true,
+      "task_branch_deleted_remote": true
     },
     "transitions": [
       {
@@ -69227,8 +69236,15 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2607 after DIMMAP-01 local validation and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T17:00:55Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2607 merged; origin/main contains merge commit; local main synced; task branches cleaned. Recorded during PAIRMODULE-01 ledger reconciliation."
       }
-    ]
+    ],
+    "merge_commit_sha": "a06961745d5860df3bb890e08ff56a2a1fb0a60c"
   },
   "RIASEC-CONTENT-PAIRMODULE-01": {
     "id": "RIASEC-CONTENT-PAIRMODULE-01",
@@ -69240,19 +69256,44 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "authorized_pending_start",
+    "status": "local_validation_passed",
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "166 tests, 95321 assertions"
+      },
+      "phpunit_pairmodule_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "12 tests, 1013 assertions"
+      },
+      "pint": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecReportModuleSelector.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php",
+        "status": "passed"
+      },
+      "manifest_state_parse_and_diff_check": {
+        "command": "ruby YAML parse; python JSON parse; git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecReportModuleSelector.php",
+        "backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php",
+        "backend/tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -69260,6 +69301,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T17:00:55Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Implemented PAIRMODULE-01 pair visibility governance; local RIASEC unit subset and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65603,7 +65603,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-02T17:00:55Z",
+  "updated_at": "2026-07-02T17:01:59Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",
@@ -69256,9 +69256,9 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "3cfb0401a772e0bccf30dccd6dac385f845f45c0",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2610",
     "checks": {
       "phpunit_riasec_unit_subset": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
@@ -69307,6 +69307,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Implemented PAIRMODULE-01 pair visibility governance; local RIASEC unit subset and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T17:01:59Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2610 after PAIRMODULE-01 local validation and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Tightened `pair_blend` visibility rules so pair copy only appears strongly when the profile can support it.
- Added backend-owned `risk_boundary` metadata to module visibility decisions.
- Kept pair blend visible for clear/blended and near-tie candidate-pair reading, collapsed for caution/broad/low-clarity, and hidden for low-quality.
- Added selector and full matrix tests for pair visibility, reasons, and risk boundaries.
- Reconciled DIMMAP-01 merge/cleanup truth in the PR train state ledger.

## Why
Pair modules can be misread as job fit, ranking, or a final combination label when profile clarity or quality is weak. This PR makes visibility depend on backend quality/profile state and keeps the pair module as activity context, not a career or identity conclusion.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php --no-ansi --display-warnings`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecReportModuleSelector.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Scope validation
Changed files stayed within PAIRMODULE-01 allowed paths:
- `backend/app/Services/Riasec/RiasecReportModuleSelector.php`
- `backend/tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php`
- `backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php`
- `docs/codex/pr-train-state.json`

## Intentionally deferred
- No pair deep-copy asset prose rewrite, activity explorer, occupation examples, 140Q, share/PDF/history, feedback, quality, aspiration, disagree, or final QA repairs in this PR.
- No CMS write, production import, DB migration, SEO runtime, sitemap, llms, canonical/noindex/JSON-LD, server deploy, staging wait, or production deploy.
- No fap-web public editorial content changes.

## Repository rule impact
RIASEC remains backend-content-authoritative. This PR changes backend module selection policy, backend tests, and PR-train state only; it adds no frontend fallback content and changes no publishing authority.
