### PR TITLE
PR-EQ-ASSET-SCI-03: strengthen EQ scientific_contract boundaries

### DIFF
--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T16:51:18.216438Z",
+    "generated_at": "2026-07-02T17:08:38.421048Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -10,28 +10,28 @@
             "assets": {
                 "eq.scientific_contract.default": {
                     "zh-CN": {
-                        "test_definition": "这份报告基于你对 60 道题的自我报告作答，解释你对自身情绪与关系模式的主观感知。它不是外部观察、现场行为记录、客观能力测验或认证评估。",
-                        "self_report_statement": "EQ-60 是自我报告测评：结果反映你如何描述自己的情绪觉察、调节、共情理解和关系行动倾向，不直接证明你在真实场景中的表现。",
-                        "non_clinical_statement": "本报告不用于临床诊断、治疗评估、医疗建议、危机处置或风险判断。若困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士支持。",
-                        "non_hiring_statement": "本结果不应用于招聘、录用、淘汰、晋升、岗位分配、绩效评估或任何高风险组织决策。",
-                        "non_ability_statement": "EQ-60 不是情绪能力测验，不是 MSCEIT，也不是认证能力评估。未来情境判断模块也只会补充情境选择线索，不会把报告变成能力证明。",
-                        "norm_status_statement": "当前标准分、百分位和等级来自阶段性常模与版本化解释。百分位只提供当前样本中的相对位置感，不是能力排名、真实水平排名或全球正式常模排名。",
-                        "quality_rules_statement": "报告会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索来估计解释置信度。低置信结果不适合强画像、强职业判断或强行动处方。",
-                        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同决定。版本记录让复测、客服和内容审校能追踪同一结果如何生成。",
-                        "user_safe_summary": "适合用于自我理解、关系复盘和低风险成长规划。",
-                        "do_not_overread": "这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。"
+                        "test_definition": "这份报告基于你对 60 道题的自我报告作答，整理你如何描述自己的情绪觉察、情绪调节、共情理解和关系行动倾向。它解释的是本次作答中的自我感知模式，不是外部观察、现场行为记录、客观能力测验或认证评估。",
+                        "self_report_statement": "EQ-60 是 self-report 测评：结果来自你的主观描述，因此适合用于自我理解和复盘，不直接证明你在所有真实场景中的实际表现，也不能替代他人观察或情境任务数据。",
+                        "non_clinical_statement": "本报告不用于临床诊断、治疗评估、医疗建议、危机处置或心理风险判断。若情绪困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士或现实支持。",
+                        "non_hiring_statement": "本结果不得用于招聘、录用、淘汰、晋升、岗位分配、绩效评估、团队筛选或任何高风险组织决策，也不应用来评价他人是否适合某个岗位。",
+                        "non_ability_statement": "EQ-60 不是情绪能力测验，不是 MSCEIT，也不是认证型情绪智力评估。它不能证明真实情绪能力、沟通能力或关系能力；未来 EQ-SJT 若上线，也只会补充情境选择线索，不会把报告变成能力证明。",
+                        "norm_status_statement": "当前标准分、百分位和等级来自阶段性常模与版本化解释。百分位只提供当前样本中的相对位置参考，不是能力排名、真实水平排名、全球正式常模排名或职业竞争力排名。",
+                        "quality_rules_statement": "解释置信度会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索。低置信结果应优先作为作答质量提示和复测建议，不适合输出强画像、强职业判断或强行动处方。",
+                        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同生成。版本记录用于复测比较、客服排查和内容审校；它不代表结果获得了临床、招聘或能力认证。",
+                        "user_safe_summary": "适合用于自我理解、关系复盘、低风险沟通练习和职业环境变量反思。",
+                        "do_not_overread": "请把这份报告理解为本次 60 题自我报告形成的解释草图，而不是外部观察、客观能力分、稳定人格诊断、招聘信号、职业预测或工作表现预测。"
                     },
                     "en": {
-                        "test_definition": "This report is based on your self-reported responses to 60 items. It explains your perceived emotional and relational patterns; it is not external observation, a live behavior record, an objective ability test, or a certification.",
-                        "self_report_statement": "EQ-60 is a self-report assessment: results reflect how you describe your self-awareness, regulation, empathic understanding, and relational action tendencies. They do not directly prove real-world performance.",
-                        "non_clinical_statement": "This report is not for clinical diagnosis, treatment evaluation, medical advice, crisis decisions, or risk assessment. If distress affects sleep, work, safety, or daily functioning, consult a qualified professional.",
-                        "non_hiring_statement": "This result must not be used for hiring, selection, rejection, promotion, role assignment, performance review, or any high-stakes organizational decision.",
-                        "non_ability_statement": "EQ-60 is not an self-reported emotional pattern test, not MSCEIT, and not a certified capability evaluation. A future scenario module may add situational-choice signals, but it will not turn the report into an ability credential.",
-                        "norm_status_statement": "Standard scores, percentiles, and bands currently use provisional norms and versioned interpretation. Percentiles provide relative position in the current sample, not an ability ranking, true-level ranking, or final global norm.",
-                        "quality_rules_statement": "The report considers speed, repeated identical choices, extreme choices, neutral choices, and consistency signals to estimate interpretation confidence. Low-confidence results are not suitable for strong profiling, career conclusions, or action prescriptions.",
-                        "version_statement": "The report is shaped by item version, scoring version, norm version, and content asset version. Versioning lets retests, support, and editorial review trace how a result was produced.",
-                        "user_safe_summary": "Use it for self-understanding, relational reflection, and low-risk growth planning.",
-                        "do_not_overread": "This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance."
+                        "test_definition": "This report is based on your self-reported responses to 60 items. It organizes how you describe your emotional awareness, emotion regulation, empathic understanding, and relational action tendencies. It explains a self-perception pattern from this response session; it is not external observation, a live behavior record, an objective ability test, or a certification.",
+                        "self_report_statement": "EQ-60 is a self-report assessment: results come from your own descriptions. They are useful for self-understanding and review, but they do not directly prove how you perform in every real situation and cannot replace observer ratings or scenario-task data.",
+                        "non_clinical_statement": "This report is not for clinical diagnosis, treatment evaluation, medical advice, crisis decisions, or psychological risk assessment. If distress keeps affecting sleep, work, interpersonal safety, or daily functioning, seek qualified professional or real-world support.",
+                        "non_hiring_statement": "This result must not be used for hiring, selection, rejection, promotion, role assignment, performance review, team screening, or any high-stakes organizational decision. It should not be used to judge whether another person is suitable for a role.",
+                        "non_ability_statement": "EQ-60 is not an emotional-ability test, not MSCEIT, and not a certified emotional-intelligence assessment. It cannot prove true emotional ability, communication ability, or relationship ability. If EQ-SJT is added later, it will only add scenario-choice signals; it will not turn the report into an ability credential.",
+                        "norm_status_statement": "Standard scores, percentiles, and bands currently use provisional norms and versioned interpretation. Percentiles provide a relative-position reference within the current sample, not an ability ranking, true-level ranking, final global norm, or career-competitiveness ranking.",
+                        "quality_rules_statement": "Interpretation confidence considers response speed, repeated identical choices, extreme choices, neutral choices, and consistency signals. Low-confidence results should be treated primarily as response-quality guidance and retest advice, not as strong profiling, career conclusions, or action prescriptions.",
+                        "version_statement": "The report is generated from the item version, scoring version, norm version, and content-asset version. Versioning supports retest comparison, support investigation, and editorial review; it does not mean the result has clinical, hiring, or ability certification.",
+                        "user_safe_summary": "Use it for self-understanding, relational reflection, low-risk communication practice, and work-environment variable review.",
+                        "do_not_overread": "Read this report as an interpretive sketch from this 60-item self-report session, not as external observation, an objective ability score, a stable personality diagnosis, a hiring signal, a career prediction, or a prediction of job performance."
                     }
                 }
             }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/scientific_contract.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/scientific_contract.json
@@ -4,28 +4,28 @@
   "assets": {
     "eq.scientific_contract.default": {
       "zh-CN": {
-        "test_definition": "这份报告基于你对 60 道题的自我报告作答，解释你对自身情绪与关系模式的主观感知。它不是外部观察、现场行为记录、客观能力测验或认证评估。",
-        "self_report_statement": "EQ-60 是自我报告测评：结果反映你如何描述自己的情绪觉察、调节、共情理解和关系行动倾向，不直接证明你在真实场景中的表现。",
-        "non_clinical_statement": "本报告不用于临床诊断、治疗评估、医疗建议、危机处置或风险判断。若困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士支持。",
-        "non_hiring_statement": "本结果不应用于招聘、录用、淘汰、晋升、岗位分配、绩效评估或任何高风险组织决策。",
-        "non_ability_statement": "EQ-60 不是情绪能力测验，不是 MSCEIT，也不是认证能力评估。未来情境判断模块也只会补充情境选择线索，不会把报告变成能力证明。",
-        "norm_status_statement": "当前标准分、百分位和等级来自阶段性常模与版本化解释。百分位只提供当前样本中的相对位置感，不是能力排名、真实水平排名或全球正式常模排名。",
-        "quality_rules_statement": "报告会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索来估计解释置信度。低置信结果不适合强画像、强职业判断或强行动处方。",
-        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同决定。版本记录让复测、客服和内容审校能追踪同一结果如何生成。",
-        "user_safe_summary": "适合用于自我理解、关系复盘和低风险成长规划。",
-        "do_not_overread": "这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。"
+        "test_definition": "这份报告基于你对 60 道题的自我报告作答，整理你如何描述自己的情绪觉察、情绪调节、共情理解和关系行动倾向。它解释的是本次作答中的自我感知模式，不是外部观察、现场行为记录、客观能力测验或认证评估。",
+        "self_report_statement": "EQ-60 是 self-report 测评：结果来自你的主观描述，因此适合用于自我理解和复盘，不直接证明你在所有真实场景中的实际表现，也不能替代他人观察或情境任务数据。",
+        "non_clinical_statement": "本报告不用于临床诊断、治疗评估、医疗建议、危机处置或心理风险判断。若情绪困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士或现实支持。",
+        "non_hiring_statement": "本结果不得用于招聘、录用、淘汰、晋升、岗位分配、绩效评估、团队筛选或任何高风险组织决策，也不应用来评价他人是否适合某个岗位。",
+        "non_ability_statement": "EQ-60 不是情绪能力测验，不是 MSCEIT，也不是认证型情绪智力评估。它不能证明真实情绪能力、沟通能力或关系能力；未来 EQ-SJT 若上线，也只会补充情境选择线索，不会把报告变成能力证明。",
+        "norm_status_statement": "当前标准分、百分位和等级来自阶段性常模与版本化解释。百分位只提供当前样本中的相对位置参考，不是能力排名、真实水平排名、全球正式常模排名或职业竞争力排名。",
+        "quality_rules_statement": "解释置信度会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索。低置信结果应优先作为作答质量提示和复测建议，不适合输出强画像、强职业判断或强行动处方。",
+        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同生成。版本记录用于复测比较、客服排查和内容审校；它不代表结果获得了临床、招聘或能力认证。",
+        "user_safe_summary": "适合用于自我理解、关系复盘、低风险沟通练习和职业环境变量反思。",
+        "do_not_overread": "请把这份报告理解为本次 60 题自我报告形成的解释草图，而不是外部观察、客观能力分、稳定人格诊断、招聘信号、职业预测或工作表现预测。"
       },
       "en": {
-        "test_definition": "This report is based on your self-reported responses to 60 items. It explains your perceived emotional and relational patterns; it is not external observation, a live behavior record, an objective ability test, or a certification.",
-        "self_report_statement": "EQ-60 is a self-report assessment: results reflect how you describe your self-awareness, regulation, empathic understanding, and relational action tendencies. They do not directly prove real-world performance.",
-        "non_clinical_statement": "This report is not for clinical diagnosis, treatment evaluation, medical advice, crisis decisions, or risk assessment. If distress affects sleep, work, safety, or daily functioning, consult a qualified professional.",
-        "non_hiring_statement": "This result must not be used for hiring, selection, rejection, promotion, role assignment, performance review, or any high-stakes organizational decision.",
-        "non_ability_statement": "EQ-60 is not an self-reported emotional pattern test, not MSCEIT, and not a certified capability evaluation. A future scenario module may add situational-choice signals, but it will not turn the report into an ability credential.",
-        "norm_status_statement": "Standard scores, percentiles, and bands currently use provisional norms and versioned interpretation. Percentiles provide relative position in the current sample, not an ability ranking, true-level ranking, or final global norm.",
-        "quality_rules_statement": "The report considers speed, repeated identical choices, extreme choices, neutral choices, and consistency signals to estimate interpretation confidence. Low-confidence results are not suitable for strong profiling, career conclusions, or action prescriptions.",
-        "version_statement": "The report is shaped by item version, scoring version, norm version, and content asset version. Versioning lets retests, support, and editorial review trace how a result was produced.",
-        "user_safe_summary": "Use it for self-understanding, relational reflection, and low-risk growth planning.",
-        "do_not_overread": "This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance."
+        "test_definition": "This report is based on your self-reported responses to 60 items. It organizes how you describe your emotional awareness, emotion regulation, empathic understanding, and relational action tendencies. It explains a self-perception pattern from this response session; it is not external observation, a live behavior record, an objective ability test, or a certification.",
+        "self_report_statement": "EQ-60 is a self-report assessment: results come from your own descriptions. They are useful for self-understanding and review, but they do not directly prove how you perform in every real situation and cannot replace observer ratings or scenario-task data.",
+        "non_clinical_statement": "This report is not for clinical diagnosis, treatment evaluation, medical advice, crisis decisions, or psychological risk assessment. If distress keeps affecting sleep, work, interpersonal safety, or daily functioning, seek qualified professional or real-world support.",
+        "non_hiring_statement": "This result must not be used for hiring, selection, rejection, promotion, role assignment, performance review, team screening, or any high-stakes organizational decision. It should not be used to judge whether another person is suitable for a role.",
+        "non_ability_statement": "EQ-60 is not an emotional-ability test, not MSCEIT, and not a certified emotional-intelligence assessment. It cannot prove true emotional ability, communication ability, or relationship ability. If EQ-SJT is added later, it will only add scenario-choice signals; it will not turn the report into an ability credential.",
+        "norm_status_statement": "Standard scores, percentiles, and bands currently use provisional norms and versioned interpretation. Percentiles provide a relative-position reference within the current sample, not an ability ranking, true-level ranking, final global norm, or career-competitiveness ranking.",
+        "quality_rules_statement": "Interpretation confidence considers response speed, repeated identical choices, extreme choices, neutral choices, and consistency signals. Low-confidence results should be treated primarily as response-quality guidance and retest advice, not as strong profiling, career conclusions, or action prescriptions.",
+        "version_statement": "The report is generated from the item version, scoring version, norm version, and content-asset version. Versioning supports retest comparison, support investigation, and editorial review; it does not mean the result has clinical, hiring, or ability certification.",
+        "user_safe_summary": "Use it for self-understanding, relational reflection, low-risk communication practice, and work-environment variable review.",
+        "do_not_overread": "Read this report as an interpretive sketch from this 60-item self-report session, not as external observation, an objective ability score, a stable personality diagnosis, a hiring signal, a career prediction, or a prediction of job performance."
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T16:51:18.216438Z",
+    "generated_at": "2026-07-02T17:08:38.421048Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -10,28 +10,28 @@
             "assets": {
                 "eq.scientific_contract.default": {
                     "zh-CN": {
-                        "test_definition": "这份报告基于你对 60 道题的自我报告作答，解释你对自身情绪与关系模式的主观感知。它不是外部观察、现场行为记录、客观能力测验或认证评估。",
-                        "self_report_statement": "EQ-60 是自我报告测评：结果反映你如何描述自己的情绪觉察、调节、共情理解和关系行动倾向，不直接证明你在真实场景中的表现。",
-                        "non_clinical_statement": "本报告不用于临床诊断、治疗评估、医疗建议、危机处置或风险判断。若困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士支持。",
-                        "non_hiring_statement": "本结果不应用于招聘、录用、淘汰、晋升、岗位分配、绩效评估或任何高风险组织决策。",
-                        "non_ability_statement": "EQ-60 不是情绪能力测验，不是 MSCEIT，也不是认证能力评估。未来情境判断模块也只会补充情境选择线索，不会把报告变成能力证明。",
-                        "norm_status_statement": "当前标准分、百分位和等级来自阶段性常模与版本化解释。百分位只提供当前样本中的相对位置感，不是能力排名、真实水平排名或全球正式常模排名。",
-                        "quality_rules_statement": "报告会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索来估计解释置信度。低置信结果不适合强画像、强职业判断或强行动处方。",
-                        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同决定。版本记录让复测、客服和内容审校能追踪同一结果如何生成。",
-                        "user_safe_summary": "适合用于自我理解、关系复盘和低风险成长规划。",
-                        "do_not_overread": "这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。"
+                        "test_definition": "这份报告基于你对 60 道题的自我报告作答，整理你如何描述自己的情绪觉察、情绪调节、共情理解和关系行动倾向。它解释的是本次作答中的自我感知模式，不是外部观察、现场行为记录、客观能力测验或认证评估。",
+                        "self_report_statement": "EQ-60 是 self-report 测评：结果来自你的主观描述，因此适合用于自我理解和复盘，不直接证明你在所有真实场景中的实际表现，也不能替代他人观察或情境任务数据。",
+                        "non_clinical_statement": "本报告不用于临床诊断、治疗评估、医疗建议、危机处置或心理风险判断。若情绪困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士或现实支持。",
+                        "non_hiring_statement": "本结果不得用于招聘、录用、淘汰、晋升、岗位分配、绩效评估、团队筛选或任何高风险组织决策，也不应用来评价他人是否适合某个岗位。",
+                        "non_ability_statement": "EQ-60 不是情绪能力测验，不是 MSCEIT，也不是认证型情绪智力评估。它不能证明真实情绪能力、沟通能力或关系能力；未来 EQ-SJT 若上线，也只会补充情境选择线索，不会把报告变成能力证明。",
+                        "norm_status_statement": "当前标准分、百分位和等级来自阶段性常模与版本化解释。百分位只提供当前样本中的相对位置参考，不是能力排名、真实水平排名、全球正式常模排名或职业竞争力排名。",
+                        "quality_rules_statement": "解释置信度会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索。低置信结果应优先作为作答质量提示和复测建议，不适合输出强画像、强职业判断或强行动处方。",
+                        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同生成。版本记录用于复测比较、客服排查和内容审校；它不代表结果获得了临床、招聘或能力认证。",
+                        "user_safe_summary": "适合用于自我理解、关系复盘、低风险沟通练习和职业环境变量反思。",
+                        "do_not_overread": "请把这份报告理解为本次 60 题自我报告形成的解释草图，而不是外部观察、客观能力分、稳定人格诊断、招聘信号、职业预测或工作表现预测。"
                     },
                     "en": {
-                        "test_definition": "This report is based on your self-reported responses to 60 items. It explains your perceived emotional and relational patterns; it is not external observation, a live behavior record, an objective ability test, or a certification.",
-                        "self_report_statement": "EQ-60 is a self-report assessment: results reflect how you describe your self-awareness, regulation, empathic understanding, and relational action tendencies. They do not directly prove real-world performance.",
-                        "non_clinical_statement": "This report is not for clinical diagnosis, treatment evaluation, medical advice, crisis decisions, or risk assessment. If distress affects sleep, work, safety, or daily functioning, consult a qualified professional.",
-                        "non_hiring_statement": "This result must not be used for hiring, selection, rejection, promotion, role assignment, performance review, or any high-stakes organizational decision.",
-                        "non_ability_statement": "EQ-60 is not an self-reported emotional pattern test, not MSCEIT, and not a certified capability evaluation. A future scenario module may add situational-choice signals, but it will not turn the report into an ability credential.",
-                        "norm_status_statement": "Standard scores, percentiles, and bands currently use provisional norms and versioned interpretation. Percentiles provide relative position in the current sample, not an ability ranking, true-level ranking, or final global norm.",
-                        "quality_rules_statement": "The report considers speed, repeated identical choices, extreme choices, neutral choices, and consistency signals to estimate interpretation confidence. Low-confidence results are not suitable for strong profiling, career conclusions, or action prescriptions.",
-                        "version_statement": "The report is shaped by item version, scoring version, norm version, and content asset version. Versioning lets retests, support, and editorial review trace how a result was produced.",
-                        "user_safe_summary": "Use it for self-understanding, relational reflection, and low-risk growth planning.",
-                        "do_not_overread": "This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance."
+                        "test_definition": "This report is based on your self-reported responses to 60 items. It organizes how you describe your emotional awareness, emotion regulation, empathic understanding, and relational action tendencies. It explains a self-perception pattern from this response session; it is not external observation, a live behavior record, an objective ability test, or a certification.",
+                        "self_report_statement": "EQ-60 is a self-report assessment: results come from your own descriptions. They are useful for self-understanding and review, but they do not directly prove how you perform in every real situation and cannot replace observer ratings or scenario-task data.",
+                        "non_clinical_statement": "This report is not for clinical diagnosis, treatment evaluation, medical advice, crisis decisions, or psychological risk assessment. If distress keeps affecting sleep, work, interpersonal safety, or daily functioning, seek qualified professional or real-world support.",
+                        "non_hiring_statement": "This result must not be used for hiring, selection, rejection, promotion, role assignment, performance review, team screening, or any high-stakes organizational decision. It should not be used to judge whether another person is suitable for a role.",
+                        "non_ability_statement": "EQ-60 is not an emotional-ability test, not MSCEIT, and not a certified emotional-intelligence assessment. It cannot prove true emotional ability, communication ability, or relationship ability. If EQ-SJT is added later, it will only add scenario-choice signals; it will not turn the report into an ability credential.",
+                        "norm_status_statement": "Standard scores, percentiles, and bands currently use provisional norms and versioned interpretation. Percentiles provide a relative-position reference within the current sample, not an ability ranking, true-level ranking, final global norm, or career-competitiveness ranking.",
+                        "quality_rules_statement": "Interpretation confidence considers response speed, repeated identical choices, extreme choices, neutral choices, and consistency signals. Low-confidence results should be treated primarily as response-quality guidance and retest advice, not as strong profiling, career conclusions, or action prescriptions.",
+                        "version_statement": "The report is generated from the item version, scoring version, norm version, and content-asset version. Versioning supports retest comparison, support investigation, and editorial review; it does not mean the result has clinical, hiring, or ability certification.",
+                        "user_safe_summary": "Use it for self-understanding, relational reflection, low-risk communication practice, and work-environment variable review.",
+                        "do_not_overread": "Read this report as an interpretive sketch from this 60-item self-report session, not as external observation, an objective ability score, a stable personality diagnosis, a hiring signal, a career prediction, or a prediction of job performance."
                     }
                 }
             }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/scientific_contract.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/scientific_contract.json
@@ -4,28 +4,28 @@
   "assets": {
     "eq.scientific_contract.default": {
       "zh-CN": {
-        "test_definition": "这份报告基于你对 60 道题的自我报告作答，解释你对自身情绪与关系模式的主观感知。它不是外部观察、现场行为记录、客观能力测验或认证评估。",
-        "self_report_statement": "EQ-60 是自我报告测评：结果反映你如何描述自己的情绪觉察、调节、共情理解和关系行动倾向，不直接证明你在真实场景中的表现。",
-        "non_clinical_statement": "本报告不用于临床诊断、治疗评估、医疗建议、危机处置或风险判断。若困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士支持。",
-        "non_hiring_statement": "本结果不应用于招聘、录用、淘汰、晋升、岗位分配、绩效评估或任何高风险组织决策。",
-        "non_ability_statement": "EQ-60 不是情绪能力测验，不是 MSCEIT，也不是认证能力评估。未来情境判断模块也只会补充情境选择线索，不会把报告变成能力证明。",
-        "norm_status_statement": "当前标准分、百分位和等级来自阶段性常模与版本化解释。百分位只提供当前样本中的相对位置感，不是能力排名、真实水平排名或全球正式常模排名。",
-        "quality_rules_statement": "报告会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索来估计解释置信度。低置信结果不适合强画像、强职业判断或强行动处方。",
-        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同决定。版本记录让复测、客服和内容审校能追踪同一结果如何生成。",
-        "user_safe_summary": "适合用于自我理解、关系复盘和低风险成长规划。",
-        "do_not_overread": "这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。"
+        "test_definition": "这份报告基于你对 60 道题的自我报告作答，整理你如何描述自己的情绪觉察、情绪调节、共情理解和关系行动倾向。它解释的是本次作答中的自我感知模式，不是外部观察、现场行为记录、客观能力测验或认证评估。",
+        "self_report_statement": "EQ-60 是 self-report 测评：结果来自你的主观描述，因此适合用于自我理解和复盘，不直接证明你在所有真实场景中的实际表现，也不能替代他人观察或情境任务数据。",
+        "non_clinical_statement": "本报告不用于临床诊断、治疗评估、医疗建议、危机处置或心理风险判断。若情绪困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士或现实支持。",
+        "non_hiring_statement": "本结果不得用于招聘、录用、淘汰、晋升、岗位分配、绩效评估、团队筛选或任何高风险组织决策，也不应用来评价他人是否适合某个岗位。",
+        "non_ability_statement": "EQ-60 不是情绪能力测验，不是 MSCEIT，也不是认证型情绪智力评估。它不能证明真实情绪能力、沟通能力或关系能力；未来 EQ-SJT 若上线，也只会补充情境选择线索，不会把报告变成能力证明。",
+        "norm_status_statement": "当前标准分、百分位和等级来自阶段性常模与版本化解释。百分位只提供当前样本中的相对位置参考，不是能力排名、真实水平排名、全球正式常模排名或职业竞争力排名。",
+        "quality_rules_statement": "解释置信度会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索。低置信结果应优先作为作答质量提示和复测建议，不适合输出强画像、强职业判断或强行动处方。",
+        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同生成。版本记录用于复测比较、客服排查和内容审校；它不代表结果获得了临床、招聘或能力认证。",
+        "user_safe_summary": "适合用于自我理解、关系复盘、低风险沟通练习和职业环境变量反思。",
+        "do_not_overread": "请把这份报告理解为本次 60 题自我报告形成的解释草图，而不是外部观察、客观能力分、稳定人格诊断、招聘信号、职业预测或工作表现预测。"
       },
       "en": {
-        "test_definition": "This report is based on your self-reported responses to 60 items. It explains your perceived emotional and relational patterns; it is not external observation, a live behavior record, an objective ability test, or a certification.",
-        "self_report_statement": "EQ-60 is a self-report assessment: results reflect how you describe your self-awareness, regulation, empathic understanding, and relational action tendencies. They do not directly prove real-world performance.",
-        "non_clinical_statement": "This report is not for clinical diagnosis, treatment evaluation, medical advice, crisis decisions, or risk assessment. If distress affects sleep, work, safety, or daily functioning, consult a qualified professional.",
-        "non_hiring_statement": "This result must not be used for hiring, selection, rejection, promotion, role assignment, performance review, or any high-stakes organizational decision.",
-        "non_ability_statement": "EQ-60 is not an self-reported emotional pattern test, not MSCEIT, and not a certified capability evaluation. A future scenario module may add situational-choice signals, but it will not turn the report into an ability credential.",
-        "norm_status_statement": "Standard scores, percentiles, and bands currently use provisional norms and versioned interpretation. Percentiles provide relative position in the current sample, not an ability ranking, true-level ranking, or final global norm.",
-        "quality_rules_statement": "The report considers speed, repeated identical choices, extreme choices, neutral choices, and consistency signals to estimate interpretation confidence. Low-confidence results are not suitable for strong profiling, career conclusions, or action prescriptions.",
-        "version_statement": "The report is shaped by item version, scoring version, norm version, and content asset version. Versioning lets retests, support, and editorial review trace how a result was produced.",
-        "user_safe_summary": "Use it for self-understanding, relational reflection, and low-risk growth planning.",
-        "do_not_overread": "This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance."
+        "test_definition": "This report is based on your self-reported responses to 60 items. It organizes how you describe your emotional awareness, emotion regulation, empathic understanding, and relational action tendencies. It explains a self-perception pattern from this response session; it is not external observation, a live behavior record, an objective ability test, or a certification.",
+        "self_report_statement": "EQ-60 is a self-report assessment: results come from your own descriptions. They are useful for self-understanding and review, but they do not directly prove how you perform in every real situation and cannot replace observer ratings or scenario-task data.",
+        "non_clinical_statement": "This report is not for clinical diagnosis, treatment evaluation, medical advice, crisis decisions, or psychological risk assessment. If distress keeps affecting sleep, work, interpersonal safety, or daily functioning, seek qualified professional or real-world support.",
+        "non_hiring_statement": "This result must not be used for hiring, selection, rejection, promotion, role assignment, performance review, team screening, or any high-stakes organizational decision. It should not be used to judge whether another person is suitable for a role.",
+        "non_ability_statement": "EQ-60 is not an emotional-ability test, not MSCEIT, and not a certified emotional-intelligence assessment. It cannot prove true emotional ability, communication ability, or relationship ability. If EQ-SJT is added later, it will only add scenario-choice signals; it will not turn the report into an ability credential.",
+        "norm_status_statement": "Standard scores, percentiles, and bands currently use provisional norms and versioned interpretation. Percentiles provide a relative-position reference within the current sample, not an ability ranking, true-level ranking, final global norm, or career-competitiveness ranking.",
+        "quality_rules_statement": "Interpretation confidence considers response speed, repeated identical choices, extreme choices, neutral choices, and consistency signals. Low-confidence results should be treated primarily as response-quality guidance and retest advice, not as strong profiling, career conclusions, or action prescriptions.",
+        "version_statement": "The report is generated from the item version, scoring version, norm version, and content-asset version. Versioning supports retest comparison, support investigation, and editorial review; it does not mean the result has clinical, hiring, or ability certification.",
+        "user_safe_summary": "Use it for self-understanding, relational reflection, low-risk communication practice, and work-environment variable review.",
+        "do_not_overread": "Read this report as an interpretive sketch from this 60-item self-report session, not as external observation, an objective ability score, a stable personality diagnosis, a hiring signal, a career prediction, or a prediction of job performance."
       }
     }
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -68447,8 +68447,8 @@
     "depends_on": [
       "PR-EQ-ASSET-AUDIT-00"
     ],
-    "status": "pr_open",
-    "commit_sha": "fd642afed0b7d5e26b0d16c86c6e1a10808ef356",
+    "status": "merged",
+    "commit_sha": "dd254a9714bee427d7a5e430543bb39201bb7668",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2608",
     "checks": [
       {
@@ -68503,14 +68503,14 @@
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T17:01:21Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -68529,6 +68529,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "summary": "Opened PR #2608 after scoped local validation passed."
+      },
+      {
+        "at": "2026-07-02T17:07:30.591401Z",
+        "from": "pr_open",
+        "to": "merged",
+        "summary": "Reconciled PR #2608 merge commit f31fc4e9328dd471e9fe11e8f7fdd53c5e8a60d0; origin/main contains merge commit and task branch was cleaned."
       }
     ]
   },
@@ -68541,17 +68547,63 @@
     "depends_on": [
       "PR-EQ-ASSET-AUDIT-00"
     ],
-    "status": "user_authorized",
-    "commit_sha": null,
-    "pr_url": null,
-    "checks": [],
+    "status": "pr_open",
+    "commit_sha": "c5478e267a0c9f724a2fef186b77364a2ae1ece5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2611",
+    "checks": [
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; scoped compiled report assets retained."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 432 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed_with_warnings",
+        "summary": "12 tests passed, 683 assertions; PHPUnit reported environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 208 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed_with_warnings",
+        "summary": "4 tests passed, 130 assertions; PHPUnit reported environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 16 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "python3 -m json.tool scientific_contract raw files",
+        "status": "passed",
+        "summary": "EQ_60 and EQ_EMOTIONAL_INTELLIGENCE scientific_contract JSON files parse."
+      },
+      {
+        "command": "cmp EQ_60 and EQ_EMOTIONAL_INTELLIGENCE scientific_contract raw assets",
+        "status": "passed",
+        "summary": "Alias raw asset mirror is byte-for-byte identical."
+      }
+    ],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -68560,6 +68612,18 @@
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      },
+      {
+        "at": "2026-07-02T17:07:30.591401Z",
+        "from": "user_authorized",
+        "to": "local_checks_passed",
+        "summary": "Rewrote scientific_contract boundaries for self-report, non-ability, non-MSCEIT, non-clinical, non-hiring, provisional norms, quality confidence, and non-prediction claims; local EQ content and report contract checks passed."
+      },
+      {
+        "at": "2026-07-02T17:09:50.287626Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "summary": "Opened PR #2611 after scoped local validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Rewrote the EQ scientific contract copy in zh-CN and en within the existing schema fields.
- Clarified EQ-60 as a self-report assessment, not external observation, objective ability testing, MSCEIT, clinical diagnosis, hiring/selection evidence, career prediction, or job-performance prediction.
- Clarified provisional score/norm interpretation, quality-confidence limits, versioning purpose, and safe user use cases.
- Mirrored EQ_60 raw and compiled report assets into EQ_EMOTIONAL_INTELLIGENCE.
- Reconciled PR-EQ-ASSET-SCI-02 merged state in the PR-train ledger and recorded SCI-03 local validation.

## Why
SCI-03 is scoped to the global scientific contract. This boundary asset has to set the safest interpretation frame for every downstream EQ result-page section.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest`
- YAML/JSON parse checks
- scientific-contract sanity scan for known unsafe phrases
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No score-system changes.
- No formulation, mechanism, scene, career, action, quality-runtime, composer, frontend, SJT, commerce, CMS, SEO runtime, or deployment changes.