### PR TITLE
PR-EQ-ASSET-SCI-04: clarify EQ score_system boundaries

### DIFF
--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T17:08:38.421048Z",
+    "generated_at": "2026-07-02T17:18:52.198969Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -41,16 +41,16 @@
             "pack_id": "EQ_60",
             "global_index": {
                 "zh-CN": {
-                    "label": "情绪与关系综合指数 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                    "definition": "综合指数把四个自我报告维度合并成一个阅读入口，用来帮助你理解本次作答呈现的情绪与关系模式。",
-                    "not_a_capability_score": "分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                    "how_to_use": "先看总览，再回到四维、质量提示、证据状态和场景边界。不要把总分当作能力排名。"
+                    "label": "情绪与关系综合指数",
+                    "definition": "综合指数把四个自我报告维度合并成一个阅读入口，用来概览本次作答呈现的情绪与关系自我感知模式。",
+                    "not_a_capability_score": "它不是情绪能力分、真实表现分、职业竞争力分或全球正式常模排名；更适合当作进入四维和场景解释的导航。",
+                    "how_to_use": "先用总览定位，再回到四维、答题质量、证据状态和现实场景。不要用总分单独评价自己或他人。"
                 },
                 "en": {
-                    "label": "Emotional & Relational Functioning Index Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                    "definition": "The index combines four self-report dimensions into a reading entry for the emotional and relational pattern shown in this session.",
-                    "not_a_capability_score": "Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                    "how_to_use": "Start with the overview, then return to dimensions, confidence, evidence status, and scene boundaries. Do not treat the total score as an ability ranking."
+                    "label": "Emotional & Relational Functioning Index",
+                    "definition": "The index combines four self-report dimensions into a reading entry for the emotional and relational self-perception pattern shown in this response session.",
+                    "not_a_capability_score": "It is not an emotional-ability score, live-performance score, career-competitiveness score, or final global norm ranking; use it as navigation into dimensions and scene explanations.",
+                    "how_to_use": "Use the overview first, then return to dimensions, response quality, evidence status, and real-life scenes. Do not use the total score by itself to judge yourself or others."
                 }
             },
             "bands": {
@@ -78,82 +78,82 @@
             "dimensions": {
                 "SA": {
                     "zh-CN": {
-                        "label": "自我觉察 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "自我觉察",
                         "short_label": "自我觉察",
-                        "definition": "对自己情绪、触发点和需要的自我报告识别倾向；它不是外部观察到的自我理解能力。",
+                        "definition": "对自己情绪、触发点、身体信号和当下需要的自我报告识别倾向；它不是外部观察到的自我理解能力，也不保证现场表达一定清楚。",
                         "what_high_can_look_like": "你能较快识别自己的感受和触发点，但仍需把觉察转化为行动。",
                         "what_low_can_look_like": "情绪常在事后才变清楚，容易先反应后理解。",
                         "development_question": "我此刻真正的感受和需要是什么？",
-                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "自我觉察分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
                     },
                     "en": {
-                        "label": "Self-Awareness Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Self-Awareness",
                         "short_label": "Self-Awareness",
-                        "definition": "A self-reported tendency to notice emotions, triggers, and needs; it is not externally observed self-knowledge ability.",
+                        "definition": "A self-reported tendency to notice emotions, triggers, body signals, and current needs; it is not externally observed self-knowledge ability and does not guarantee clear expression in the moment.",
                         "what_high_can_look_like": "You can often identify feelings and triggers quickly, while still needing to turn awareness into action.",
                         "what_low_can_look_like": "Feelings may become clear only afterward, making it easier to react before understanding.",
                         "development_question": "What am I actually feeling and needing right now?",
-                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The Self-Awareness score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
                     }
                 },
                 "ER": {
                     "zh-CN": {
-                        "label": "情绪调节 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "情绪调节",
                         "short_label": "情绪调节",
-                        "definition": "对自己在压力、反馈、挫败或冲突后暂停、复位和选择回应方式的自我报告倾向；它不等同于永远冷静或抗压能力证明。",
+                        "definition": "对自己在压力、反馈、挫败或冲突后暂停、复位和选择回应方式的自我报告倾向；它不等同于永远冷静、压住情绪或抗压能力证明。",
                         "what_high_can_look_like": "你在压力中较能暂停、恢复和选择回应，但不代表没有情绪。",
                         "what_low_can_look_like": "被触发后恢复较慢，容易用回避、解释或压抑处理。",
                         "development_question": "我能不能先让自己降一点温，再决定怎么回应？",
-                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "情绪调节分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
                     },
                     "en": {
-                        "label": "Emotion Regulation Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Emotion Regulation",
                         "short_label": "Emotion Regulation",
-                        "definition": "A self-reported tendency to pause, reset, and choose responses after pressure, feedback, frustration, or conflict; it is not proof of being calm or resilient in every situation.",
+                        "definition": "A self-reported tendency to pause, reset, and choose responses after pressure, feedback, frustration, or conflict; it is not the same as always staying calm, suppressing emotion, or proving resilience.",
                         "what_high_can_look_like": "You can often pause, recover, and choose a response under pressure, without being emotionless.",
                         "what_low_can_look_like": "Recovery may take longer after being triggered, with avoidance, over-explaining, or suppression becoming common.",
                         "development_question": "Can I lower the heat first before choosing my response?",
-                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The Emotion Regulation score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
                     }
                 },
                 "EM": {
                     "zh-CN": {
-                        "label": "共情理解 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "共情理解",
                         "short_label": "共情理解",
-                        "definition": "对他人情绪线索、观点和可能感受的自我报告理解倾向；它不等同于实际读心准确率、亲社会行为或替他人承担情绪。",
+                        "definition": "对他人情绪线索、观点和可能感受的自我报告理解倾向；它包含认知共情和情感共鸣线索，但不等同于读心准确率、亲社会行为或替他人承担情绪痛苦。",
                         "what_high_can_look_like": "你能敏锐捕捉他人的状态，但需要避免过度吸收。",
                         "what_low_can_look_like": "可能更关注任务或事实，较容易漏过对方的情绪线索。",
                         "development_question": "对方真正担心或在意的是什么？",
-                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "共情理解分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
                     },
                     "en": {
-                        "label": "Empathy Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Empathy",
                         "short_label": "Empathy",
-                        "definition": "A self-reported tendency to understand others’ emotional cues, perspectives, and possible feelings; it is not the same as actual mind-reading accuracy, prosocial behavior, or carrying others’ emotions.",
+                        "definition": "A self-reported tendency to understand others’ emotional cues, perspectives, and possible feelings; it may reflect cognitive and affective empathy signals, but it is not mind-reading accuracy, prosocial behavior, or taking on others’ distress.",
                         "what_high_can_look_like": "You can notice others’ emotional states, while still needing boundaries against over-absorbing.",
                         "what_low_can_look_like": "You may focus on tasks or facts and miss some emotional cues.",
                         "development_question": "What is the other person really concerned about?",
-                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The Empathy score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
                     }
                 },
                 "RM": {
                     "zh-CN": {
-                        "label": "关系管理 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "关系管理",
                         "short_label": "关系管理",
-                        "definition": "对表达、协作、边界和修复的自我报告倾向；它不直接预测关系质量、领导力或他人评价。",
+                        "definition": "对表达、协作、边界和关系修复的自我报告倾向；它不直接预测关系质量、领导力、受欢迎程度或他人评价。",
                         "what_high_can_look_like": "你能维护沟通和关系质量，但仍需留意真实表达和边界。",
                         "what_low_can_look_like": "知道自己或对方感受后，不一定能把对话修复或推进。",
                         "development_question": "这句话怎样说，既真实又能让关系继续对话？",
-                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "关系管理分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
                     },
                     "en": {
-                        "label": "Relationship Management Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Relationship Management",
                         "short_label": "Relationship Management",
-                        "definition": "A self-reported tendency around expression, collaboration, boundaries, and repair; it does not directly predict relationship quality, leadership, or others’ evaluations.",
+                        "definition": "A self-reported tendency around expression, collaboration, boundaries, and relationship repair; it does not directly predict relationship quality, leadership, popularity, or others’ evaluations.",
                         "what_high_can_look_like": "You can maintain communication and relationship quality, while still watching for honest expression and boundaries.",
                         "what_low_can_look_like": "Even when feelings are clear, repairing or moving the conversation forward may be harder.",
                         "development_question": "How can I say this honestly while keeping the conversation open?",
-                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The Relationship Management score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
                     }
                 }
             },
@@ -161,517 +161,517 @@
                 "SA": {
                     "foundational": {
                         "zh-CN": {
-                            "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。",
                             "strength": "愿意回头复盘时，能够逐步看见真实感受。",
                             "risk": "现场容易先解释、压住或转移，之后才发现自己被触发。",
                             "typical_scene": "别人问“你怎么了”时，你可能需要一段时间才说得清。",
                             "practice_focus": "每天记录一个情绪词、一个触发点和一个身体反应。",
-                            "do_not_overread": "这不代表你不懂自己，只说明当下觉察信号还需要更稳定的捕捉方式。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 基础发展中"
                         },
                         "en": {
-                            "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably.",
                             "strength": "When you review an event afterward, you can gradually identify what was actually happening inside.",
                             "risk": "In the moment, you may explain, suppress, or move on before noticing that you were triggered.",
                             "typical_scene": "When someone asks what is wrong, you may need time before you can answer clearly.",
                             "practice_focus": "Track one emotion word, one trigger, and one body signal each day.",
-                            "do_not_overread": "This does not mean you lack self-understanding; it means your emotional signals need a more stable capture method. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Foundational"
                         }
                     },
                     "developing": {
                         "zh-CN": {
-                            "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。",
                             "strength": "你开始能把情绪从混乱体验里拆出来。",
                             "risk": "觉察到情绪后，可能仍会被它带着走。",
                             "typical_scene": "收到批评时，你能意识到不舒服，但需要时间判断这份不舒服来自哪里。",
                             "practice_focus": "用“我感到…因为我在意…”练习把感受说具体。",
-                            "do_not_overread": "发展中不是不稳定人格，而是觉察速度和表达精度仍在形成。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 发展中"
                         },
                         "en": {
-                            "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly.",
                             "strength": "You are beginning to separate emotion from the overall sense of confusion.",
                             "risk": "After noticing a feeling, you may still be carried by it before choosing a response.",
                             "typical_scene": "When criticized, you know something feels uncomfortable but need time to identify the source.",
                             "practice_focus": "Practice the sentence: “I feel... because I care about...”",
-                            "do_not_overread": "Developing does not mean an unstable personality; it means speed and precision of awareness are still forming. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Developing"
                         }
                     },
                     "stable": {
                         "zh-CN": {
-                            "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。",
                             "strength": "你通常能说清楚自己为什么被影响。",
                             "risk": "压力升高时，觉察可能变成反复分析，而不是行动。",
                             "typical_scene": "复盘一次对话时，你能指出哪个细节让自己紧张或防御。",
                             "practice_focus": "每次觉察后补一句：“我现在可以选择的下一步是…”。",
-                            "do_not_overread": "稳定可用不等于任何场景都冷静，只表示多数日常场景有可靠基础。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 稳定可用"
                         },
                         "en": {
-                            "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure.",
                             "strength": "You can usually explain why something affected you.",
                             "risk": "Under higher pressure, awareness may turn into repeated analysis rather than action.",
                             "typical_scene": "When reviewing a conversation, you can point to the detail that made you tense or defensive.",
                             "practice_focus": "After naming the feeling, add: “The next step I can choose is...”",
-                            "do_not_overread": "Stable does not mean calm in every situation; it means you have a reliable base in most everyday settings. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Stable"
                         }
                     },
                     "proficient": {
                         "zh-CN": {
-                            "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。",
                             "strength": "你能把复杂感受组织成比较清楚的表达。",
                             "risk": "容易把每个反应都分析得很细，反而延迟沟通或恢复。",
                             "typical_scene": "在重要对话前，你能预判自己可能被哪些点触发。",
                             "practice_focus": "给觉察设时间盒：命名、确认需要、选择一个小行动。",
-                            "do_not_overread": "熟练成熟不代表你必须解释所有感受，也不代表别人一定会立即理解。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 熟练成熟"
                         },
                         "en": {
-                            "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis.",
                             "strength": "You can organize complex feelings into relatively clear expression.",
                             "risk": "You may analyze every reaction in detail and delay communication or recovery.",
                             "typical_scene": "Before an important conversation, you can anticipate which points may trigger you.",
                             "practice_focus": "Time-box awareness: name the feeling, identify the need, then choose one small action.",
-                            "do_not_overread": "Proficient does not mean you must explain every feeling, or that others will immediately understand it. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Proficient"
                         }
                     },
                     "integrated": {
                         "zh-CN": {
-                            "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。",
                             "strength": "你能在真实场景中使用觉察，而不只是事后理解。",
                             "risk": "可能默认自己必须一直清楚、一直成熟，从而忽略疲劳。",
                             "typical_scene": "冲突中，你能觉察自己的防御反应，并调整说话方式。",
                             "practice_focus": "保留轻量复盘，重点观察“我是否也给了自己恢复空间”。",
-                            "do_not_overread": "高度整合不是永远理性，而是更常能在觉察和行动之间保持连接。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 高度整合"
                         },
                         "en": {
-                            "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover.",
                             "strength": "You can use awareness in real time, not only in later reflection.",
                             "risk": "You may expect yourself to stay clear and mature all the time, which can hide fatigue.",
                             "typical_scene": "In conflict, you can notice defensiveness and adjust how you speak.",
                             "practice_focus": "Keep a light review habit and ask: “Did I also give myself room to recover?”",
-                            "do_not_overread": "Integrated does not mean permanently rational; it means awareness and action stay connected more often. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Integrated"
                         }
                     }
                 },
                 "ER": {
                     "foundational": {
                         "zh-CN": {
-                            "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。",
                             "strength": "你能从明显的情绪反应中发现需要练习的场景。",
                             "risk": "压力下容易直接回应、回避或进入长时间内耗。",
                             "typical_scene": "冲突结束后，你可能还会在脑中反复回放很久。",
                             "practice_focus": "先练 30 秒暂停：停下、呼吸、说“我需要一点时间”。",
-                            "do_not_overread": "这不等于情绪失控，只说明恢复策略还没有稳定自动化。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 基础发展中"
                         },
                         "en": {
-                            "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately.",
                             "strength": "Clear emotional reactions can show you exactly which situations need practice.",
                             "risk": "Under stress, you may respond too quickly, avoid the issue, or stay mentally stuck afterward.",
                             "typical_scene": "After a conflict, you may replay the conversation for a long time.",
                             "practice_focus": "Practice a 30-second pause: stop, breathe, and say, “I need a little time.”",
-                            "do_not_overread": "This does not mean you are out of control; it means recovery strategies are not yet automatic. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Foundational"
                         }
                     },
                     "developing": {
                         "zh-CN": {
-                            "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。",
                             "strength": "你已经知道某些做法能帮自己缓下来。",
                             "risk": "情绪强度一高，原本有效的方法可能想不起来。",
                             "typical_scene": "你知道先不要回消息更好，但仍可能忍不住马上解释。",
                             "practice_focus": "准备一个固定恢复菜单：离开现场、写三句话、延迟回复。",
-                            "do_not_overread": "发展中不代表无法调节，而是需要把策略从偶发变成默认选项。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 发展中"
                         },
                         "en": {
-                            "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process.",
                             "strength": "You already know that some actions help you settle.",
                             "risk": "When intensity rises, strategies that usually work may be hard to remember.",
                             "typical_scene": "You know it would be better not to reply immediately, but still feel pulled to explain.",
                             "practice_focus": "Prepare a recovery menu: step away, write three sentences, delay the reply.",
-                            "do_not_overread": "Developing does not mean you cannot regulate; it means strategy needs to become a default option. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Developing"
                         }
                     },
                     "stable": {
                         "zh-CN": {
-                            "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。",
                             "strength": "你能把情绪从“主导全局”降到“可以被管理”。",
                             "risk": "如果持续压着自己保持稳定，后续可能出现疲劳或延迟爆发。",
                             "typical_scene": "紧张会议后，你能逐渐恢复工作节奏。",
                             "practice_focus": "给恢复安排边界：什么时候暂停、什么时候回来处理。",
-                            "do_not_overread": "稳定可用不是没有波动，而是多数时候能回到可选择状态。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 稳定可用"
                         },
                         "en": {
-                            "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder.",
                             "strength": "You can reduce emotion from “running the situation” to “something manageable.”",
                             "risk": "If you keep forcing yourself to stay stable, fatigue or delayed escalation may follow.",
                             "typical_scene": "After a tense meeting, you can gradually return to your work rhythm.",
                             "practice_focus": "Set recovery boundaries: when to pause and when to return to the issue.",
-                            "do_not_overread": "Stable does not mean no fluctuation; it means you can usually return to a state of choice. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Stable"
                         }
                     },
                     "proficient": {
                         "zh-CN": {
-                            "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。",
                             "strength": "你能为沟通争取到更好的时机和语气。",
                             "risk": "有时会显得太冷静，让别人感受不到你的真实立场。",
                             "typical_scene": "被挑战时，你能先稳住语气，再回应重点。",
                             "practice_focus": "调节后补充真实表达：“我需要想清楚，但这件事对我重要。”",
-                            "do_not_overread": "熟练调节不等于必须压住情绪，真实表达仍然是关系信息。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 熟练成熟"
                         },
                         "en": {
-                            "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance.",
                             "strength": "You can create better timing and tone for communication.",
                             "risk": "At times, you may appear so calm that others cannot read your real position.",
                             "typical_scene": "When challenged, you can steady your tone before addressing the point.",
                             "practice_focus": "After regulating, add authentic expression: “I need to think, but this matters to me.”",
-                            "do_not_overread": "Proficient regulation does not mean suppressing emotion; honest expression is still relational information. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Proficient"
                         }
                     },
                     "integrated": {
                         "zh-CN": {
-                            "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。",
                             "strength": "你能让情绪成为信息，而不是让它接管关系或判断。",
                             "risk": "别人可能过度依赖你的稳定，你也可能承担过多调停责任。",
                             "typical_scene": "冲突中，你能暂停升级，同时保留清晰边界。",
                             "practice_focus": "定期检查：我是在稳定局面，还是在替所有人承担情绪成本？",
-                            "do_not_overread": "高度整合不是永远平静，而是更能在高压中保留恢复和选择。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 高度整合"
                         },
                         "en": {
-                            "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy.",
                             "strength": "You can use emotion as information instead of letting it take over relationships or judgment.",
                             "risk": "Others may rely too heavily on your stability, and you may take on too much mediation.",
                             "typical_scene": "In conflict, you can slow escalation while keeping a clear boundary.",
                             "practice_focus": "Check regularly: “Am I stabilizing the situation, or carrying everyone’s emotional cost?”",
-                            "do_not_overread": "Integrated does not mean permanently calm; it means more room for recovery and choice under pressure. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Integrated"
                         }
                     }
                 },
                 "EM": {
                     "foundational": {
                         "zh-CN": {
-                            "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。",
                             "strength": "你可以通过直接提问建立更清楚的信息。",
                             "risk": "容易把沉默、语气或表情理解得过少或过多。",
                             "typical_scene": "对方说“没事”时，你不确定该继续问还是停下。",
                             "practice_focus": "使用确认句：“我不确定我理解得对不对，你现在更需要空间还是回应？”",
-                            "do_not_overread": "这不代表你冷漠，只说明读取线索时需要更明确的信息支持。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 基础发展中"
                         },
                         "en": {
-                            "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking.",
                             "strength": "Direct questions can give you clearer information.",
                             "risk": "You may read too little or too much into silence, tone, or facial expression.",
                             "typical_scene": "When someone says “I’m fine,” you are not sure whether to ask again or step back.",
                             "practice_focus": "Use a checking sentence: “I may be wrong; do you need space or a response right now?”",
-                            "do_not_overread": "This does not mean you are uncaring; it means cue reading needs clearer information support. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Foundational"
                         }
                     },
                     "developing": {
                         "zh-CN": {
-                            "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。",
                             "strength": "你开始关注关系中的情绪温度。",
                             "risk": "可能过早判断别人不高兴、失望或疏远。",
                             "typical_scene": "朋友回复变短时，你会察觉异常，但不确定原因。",
                             "practice_focus": "把判断拆成两句：我观察到什么？我还不知道什么？",
-                            "do_not_overread": "发展中不代表共情差，而是需要让共情建立在证据上。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 发展中"
                         },
                         "en": {
-                            "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation.",
                             "strength": "You are starting to track the emotional temperature in relationships.",
                             "risk": "You may too quickly assume someone is upset, disappointed, or distant.",
                             "typical_scene": "When a friend’s replies become shorter, you notice a shift but do not know the reason.",
                             "practice_focus": "Split the judgment into two questions: What did I observe? What do I not know yet?",
-                            "do_not_overread": "Developing does not mean weak empathy; it means empathy needs to be grounded in evidence. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Developing"
                         }
                     },
                     "stable": {
                         "zh-CN": {
-                            "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。",
                             "strength": "你能让对方感到被看见和被认真对待。",
                             "risk": "在关系压力中，可能为了照顾别人而忽略自己的容量。",
                             "typical_scene": "同事语气紧张时，你能意识到对方可能在承压。",
                             "practice_focus": "共情后加一句边界：“我理解你现在很难，我能帮的是…”",
-                            "do_not_overread": "稳定共情不是读心，也不是无限承担别人的情绪。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 稳定可用"
                         },
                         "en": {
-                            "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them.",
                             "strength": "You can help others feel seen and taken seriously.",
                             "risk": "Under relational pressure, you may ignore your own capacity while caring for others.",
                             "typical_scene": "When a colleague sounds tense, you can recognize that they may be under pressure.",
                             "practice_focus": "After empathy, add a boundary: “I understand this is hard; what I can help with is...”",
-                            "do_not_overread": "Stable empathy is not mind-reading, and it is not unlimited responsibility for another person’s emotion. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Stable"
                         }
                     },
                     "proficient": {
                         "zh-CN": {
-                            "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。",
                             "strength": "你能在复杂关系中捕捉未说出口的信息。",
                             "risk": "容易把别人的紧张、失望或期待变成自己的责任。",
                             "typical_scene": "会议里气氛变了，你能很快察觉谁在退缩或不安。",
                             "practice_focus": "先验证再承担：“我感觉你可能有顾虑，我理解对吗？”",
-                            "do_not_overread": "熟练共情不等于你必须解决所有人的感受。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 熟练成熟"
                         },
                         "en": {
-                            "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries.",
                             "strength": "You can notice unspoken information in complex relationships.",
                             "risk": "You may turn others’ tension, disappointment, or expectations into your responsibility.",
                             "typical_scene": "When the mood changes in a meeting, you quickly notice who is withdrawing or uneasy.",
                             "practice_focus": "Validate before carrying: “I sense you may have a concern; am I reading that correctly?”",
-                            "do_not_overread": "Proficient empathy does not mean you must solve everyone’s feelings. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Proficient"
                         }
                     },
                     "integrated": {
                         "zh-CN": {
-                            "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。",
                             "strength": "你能在理解别人时仍保持清晰位置。",
                             "risk": "别人可能习惯向你倾倒情绪，你也可能被期待持续照顾场面。",
                             "typical_scene": "对方情绪很强时，你能回应感受，同时不接下不属于你的责任。",
                             "practice_focus": "练习“理解 + 边界 + 下一步”三段回应。",
-                            "do_not_overread": "高度整合的共情不是永远温柔，而是能同时保留理解和判断。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 高度整合"
                         },
                         "en": {
-                            "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility.",
                             "strength": "You can understand others while keeping a clear position.",
                             "risk": "Others may become used to unloading emotion onto you, and you may be expected to manage the room.",
                             "typical_scene": "When someone is highly emotional, you can respond to the feeling without taking responsibility that is not yours.",
                             "practice_focus": "Practice a three-part response: understanding, boundary, next step.",
-                            "do_not_overread": "Integrated empathy is not endless softness; it is the ability to hold understanding and judgment together. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Integrated"
                         }
                     }
                 },
                 "RM": {
                     "foundational": {
                         "zh-CN": {
-                            "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。",
                             "strength": "只要有清楚步骤，你可以逐步提升关系处理能力。",
                             "risk": "容易在不舒服时沉默、解释过多或直接退出。",
                             "typical_scene": "争执后，你知道需要修复，但不知道第一句话怎么说。",
                             "practice_focus": "准备一句开场：“刚才那段对话有点卡住了，我想重新说一次。”",
-                            "do_not_overread": "这不代表你不重视关系，只说明修复工具还不够熟。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 基础发展中"
                         },
                         "en": {
-                            "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again.",
                             "strength": "With clear steps, your relationship skills can improve steadily.",
                             "risk": "When uncomfortable, you may go silent, over-explain, or exit the conversation.",
                             "typical_scene": "After an argument, you know repair is needed but do not know the first sentence.",
                             "practice_focus": "Prepare an opener: “That conversation got stuck. I’d like to try saying it again.”",
-                            "do_not_overread": "This does not mean you do not value relationships; it means repair tools are not yet familiar. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Foundational"
                         }
                     },
                     "developing": {
                         "zh-CN": {
-                            "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。",
                             "strength": "你已经能意识到关系需要被处理，而不是只等它过去。",
                             "risk": "可能一边想维护关系，一边又把真实想法说得不够清楚。",
                             "typical_scene": "你想缓和气氛，但担心一开口又引发冲突。",
                             "practice_focus": "使用“事实 + 感受 + 请求”三句结构。",
-                            "do_not_overread": "发展中不代表关系能力差，而是现场压力下需要更可依赖的表达框架。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 发展中"
                         },
                         "en": {
-                            "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance.",
                             "strength": "You already recognize that relationships need to be addressed, not simply waited out.",
                             "risk": "You may try to preserve the relationship while leaving your real position unclear.",
                             "typical_scene": "You want to ease the atmosphere but worry that speaking will restart the conflict.",
                             "practice_focus": "Use a three-sentence structure: fact, feeling, request.",
-                            "do_not_overread": "Developing does not mean weak relationship ability; it means pressure requires a more reliable expression frame. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Developing"
                         }
                     },
                     "stable": {
                         "zh-CN": {
-                            "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。",
                             "strength": "你能让关系在小摩擦后回到可合作状态。",
                             "risk": "为了维持顺畅，可能回避更难但必要的话题。",
                             "typical_scene": "误会出现后，你通常愿意解释并重新对齐。",
                             "practice_focus": "在修复之外补充边界：“下次我们可以用这个方式处理。”",
-                            "do_not_overread": "稳定可用不等于没有冲突，而是多数冲突后还能回到工作关系。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 稳定可用"
                         },
                         "en": {
-                            "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations.",
                             "strength": "You can help a relationship return to cooperation after small friction.",
                             "risk": "To keep things smooth, you may avoid harder but necessary topics.",
                             "typical_scene": "After a misunderstanding, you are usually willing to explain and realign.",
                             "practice_focus": "Add a boundary after repair: “Next time, we can handle it this way.”",
-                            "do_not_overread": "Stable does not mean no conflict; it means most conflicts can return to a workable relationship. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Stable"
                         }
                     },
                     "proficient": {
                         "zh-CN": {
-                            "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。",
                             "strength": "你能把冲突转化为更清楚的协作规则。",
                             "risk": "别人可能默认你来收拾关系残局。",
                             "typical_scene": "团队意见不合时，你能帮助大家回到事实和下一步。",
                             "practice_focus": "在协调前先确认职责：“这件事需要谁来决定，谁来执行？”",
-                            "do_not_overread": "熟练关系管理不是永远做中间人，也不是牺牲自己的边界。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 熟练成熟"
                         },
                         "en": {
-                            "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role.",
                             "strength": "You can turn conflict into clearer rules for collaboration.",
                             "risk": "Others may assume you will clean up the relational aftermath.",
                             "typical_scene": "When a team disagrees, you can help people return to facts and next steps.",
                             "practice_focus": "Before coordinating, clarify roles: “Who decides this, and who executes it?”",
-                            "do_not_overread": "Proficient relationship management is not permanent mediation, and it does not require sacrificing your boundary. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Proficient"
                         }
                     },
                     "integrated": {
                         "zh-CN": {
-                            "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。",
                             "strength": "你能在复杂关系中创造清晰、可持续的合作方式。",
                             "risk": "因为你能处理关系，系统可能把过多情绪劳动交给你。",
                             "typical_scene": "冲突升级时，你能帮助各方降温、对齐目标，并明确责任。",
                             "practice_focus": "把个人调停转成系统规则：节奏、边界、责任和复盘。",
-                            "do_not_overread": "高度整合不代表你必须承担所有关系维护工作。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 高度整合"
                         },
                         "en": {
-                            "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone.",
                             "strength": "You can create clear and sustainable collaboration in complex relationships.",
                             "risk": "Because you can handle relationships, the system may hand you too much emotional labor.",
                             "typical_scene": "When conflict escalates, you can help people cool down, align goals, and clarify responsibility.",
                             "practice_focus": "Turn personal mediation into system rules: rhythm, boundary, responsibility, and review.",
-                            "do_not_overread": "Integrated does not mean you must carry all relationship maintenance. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Integrated"
                         }
                     }
                 }
             },
             "score_notes": {
                 "zh-CN": {
-                    "percentile": "百分位只表示在当前阶段性样本中的相对位置感，不是能力排名、真实水平排名或全球正式常模排名。",
-                    "standard_score": "标准分用于稳定展示和维度比较；它是解释入口，不是现场表现证明。",
-                    "band": "等级用于帮助阅读，不代表固定人格、能力证书或临床/职业判断。",
-                    "provisional_norm": "当前常模为阶段性常模，后续样本、语言和版本更新可能改变解释边界。",
-                    "commercial_boundary": "总分用于定位阅读入口，最终解释以四维、质量、证据状态和场景边界为准。"
+                    "percentile": "百分位只表示当前阶段性样本中的相对位置参考，不是能力排名、真实水平排名、全球正式常模排名或职业竞争力排名。",
+                    "standard_score": "标准分用于稳定展示和维度比较，是阅读入口，不是现场表现证明或能力证明。",
+                    "band": "等级用于降低阅读负担，不代表固定人格、能力证书、临床结论、招聘信号或职业判断。",
+                    "provisional_norm": "当前常模为阶段性常模，后续样本、语言版本和内容版本更新都可能改变解释边界。",
+                    "commercial_boundary": "总分不应单独使用；完整解释必须结合四维、质量、证据状态、机制和场景边界。"
                 },
                 "en": {
-                    "percentile": "Percentile only describes relative position in the current provisional sample. It is not an ability ranking, true-level ranking, or final global norm.",
-                    "standard_score": "Standard score supports stable display and dimension comparison; it is a reading entry, not proof of live performance.",
-                    "band": "Bands help users read the result; they are not fixed identities, credentials, clinical findings, or work decisions.",
-                    "provisional_norm": "Current norms are provisional. Future samples, languages, and versions may change interpretation boundaries.",
-                    "commercial_boundary": "The total score is a reading entry; interpretation depends on dimensions, confidence, evidence status, and scene boundaries."
+                    "percentile": "Percentile only provides a relative-position reference within the current provisional sample. It is not an ability ranking, true-level ranking, final global norm, or career-competitiveness ranking.",
+                    "standard_score": "Standard score supports stable display and dimension comparison. It is a reading entry, not proof of live performance or ability.",
+                    "band": "Bands reduce reading effort; they are not fixed identities, credentials, clinical findings, hiring signals, or career judgments.",
+                    "provisional_norm": "Current norms are provisional. Future samples, language versions, and content versions may change interpretation boundaries.",
+                    "commercial_boundary": "The total score should not be used alone; full interpretation requires dimensions, quality, evidence status, mechanisms, and scene boundaries."
                 }
             },
             "band_details": {
                 "foundational": {
                     "zh-CN": {
-                        "label": "基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "当前信号提示本次结果提示可以先先建立更清晰的识别、命名和复位习惯。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "基础发展中",
+                        "meaning": "当前信号提示本次结果提示可以先建立更清晰的识别、命名和复位习惯。",
                         "strength": "从一个小而重复的动作开始，进步会更稳定。",
                         "risk": "如果直接追求复杂沟通技巧，容易因为基础信号不清而挫败。",
                         "practice_focus": "每天一次情绪命名，配合一个低成本复位动作。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "The current signal suggests starting with clearer recognition, naming, and reset habits. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Foundational",
+                        "meaning": "The current self-report signal suggests starting with clearer recognition, naming, and reset habits.",
                         "strength": "Small repeatable actions can create more stable progress.",
                         "risk": "Jumping into complex communication tactics may frustrate you if the base signal is unclear.",
                         "practice_focus": "Name one emotion daily and pair it with one low-cost reset action.",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 },
                 "developing": {
                     "zh-CN": {
-                        "label": "发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "发展中",
+                        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。",
                         "strength": "你已经能抓住一部分线索，适合把它们转成固定流程。",
                         "risk": "最容易卡在“知道一点，但现场用不上”。",
                         "practice_focus": "选择一个高频场景，提前准备一句回应。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Developing",
+                        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension.",
                         "strength": "You already catch part of the signal and can turn it into a routine.",
                         "risk": "The common trap is knowing something but not using it in the moment.",
                         "practice_focus": "Pick one frequent scene and prepare one response sentence.",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 },
                 "stable": {
                     "zh-CN": {
-                        "label": "稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "多数日常场景中，你能使用这些情绪与关系能力，但仍有明确触发点。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "稳定可用",
+                        "meaning": "多数日常场景中，你能使用这些情绪与关系模式，但仍有明确触发点。",
                         "strength": "你的结果已经能支持更精细的场景训练。",
                         "risk": "稳定不等于没有代价，尤其在高强度关系环境中。",
                         "practice_focus": "找出最容易失稳的一个场景，做事后复盘。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "In many everyday settings, these emotional and relational skills are usable, with specific triggers still visible. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Stable",
+                        "meaning": "In many everyday settings, these emotional and relational patterns are easier to use, with specific triggers still visible.",
                         "strength": "Your result can support more precise scene-based practice.",
                         "risk": "Stability does not mean no cost, especially in high-intensity relational environments.",
                         "practice_focus": "Identify one scene where stability drops and review it afterward.",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 },
                 "proficient": {
                     "zh-CN": {
-                        "label": "熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "你通常能较稳定地识别、调节和处理关系信号。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "熟练成熟",
+                        "meaning": "你通常能较稳定地识别、调节和处理关系信号。",
                         "strength": "你可以把个人优势转成可复制的沟通习惯。",
                         "risk": "他人可能默认你应该一直承担稳定局面的角色。",
                         "practice_focus": "把“我能处理”升级为“我选择如何处理”。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Proficient",
+                        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency.",
                         "strength": "You can turn personal strengths into repeatable communication habits.",
                         "risk": "Others may assume you should always be the stabilizing person.",
                         "practice_focus": "Move from “I can handle this” to “I choose how to handle this.”",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 },
                 "integrated": {
                     "zh-CN": {
-                        "label": "高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "高度整合",
+                        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。",
                         "strength": "你适合把优势系统化，形成边界、修复和恢复节奏。",
                         "risk": "高整合也可能带来过度承担和高标准疲劳。",
                         "practice_focus": "建立恢复边界，避免把稳定别人变成默认责任。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Integrated",
+                        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view.",
                         "strength": "You can systematize strengths into boundaries, repair, and recovery rhythm.",
                         "risk": "High integration may still create over-responsibility and high-standard fatigue.",
                         "practice_focus": "Build recovery boundaries so stabilizing others does not become your default duty.",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 }
             }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/score_system.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/score_system.json
@@ -3,16 +3,16 @@
   "pack_id": "EQ_60",
   "global_index": {
     "zh-CN": {
-      "label": "情绪与关系综合指数 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-      "definition": "综合指数把四个自我报告维度合并成一个阅读入口，用来帮助你理解本次作答呈现的情绪与关系模式。",
-      "not_a_capability_score": "分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-      "how_to_use": "先看总览，再回到四维、质量提示、证据状态和场景边界。不要把总分当作能力排名。"
+      "label": "情绪与关系综合指数",
+      "definition": "综合指数把四个自我报告维度合并成一个阅读入口，用来概览本次作答呈现的情绪与关系自我感知模式。",
+      "not_a_capability_score": "它不是情绪能力分、真实表现分、职业竞争力分或全球正式常模排名；更适合当作进入四维和场景解释的导航。",
+      "how_to_use": "先用总览定位，再回到四维、答题质量、证据状态和现实场景。不要用总分单独评价自己或他人。"
     },
     "en": {
-      "label": "Emotional & Relational Functioning Index Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-      "definition": "The index combines four self-report dimensions into a reading entry for the emotional and relational pattern shown in this session.",
-      "not_a_capability_score": "Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-      "how_to_use": "Start with the overview, then return to dimensions, confidence, evidence status, and scene boundaries. Do not treat the total score as an ability ranking."
+      "label": "Emotional & Relational Functioning Index",
+      "definition": "The index combines four self-report dimensions into a reading entry for the emotional and relational self-perception pattern shown in this response session.",
+      "not_a_capability_score": "It is not an emotional-ability score, live-performance score, career-competitiveness score, or final global norm ranking; use it as navigation into dimensions and scene explanations.",
+      "how_to_use": "Use the overview first, then return to dimensions, response quality, evidence status, and real-life scenes. Do not use the total score by itself to judge yourself or others."
     }
   },
   "bands": {
@@ -40,82 +40,82 @@
   "dimensions": {
     "SA": {
       "zh-CN": {
-        "label": "自我觉察 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "自我觉察",
         "short_label": "自我觉察",
-        "definition": "对自己情绪、触发点和需要的自我报告识别倾向；它不是外部观察到的自我理解能力。",
+        "definition": "对自己情绪、触发点、身体信号和当下需要的自我报告识别倾向；它不是外部观察到的自我理解能力，也不保证现场表达一定清楚。",
         "what_high_can_look_like": "你能较快识别自己的感受和触发点，但仍需把觉察转化为行动。",
         "what_low_can_look_like": "情绪常在事后才变清楚，容易先反应后理解。",
         "development_question": "我此刻真正的感受和需要是什么？",
-        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "自我觉察分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
       },
       "en": {
-        "label": "Self-Awareness Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Self-Awareness",
         "short_label": "Self-Awareness",
-        "definition": "A self-reported tendency to notice emotions, triggers, and needs; it is not externally observed self-knowledge ability.",
+        "definition": "A self-reported tendency to notice emotions, triggers, body signals, and current needs; it is not externally observed self-knowledge ability and does not guarantee clear expression in the moment.",
         "what_high_can_look_like": "You can often identify feelings and triggers quickly, while still needing to turn awareness into action.",
         "what_low_can_look_like": "Feelings may become clear only afterward, making it easier to react before understanding.",
         "development_question": "What am I actually feeling and needing right now?",
-        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The Self-Awareness score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
       }
     },
     "ER": {
       "zh-CN": {
-        "label": "情绪调节 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "情绪调节",
         "short_label": "情绪调节",
-        "definition": "对自己在压力、反馈、挫败或冲突后暂停、复位和选择回应方式的自我报告倾向；它不等同于永远冷静或抗压能力证明。",
+        "definition": "对自己在压力、反馈、挫败或冲突后暂停、复位和选择回应方式的自我报告倾向；它不等同于永远冷静、压住情绪或抗压能力证明。",
         "what_high_can_look_like": "你在压力中较能暂停、恢复和选择回应，但不代表没有情绪。",
         "what_low_can_look_like": "被触发后恢复较慢，容易用回避、解释或压抑处理。",
         "development_question": "我能不能先让自己降一点温，再决定怎么回应？",
-        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "情绪调节分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
       },
       "en": {
-        "label": "Emotion Regulation Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Emotion Regulation",
         "short_label": "Emotion Regulation",
-        "definition": "A self-reported tendency to pause, reset, and choose responses after pressure, feedback, frustration, or conflict; it is not proof of being calm or resilient in every situation.",
+        "definition": "A self-reported tendency to pause, reset, and choose responses after pressure, feedback, frustration, or conflict; it is not the same as always staying calm, suppressing emotion, or proving resilience.",
         "what_high_can_look_like": "You can often pause, recover, and choose a response under pressure, without being emotionless.",
         "what_low_can_look_like": "Recovery may take longer after being triggered, with avoidance, over-explaining, or suppression becoming common.",
         "development_question": "Can I lower the heat first before choosing my response?",
-        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The Emotion Regulation score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
       }
     },
     "EM": {
       "zh-CN": {
-        "label": "共情理解 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "共情理解",
         "short_label": "共情理解",
-        "definition": "对他人情绪线索、观点和可能感受的自我报告理解倾向；它不等同于实际读心准确率、亲社会行为或替他人承担情绪。",
+        "definition": "对他人情绪线索、观点和可能感受的自我报告理解倾向；它包含认知共情和情感共鸣线索，但不等同于读心准确率、亲社会行为或替他人承担情绪痛苦。",
         "what_high_can_look_like": "你能敏锐捕捉他人的状态，但需要避免过度吸收。",
         "what_low_can_look_like": "可能更关注任务或事实，较容易漏过对方的情绪线索。",
         "development_question": "对方真正担心或在意的是什么？",
-        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "共情理解分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
       },
       "en": {
-        "label": "Empathy Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Empathy",
         "short_label": "Empathy",
-        "definition": "A self-reported tendency to understand others’ emotional cues, perspectives, and possible feelings; it is not the same as actual mind-reading accuracy, prosocial behavior, or carrying others’ emotions.",
+        "definition": "A self-reported tendency to understand others’ emotional cues, perspectives, and possible feelings; it may reflect cognitive and affective empathy signals, but it is not mind-reading accuracy, prosocial behavior, or taking on others’ distress.",
         "what_high_can_look_like": "You can notice others’ emotional states, while still needing boundaries against over-absorbing.",
         "what_low_can_look_like": "You may focus on tasks or facts and miss some emotional cues.",
         "development_question": "What is the other person really concerned about?",
-        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The Empathy score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
       }
     },
     "RM": {
       "zh-CN": {
-        "label": "关系管理 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "关系管理",
         "short_label": "关系管理",
-        "definition": "对表达、协作、边界和修复的自我报告倾向；它不直接预测关系质量、领导力或他人评价。",
+        "definition": "对表达、协作、边界和关系修复的自我报告倾向；它不直接预测关系质量、领导力、受欢迎程度或他人评价。",
         "what_high_can_look_like": "你能维护沟通和关系质量，但仍需留意真实表达和边界。",
         "what_low_can_look_like": "知道自己或对方感受后，不一定能把对话修复或推进。",
         "development_question": "这句话怎样说，既真实又能让关系继续对话？",
-        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "关系管理分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
       },
       "en": {
-        "label": "Relationship Management Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Relationship Management",
         "short_label": "Relationship Management",
-        "definition": "A self-reported tendency around expression, collaboration, boundaries, and repair; it does not directly predict relationship quality, leadership, or others’ evaluations.",
+        "definition": "A self-reported tendency around expression, collaboration, boundaries, and relationship repair; it does not directly predict relationship quality, leadership, popularity, or others’ evaluations.",
         "what_high_can_look_like": "You can maintain communication and relationship quality, while still watching for honest expression and boundaries.",
         "what_low_can_look_like": "Even when feelings are clear, repairing or moving the conversation forward may be harder.",
         "development_question": "How can I say this honestly while keeping the conversation open?",
-        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The Relationship Management score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
       }
     }
   },
@@ -123,517 +123,517 @@
     "SA": {
       "foundational": {
         "zh-CN": {
-          "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。",
           "strength": "愿意回头复盘时，能够逐步看见真实感受。",
           "risk": "现场容易先解释、压住或转移，之后才发现自己被触发。",
           "typical_scene": "别人问“你怎么了”时，你可能需要一段时间才说得清。",
           "practice_focus": "每天记录一个情绪词、一个触发点和一个身体反应。",
-          "do_not_overread": "这不代表你不懂自己，只说明当下觉察信号还需要更稳定的捕捉方式。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 基础发展中"
         },
         "en": {
-          "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably.",
           "strength": "When you review an event afterward, you can gradually identify what was actually happening inside.",
           "risk": "In the moment, you may explain, suppress, or move on before noticing that you were triggered.",
           "typical_scene": "When someone asks what is wrong, you may need time before you can answer clearly.",
           "practice_focus": "Track one emotion word, one trigger, and one body signal each day.",
-          "do_not_overread": "This does not mean you lack self-understanding; it means your emotional signals need a more stable capture method. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Foundational"
         }
       },
       "developing": {
         "zh-CN": {
-          "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。",
           "strength": "你开始能把情绪从混乱体验里拆出来。",
           "risk": "觉察到情绪后，可能仍会被它带着走。",
           "typical_scene": "收到批评时，你能意识到不舒服，但需要时间判断这份不舒服来自哪里。",
           "practice_focus": "用“我感到…因为我在意…”练习把感受说具体。",
-          "do_not_overread": "发展中不是不稳定人格，而是觉察速度和表达精度仍在形成。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 发展中"
         },
         "en": {
-          "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly.",
           "strength": "You are beginning to separate emotion from the overall sense of confusion.",
           "risk": "After noticing a feeling, you may still be carried by it before choosing a response.",
           "typical_scene": "When criticized, you know something feels uncomfortable but need time to identify the source.",
           "practice_focus": "Practice the sentence: “I feel... because I care about...”",
-          "do_not_overread": "Developing does not mean an unstable personality; it means speed and precision of awareness are still forming. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Developing"
         }
       },
       "stable": {
         "zh-CN": {
-          "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。",
           "strength": "你通常能说清楚自己为什么被影响。",
           "risk": "压力升高时，觉察可能变成反复分析，而不是行动。",
           "typical_scene": "复盘一次对话时，你能指出哪个细节让自己紧张或防御。",
           "practice_focus": "每次觉察后补一句：“我现在可以选择的下一步是…”。",
-          "do_not_overread": "稳定可用不等于任何场景都冷静，只表示多数日常场景有可靠基础。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 稳定可用"
         },
         "en": {
-          "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure.",
           "strength": "You can usually explain why something affected you.",
           "risk": "Under higher pressure, awareness may turn into repeated analysis rather than action.",
           "typical_scene": "When reviewing a conversation, you can point to the detail that made you tense or defensive.",
           "practice_focus": "After naming the feeling, add: “The next step I can choose is...”",
-          "do_not_overread": "Stable does not mean calm in every situation; it means you have a reliable base in most everyday settings. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Stable"
         }
       },
       "proficient": {
         "zh-CN": {
-          "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。",
           "strength": "你能把复杂感受组织成比较清楚的表达。",
           "risk": "容易把每个反应都分析得很细，反而延迟沟通或恢复。",
           "typical_scene": "在重要对话前，你能预判自己可能被哪些点触发。",
           "practice_focus": "给觉察设时间盒：命名、确认需要、选择一个小行动。",
-          "do_not_overread": "熟练成熟不代表你必须解释所有感受，也不代表别人一定会立即理解。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 熟练成熟"
         },
         "en": {
-          "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis.",
           "strength": "You can organize complex feelings into relatively clear expression.",
           "risk": "You may analyze every reaction in detail and delay communication or recovery.",
           "typical_scene": "Before an important conversation, you can anticipate which points may trigger you.",
           "practice_focus": "Time-box awareness: name the feeling, identify the need, then choose one small action.",
-          "do_not_overread": "Proficient does not mean you must explain every feeling, or that others will immediately understand it. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Proficient"
         }
       },
       "integrated": {
         "zh-CN": {
-          "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。",
           "strength": "你能在真实场景中使用觉察，而不只是事后理解。",
           "risk": "可能默认自己必须一直清楚、一直成熟，从而忽略疲劳。",
           "typical_scene": "冲突中，你能觉察自己的防御反应，并调整说话方式。",
           "practice_focus": "保留轻量复盘，重点观察“我是否也给了自己恢复空间”。",
-          "do_not_overread": "高度整合不是永远理性，而是更常能在觉察和行动之间保持连接。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 高度整合"
         },
         "en": {
-          "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover.",
           "strength": "You can use awareness in real time, not only in later reflection.",
           "risk": "You may expect yourself to stay clear and mature all the time, which can hide fatigue.",
           "typical_scene": "In conflict, you can notice defensiveness and adjust how you speak.",
           "practice_focus": "Keep a light review habit and ask: “Did I also give myself room to recover?”",
-          "do_not_overread": "Integrated does not mean permanently rational; it means awareness and action stay connected more often. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Integrated"
         }
       }
     },
     "ER": {
       "foundational": {
         "zh-CN": {
-          "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。",
           "strength": "你能从明显的情绪反应中发现需要练习的场景。",
           "risk": "压力下容易直接回应、回避或进入长时间内耗。",
           "typical_scene": "冲突结束后，你可能还会在脑中反复回放很久。",
           "practice_focus": "先练 30 秒暂停：停下、呼吸、说“我需要一点时间”。",
-          "do_not_overread": "这不等于情绪失控，只说明恢复策略还没有稳定自动化。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 基础发展中"
         },
         "en": {
-          "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately.",
           "strength": "Clear emotional reactions can show you exactly which situations need practice.",
           "risk": "Under stress, you may respond too quickly, avoid the issue, or stay mentally stuck afterward.",
           "typical_scene": "After a conflict, you may replay the conversation for a long time.",
           "practice_focus": "Practice a 30-second pause: stop, breathe, and say, “I need a little time.”",
-          "do_not_overread": "This does not mean you are out of control; it means recovery strategies are not yet automatic. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Foundational"
         }
       },
       "developing": {
         "zh-CN": {
-          "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。",
           "strength": "你已经知道某些做法能帮自己缓下来。",
           "risk": "情绪强度一高，原本有效的方法可能想不起来。",
           "typical_scene": "你知道先不要回消息更好，但仍可能忍不住马上解释。",
           "practice_focus": "准备一个固定恢复菜单：离开现场、写三句话、延迟回复。",
-          "do_not_overread": "发展中不代表无法调节，而是需要把策略从偶发变成默认选项。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 发展中"
         },
         "en": {
-          "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process.",
           "strength": "You already know that some actions help you settle.",
           "risk": "When intensity rises, strategies that usually work may be hard to remember.",
           "typical_scene": "You know it would be better not to reply immediately, but still feel pulled to explain.",
           "practice_focus": "Prepare a recovery menu: step away, write three sentences, delay the reply.",
-          "do_not_overread": "Developing does not mean you cannot regulate; it means strategy needs to become a default option. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Developing"
         }
       },
       "stable": {
         "zh-CN": {
-          "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。",
           "strength": "你能把情绪从“主导全局”降到“可以被管理”。",
           "risk": "如果持续压着自己保持稳定，后续可能出现疲劳或延迟爆发。",
           "typical_scene": "紧张会议后，你能逐渐恢复工作节奏。",
           "practice_focus": "给恢复安排边界：什么时候暂停、什么时候回来处理。",
-          "do_not_overread": "稳定可用不是没有波动，而是多数时候能回到可选择状态。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 稳定可用"
         },
         "en": {
-          "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder.",
           "strength": "You can reduce emotion from “running the situation” to “something manageable.”",
           "risk": "If you keep forcing yourself to stay stable, fatigue or delayed escalation may follow.",
           "typical_scene": "After a tense meeting, you can gradually return to your work rhythm.",
           "practice_focus": "Set recovery boundaries: when to pause and when to return to the issue.",
-          "do_not_overread": "Stable does not mean no fluctuation; it means you can usually return to a state of choice. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Stable"
         }
       },
       "proficient": {
         "zh-CN": {
-          "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。",
           "strength": "你能为沟通争取到更好的时机和语气。",
           "risk": "有时会显得太冷静，让别人感受不到你的真实立场。",
           "typical_scene": "被挑战时，你能先稳住语气，再回应重点。",
           "practice_focus": "调节后补充真实表达：“我需要想清楚，但这件事对我重要。”",
-          "do_not_overread": "熟练调节不等于必须压住情绪，真实表达仍然是关系信息。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 熟练成熟"
         },
         "en": {
-          "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance.",
           "strength": "You can create better timing and tone for communication.",
           "risk": "At times, you may appear so calm that others cannot read your real position.",
           "typical_scene": "When challenged, you can steady your tone before addressing the point.",
           "practice_focus": "After regulating, add authentic expression: “I need to think, but this matters to me.”",
-          "do_not_overread": "Proficient regulation does not mean suppressing emotion; honest expression is still relational information. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Proficient"
         }
       },
       "integrated": {
         "zh-CN": {
-          "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。",
           "strength": "你能让情绪成为信息，而不是让它接管关系或判断。",
           "risk": "别人可能过度依赖你的稳定，你也可能承担过多调停责任。",
           "typical_scene": "冲突中，你能暂停升级，同时保留清晰边界。",
           "practice_focus": "定期检查：我是在稳定局面，还是在替所有人承担情绪成本？",
-          "do_not_overread": "高度整合不是永远平静，而是更能在高压中保留恢复和选择。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 高度整合"
         },
         "en": {
-          "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy.",
           "strength": "You can use emotion as information instead of letting it take over relationships or judgment.",
           "risk": "Others may rely too heavily on your stability, and you may take on too much mediation.",
           "typical_scene": "In conflict, you can slow escalation while keeping a clear boundary.",
           "practice_focus": "Check regularly: “Am I stabilizing the situation, or carrying everyone’s emotional cost?”",
-          "do_not_overread": "Integrated does not mean permanently calm; it means more room for recovery and choice under pressure. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Integrated"
         }
       }
     },
     "EM": {
       "foundational": {
         "zh-CN": {
-          "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。",
           "strength": "你可以通过直接提问建立更清楚的信息。",
           "risk": "容易把沉默、语气或表情理解得过少或过多。",
           "typical_scene": "对方说“没事”时，你不确定该继续问还是停下。",
           "practice_focus": "使用确认句：“我不确定我理解得对不对，你现在更需要空间还是回应？”",
-          "do_not_overread": "这不代表你冷漠，只说明读取线索时需要更明确的信息支持。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 基础发展中"
         },
         "en": {
-          "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking.",
           "strength": "Direct questions can give you clearer information.",
           "risk": "You may read too little or too much into silence, tone, or facial expression.",
           "typical_scene": "When someone says “I’m fine,” you are not sure whether to ask again or step back.",
           "practice_focus": "Use a checking sentence: “I may be wrong; do you need space or a response right now?”",
-          "do_not_overread": "This does not mean you are uncaring; it means cue reading needs clearer information support. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Foundational"
         }
       },
       "developing": {
         "zh-CN": {
-          "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。",
           "strength": "你开始关注关系中的情绪温度。",
           "risk": "可能过早判断别人不高兴、失望或疏远。",
           "typical_scene": "朋友回复变短时，你会察觉异常，但不确定原因。",
           "practice_focus": "把判断拆成两句：我观察到什么？我还不知道什么？",
-          "do_not_overread": "发展中不代表共情差，而是需要让共情建立在证据上。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 发展中"
         },
         "en": {
-          "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation.",
           "strength": "You are starting to track the emotional temperature in relationships.",
           "risk": "You may too quickly assume someone is upset, disappointed, or distant.",
           "typical_scene": "When a friend’s replies become shorter, you notice a shift but do not know the reason.",
           "practice_focus": "Split the judgment into two questions: What did I observe? What do I not know yet?",
-          "do_not_overread": "Developing does not mean weak empathy; it means empathy needs to be grounded in evidence. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Developing"
         }
       },
       "stable": {
         "zh-CN": {
-          "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。",
           "strength": "你能让对方感到被看见和被认真对待。",
           "risk": "在关系压力中，可能为了照顾别人而忽略自己的容量。",
           "typical_scene": "同事语气紧张时，你能意识到对方可能在承压。",
           "practice_focus": "共情后加一句边界：“我理解你现在很难，我能帮的是…”",
-          "do_not_overread": "稳定共情不是读心，也不是无限承担别人的情绪。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 稳定可用"
         },
         "en": {
-          "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them.",
           "strength": "You can help others feel seen and taken seriously.",
           "risk": "Under relational pressure, you may ignore your own capacity while caring for others.",
           "typical_scene": "When a colleague sounds tense, you can recognize that they may be under pressure.",
           "practice_focus": "After empathy, add a boundary: “I understand this is hard; what I can help with is...”",
-          "do_not_overread": "Stable empathy is not mind-reading, and it is not unlimited responsibility for another person’s emotion. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Stable"
         }
       },
       "proficient": {
         "zh-CN": {
-          "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。",
           "strength": "你能在复杂关系中捕捉未说出口的信息。",
           "risk": "容易把别人的紧张、失望或期待变成自己的责任。",
           "typical_scene": "会议里气氛变了，你能很快察觉谁在退缩或不安。",
           "practice_focus": "先验证再承担：“我感觉你可能有顾虑，我理解对吗？”",
-          "do_not_overread": "熟练共情不等于你必须解决所有人的感受。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 熟练成熟"
         },
         "en": {
-          "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries.",
           "strength": "You can notice unspoken information in complex relationships.",
           "risk": "You may turn others’ tension, disappointment, or expectations into your responsibility.",
           "typical_scene": "When the mood changes in a meeting, you quickly notice who is withdrawing or uneasy.",
           "practice_focus": "Validate before carrying: “I sense you may have a concern; am I reading that correctly?”",
-          "do_not_overread": "Proficient empathy does not mean you must solve everyone’s feelings. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Proficient"
         }
       },
       "integrated": {
         "zh-CN": {
-          "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。",
           "strength": "你能在理解别人时仍保持清晰位置。",
           "risk": "别人可能习惯向你倾倒情绪，你也可能被期待持续照顾场面。",
           "typical_scene": "对方情绪很强时，你能回应感受，同时不接下不属于你的责任。",
           "practice_focus": "练习“理解 + 边界 + 下一步”三段回应。",
-          "do_not_overread": "高度整合的共情不是永远温柔，而是能同时保留理解和判断。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 高度整合"
         },
         "en": {
-          "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility.",
           "strength": "You can understand others while keeping a clear position.",
           "risk": "Others may become used to unloading emotion onto you, and you may be expected to manage the room.",
           "typical_scene": "When someone is highly emotional, you can respond to the feeling without taking responsibility that is not yours.",
           "practice_focus": "Practice a three-part response: understanding, boundary, next step.",
-          "do_not_overread": "Integrated empathy is not endless softness; it is the ability to hold understanding and judgment together. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Integrated"
         }
       }
     },
     "RM": {
       "foundational": {
         "zh-CN": {
-          "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。",
           "strength": "只要有清楚步骤，你可以逐步提升关系处理能力。",
           "risk": "容易在不舒服时沉默、解释过多或直接退出。",
           "typical_scene": "争执后，你知道需要修复，但不知道第一句话怎么说。",
           "practice_focus": "准备一句开场：“刚才那段对话有点卡住了，我想重新说一次。”",
-          "do_not_overread": "这不代表你不重视关系，只说明修复工具还不够熟。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 基础发展中"
         },
         "en": {
-          "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again.",
           "strength": "With clear steps, your relationship skills can improve steadily.",
           "risk": "When uncomfortable, you may go silent, over-explain, or exit the conversation.",
           "typical_scene": "After an argument, you know repair is needed but do not know the first sentence.",
           "practice_focus": "Prepare an opener: “That conversation got stuck. I’d like to try saying it again.”",
-          "do_not_overread": "This does not mean you do not value relationships; it means repair tools are not yet familiar. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Foundational"
         }
       },
       "developing": {
         "zh-CN": {
-          "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。",
           "strength": "你已经能意识到关系需要被处理，而不是只等它过去。",
           "risk": "可能一边想维护关系，一边又把真实想法说得不够清楚。",
           "typical_scene": "你想缓和气氛，但担心一开口又引发冲突。",
           "practice_focus": "使用“事实 + 感受 + 请求”三句结构。",
-          "do_not_overread": "发展中不代表关系能力差，而是现场压力下需要更可依赖的表达框架。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 发展中"
         },
         "en": {
-          "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance.",
           "strength": "You already recognize that relationships need to be addressed, not simply waited out.",
           "risk": "You may try to preserve the relationship while leaving your real position unclear.",
           "typical_scene": "You want to ease the atmosphere but worry that speaking will restart the conflict.",
           "practice_focus": "Use a three-sentence structure: fact, feeling, request.",
-          "do_not_overread": "Developing does not mean weak relationship ability; it means pressure requires a more reliable expression frame. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Developing"
         }
       },
       "stable": {
         "zh-CN": {
-          "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。",
           "strength": "你能让关系在小摩擦后回到可合作状态。",
           "risk": "为了维持顺畅，可能回避更难但必要的话题。",
           "typical_scene": "误会出现后，你通常愿意解释并重新对齐。",
           "practice_focus": "在修复之外补充边界：“下次我们可以用这个方式处理。”",
-          "do_not_overread": "稳定可用不等于没有冲突，而是多数冲突后还能回到工作关系。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 稳定可用"
         },
         "en": {
-          "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations.",
           "strength": "You can help a relationship return to cooperation after small friction.",
           "risk": "To keep things smooth, you may avoid harder but necessary topics.",
           "typical_scene": "After a misunderstanding, you are usually willing to explain and realign.",
           "practice_focus": "Add a boundary after repair: “Next time, we can handle it this way.”",
-          "do_not_overread": "Stable does not mean no conflict; it means most conflicts can return to a workable relationship. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Stable"
         }
       },
       "proficient": {
         "zh-CN": {
-          "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。",
           "strength": "你能把冲突转化为更清楚的协作规则。",
           "risk": "别人可能默认你来收拾关系残局。",
           "typical_scene": "团队意见不合时，你能帮助大家回到事实和下一步。",
           "practice_focus": "在协调前先确认职责：“这件事需要谁来决定，谁来执行？”",
-          "do_not_overread": "熟练关系管理不是永远做中间人，也不是牺牲自己的边界。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 熟练成熟"
         },
         "en": {
-          "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role.",
           "strength": "You can turn conflict into clearer rules for collaboration.",
           "risk": "Others may assume you will clean up the relational aftermath.",
           "typical_scene": "When a team disagrees, you can help people return to facts and next steps.",
           "practice_focus": "Before coordinating, clarify roles: “Who decides this, and who executes it?”",
-          "do_not_overread": "Proficient relationship management is not permanent mediation, and it does not require sacrificing your boundary. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Proficient"
         }
       },
       "integrated": {
         "zh-CN": {
-          "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。",
           "strength": "你能在复杂关系中创造清晰、可持续的合作方式。",
           "risk": "因为你能处理关系，系统可能把过多情绪劳动交给你。",
           "typical_scene": "冲突升级时，你能帮助各方降温、对齐目标，并明确责任。",
           "practice_focus": "把个人调停转成系统规则：节奏、边界、责任和复盘。",
-          "do_not_overread": "高度整合不代表你必须承担所有关系维护工作。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 高度整合"
         },
         "en": {
-          "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone.",
           "strength": "You can create clear and sustainable collaboration in complex relationships.",
           "risk": "Because you can handle relationships, the system may hand you too much emotional labor.",
           "typical_scene": "When conflict escalates, you can help people cool down, align goals, and clarify responsibility.",
           "practice_focus": "Turn personal mediation into system rules: rhythm, boundary, responsibility, and review.",
-          "do_not_overread": "Integrated does not mean you must carry all relationship maintenance. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Integrated"
         }
       }
     }
   },
   "score_notes": {
     "zh-CN": {
-      "percentile": "百分位只表示在当前阶段性样本中的相对位置感，不是能力排名、真实水平排名或全球正式常模排名。",
-      "standard_score": "标准分用于稳定展示和维度比较；它是解释入口，不是现场表现证明。",
-      "band": "等级用于帮助阅读，不代表固定人格、能力证书或临床/职业判断。",
-      "provisional_norm": "当前常模为阶段性常模，后续样本、语言和版本更新可能改变解释边界。",
-      "commercial_boundary": "总分用于定位阅读入口，最终解释以四维、质量、证据状态和场景边界为准。"
+      "percentile": "百分位只表示当前阶段性样本中的相对位置参考，不是能力排名、真实水平排名、全球正式常模排名或职业竞争力排名。",
+      "standard_score": "标准分用于稳定展示和维度比较，是阅读入口，不是现场表现证明或能力证明。",
+      "band": "等级用于降低阅读负担，不代表固定人格、能力证书、临床结论、招聘信号或职业判断。",
+      "provisional_norm": "当前常模为阶段性常模，后续样本、语言版本和内容版本更新都可能改变解释边界。",
+      "commercial_boundary": "总分不应单独使用；完整解释必须结合四维、质量、证据状态、机制和场景边界。"
     },
     "en": {
-      "percentile": "Percentile only describes relative position in the current provisional sample. It is not an ability ranking, true-level ranking, or final global norm.",
-      "standard_score": "Standard score supports stable display and dimension comparison; it is a reading entry, not proof of live performance.",
-      "band": "Bands help users read the result; they are not fixed identities, credentials, clinical findings, or work decisions.",
-      "provisional_norm": "Current norms are provisional. Future samples, languages, and versions may change interpretation boundaries.",
-      "commercial_boundary": "The total score is a reading entry; interpretation depends on dimensions, confidence, evidence status, and scene boundaries."
+      "percentile": "Percentile only provides a relative-position reference within the current provisional sample. It is not an ability ranking, true-level ranking, final global norm, or career-competitiveness ranking.",
+      "standard_score": "Standard score supports stable display and dimension comparison. It is a reading entry, not proof of live performance or ability.",
+      "band": "Bands reduce reading effort; they are not fixed identities, credentials, clinical findings, hiring signals, or career judgments.",
+      "provisional_norm": "Current norms are provisional. Future samples, language versions, and content versions may change interpretation boundaries.",
+      "commercial_boundary": "The total score should not be used alone; full interpretation requires dimensions, quality, evidence status, mechanisms, and scene boundaries."
     }
   },
   "band_details": {
     "foundational": {
       "zh-CN": {
-        "label": "基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "当前信号提示本次结果提示可以先先建立更清晰的识别、命名和复位习惯。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "基础发展中",
+        "meaning": "当前信号提示本次结果提示可以先建立更清晰的识别、命名和复位习惯。",
         "strength": "从一个小而重复的动作开始，进步会更稳定。",
         "risk": "如果直接追求复杂沟通技巧，容易因为基础信号不清而挫败。",
         "practice_focus": "每天一次情绪命名，配合一个低成本复位动作。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "The current signal suggests starting with clearer recognition, naming, and reset habits. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Foundational",
+        "meaning": "The current self-report signal suggests starting with clearer recognition, naming, and reset habits.",
         "strength": "Small repeatable actions can create more stable progress.",
         "risk": "Jumping into complex communication tactics may frustrate you if the base signal is unclear.",
         "practice_focus": "Name one emotion daily and pair it with one low-cost reset action.",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     },
     "developing": {
       "zh-CN": {
-        "label": "发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "发展中",
+        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。",
         "strength": "你已经能抓住一部分线索，适合把它们转成固定流程。",
         "risk": "最容易卡在“知道一点，但现场用不上”。",
         "practice_focus": "选择一个高频场景，提前准备一句回应。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Developing",
+        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension.",
         "strength": "You already catch part of the signal and can turn it into a routine.",
         "risk": "The common trap is knowing something but not using it in the moment.",
         "practice_focus": "Pick one frequent scene and prepare one response sentence.",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     },
     "stable": {
       "zh-CN": {
-        "label": "稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "多数日常场景中，你能使用这些情绪与关系能力，但仍有明确触发点。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "稳定可用",
+        "meaning": "多数日常场景中，你能使用这些情绪与关系模式，但仍有明确触发点。",
         "strength": "你的结果已经能支持更精细的场景训练。",
         "risk": "稳定不等于没有代价，尤其在高强度关系环境中。",
         "practice_focus": "找出最容易失稳的一个场景，做事后复盘。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "In many everyday settings, these emotional and relational skills are usable, with specific triggers still visible. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Stable",
+        "meaning": "In many everyday settings, these emotional and relational patterns are easier to use, with specific triggers still visible.",
         "strength": "Your result can support more precise scene-based practice.",
         "risk": "Stability does not mean no cost, especially in high-intensity relational environments.",
         "practice_focus": "Identify one scene where stability drops and review it afterward.",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     },
     "proficient": {
       "zh-CN": {
-        "label": "熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "你通常能较稳定地识别、调节和处理关系信号。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "熟练成熟",
+        "meaning": "你通常能较稳定地识别、调节和处理关系信号。",
         "strength": "你可以把个人优势转成可复制的沟通习惯。",
         "risk": "他人可能默认你应该一直承担稳定局面的角色。",
         "practice_focus": "把“我能处理”升级为“我选择如何处理”。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Proficient",
+        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency.",
         "strength": "You can turn personal strengths into repeatable communication habits.",
         "risk": "Others may assume you should always be the stabilizing person.",
         "practice_focus": "Move from “I can handle this” to “I choose how to handle this.”",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     },
     "integrated": {
       "zh-CN": {
-        "label": "高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "高度整合",
+        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。",
         "strength": "你适合把优势系统化，形成边界、修复和恢复节奏。",
         "risk": "高整合也可能带来过度承担和高标准疲劳。",
         "practice_focus": "建立恢复边界，避免把稳定别人变成默认责任。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Integrated",
+        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view.",
         "strength": "You can systematize strengths into boundaries, repair, and recovery rhythm.",
         "risk": "High integration may still create over-responsibility and high-standard fatigue.",
         "practice_focus": "Build recovery boundaries so stabilizing others does not become your default duty.",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T17:08:38.421048Z",
+    "generated_at": "2026-07-02T17:18:52.198969Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -41,16 +41,16 @@
             "pack_id": "EQ_60",
             "global_index": {
                 "zh-CN": {
-                    "label": "情绪与关系综合指数 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                    "definition": "综合指数把四个自我报告维度合并成一个阅读入口，用来帮助你理解本次作答呈现的情绪与关系模式。",
-                    "not_a_capability_score": "分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                    "how_to_use": "先看总览，再回到四维、质量提示、证据状态和场景边界。不要把总分当作能力排名。"
+                    "label": "情绪与关系综合指数",
+                    "definition": "综合指数把四个自我报告维度合并成一个阅读入口，用来概览本次作答呈现的情绪与关系自我感知模式。",
+                    "not_a_capability_score": "它不是情绪能力分、真实表现分、职业竞争力分或全球正式常模排名；更适合当作进入四维和场景解释的导航。",
+                    "how_to_use": "先用总览定位，再回到四维、答题质量、证据状态和现实场景。不要用总分单独评价自己或他人。"
                 },
                 "en": {
-                    "label": "Emotional & Relational Functioning Index Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                    "definition": "The index combines four self-report dimensions into a reading entry for the emotional and relational pattern shown in this session.",
-                    "not_a_capability_score": "Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                    "how_to_use": "Start with the overview, then return to dimensions, confidence, evidence status, and scene boundaries. Do not treat the total score as an ability ranking."
+                    "label": "Emotional & Relational Functioning Index",
+                    "definition": "The index combines four self-report dimensions into a reading entry for the emotional and relational self-perception pattern shown in this response session.",
+                    "not_a_capability_score": "It is not an emotional-ability score, live-performance score, career-competitiveness score, or final global norm ranking; use it as navigation into dimensions and scene explanations.",
+                    "how_to_use": "Use the overview first, then return to dimensions, response quality, evidence status, and real-life scenes. Do not use the total score by itself to judge yourself or others."
                 }
             },
             "bands": {
@@ -78,82 +78,82 @@
             "dimensions": {
                 "SA": {
                     "zh-CN": {
-                        "label": "自我觉察 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "自我觉察",
                         "short_label": "自我觉察",
-                        "definition": "对自己情绪、触发点和需要的自我报告识别倾向；它不是外部观察到的自我理解能力。",
+                        "definition": "对自己情绪、触发点、身体信号和当下需要的自我报告识别倾向；它不是外部观察到的自我理解能力，也不保证现场表达一定清楚。",
                         "what_high_can_look_like": "你能较快识别自己的感受和触发点，但仍需把觉察转化为行动。",
                         "what_low_can_look_like": "情绪常在事后才变清楚，容易先反应后理解。",
                         "development_question": "我此刻真正的感受和需要是什么？",
-                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "自我觉察分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
                     },
                     "en": {
-                        "label": "Self-Awareness Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Self-Awareness",
                         "short_label": "Self-Awareness",
-                        "definition": "A self-reported tendency to notice emotions, triggers, and needs; it is not externally observed self-knowledge ability.",
+                        "definition": "A self-reported tendency to notice emotions, triggers, body signals, and current needs; it is not externally observed self-knowledge ability and does not guarantee clear expression in the moment.",
                         "what_high_can_look_like": "You can often identify feelings and triggers quickly, while still needing to turn awareness into action.",
                         "what_low_can_look_like": "Feelings may become clear only afterward, making it easier to react before understanding.",
                         "development_question": "What am I actually feeling and needing right now?",
-                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The Self-Awareness score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
                     }
                 },
                 "ER": {
                     "zh-CN": {
-                        "label": "情绪调节 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "情绪调节",
                         "short_label": "情绪调节",
-                        "definition": "对自己在压力、反馈、挫败或冲突后暂停、复位和选择回应方式的自我报告倾向；它不等同于永远冷静或抗压能力证明。",
+                        "definition": "对自己在压力、反馈、挫败或冲突后暂停、复位和选择回应方式的自我报告倾向；它不等同于永远冷静、压住情绪或抗压能力证明。",
                         "what_high_can_look_like": "你在压力中较能暂停、恢复和选择回应，但不代表没有情绪。",
                         "what_low_can_look_like": "被触发后恢复较慢，容易用回避、解释或压抑处理。",
                         "development_question": "我能不能先让自己降一点温，再决定怎么回应？",
-                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "情绪调节分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
                     },
                     "en": {
-                        "label": "Emotion Regulation Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Emotion Regulation",
                         "short_label": "Emotion Regulation",
-                        "definition": "A self-reported tendency to pause, reset, and choose responses after pressure, feedback, frustration, or conflict; it is not proof of being calm or resilient in every situation.",
+                        "definition": "A self-reported tendency to pause, reset, and choose responses after pressure, feedback, frustration, or conflict; it is not the same as always staying calm, suppressing emotion, or proving resilience.",
                         "what_high_can_look_like": "You can often pause, recover, and choose a response under pressure, without being emotionless.",
                         "what_low_can_look_like": "Recovery may take longer after being triggered, with avoidance, over-explaining, or suppression becoming common.",
                         "development_question": "Can I lower the heat first before choosing my response?",
-                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The Emotion Regulation score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
                     }
                 },
                 "EM": {
                     "zh-CN": {
-                        "label": "共情理解 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "共情理解",
                         "short_label": "共情理解",
-                        "definition": "对他人情绪线索、观点和可能感受的自我报告理解倾向；它不等同于实际读心准确率、亲社会行为或替他人承担情绪。",
+                        "definition": "对他人情绪线索、观点和可能感受的自我报告理解倾向；它包含认知共情和情感共鸣线索，但不等同于读心准确率、亲社会行为或替他人承担情绪痛苦。",
                         "what_high_can_look_like": "你能敏锐捕捉他人的状态，但需要避免过度吸收。",
                         "what_low_can_look_like": "可能更关注任务或事实，较容易漏过对方的情绪线索。",
                         "development_question": "对方真正担心或在意的是什么？",
-                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "共情理解分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
                     },
                     "en": {
-                        "label": "Empathy Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Empathy",
                         "short_label": "Empathy",
-                        "definition": "A self-reported tendency to understand others’ emotional cues, perspectives, and possible feelings; it is not the same as actual mind-reading accuracy, prosocial behavior, or carrying others’ emotions.",
+                        "definition": "A self-reported tendency to understand others’ emotional cues, perspectives, and possible feelings; it may reflect cognitive and affective empathy signals, but it is not mind-reading accuracy, prosocial behavior, or taking on others’ distress.",
                         "what_high_can_look_like": "You can notice others’ emotional states, while still needing boundaries against over-absorbing.",
                         "what_low_can_look_like": "You may focus on tasks or facts and miss some emotional cues.",
                         "development_question": "What is the other person really concerned about?",
-                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The Empathy score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
                     }
                 },
                 "RM": {
                     "zh-CN": {
-                        "label": "关系管理 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "关系管理",
                         "short_label": "关系管理",
-                        "definition": "对表达、协作、边界和修复的自我报告倾向；它不直接预测关系质量、领导力或他人评价。",
+                        "definition": "对表达、协作、边界和关系修复的自我报告倾向；它不直接预测关系质量、领导力、受欢迎程度或他人评价。",
                         "what_high_can_look_like": "你能维护沟通和关系质量，但仍需留意真实表达和边界。",
                         "what_low_can_look_like": "知道自己或对方感受后，不一定能把对话修复或推进。",
                         "development_question": "这句话怎样说，既真实又能让关系继续对话？",
-                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "关系管理分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
                     },
                     "en": {
-                        "label": "Relationship Management Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Relationship Management",
                         "short_label": "Relationship Management",
-                        "definition": "A self-reported tendency around expression, collaboration, boundaries, and repair; it does not directly predict relationship quality, leadership, or others’ evaluations.",
+                        "definition": "A self-reported tendency around expression, collaboration, boundaries, and relationship repair; it does not directly predict relationship quality, leadership, popularity, or others’ evaluations.",
                         "what_high_can_look_like": "You can maintain communication and relationship quality, while still watching for honest expression and boundaries.",
                         "what_low_can_look_like": "Even when feelings are clear, repairing or moving the conversation forward may be harder.",
                         "development_question": "How can I say this honestly while keeping the conversation open?",
-                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The Relationship Management score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
                     }
                 }
             },
@@ -161,517 +161,517 @@
                 "SA": {
                     "foundational": {
                         "zh-CN": {
-                            "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。",
                             "strength": "愿意回头复盘时，能够逐步看见真实感受。",
                             "risk": "现场容易先解释、压住或转移，之后才发现自己被触发。",
                             "typical_scene": "别人问“你怎么了”时，你可能需要一段时间才说得清。",
                             "practice_focus": "每天记录一个情绪词、一个触发点和一个身体反应。",
-                            "do_not_overread": "这不代表你不懂自己，只说明当下觉察信号还需要更稳定的捕捉方式。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 基础发展中"
                         },
                         "en": {
-                            "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably.",
                             "strength": "When you review an event afterward, you can gradually identify what was actually happening inside.",
                             "risk": "In the moment, you may explain, suppress, or move on before noticing that you were triggered.",
                             "typical_scene": "When someone asks what is wrong, you may need time before you can answer clearly.",
                             "practice_focus": "Track one emotion word, one trigger, and one body signal each day.",
-                            "do_not_overread": "This does not mean you lack self-understanding; it means your emotional signals need a more stable capture method. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Foundational"
                         }
                     },
                     "developing": {
                         "zh-CN": {
-                            "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。",
                             "strength": "你开始能把情绪从混乱体验里拆出来。",
                             "risk": "觉察到情绪后，可能仍会被它带着走。",
                             "typical_scene": "收到批评时，你能意识到不舒服，但需要时间判断这份不舒服来自哪里。",
                             "practice_focus": "用“我感到…因为我在意…”练习把感受说具体。",
-                            "do_not_overread": "发展中不是不稳定人格，而是觉察速度和表达精度仍在形成。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 发展中"
                         },
                         "en": {
-                            "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly.",
                             "strength": "You are beginning to separate emotion from the overall sense of confusion.",
                             "risk": "After noticing a feeling, you may still be carried by it before choosing a response.",
                             "typical_scene": "When criticized, you know something feels uncomfortable but need time to identify the source.",
                             "practice_focus": "Practice the sentence: “I feel... because I care about...”",
-                            "do_not_overread": "Developing does not mean an unstable personality; it means speed and precision of awareness are still forming. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Developing"
                         }
                     },
                     "stable": {
                         "zh-CN": {
-                            "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。",
                             "strength": "你通常能说清楚自己为什么被影响。",
                             "risk": "压力升高时，觉察可能变成反复分析，而不是行动。",
                             "typical_scene": "复盘一次对话时，你能指出哪个细节让自己紧张或防御。",
                             "practice_focus": "每次觉察后补一句：“我现在可以选择的下一步是…”。",
-                            "do_not_overread": "稳定可用不等于任何场景都冷静，只表示多数日常场景有可靠基础。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 稳定可用"
                         },
                         "en": {
-                            "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure.",
                             "strength": "You can usually explain why something affected you.",
                             "risk": "Under higher pressure, awareness may turn into repeated analysis rather than action.",
                             "typical_scene": "When reviewing a conversation, you can point to the detail that made you tense or defensive.",
                             "practice_focus": "After naming the feeling, add: “The next step I can choose is...”",
-                            "do_not_overread": "Stable does not mean calm in every situation; it means you have a reliable base in most everyday settings. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Stable"
                         }
                     },
                     "proficient": {
                         "zh-CN": {
-                            "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。",
                             "strength": "你能把复杂感受组织成比较清楚的表达。",
                             "risk": "容易把每个反应都分析得很细，反而延迟沟通或恢复。",
                             "typical_scene": "在重要对话前，你能预判自己可能被哪些点触发。",
                             "practice_focus": "给觉察设时间盒：命名、确认需要、选择一个小行动。",
-                            "do_not_overread": "熟练成熟不代表你必须解释所有感受，也不代表别人一定会立即理解。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 熟练成熟"
                         },
                         "en": {
-                            "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis.",
                             "strength": "You can organize complex feelings into relatively clear expression.",
                             "risk": "You may analyze every reaction in detail and delay communication or recovery.",
                             "typical_scene": "Before an important conversation, you can anticipate which points may trigger you.",
                             "practice_focus": "Time-box awareness: name the feeling, identify the need, then choose one small action.",
-                            "do_not_overread": "Proficient does not mean you must explain every feeling, or that others will immediately understand it. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Proficient"
                         }
                     },
                     "integrated": {
                         "zh-CN": {
-                            "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。",
                             "strength": "你能在真实场景中使用觉察，而不只是事后理解。",
                             "risk": "可能默认自己必须一直清楚、一直成熟，从而忽略疲劳。",
                             "typical_scene": "冲突中，你能觉察自己的防御反应，并调整说话方式。",
                             "practice_focus": "保留轻量复盘，重点观察“我是否也给了自己恢复空间”。",
-                            "do_not_overread": "高度整合不是永远理性，而是更常能在觉察和行动之间保持连接。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "自我觉察 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "自我觉察 · 高度整合"
                         },
                         "en": {
-                            "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover.",
                             "strength": "You can use awareness in real time, not only in later reflection.",
                             "risk": "You may expect yourself to stay clear and mature all the time, which can hide fatigue.",
                             "typical_scene": "In conflict, you can notice defensiveness and adjust how you speak.",
                             "practice_focus": "Keep a light review habit and ask: “Did I also give myself room to recover?”",
-                            "do_not_overread": "Integrated does not mean permanently rational; it means awareness and action stay connected more often. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Self-awareness · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Self-Awareness · Integrated"
                         }
                     }
                 },
                 "ER": {
                     "foundational": {
                         "zh-CN": {
-                            "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。",
                             "strength": "你能从明显的情绪反应中发现需要练习的场景。",
                             "risk": "压力下容易直接回应、回避或进入长时间内耗。",
                             "typical_scene": "冲突结束后，你可能还会在脑中反复回放很久。",
                             "practice_focus": "先练 30 秒暂停：停下、呼吸、说“我需要一点时间”。",
-                            "do_not_overread": "这不等于情绪失控，只说明恢复策略还没有稳定自动化。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 基础发展中"
                         },
                         "en": {
-                            "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately.",
                             "strength": "Clear emotional reactions can show you exactly which situations need practice.",
                             "risk": "Under stress, you may respond too quickly, avoid the issue, or stay mentally stuck afterward.",
                             "typical_scene": "After a conflict, you may replay the conversation for a long time.",
                             "practice_focus": "Practice a 30-second pause: stop, breathe, and say, “I need a little time.”",
-                            "do_not_overread": "This does not mean you are out of control; it means recovery strategies are not yet automatic. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Foundational"
                         }
                     },
                     "developing": {
                         "zh-CN": {
-                            "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。",
                             "strength": "你已经知道某些做法能帮自己缓下来。",
                             "risk": "情绪强度一高，原本有效的方法可能想不起来。",
                             "typical_scene": "你知道先不要回消息更好，但仍可能忍不住马上解释。",
                             "practice_focus": "准备一个固定恢复菜单：离开现场、写三句话、延迟回复。",
-                            "do_not_overread": "发展中不代表无法调节，而是需要把策略从偶发变成默认选项。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 发展中"
                         },
                         "en": {
-                            "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process.",
                             "strength": "You already know that some actions help you settle.",
                             "risk": "When intensity rises, strategies that usually work may be hard to remember.",
                             "typical_scene": "You know it would be better not to reply immediately, but still feel pulled to explain.",
                             "practice_focus": "Prepare a recovery menu: step away, write three sentences, delay the reply.",
-                            "do_not_overread": "Developing does not mean you cannot regulate; it means strategy needs to become a default option. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Developing"
                         }
                     },
                     "stable": {
                         "zh-CN": {
-                            "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。",
                             "strength": "你能把情绪从“主导全局”降到“可以被管理”。",
                             "risk": "如果持续压着自己保持稳定，后续可能出现疲劳或延迟爆发。",
                             "typical_scene": "紧张会议后，你能逐渐恢复工作节奏。",
                             "practice_focus": "给恢复安排边界：什么时候暂停、什么时候回来处理。",
-                            "do_not_overread": "稳定可用不是没有波动，而是多数时候能回到可选择状态。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 稳定可用"
                         },
                         "en": {
-                            "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder.",
                             "strength": "You can reduce emotion from “running the situation” to “something manageable.”",
                             "risk": "If you keep forcing yourself to stay stable, fatigue or delayed escalation may follow.",
                             "typical_scene": "After a tense meeting, you can gradually return to your work rhythm.",
                             "practice_focus": "Set recovery boundaries: when to pause and when to return to the issue.",
-                            "do_not_overread": "Stable does not mean no fluctuation; it means you can usually return to a state of choice. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Stable"
                         }
                     },
                     "proficient": {
                         "zh-CN": {
-                            "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。",
                             "strength": "你能为沟通争取到更好的时机和语气。",
                             "risk": "有时会显得太冷静，让别人感受不到你的真实立场。",
                             "typical_scene": "被挑战时，你能先稳住语气，再回应重点。",
                             "practice_focus": "调节后补充真实表达：“我需要想清楚，但这件事对我重要。”",
-                            "do_not_overread": "熟练调节不等于必须压住情绪，真实表达仍然是关系信息。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 熟练成熟"
                         },
                         "en": {
-                            "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance.",
                             "strength": "You can create better timing and tone for communication.",
                             "risk": "At times, you may appear so calm that others cannot read your real position.",
                             "typical_scene": "When challenged, you can steady your tone before addressing the point.",
                             "practice_focus": "After regulating, add authentic expression: “I need to think, but this matters to me.”",
-                            "do_not_overread": "Proficient regulation does not mean suppressing emotion; honest expression is still relational information. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Proficient"
                         }
                     },
                     "integrated": {
                         "zh-CN": {
-                            "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。",
                             "strength": "你能让情绪成为信息，而不是让它接管关系或判断。",
                             "risk": "别人可能过度依赖你的稳定，你也可能承担过多调停责任。",
                             "typical_scene": "冲突中，你能暂停升级，同时保留清晰边界。",
                             "practice_focus": "定期检查：我是在稳定局面，还是在替所有人承担情绪成本？",
-                            "do_not_overread": "高度整合不是永远平静，而是更能在高压中保留恢复和选择。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "情绪调节 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "情绪调节 · 高度整合"
                         },
                         "en": {
-                            "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy.",
                             "strength": "You can use emotion as information instead of letting it take over relationships or judgment.",
                             "risk": "Others may rely too heavily on your stability, and you may take on too much mediation.",
                             "typical_scene": "In conflict, you can slow escalation while keeping a clear boundary.",
                             "practice_focus": "Check regularly: “Am I stabilizing the situation, or carrying everyone’s emotional cost?”",
-                            "do_not_overread": "Integrated does not mean permanently calm; it means more room for recovery and choice under pressure. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Emotion regulation · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Emotion Regulation · Integrated"
                         }
                     }
                 },
                 "EM": {
                     "foundational": {
                         "zh-CN": {
-                            "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。",
                             "strength": "你可以通过直接提问建立更清楚的信息。",
                             "risk": "容易把沉默、语气或表情理解得过少或过多。",
                             "typical_scene": "对方说“没事”时，你不确定该继续问还是停下。",
                             "practice_focus": "使用确认句：“我不确定我理解得对不对，你现在更需要空间还是回应？”",
-                            "do_not_overread": "这不代表你冷漠，只说明读取线索时需要更明确的信息支持。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 基础发展中"
                         },
                         "en": {
-                            "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking.",
                             "strength": "Direct questions can give you clearer information.",
                             "risk": "You may read too little or too much into silence, tone, or facial expression.",
                             "typical_scene": "When someone says “I’m fine,” you are not sure whether to ask again or step back.",
                             "practice_focus": "Use a checking sentence: “I may be wrong; do you need space or a response right now?”",
-                            "do_not_overread": "This does not mean you are uncaring; it means cue reading needs clearer information support. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Foundational"
                         }
                     },
                     "developing": {
                         "zh-CN": {
-                            "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。",
                             "strength": "你开始关注关系中的情绪温度。",
                             "risk": "可能过早判断别人不高兴、失望或疏远。",
                             "typical_scene": "朋友回复变短时，你会察觉异常，但不确定原因。",
                             "practice_focus": "把判断拆成两句：我观察到什么？我还不知道什么？",
-                            "do_not_overread": "发展中不代表共情差，而是需要让共情建立在证据上。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 发展中"
                         },
                         "en": {
-                            "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation.",
                             "strength": "You are starting to track the emotional temperature in relationships.",
                             "risk": "You may too quickly assume someone is upset, disappointed, or distant.",
                             "typical_scene": "When a friend’s replies become shorter, you notice a shift but do not know the reason.",
                             "practice_focus": "Split the judgment into two questions: What did I observe? What do I not know yet?",
-                            "do_not_overread": "Developing does not mean weak empathy; it means empathy needs to be grounded in evidence. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Developing"
                         }
                     },
                     "stable": {
                         "zh-CN": {
-                            "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。",
                             "strength": "你能让对方感到被看见和被认真对待。",
                             "risk": "在关系压力中，可能为了照顾别人而忽略自己的容量。",
                             "typical_scene": "同事语气紧张时，你能意识到对方可能在承压。",
                             "practice_focus": "共情后加一句边界：“我理解你现在很难，我能帮的是…”",
-                            "do_not_overread": "稳定共情不是读心，也不是无限承担别人的情绪。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 稳定可用"
                         },
                         "en": {
-                            "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them.",
                             "strength": "You can help others feel seen and taken seriously.",
                             "risk": "Under relational pressure, you may ignore your own capacity while caring for others.",
                             "typical_scene": "When a colleague sounds tense, you can recognize that they may be under pressure.",
                             "practice_focus": "After empathy, add a boundary: “I understand this is hard; what I can help with is...”",
-                            "do_not_overread": "Stable empathy is not mind-reading, and it is not unlimited responsibility for another person’s emotion. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Stable"
                         }
                     },
                     "proficient": {
                         "zh-CN": {
-                            "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。",
                             "strength": "你能在复杂关系中捕捉未说出口的信息。",
                             "risk": "容易把别人的紧张、失望或期待变成自己的责任。",
                             "typical_scene": "会议里气氛变了，你能很快察觉谁在退缩或不安。",
                             "practice_focus": "先验证再承担：“我感觉你可能有顾虑，我理解对吗？”",
-                            "do_not_overread": "熟练共情不等于你必须解决所有人的感受。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 熟练成熟"
                         },
                         "en": {
-                            "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries.",
                             "strength": "You can notice unspoken information in complex relationships.",
                             "risk": "You may turn others’ tension, disappointment, or expectations into your responsibility.",
                             "typical_scene": "When the mood changes in a meeting, you quickly notice who is withdrawing or uneasy.",
                             "practice_focus": "Validate before carrying: “I sense you may have a concern; am I reading that correctly?”",
-                            "do_not_overread": "Proficient empathy does not mean you must solve everyone’s feelings. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Proficient"
                         }
                     },
                     "integrated": {
                         "zh-CN": {
-                            "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。",
                             "strength": "你能在理解别人时仍保持清晰位置。",
                             "risk": "别人可能习惯向你倾倒情绪，你也可能被期待持续照顾场面。",
                             "typical_scene": "对方情绪很强时，你能回应感受，同时不接下不属于你的责任。",
                             "practice_focus": "练习“理解 + 边界 + 下一步”三段回应。",
-                            "do_not_overread": "高度整合的共情不是永远温柔，而是能同时保留理解和判断。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "共情理解 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "共情理解 · 高度整合"
                         },
                         "en": {
-                            "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility.",
                             "strength": "You can understand others while keeping a clear position.",
                             "risk": "Others may become used to unloading emotion onto you, and you may be expected to manage the room.",
                             "typical_scene": "When someone is highly emotional, you can respond to the feeling without taking responsibility that is not yours.",
                             "practice_focus": "Practice a three-part response: understanding, boundary, next step.",
-                            "do_not_overread": "Integrated empathy is not endless softness; it is the ability to hold understanding and judgment together. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Empathic understanding · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Empathy · Integrated"
                         }
                     }
                 },
                 "RM": {
                     "foundational": {
                         "zh-CN": {
-                            "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。",
                             "strength": "只要有清楚步骤，你可以逐步提升关系处理能力。",
                             "risk": "容易在不舒服时沉默、解释过多或直接退出。",
                             "typical_scene": "争执后，你知道需要修复，但不知道第一句话怎么说。",
                             "practice_focus": "准备一句开场：“刚才那段对话有点卡住了，我想重新说一次。”",
-                            "do_not_overread": "这不代表你不重视关系，只说明修复工具还不够熟。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 基础发展中"
                         },
                         "en": {
-                            "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again.",
                             "strength": "With clear steps, your relationship skills can improve steadily.",
                             "risk": "When uncomfortable, you may go silent, over-explain, or exit the conversation.",
                             "typical_scene": "After an argument, you know repair is needed but do not know the first sentence.",
                             "practice_focus": "Prepare an opener: “That conversation got stuck. I’d like to try saying it again.”",
-                            "do_not_overread": "This does not mean you do not value relationships; it means repair tools are not yet familiar. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Foundational"
                         }
                     },
                     "developing": {
                         "zh-CN": {
-                            "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。",
                             "strength": "你已经能意识到关系需要被处理，而不是只等它过去。",
                             "risk": "可能一边想维护关系，一边又把真实想法说得不够清楚。",
                             "typical_scene": "你想缓和气氛，但担心一开口又引发冲突。",
                             "practice_focus": "使用“事实 + 感受 + 请求”三句结构。",
-                            "do_not_overread": "发展中不代表关系能力差，而是现场压力下需要更可依赖的表达框架。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 发展中"
                         },
                         "en": {
-                            "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance.",
                             "strength": "You already recognize that relationships need to be addressed, not simply waited out.",
                             "risk": "You may try to preserve the relationship while leaving your real position unclear.",
                             "typical_scene": "You want to ease the atmosphere but worry that speaking will restart the conflict.",
                             "practice_focus": "Use a three-sentence structure: fact, feeling, request.",
-                            "do_not_overread": "Developing does not mean weak relationship ability; it means pressure requires a more reliable expression frame. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Developing"
                         }
                     },
                     "stable": {
                         "zh-CN": {
-                            "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。",
                             "strength": "你能让关系在小摩擦后回到可合作状态。",
                             "risk": "为了维持顺畅，可能回避更难但必要的话题。",
                             "typical_scene": "误会出现后，你通常愿意解释并重新对齐。",
                             "practice_focus": "在修复之外补充边界：“下次我们可以用这个方式处理。”",
-                            "do_not_overread": "稳定可用不等于没有冲突，而是多数冲突后还能回到工作关系。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 稳定可用"
                         },
                         "en": {
-                            "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations.",
                             "strength": "You can help a relationship return to cooperation after small friction.",
                             "risk": "To keep things smooth, you may avoid harder but necessary topics.",
                             "typical_scene": "After a misunderstanding, you are usually willing to explain and realign.",
                             "practice_focus": "Add a boundary after repair: “Next time, we can handle it this way.”",
-                            "do_not_overread": "Stable does not mean no conflict; it means most conflicts can return to a workable relationship. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Stable"
                         }
                     },
                     "proficient": {
                         "zh-CN": {
-                            "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。",
                             "strength": "你能把冲突转化为更清楚的协作规则。",
                             "risk": "别人可能默认你来收拾关系残局。",
                             "typical_scene": "团队意见不合时，你能帮助大家回到事实和下一步。",
                             "practice_focus": "在协调前先确认职责：“这件事需要谁来决定，谁来执行？”",
-                            "do_not_overread": "熟练关系管理不是永远做中间人，也不是牺牲自己的边界。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 熟练成熟"
                         },
                         "en": {
-                            "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role.",
                             "strength": "You can turn conflict into clearer rules for collaboration.",
                             "risk": "Others may assume you will clean up the relational aftermath.",
                             "typical_scene": "When a team disagrees, you can help people return to facts and next steps.",
                             "practice_focus": "Before coordinating, clarify roles: “Who decides this, and who executes it?”",
-                            "do_not_overread": "Proficient relationship management is not permanent mediation, and it does not require sacrificing your boundary. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Proficient"
                         }
                     },
                     "integrated": {
                         "zh-CN": {
-                            "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                            "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。",
                             "strength": "你能在复杂关系中创造清晰、可持续的合作方式。",
                             "risk": "因为你能处理关系，系统可能把过多情绪劳动交给你。",
                             "typical_scene": "冲突升级时，你能帮助各方降温、对齐目标，并明确责任。",
                             "practice_focus": "把个人调停转成系统规则：节奏、边界、责任和复盘。",
-                            "do_not_overread": "高度整合不代表你必须承担所有关系维护工作。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-                            "label": "关系管理 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+                            "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+                            "label": "关系管理 · 高度整合"
                         },
                         "en": {
-                            "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                            "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone.",
                             "strength": "You can create clear and sustainable collaboration in complex relationships.",
                             "risk": "Because you can handle relationships, the system may hand you too much emotional labor.",
                             "typical_scene": "When conflict escalates, you can help people cool down, align goals, and clarify responsibility.",
                             "practice_focus": "Turn personal mediation into system rules: rhythm, boundary, responsibility, and review.",
-                            "do_not_overread": "Integrated does not mean you must carry all relationship maintenance. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-                            "label": "Relationship management · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+                            "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+                            "label": "Relationship Management · Integrated"
                         }
                     }
                 }
             },
             "score_notes": {
                 "zh-CN": {
-                    "percentile": "百分位只表示在当前阶段性样本中的相对位置感，不是能力排名、真实水平排名或全球正式常模排名。",
-                    "standard_score": "标准分用于稳定展示和维度比较；它是解释入口，不是现场表现证明。",
-                    "band": "等级用于帮助阅读，不代表固定人格、能力证书或临床/职业判断。",
-                    "provisional_norm": "当前常模为阶段性常模，后续样本、语言和版本更新可能改变解释边界。",
-                    "commercial_boundary": "总分用于定位阅读入口，最终解释以四维、质量、证据状态和场景边界为准。"
+                    "percentile": "百分位只表示当前阶段性样本中的相对位置参考，不是能力排名、真实水平排名、全球正式常模排名或职业竞争力排名。",
+                    "standard_score": "标准分用于稳定展示和维度比较，是阅读入口，不是现场表现证明或能力证明。",
+                    "band": "等级用于降低阅读负担，不代表固定人格、能力证书、临床结论、招聘信号或职业判断。",
+                    "provisional_norm": "当前常模为阶段性常模，后续样本、语言版本和内容版本更新都可能改变解释边界。",
+                    "commercial_boundary": "总分不应单独使用；完整解释必须结合四维、质量、证据状态、机制和场景边界。"
                 },
                 "en": {
-                    "percentile": "Percentile only describes relative position in the current provisional sample. It is not an ability ranking, true-level ranking, or final global norm.",
-                    "standard_score": "Standard score supports stable display and dimension comparison; it is a reading entry, not proof of live performance.",
-                    "band": "Bands help users read the result; they are not fixed identities, credentials, clinical findings, or work decisions.",
-                    "provisional_norm": "Current norms are provisional. Future samples, languages, and versions may change interpretation boundaries.",
-                    "commercial_boundary": "The total score is a reading entry; interpretation depends on dimensions, confidence, evidence status, and scene boundaries."
+                    "percentile": "Percentile only provides a relative-position reference within the current provisional sample. It is not an ability ranking, true-level ranking, final global norm, or career-competitiveness ranking.",
+                    "standard_score": "Standard score supports stable display and dimension comparison. It is a reading entry, not proof of live performance or ability.",
+                    "band": "Bands reduce reading effort; they are not fixed identities, credentials, clinical findings, hiring signals, or career judgments.",
+                    "provisional_norm": "Current norms are provisional. Future samples, language versions, and content versions may change interpretation boundaries.",
+                    "commercial_boundary": "The total score should not be used alone; full interpretation requires dimensions, quality, evidence status, mechanisms, and scene boundaries."
                 }
             },
             "band_details": {
                 "foundational": {
                     "zh-CN": {
-                        "label": "基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "当前信号提示本次结果提示可以先先建立更清晰的识别、命名和复位习惯。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "基础发展中",
+                        "meaning": "当前信号提示本次结果提示可以先建立更清晰的识别、命名和复位习惯。",
                         "strength": "从一个小而重复的动作开始，进步会更稳定。",
                         "risk": "如果直接追求复杂沟通技巧，容易因为基础信号不清而挫败。",
                         "practice_focus": "每天一次情绪命名，配合一个低成本复位动作。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "The current signal suggests starting with clearer recognition, naming, and reset habits. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Foundational",
+                        "meaning": "The current self-report signal suggests starting with clearer recognition, naming, and reset habits.",
                         "strength": "Small repeatable actions can create more stable progress.",
                         "risk": "Jumping into complex communication tactics may frustrate you if the base signal is unclear.",
                         "practice_focus": "Name one emotion daily and pair it with one low-cost reset action.",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 },
                 "developing": {
                     "zh-CN": {
-                        "label": "发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "发展中",
+                        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。",
                         "strength": "你已经能抓住一部分线索，适合把它们转成固定流程。",
                         "risk": "最容易卡在“知道一点，但现场用不上”。",
                         "practice_focus": "选择一个高频场景，提前准备一句回应。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Developing",
+                        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension.",
                         "strength": "You already catch part of the signal and can turn it into a routine.",
                         "risk": "The common trap is knowing something but not using it in the moment.",
                         "practice_focus": "Pick one frequent scene and prepare one response sentence.",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 },
                 "stable": {
                     "zh-CN": {
-                        "label": "稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "多数日常场景中，你能使用这些情绪与关系能力，但仍有明确触发点。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "稳定可用",
+                        "meaning": "多数日常场景中，你能使用这些情绪与关系模式，但仍有明确触发点。",
                         "strength": "你的结果已经能支持更精细的场景训练。",
                         "risk": "稳定不等于没有代价，尤其在高强度关系环境中。",
                         "practice_focus": "找出最容易失稳的一个场景，做事后复盘。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "In many everyday settings, these emotional and relational skills are usable, with specific triggers still visible. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Stable",
+                        "meaning": "In many everyday settings, these emotional and relational patterns are easier to use, with specific triggers still visible.",
                         "strength": "Your result can support more precise scene-based practice.",
                         "risk": "Stability does not mean no cost, especially in high-intensity relational environments.",
                         "practice_focus": "Identify one scene where stability drops and review it afterward.",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 },
                 "proficient": {
                     "zh-CN": {
-                        "label": "熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "你通常能较稳定地识别、调节和处理关系信号。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "熟练成熟",
+                        "meaning": "你通常能较稳定地识别、调节和处理关系信号。",
                         "strength": "你可以把个人优势转成可复制的沟通习惯。",
                         "risk": "他人可能默认你应该一直承担稳定局面的角色。",
                         "practice_focus": "把“我能处理”升级为“我选择如何处理”。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Proficient",
+                        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency.",
                         "strength": "You can turn personal strengths into repeatable communication habits.",
                         "risk": "Others may assume you should always be the stabilizing person.",
                         "practice_focus": "Move from “I can handle this” to “I choose how to handle this.”",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 },
                 "integrated": {
                     "zh-CN": {
-                        "label": "高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-                        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+                        "label": "高度整合",
+                        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。",
                         "strength": "你适合把优势系统化，形成边界、修复和恢复节奏。",
                         "risk": "高整合也可能带来过度承担和高标准疲劳。",
                         "practice_focus": "建立恢复边界，避免把稳定别人变成默认责任。",
-                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+                        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
                     },
                     "en": {
-                        "label": "Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-                        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+                        "label": "Integrated",
+                        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view.",
                         "strength": "You can systematize strengths into boundaries, repair, and recovery rhythm.",
                         "risk": "High integration may still create over-responsibility and high-standard fatigue.",
                         "practice_focus": "Build recovery boundaries so stabilizing others does not become your default duty.",
-                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+                        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
                     }
                 }
             }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/score_system.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/score_system.json
@@ -3,16 +3,16 @@
   "pack_id": "EQ_60",
   "global_index": {
     "zh-CN": {
-      "label": "情绪与关系综合指数 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-      "definition": "综合指数把四个自我报告维度合并成一个阅读入口，用来帮助你理解本次作答呈现的情绪与关系模式。",
-      "not_a_capability_score": "分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-      "how_to_use": "先看总览，再回到四维、质量提示、证据状态和场景边界。不要把总分当作能力排名。"
+      "label": "情绪与关系综合指数",
+      "definition": "综合指数把四个自我报告维度合并成一个阅读入口，用来概览本次作答呈现的情绪与关系自我感知模式。",
+      "not_a_capability_score": "它不是情绪能力分、真实表现分、职业竞争力分或全球正式常模排名；更适合当作进入四维和场景解释的导航。",
+      "how_to_use": "先用总览定位，再回到四维、答题质量、证据状态和现实场景。不要用总分单独评价自己或他人。"
     },
     "en": {
-      "label": "Emotional & Relational Functioning Index Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-      "definition": "The index combines four self-report dimensions into a reading entry for the emotional and relational pattern shown in this session.",
-      "not_a_capability_score": "Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-      "how_to_use": "Start with the overview, then return to dimensions, confidence, evidence status, and scene boundaries. Do not treat the total score as an ability ranking."
+      "label": "Emotional & Relational Functioning Index",
+      "definition": "The index combines four self-report dimensions into a reading entry for the emotional and relational self-perception pattern shown in this response session.",
+      "not_a_capability_score": "It is not an emotional-ability score, live-performance score, career-competitiveness score, or final global norm ranking; use it as navigation into dimensions and scene explanations.",
+      "how_to_use": "Use the overview first, then return to dimensions, response quality, evidence status, and real-life scenes. Do not use the total score by itself to judge yourself or others."
     }
   },
   "bands": {
@@ -40,82 +40,82 @@
   "dimensions": {
     "SA": {
       "zh-CN": {
-        "label": "自我觉察 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "自我觉察",
         "short_label": "自我觉察",
-        "definition": "对自己情绪、触发点和需要的自我报告识别倾向；它不是外部观察到的自我理解能力。",
+        "definition": "对自己情绪、触发点、身体信号和当下需要的自我报告识别倾向；它不是外部观察到的自我理解能力，也不保证现场表达一定清楚。",
         "what_high_can_look_like": "你能较快识别自己的感受和触发点，但仍需把觉察转化为行动。",
         "what_low_can_look_like": "情绪常在事后才变清楚，容易先反应后理解。",
         "development_question": "我此刻真正的感受和需要是什么？",
-        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "自我觉察分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
       },
       "en": {
-        "label": "Self-Awareness Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Self-Awareness",
         "short_label": "Self-Awareness",
-        "definition": "A self-reported tendency to notice emotions, triggers, and needs; it is not externally observed self-knowledge ability.",
+        "definition": "A self-reported tendency to notice emotions, triggers, body signals, and current needs; it is not externally observed self-knowledge ability and does not guarantee clear expression in the moment.",
         "what_high_can_look_like": "You can often identify feelings and triggers quickly, while still needing to turn awareness into action.",
         "what_low_can_look_like": "Feelings may become clear only afterward, making it easier to react before understanding.",
         "development_question": "What am I actually feeling and needing right now?",
-        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The Self-Awareness score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
       }
     },
     "ER": {
       "zh-CN": {
-        "label": "情绪调节 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "情绪调节",
         "short_label": "情绪调节",
-        "definition": "对自己在压力、反馈、挫败或冲突后暂停、复位和选择回应方式的自我报告倾向；它不等同于永远冷静或抗压能力证明。",
+        "definition": "对自己在压力、反馈、挫败或冲突后暂停、复位和选择回应方式的自我报告倾向；它不等同于永远冷静、压住情绪或抗压能力证明。",
         "what_high_can_look_like": "你在压力中较能暂停、恢复和选择回应，但不代表没有情绪。",
         "what_low_can_look_like": "被触发后恢复较慢，容易用回避、解释或压抑处理。",
         "development_question": "我能不能先让自己降一点温，再决定怎么回应？",
-        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "情绪调节分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
       },
       "en": {
-        "label": "Emotion Regulation Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Emotion Regulation",
         "short_label": "Emotion Regulation",
-        "definition": "A self-reported tendency to pause, reset, and choose responses after pressure, feedback, frustration, or conflict; it is not proof of being calm or resilient in every situation.",
+        "definition": "A self-reported tendency to pause, reset, and choose responses after pressure, feedback, frustration, or conflict; it is not the same as always staying calm, suppressing emotion, or proving resilience.",
         "what_high_can_look_like": "You can often pause, recover, and choose a response under pressure, without being emotionless.",
         "what_low_can_look_like": "Recovery may take longer after being triggered, with avoidance, over-explaining, or suppression becoming common.",
         "development_question": "Can I lower the heat first before choosing my response?",
-        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The Emotion Regulation score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
       }
     },
     "EM": {
       "zh-CN": {
-        "label": "共情理解 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "共情理解",
         "short_label": "共情理解",
-        "definition": "对他人情绪线索、观点和可能感受的自我报告理解倾向；它不等同于实际读心准确率、亲社会行为或替他人承担情绪。",
+        "definition": "对他人情绪线索、观点和可能感受的自我报告理解倾向；它包含认知共情和情感共鸣线索，但不等同于读心准确率、亲社会行为或替他人承担情绪痛苦。",
         "what_high_can_look_like": "你能敏锐捕捉他人的状态，但需要避免过度吸收。",
         "what_low_can_look_like": "可能更关注任务或事实，较容易漏过对方的情绪线索。",
         "development_question": "对方真正担心或在意的是什么？",
-        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "共情理解分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
       },
       "en": {
-        "label": "Empathy Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Empathy",
         "short_label": "Empathy",
-        "definition": "A self-reported tendency to understand others’ emotional cues, perspectives, and possible feelings; it is not the same as actual mind-reading accuracy, prosocial behavior, or carrying others’ emotions.",
+        "definition": "A self-reported tendency to understand others’ emotional cues, perspectives, and possible feelings; it may reflect cognitive and affective empathy signals, but it is not mind-reading accuracy, prosocial behavior, or taking on others’ distress.",
         "what_high_can_look_like": "You can notice others’ emotional states, while still needing boundaries against over-absorbing.",
         "what_low_can_look_like": "You may focus on tasks or facts and miss some emotional cues.",
         "development_question": "What is the other person really concerned about?",
-        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The Empathy score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
       }
     },
     "RM": {
       "zh-CN": {
-        "label": "关系管理 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "关系管理",
         "short_label": "关系管理",
-        "definition": "对表达、协作、边界和修复的自我报告倾向；它不直接预测关系质量、领导力或他人评价。",
+        "definition": "对表达、协作、边界和关系修复的自我报告倾向；它不直接预测关系质量、领导力、受欢迎程度或他人评价。",
         "what_high_can_look_like": "你能维护沟通和关系质量，但仍需留意真实表达和边界。",
         "what_low_can_look_like": "知道自己或对方感受后，不一定能把对话修复或推进。",
         "development_question": "这句话怎样说，既真实又能让关系继续对话？",
-        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "关系管理分数描述本次自我报告中的相对倾向，不是能力证明、固定标签、诊断结论或外部行为预测。"
       },
       "en": {
-        "label": "Relationship Management Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Relationship Management",
         "short_label": "Relationship Management",
-        "definition": "A self-reported tendency around expression, collaboration, boundaries, and repair; it does not directly predict relationship quality, leadership, or others’ evaluations.",
+        "definition": "A self-reported tendency around expression, collaboration, boundaries, and relationship repair; it does not directly predict relationship quality, leadership, popularity, or others’ evaluations.",
         "what_high_can_look_like": "You can maintain communication and relationship quality, while still watching for honest expression and boundaries.",
         "what_low_can_look_like": "Even when feelings are clear, repairing or moving the conversation forward may be harder.",
         "development_question": "How can I say this honestly while keeping the conversation open?",
-        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The Relationship Management score describes a relative tendency in this self-report session; it is not proof of ability, a fixed label, a diagnosis, or a prediction of external behavior."
       }
     }
   },
@@ -123,517 +123,517 @@
     "SA": {
       "foundational": {
         "zh-CN": {
-          "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。",
           "strength": "愿意回头复盘时，能够逐步看见真实感受。",
           "risk": "现场容易先解释、压住或转移，之后才发现自己被触发。",
           "typical_scene": "别人问“你怎么了”时，你可能需要一段时间才说得清。",
           "practice_focus": "每天记录一个情绪词、一个触发点和一个身体反应。",
-          "do_not_overread": "这不代表你不懂自己，只说明当下觉察信号还需要更稳定的捕捉方式。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 基础发展中"
         },
         "en": {
-          "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably.",
           "strength": "When you review an event afterward, you can gradually identify what was actually happening inside.",
           "risk": "In the moment, you may explain, suppress, or move on before noticing that you were triggered.",
           "typical_scene": "When someone asks what is wrong, you may need time before you can answer clearly.",
           "practice_focus": "Track one emotion word, one trigger, and one body signal each day.",
-          "do_not_overread": "This does not mean you lack self-understanding; it means your emotional signals need a more stable capture method. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Foundational"
         }
       },
       "developing": {
         "zh-CN": {
-          "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。",
           "strength": "你开始能把情绪从混乱体验里拆出来。",
           "risk": "觉察到情绪后，可能仍会被它带着走。",
           "typical_scene": "收到批评时，你能意识到不舒服，但需要时间判断这份不舒服来自哪里。",
           "practice_focus": "用“我感到…因为我在意…”练习把感受说具体。",
-          "do_not_overread": "发展中不是不稳定人格，而是觉察速度和表达精度仍在形成。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 发展中"
         },
         "en": {
-          "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly.",
           "strength": "You are beginning to separate emotion from the overall sense of confusion.",
           "risk": "After noticing a feeling, you may still be carried by it before choosing a response.",
           "typical_scene": "When criticized, you know something feels uncomfortable but need time to identify the source.",
           "practice_focus": "Practice the sentence: “I feel... because I care about...”",
-          "do_not_overread": "Developing does not mean an unstable personality; it means speed and precision of awareness are still forming. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Developing"
         }
       },
       "stable": {
         "zh-CN": {
-          "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。",
           "strength": "你通常能说清楚自己为什么被影响。",
           "risk": "压力升高时，觉察可能变成反复分析，而不是行动。",
           "typical_scene": "复盘一次对话时，你能指出哪个细节让自己紧张或防御。",
           "practice_focus": "每次觉察后补一句：“我现在可以选择的下一步是…”。",
-          "do_not_overread": "稳定可用不等于任何场景都冷静，只表示多数日常场景有可靠基础。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 稳定可用"
         },
         "en": {
-          "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure.",
           "strength": "You can usually explain why something affected you.",
           "risk": "Under higher pressure, awareness may turn into repeated analysis rather than action.",
           "typical_scene": "When reviewing a conversation, you can point to the detail that made you tense or defensive.",
           "practice_focus": "After naming the feeling, add: “The next step I can choose is...”",
-          "do_not_overread": "Stable does not mean calm in every situation; it means you have a reliable base in most everyday settings. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Stable"
         }
       },
       "proficient": {
         "zh-CN": {
-          "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。",
           "strength": "你能把复杂感受组织成比较清楚的表达。",
           "risk": "容易把每个反应都分析得很细，反而延迟沟通或恢复。",
           "typical_scene": "在重要对话前，你能预判自己可能被哪些点触发。",
           "practice_focus": "给觉察设时间盒：命名、确认需要、选择一个小行动。",
-          "do_not_overread": "熟练成熟不代表你必须解释所有感受，也不代表别人一定会立即理解。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 熟练成熟"
         },
         "en": {
-          "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis.",
           "strength": "You can organize complex feelings into relatively clear expression.",
           "risk": "You may analyze every reaction in detail and delay communication or recovery.",
           "typical_scene": "Before an important conversation, you can anticipate which points may trigger you.",
           "practice_focus": "Time-box awareness: name the feeling, identify the need, then choose one small action.",
-          "do_not_overread": "Proficient does not mean you must explain every feeling, or that others will immediately understand it. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Proficient"
         }
       },
       "integrated": {
         "zh-CN": {
-          "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。",
           "strength": "你能在真实场景中使用觉察，而不只是事后理解。",
           "risk": "可能默认自己必须一直清楚、一直成熟，从而忽略疲劳。",
           "typical_scene": "冲突中，你能觉察自己的防御反应，并调整说话方式。",
           "practice_focus": "保留轻量复盘，重点观察“我是否也给了自己恢复空间”。",
-          "do_not_overread": "高度整合不是永远理性，而是更常能在觉察和行动之间保持连接。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "自我觉察 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在自我觉察上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "自我觉察 · 高度整合"
         },
         "en": {
-          "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover.",
           "strength": "You can use awareness in real time, not only in later reflection.",
           "risk": "You may expect yourself to stay clear and mature all the time, which can hide fatigue.",
           "typical_scene": "In conflict, you can notice defensiveness and adjust how you speak.",
           "practice_focus": "Keep a light review habit and ask: “Did I also give myself room to recover?”",
-          "do_not_overread": "Integrated does not mean permanently rational; it means awareness and action stay connected more often. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Self-awareness · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Self-Awareness in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Self-Awareness · Integrated"
         }
       }
     },
     "ER": {
       "foundational": {
         "zh-CN": {
-          "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。",
           "strength": "你能从明显的情绪反应中发现需要练习的场景。",
           "risk": "压力下容易直接回应、回避或进入长时间内耗。",
           "typical_scene": "冲突结束后，你可能还会在脑中反复回放很久。",
           "practice_focus": "先练 30 秒暂停：停下、呼吸、说“我需要一点时间”。",
-          "do_not_overread": "这不等于情绪失控，只说明恢复策略还没有稳定自动化。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 基础发展中"
         },
         "en": {
-          "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately.",
           "strength": "Clear emotional reactions can show you exactly which situations need practice.",
           "risk": "Under stress, you may respond too quickly, avoid the issue, or stay mentally stuck afterward.",
           "typical_scene": "After a conflict, you may replay the conversation for a long time.",
           "practice_focus": "Practice a 30-second pause: stop, breathe, and say, “I need a little time.”",
-          "do_not_overread": "This does not mean you are out of control; it means recovery strategies are not yet automatic. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Foundational"
         }
       },
       "developing": {
         "zh-CN": {
-          "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。",
           "strength": "你已经知道某些做法能帮自己缓下来。",
           "risk": "情绪强度一高，原本有效的方法可能想不起来。",
           "typical_scene": "你知道先不要回消息更好，但仍可能忍不住马上解释。",
           "practice_focus": "准备一个固定恢复菜单：离开现场、写三句话、延迟回复。",
-          "do_not_overread": "发展中不代表无法调节，而是需要把策略从偶发变成默认选项。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 发展中"
         },
         "en": {
-          "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process.",
           "strength": "You already know that some actions help you settle.",
           "risk": "When intensity rises, strategies that usually work may be hard to remember.",
           "typical_scene": "You know it would be better not to reply immediately, but still feel pulled to explain.",
           "practice_focus": "Prepare a recovery menu: step away, write three sentences, delay the reply.",
-          "do_not_overread": "Developing does not mean you cannot regulate; it means strategy needs to become a default option. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Developing"
         }
       },
       "stable": {
         "zh-CN": {
-          "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。",
           "strength": "你能把情绪从“主导全局”降到“可以被管理”。",
           "risk": "如果持续压着自己保持稳定，后续可能出现疲劳或延迟爆发。",
           "typical_scene": "紧张会议后，你能逐渐恢复工作节奏。",
           "practice_focus": "给恢复安排边界：什么时候暂停、什么时候回来处理。",
-          "do_not_overread": "稳定可用不是没有波动，而是多数时候能回到可选择状态。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 稳定可用"
         },
         "en": {
-          "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder.",
           "strength": "You can reduce emotion from “running the situation” to “something manageable.”",
           "risk": "If you keep forcing yourself to stay stable, fatigue or delayed escalation may follow.",
           "typical_scene": "After a tense meeting, you can gradually return to your work rhythm.",
           "practice_focus": "Set recovery boundaries: when to pause and when to return to the issue.",
-          "do_not_overread": "Stable does not mean no fluctuation; it means you can usually return to a state of choice. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Stable"
         }
       },
       "proficient": {
         "zh-CN": {
-          "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。",
           "strength": "你能为沟通争取到更好的时机和语气。",
           "risk": "有时会显得太冷静，让别人感受不到你的真实立场。",
           "typical_scene": "被挑战时，你能先稳住语气，再回应重点。",
           "practice_focus": "调节后补充真实表达：“我需要想清楚，但这件事对我重要。”",
-          "do_not_overread": "熟练调节不等于必须压住情绪，真实表达仍然是关系信息。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 熟练成熟"
         },
         "en": {
-          "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance.",
           "strength": "You can create better timing and tone for communication.",
           "risk": "At times, you may appear so calm that others cannot read your real position.",
           "typical_scene": "When challenged, you can steady your tone before addressing the point.",
           "practice_focus": "After regulating, add authentic expression: “I need to think, but this matters to me.”",
-          "do_not_overread": "Proficient regulation does not mean suppressing emotion; honest expression is still relational information. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Proficient"
         }
       },
       "integrated": {
         "zh-CN": {
-          "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。",
           "strength": "你能让情绪成为信息，而不是让它接管关系或判断。",
           "risk": "别人可能过度依赖你的稳定，你也可能承担过多调停责任。",
           "typical_scene": "冲突中，你能暂停升级，同时保留清晰边界。",
           "practice_focus": "定期检查：我是在稳定局面，还是在替所有人承担情绪成本？",
-          "do_not_overread": "高度整合不是永远平静，而是更能在高压中保留恢复和选择。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "情绪调节 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在情绪调节上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "情绪调节 · 高度整合"
         },
         "en": {
-          "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy.",
           "strength": "You can use emotion as information instead of letting it take over relationships or judgment.",
           "risk": "Others may rely too heavily on your stability, and you may take on too much mediation.",
           "typical_scene": "In conflict, you can slow escalation while keeping a clear boundary.",
           "practice_focus": "Check regularly: “Am I stabilizing the situation, or carrying everyone’s emotional cost?”",
-          "do_not_overread": "Integrated does not mean permanently calm; it means more room for recovery and choice under pressure. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Emotion regulation · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Emotion Regulation in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Emotion Regulation · Integrated"
         }
       }
     },
     "EM": {
       "foundational": {
         "zh-CN": {
-          "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。",
           "strength": "你可以通过直接提问建立更清楚的信息。",
           "risk": "容易把沉默、语气或表情理解得过少或过多。",
           "typical_scene": "对方说“没事”时，你不确定该继续问还是停下。",
           "practice_focus": "使用确认句：“我不确定我理解得对不对，你现在更需要空间还是回应？”",
-          "do_not_overread": "这不代表你冷漠，只说明读取线索时需要更明确的信息支持。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 基础发展中"
         },
         "en": {
-          "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking.",
           "strength": "Direct questions can give you clearer information.",
           "risk": "You may read too little or too much into silence, tone, or facial expression.",
           "typical_scene": "When someone says “I’m fine,” you are not sure whether to ask again or step back.",
           "practice_focus": "Use a checking sentence: “I may be wrong; do you need space or a response right now?”",
-          "do_not_overread": "This does not mean you are uncaring; it means cue reading needs clearer information support. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Foundational"
         }
       },
       "developing": {
         "zh-CN": {
-          "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。",
           "strength": "你开始关注关系中的情绪温度。",
           "risk": "可能过早判断别人不高兴、失望或疏远。",
           "typical_scene": "朋友回复变短时，你会察觉异常，但不确定原因。",
           "practice_focus": "把判断拆成两句：我观察到什么？我还不知道什么？",
-          "do_not_overread": "发展中不代表共情差，而是需要让共情建立在证据上。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 发展中"
         },
         "en": {
-          "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation.",
           "strength": "You are starting to track the emotional temperature in relationships.",
           "risk": "You may too quickly assume someone is upset, disappointed, or distant.",
           "typical_scene": "When a friend’s replies become shorter, you notice a shift but do not know the reason.",
           "practice_focus": "Split the judgment into two questions: What did I observe? What do I not know yet?",
-          "do_not_overread": "Developing does not mean weak empathy; it means empathy needs to be grounded in evidence. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Developing"
         }
       },
       "stable": {
         "zh-CN": {
-          "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。",
           "strength": "你能让对方感到被看见和被认真对待。",
           "risk": "在关系压力中，可能为了照顾别人而忽略自己的容量。",
           "typical_scene": "同事语气紧张时，你能意识到对方可能在承压。",
           "practice_focus": "共情后加一句边界：“我理解你现在很难，我能帮的是…”",
-          "do_not_overread": "稳定共情不是读心，也不是无限承担别人的情绪。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 稳定可用"
         },
         "en": {
-          "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them.",
           "strength": "You can help others feel seen and taken seriously.",
           "risk": "Under relational pressure, you may ignore your own capacity while caring for others.",
           "typical_scene": "When a colleague sounds tense, you can recognize that they may be under pressure.",
           "practice_focus": "After empathy, add a boundary: “I understand this is hard; what I can help with is...”",
-          "do_not_overread": "Stable empathy is not mind-reading, and it is not unlimited responsibility for another person’s emotion. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Stable"
         }
       },
       "proficient": {
         "zh-CN": {
-          "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。",
           "strength": "你能在复杂关系中捕捉未说出口的信息。",
           "risk": "容易把别人的紧张、失望或期待变成自己的责任。",
           "typical_scene": "会议里气氛变了，你能很快察觉谁在退缩或不安。",
           "practice_focus": "先验证再承担：“我感觉你可能有顾虑，我理解对吗？”",
-          "do_not_overread": "熟练共情不等于你必须解决所有人的感受。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 熟练成熟"
         },
         "en": {
-          "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries.",
           "strength": "You can notice unspoken information in complex relationships.",
           "risk": "You may turn others’ tension, disappointment, or expectations into your responsibility.",
           "typical_scene": "When the mood changes in a meeting, you quickly notice who is withdrawing or uneasy.",
           "practice_focus": "Validate before carrying: “I sense you may have a concern; am I reading that correctly?”",
-          "do_not_overread": "Proficient empathy does not mean you must solve everyone’s feelings. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Proficient"
         }
       },
       "integrated": {
         "zh-CN": {
-          "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。",
           "strength": "你能在理解别人时仍保持清晰位置。",
           "risk": "别人可能习惯向你倾倒情绪，你也可能被期待持续照顾场面。",
           "typical_scene": "对方情绪很强时，你能回应感受，同时不接下不属于你的责任。",
           "practice_focus": "练习“理解 + 边界 + 下一步”三段回应。",
-          "do_not_overread": "高度整合的共情不是永远温柔，而是能同时保留理解和判断。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "共情理解 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在共情理解上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "共情理解 · 高度整合"
         },
         "en": {
-          "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility.",
           "strength": "You can understand others while keeping a clear position.",
           "risk": "Others may become used to unloading emotion onto you, and you may be expected to manage the room.",
           "typical_scene": "When someone is highly emotional, you can respond to the feeling without taking responsibility that is not yours.",
           "practice_focus": "Practice a three-part response: understanding, boundary, next step.",
-          "do_not_overread": "Integrated empathy is not endless softness; it is the ability to hold understanding and judgment together. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Empathic understanding · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Empathy in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Empathy · Integrated"
         }
       }
     },
     "RM": {
       "foundational": {
         "zh-CN": {
-          "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。",
           "strength": "只要有清楚步骤，你可以逐步提升关系处理能力。",
           "risk": "容易在不舒服时沉默、解释过多或直接退出。",
           "typical_scene": "争执后，你知道需要修复，但不知道第一句话怎么说。",
           "practice_focus": "准备一句开场：“刚才那段对话有点卡住了，我想重新说一次。”",
-          "do_not_overread": "这不代表你不重视关系，只说明修复工具还不够熟。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 基础发展中"
         },
         "en": {
-          "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again.",
           "strength": "With clear steps, your relationship skills can improve steadily.",
           "risk": "When uncomfortable, you may go silent, over-explain, or exit the conversation.",
           "typical_scene": "After an argument, you know repair is needed but do not know the first sentence.",
           "practice_focus": "Prepare an opener: “That conversation got stuck. I’d like to try saying it again.”",
-          "do_not_overread": "This does not mean you do not value relationships; it means repair tools are not yet familiar. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Foundational"
         }
       },
       "developing": {
         "zh-CN": {
-          "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。",
           "strength": "你已经能意识到关系需要被处理，而不是只等它过去。",
           "risk": "可能一边想维护关系，一边又把真实想法说得不够清楚。",
           "typical_scene": "你想缓和气氛，但担心一开口又引发冲突。",
           "practice_focus": "使用“事实 + 感受 + 请求”三句结构。",
-          "do_not_overread": "发展中不代表关系能力差，而是现场压力下需要更可依赖的表达框架。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 发展中"
         },
         "en": {
-          "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance.",
           "strength": "You already recognize that relationships need to be addressed, not simply waited out.",
           "risk": "You may try to preserve the relationship while leaving your real position unclear.",
           "typical_scene": "You want to ease the atmosphere but worry that speaking will restart the conflict.",
           "practice_focus": "Use a three-sentence structure: fact, feeling, request.",
-          "do_not_overread": "Developing does not mean weak relationship ability; it means pressure requires a more reliable expression frame. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Developing"
         }
       },
       "stable": {
         "zh-CN": {
-          "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。",
           "strength": "你能让关系在小摩擦后回到可合作状态。",
           "risk": "为了维持顺畅，可能回避更难但必要的话题。",
           "typical_scene": "误会出现后，你通常愿意解释并重新对齐。",
           "practice_focus": "在修复之外补充边界：“下次我们可以用这个方式处理。”",
-          "do_not_overread": "稳定可用不等于没有冲突，而是多数冲突后还能回到工作关系。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 稳定可用"
         },
         "en": {
-          "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations.",
           "strength": "You can help a relationship return to cooperation after small friction.",
           "risk": "To keep things smooth, you may avoid harder but necessary topics.",
           "typical_scene": "After a misunderstanding, you are usually willing to explain and realign.",
           "practice_focus": "Add a boundary after repair: “Next time, we can handle it this way.”",
-          "do_not_overread": "Stable does not mean no conflict; it means most conflicts can return to a workable relationship. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Stable"
         }
       },
       "proficient": {
         "zh-CN": {
-          "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。",
           "strength": "你能把冲突转化为更清楚的协作规则。",
           "risk": "别人可能默认你来收拾关系残局。",
           "typical_scene": "团队意见不合时，你能帮助大家回到事实和下一步。",
           "practice_focus": "在协调前先确认职责：“这件事需要谁来决定，谁来执行？”",
-          "do_not_overread": "熟练关系管理不是永远做中间人，也不是牺牲自己的边界。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 熟练成熟"
         },
         "en": {
-          "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role.",
           "strength": "You can turn conflict into clearer rules for collaboration.",
           "risk": "Others may assume you will clean up the relational aftermath.",
           "typical_scene": "When a team disagrees, you can help people return to facts and next steps.",
           "practice_focus": "Before coordinating, clarify roles: “Who decides this, and who executes it?”",
-          "do_not_overread": "Proficient relationship management is not permanent mediation, and it does not require sacrificing your boundary. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Proficient"
         }
       },
       "integrated": {
         "zh-CN": {
-          "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+          "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。",
           "strength": "你能在复杂关系中创造清晰、可持续的合作方式。",
           "risk": "因为你能处理关系，系统可能把过多情绪劳动交给你。",
           "typical_scene": "冲突升级时，你能帮助各方降温、对齐目标，并明确责任。",
           "practice_focus": "把个人调停转成系统规则：节奏、边界、责任和复盘。",
-          "do_not_overread": "高度整合不代表你必须承担所有关系维护工作。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。",
-          "label": "关系管理 · 高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。"
+          "do_not_overread": "这是本次自我报告在关系管理上的阅读层级，不是能力证明、固定标签或外部行为预测；具体解释仍要结合质量、场景和其他维度。",
+          "label": "关系管理 · 高度整合"
         },
         "en": {
-          "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+          "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone.",
           "strength": "You can create clear and sustainable collaboration in complex relationships.",
           "risk": "Because you can handle relationships, the system may hand you too much emotional labor.",
           "typical_scene": "When conflict escalates, you can help people cool down, align goals, and clarify responsibility.",
           "practice_focus": "Turn personal mediation into system rules: rhythm, boundary, responsibility, and review.",
-          "do_not_overread": "Integrated does not mean you must carry all relationship maintenance. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms.",
-          "label": "Relationship management · Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking."
+          "do_not_overread": "This is a reading band for Relationship Management in this self-report session, not proof of ability, a fixed label, or a prediction of external behavior; interpret it with quality, scenes, and other dimensions.",
+          "label": "Relationship Management · Integrated"
         }
       }
     }
   },
   "score_notes": {
     "zh-CN": {
-      "percentile": "百分位只表示在当前阶段性样本中的相对位置感，不是能力排名、真实水平排名或全球正式常模排名。",
-      "standard_score": "标准分用于稳定展示和维度比较；它是解释入口，不是现场表现证明。",
-      "band": "等级用于帮助阅读，不代表固定人格、能力证书或临床/职业判断。",
-      "provisional_norm": "当前常模为阶段性常模，后续样本、语言和版本更新可能改变解释边界。",
-      "commercial_boundary": "总分用于定位阅读入口，最终解释以四维、质量、证据状态和场景边界为准。"
+      "percentile": "百分位只表示当前阶段性样本中的相对位置参考，不是能力排名、真实水平排名、全球正式常模排名或职业竞争力排名。",
+      "standard_score": "标准分用于稳定展示和维度比较，是阅读入口，不是现场表现证明或能力证明。",
+      "band": "等级用于降低阅读负担，不代表固定人格、能力证书、临床结论、招聘信号或职业判断。",
+      "provisional_norm": "当前常模为阶段性常模，后续样本、语言版本和内容版本更新都可能改变解释边界。",
+      "commercial_boundary": "总分不应单独使用；完整解释必须结合四维、质量、证据状态、机制和场景边界。"
     },
     "en": {
-      "percentile": "Percentile only describes relative position in the current provisional sample. It is not an ability ranking, true-level ranking, or final global norm.",
-      "standard_score": "Standard score supports stable display and dimension comparison; it is a reading entry, not proof of live performance.",
-      "band": "Bands help users read the result; they are not fixed identities, credentials, clinical findings, or work decisions.",
-      "provisional_norm": "Current norms are provisional. Future samples, languages, and versions may change interpretation boundaries.",
-      "commercial_boundary": "The total score is a reading entry; interpretation depends on dimensions, confidence, evidence status, and scene boundaries."
+      "percentile": "Percentile only provides a relative-position reference within the current provisional sample. It is not an ability ranking, true-level ranking, final global norm, or career-competitiveness ranking.",
+      "standard_score": "Standard score supports stable display and dimension comparison. It is a reading entry, not proof of live performance or ability.",
+      "band": "Bands reduce reading effort; they are not fixed identities, credentials, clinical findings, hiring signals, or career judgments.",
+      "provisional_norm": "Current norms are provisional. Future samples, language versions, and content versions may change interpretation boundaries.",
+      "commercial_boundary": "The total score should not be used alone; full interpretation requires dimensions, quality, evidence status, mechanisms, and scene boundaries."
     }
   },
   "band_details": {
     "foundational": {
       "zh-CN": {
-        "label": "基础发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "当前信号提示本次结果提示可以先先建立更清晰的识别、命名和复位习惯。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "基础发展中",
+        "meaning": "当前信号提示本次结果提示可以先建立更清晰的识别、命名和复位习惯。",
         "strength": "从一个小而重复的动作开始，进步会更稳定。",
         "risk": "如果直接追求复杂沟通技巧，容易因为基础信号不清而挫败。",
         "practice_focus": "每天一次情绪命名，配合一个低成本复位动作。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Foundational Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "The current signal suggests starting with clearer recognition, naming, and reset habits. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Foundational",
+        "meaning": "The current self-report signal suggests starting with clearer recognition, naming, and reset habits.",
         "strength": "Small repeatable actions can create more stable progress.",
         "risk": "Jumping into complex communication tactics may frustrate you if the base signal is unclear.",
         "practice_focus": "Name one emotion daily and pair it with one low-cost reset action.",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     },
     "developing": {
       "zh-CN": {
-        "label": "发展中 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "发展中",
+        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。",
         "strength": "你已经能抓住一部分线索，适合把它们转成固定流程。",
         "risk": "最容易卡在“知道一点，但现场用不上”。",
         "practice_focus": "选择一个高频场景，提前准备一句回应。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Developing Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Developing",
+        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension.",
         "strength": "You already catch part of the signal and can turn it into a routine.",
         "risk": "The common trap is knowing something but not using it in the moment.",
         "practice_focus": "Pick one frequent scene and prepare one response sentence.",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     },
     "stable": {
       "zh-CN": {
-        "label": "稳定可用 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "多数日常场景中，你能使用这些情绪与关系能力，但仍有明确触发点。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "稳定可用",
+        "meaning": "多数日常场景中，你能使用这些情绪与关系模式，但仍有明确触发点。",
         "strength": "你的结果已经能支持更精细的场景训练。",
         "risk": "稳定不等于没有代价，尤其在高强度关系环境中。",
         "practice_focus": "找出最容易失稳的一个场景，做事后复盘。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Stable Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "In many everyday settings, these emotional and relational skills are usable, with specific triggers still visible. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Stable",
+        "meaning": "In many everyday settings, these emotional and relational patterns are easier to use, with specific triggers still visible.",
         "strength": "Your result can support more precise scene-based practice.",
         "risk": "Stability does not mean no cost, especially in high-intensity relational environments.",
         "practice_focus": "Identify one scene where stability drops and review it afterward.",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     },
     "proficient": {
       "zh-CN": {
-        "label": "熟练成熟 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "你通常能较稳定地识别、调节和处理关系信号。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "熟练成熟",
+        "meaning": "你通常能较稳定地识别、调节和处理关系信号。",
         "strength": "你可以把个人优势转成可复制的沟通习惯。",
         "risk": "他人可能默认你应该一直承担稳定局面的角色。",
         "practice_focus": "把“我能处理”升级为“我选择如何处理”。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Proficient Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Proficient",
+        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency.",
         "strength": "You can turn personal strengths into repeatable communication habits.",
         "risk": "Others may assume you should always be the stabilizing person.",
         "practice_focus": "Move from “I can handle this” to “I choose how to handle this.”",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     },
     "integrated": {
       "zh-CN": {
-        "label": "高度整合 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
-        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。 标准分、百分位和等级只表示阶段性样本中的自我报告相对位置，不是能力排名。",
+        "label": "高度整合",
+        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。",
         "strength": "你适合把优势系统化，形成边界、修复和恢复节奏。",
         "risk": "高整合也可能带来过度承担和高标准疲劳。",
         "practice_focus": "建立恢复边界，避免把稳定别人变成默认责任。",
-        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。 分数是当前阶段性常模中的自我报告近似指标，不是能力排名、真实水平排名或全球正式常模。"
+        "do_not_overread": "总分等级只是报告阅读入口，不能替代四维、答题质量、证据状态和场景解释；它不是能力排名、诊断结论或职业判断。"
       },
       "en": {
-        "label": "Integrated Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
-        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view. Standard scores, percentiles, and bands describe provisional relative position within a self-report sample, not an ability ranking.",
+        "label": "Integrated",
+        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view.",
         "strength": "You can systematize strengths into boundaries, repair, and recovery rhythm.",
         "risk": "High integration may still create over-responsibility and high-standard fatigue.",
         "practice_focus": "Build recovery boundaries so stabilizing others does not become your default duty.",
-        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation. Scores are approximate self-report indicators within the current provisional norm sample; they are not ability rankings, true-level rankings, or final global norms."
+        "do_not_overread": "The total-score band is only a report-reading entry. It does not replace dimensions, response quality, evidence status, or scene interpretation, and it is not an ability ranking, diagnosis, or career judgment."
       }
     }
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -68656,8 +68656,8 @@
     "depends_on": [
       "PR-EQ-ASSET-AUDIT-00"
     ],
-    "status": "pr_open",
-    "commit_sha": "c5478e267a0c9f724a2fef186b77364a2ae1ece5",
+    "status": "merged",
+    "commit_sha": "d855e8c6b440078fc517991fbe2bc7e3a5dcb474",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2611",
     "checks": [
       {
@@ -68707,14 +68707,14 @@
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T17:15:28Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -68733,6 +68733,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "summary": "Opened PR #2611 after scoped local validation passed."
+      },
+      {
+        "at": "2026-07-02T17:19:31.629240Z",
+        "from": "pr_open",
+        "to": "merged",
+        "summary": "Reconciled PR #2611 merge commit 67702f7e00644a2413b91586fe7d757b32609c17; origin/main contains merge commit and task branch was cleaned."
       }
     ]
   },
@@ -68745,17 +68751,63 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-03"
     ],
-    "status": "user_authorized",
-    "commit_sha": null,
-    "pr_url": null,
-    "checks": [],
+    "status": "pr_open",
+    "commit_sha": "295a1c7fee94a6c62f18997d835cdad96e3f19d5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2613",
+    "checks": [
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; scoped compiled report assets retained."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 432 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed_with_warnings",
+        "summary": "12 tests passed, 683 assertions; PHPUnit reported environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 208 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed_with_warnings",
+        "summary": "4 tests passed, 130 assertions; PHPUnit reported environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 16 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "score_system mechanical suffix sanity scan",
+        "status": "passed",
+        "summary": "No mechanical standard-score suffixes or known English typo patterns remain in the scoped score_system assets."
+      },
+      {
+        "command": "cmp EQ_60 and EQ_EMOTIONAL_INTELLIGENCE score_system raw assets",
+        "status": "passed",
+        "summary": "Alias raw asset mirror is byte-for-byte identical."
+      }
+    ],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -68764,6 +68816,18 @@
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      },
+      {
+        "at": "2026-07-02T17:19:31.629240Z",
+        "from": "user_authorized",
+        "to": "local_checks_passed",
+        "summary": "Reworked score_system labels, dimension definitions, band notes, percentile/standard-score boundaries, and bilingual claim strength without changing scoring or norms; local EQ checks passed."
+      },
+      {
+        "at": "2026-07-02T17:22:59.291891Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "summary": "Opened PR #2613 for scoped score_system science-boundary repair; awaiting GitHub checks."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Cleaned mechanical boundary suffixes out of score-system labels, meanings, and band copy.
- Rewrote the global index, score notes, dimension definitions, and band do-not-overread copy for zh-CN/en.
- Clarified that standard scores, percentiles, and bands are self-report reading aids, not ability rankings, clinical findings, hiring signals, career judgments, or global final norms.
- Clarified SA/ER/EM/RM definitions, including empathy boundaries and relationship-management limits.
- Mirrored EQ_60 raw and compiled report assets into EQ_EMOTIONAL_INTELLIGENCE.
- Reconciled PR-EQ-ASSET-SCI-03 merged state in the PR-train ledger and recorded SCI-04 local validation.

## Why
SCI-04 is scoped to the score_system asset. The score layer should read like a professional psychometric explanation, not a pasted disclaimer or ability-ranking claim.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest`
- mechanical suffix / typo scan
- raw mirror check
- YAML/JSON parse
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No scoring formula changes.
- No norms algorithm changes.
- No formulation, mechanism, scene, career, action, quality-runtime, composer, frontend, SJT, commerce, CMS, SEO runtime, or deployment changes.