### PR TITLE
feat(personality): establish cross-type comparison backend authority

### DIFF
--- a/backend/app/Services/Cms/Mbti64CrossTypeComparisonAssetsDryRunPlanner.php
+++ b/backend/app/Services/Cms/Mbti64CrossTypeComparisonAssetsDryRunPlanner.php
@@ -9,6 +9,31 @@ use RuntimeException;
 
 final class Mbti64CrossTypeComparisonAssetsDryRunPlanner
 {
+    private const ARTIFACT_ID = 'MBTI64-CROSS-TYPE-COMPARISON-ASSETS-DRY-RUN-01';
+
+    private const AUTHORITY_CONTRACT_VERSION = 'mbti.cross_type_comparison.authority.v1';
+
+    private const READMODEL_CONTRACT_VERSION = 'mbti.cross_type_comparison.readmodel.v1';
+
+    private const STORAGE_CONTRACT = 'backend_authority.mbti64_cross_type_comparison';
+
+    private const COMPARISON_TYPE = 'mbti_cross_type';
+
+    private const LOCALE = 'zh-CN';
+
+    private const EXPECTED_AVAILABLE_SLUGS = [
+        'enfp-vs-entp',
+        'entj-vs-intj',
+        'estj-vs-entj',
+        'infj-vs-infp',
+        'intj-vs-intp',
+        'isfp-vs-infp',
+    ];
+
+    private const PENDING_MISSING_SLUGS = [
+        'istj-vs-isfj' => 'ISTJ_vs_ISFJ_Content_Asset_Package.zip',
+    ];
+
     private const FORBIDDEN_PUBLIC_ROUTE_PATTERN =
         '~/(?:[a-z]{2}(?:-[A-Z]{2})?/)?(?:result|results|orders|order|share|pay|payment|history|private|account)(?:/|[?#\s)"\']|$)~i';
 
@@ -48,8 +73,14 @@ final class Mbti64CrossTypeComparisonAssetsDryRunPlanner
             $errors = array_merge($errors, $assetErrors);
         }
 
+        $availableSlugs = array_map(
+            static fn (array $row): string => (string) $row['slug'],
+            $rows
+        );
+        sort($availableSlugs);
+
         return [
-            'artifact' => 'MBTI64-CROSS-TYPE-COMPARISON-ASSETS-DRY-RUN-01',
+            'artifact' => self::ARTIFACT_ID,
             'status' => $errors === [] ? 'pass' : 'fail',
             'ok' => $errors === [],
             'dry_run' => true,
@@ -69,6 +100,11 @@ final class Mbti64CrossTypeComparisonAssetsDryRunPlanner
             'comparison_count' => count($rows),
             'rows_would_stage' => count($rows),
             'target_contract' => $this->targetContract(),
+            'authority_contract' => $this->authorityContract($availableSlugs),
+            'readmodel_contract' => $this->readmodelContract(),
+            'available_slugs' => $availableSlugs,
+            'expected_available_slugs' => self::EXPECTED_AVAILABLE_SLUGS,
+            'pending_missing_slugs' => $this->pendingMissingSlugs(),
             'rows' => $rows,
             'errors' => $errors,
             'warnings' => [],
@@ -120,11 +156,11 @@ final class Mbti64CrossTypeComparisonAssetsDryRunPlanner
             $errors[] = $this->issue($path.'.left_type', 'type_fields_must_match_slug', 'left_type and right_type must match the slug.');
         }
 
-        if ($this->stringValue($asset['comparison_type'] ?? null) !== 'mbti_cross_type') {
+        if ($this->stringValue($asset['comparison_type'] ?? null) !== self::COMPARISON_TYPE) {
             $errors[] = $this->issue($path.'.comparison_type', 'comparison_type_must_be_mbti_cross_type', 'comparison_type must be mbti_cross_type.');
         }
 
-        if ($this->stringValue($asset['locale'] ?? null) !== 'zh-CN') {
+        if ($this->stringValue($asset['locale'] ?? null) !== self::LOCALE) {
             $errors[] = $this->issue($path.'.locale', 'locale_must_be_zh_cn', 'Locale must be zh-CN.');
         }
 
@@ -204,14 +240,17 @@ final class Mbti64CrossTypeComparisonAssetsDryRunPlanner
             'slug' => (string) $asset['slug'],
             'left_type' => strtoupper((string) $asset['left_type']),
             'right_type' => strtoupper((string) $asset['right_type']),
-            'locale' => 'zh-CN',
+            'locale' => self::LOCALE,
             'source_file' => $this->relativePath($file),
             'source_sha256' => hash('sha256', $raw),
             'target' => [
-                'storage' => 'future_backend_authority.mbti64_cross_type_comparison',
+                'storage' => self::STORAGE_CONTRACT,
                 'write_mode' => 'draft_package_plan_only',
                 'public_api_enabled' => false,
             ],
+            'authority_contract_version' => self::AUTHORITY_CONTRACT_VERSION,
+            'readmodel_contract_version' => self::READMODEL_CONTRACT_VERSION,
+            'projection' => $this->readmodelProjection($asset, $raw),
             'draft_state_after_import' => [
                 'review_status' => 'draft',
                 'publish_status' => 'draft',
@@ -230,7 +269,7 @@ final class Mbti64CrossTypeComparisonAssetsDryRunPlanner
     private function targetContract(): array
     {
         return [
-            'storage' => 'future_backend_authority.mbti64_cross_type_comparison',
+            'storage' => self::STORAGE_CONTRACT,
             'overlay_contract' => [
                 'slug',
                 'comparison_type',
@@ -245,6 +284,134 @@ final class Mbti64CrossTypeComparisonAssetsDryRunPlanner
             ],
             'public_runtime_enabled' => false,
         ];
+    }
+
+    /**
+     * @param  list<string>  $availableSlugs
+     * @return array<string,mixed>
+     */
+    private function authorityContract(array $availableSlugs): array
+    {
+        return [
+            'contract_version' => self::AUTHORITY_CONTRACT_VERSION,
+            'artifact' => self::ARTIFACT_ID,
+            'storage' => self::STORAGE_CONTRACT,
+            'comparison_type' => self::COMPARISON_TYPE,
+            'locale' => self::LOCALE,
+            'source_package_id' => 'mbti-cross-type-comparison-content-assets-draft-20260702',
+            'source_mode' => 'operator_reviewed_draft_package',
+            'write_mode' => 'draft_package_plan_only',
+            'public_api_enabled' => false,
+            'available_slugs' => $availableSlugs,
+            'pending_missing_slugs' => $this->pendingMissingSlugs(),
+            'governance' => [
+                'cms_write_supported' => false,
+                'publish_supported' => false,
+                'indexability_supported' => false,
+                'search_release_supported' => false,
+                'sitemap_llms_release_supported' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readmodelContract(): array
+    {
+        return [
+            'contract_version' => self::READMODEL_CONTRACT_VERSION,
+            'storage' => self::STORAGE_CONTRACT,
+            'public_api_enabled' => false,
+            'fields' => [
+                'slug',
+                'comparison_type',
+                'locale',
+                'left_type',
+                'right_type',
+                'title',
+                'seo_title',
+                'seo_description',
+                'summary',
+                'section_count',
+                'faq_count',
+                'internal_link_count',
+                'claim_boundary_present',
+                'source_notes_count',
+                'review_status',
+                'publish_status',
+                'indexability_status',
+                'source_sha256',
+                'public_api_enabled',
+                'is_public',
+                'is_indexable',
+            ],
+            'forbidden_runtime_side_effects' => [
+                'cms_write',
+                'publish',
+                'queue_enqueue',
+                'search_submit',
+                'sitemap_release',
+                'llms_release',
+                'canonical_hreflang_jsonld_release',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return array<string,mixed>
+     */
+    private function readmodelProjection(array $asset, string $raw): array
+    {
+        $sections = is_array($asset['sections'] ?? null) ? $asset['sections'] : [];
+        $faq = is_array($asset['faq'] ?? null) ? $asset['faq'] : [];
+        $internalLinks = is_array($asset['internal_links'] ?? null) ? $asset['internal_links'] : [];
+        $sourceNotes = is_array($asset['source_notes'] ?? null) ? $asset['source_notes'] : [];
+
+        return [
+            'contract_version' => self::READMODEL_CONTRACT_VERSION,
+            'slug' => (string) $asset['slug'],
+            'comparison_type' => self::COMPARISON_TYPE,
+            'locale' => self::LOCALE,
+            'left_type' => strtoupper((string) $asset['left_type']),
+            'right_type' => strtoupper((string) $asset['right_type']),
+            'title' => (string) $asset['title'],
+            'seo_title' => (string) $asset['seo_title'],
+            'seo_description' => (string) $asset['seo_description'],
+            'summary' => (string) $asset['summary'],
+            'section_count' => count($sections),
+            'faq_count' => count($faq),
+            'internal_link_count' => count($internalLinks),
+            'claim_boundary_present' => $this->stringValue($asset['claim_boundary'] ?? null) !== null,
+            'source_notes_count' => count($sourceNotes),
+            'review_status' => 'draft',
+            'publish_status' => 'draft',
+            'indexability_status' => (string) ($asset['indexability_status'] ?? 'pending_review'),
+            'source_sha256' => hash('sha256', $raw),
+            'public_api_enabled' => false,
+            'is_public' => false,
+            'is_indexable' => false,
+        ];
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function pendingMissingSlugs(): array
+    {
+        $pending = [];
+
+        foreach (self::PENDING_MISSING_SLUGS as $slug => $expectedAsset) {
+            $pending[] = [
+                'slug' => $slug,
+                'status' => 'pending_asset',
+                'expected_asset' => $expectedAsset,
+                'reason' => 'requested_cross_type_asset_not_available',
+            ];
+        }
+
+        return $pending;
     }
 
     private function stringValue(mixed $value): ?string

--- a/backend/docs/seo/import-packages/mbti-cross-type-comparison-content-assets-draft-20260702/README.md
+++ b/backend/docs/seo/import-packages/mbti-cross-type-comparison-content-assets-draft-20260702/README.md
@@ -6,6 +6,9 @@ This package is a backend-only dry-run package for GPT-generated MBTI cross-type
 
 - Package: `mbti-cross-type-comparison-content-assets-draft-20260702`
 - Artifact: `MBTI64-CROSS-TYPE-COMPARISON-ASSETS-DRY-RUN-01`
+- Authority contract: `mbti.cross_type_comparison.authority.v1`
+- Readmodel contract: `mbti.cross_type_comparison.readmodel.v1`
+- Storage authority: `backend_authority.mbti64_cross_type_comparison`
 - Mode: dry-run only
 - CMS write: no
 - Publish: no
@@ -15,9 +18,16 @@ This package is a backend-only dry-run package for GPT-generated MBTI cross-type
 
 This package contains 6 draft cross-type comparison assets: `intj-vs-intp`, `infj-vs-infp`, `enfp-vs-entp`, `estj-vs-entj`, `isfp-vs-infp`, and `entj-vs-intj`.
 
+The dry-run planner exposes a formal internal readmodel projection for each asset:
+`slug`, `comparison_type`, `locale`, `left_type`, `right_type`, `title`, `seo_title`,
+`seo_description`, `summary`, section/FAQ/internal-link counts, governance status,
+source SHA, and public/indexability gates. The projection is internal-only in this
+package and keeps `public_api_enabled=false`.
+
 ## Missing requested asset
 
 `istj-vs-isfj` was requested but no matching desktop asset package was found in this scan.
+It is recorded as `pending_asset` and must not be fabricated from adjacent MBTI content.
 
 ## Validation
 
@@ -37,4 +47,3 @@ Expected dry-run summary:
 - `publish_attempted=false`
 - `search_release_attempted=false`
 - `sitemap_llms_release_attempted=false`
-

--- a/backend/docs/seo/import-packages/mbti-cross-type-comparison-content-assets-draft-20260702/manifest.json
+++ b/backend/docs/seo/import-packages/mbti-cross-type-comparison-content-assets-draft-20260702/manifest.json
@@ -3,7 +3,9 @@
     "artifact": "MBTI64-CROSS-TYPE-COMPARISON-ASSETS-DRY-RUN-01",
     "status": "draft",
     "authority_target": {
-        "storage": "future_backend_authority.mbti64_cross_type_comparison",
+        "storage": "backend_authority.mbti64_cross_type_comparison",
+        "authority_contract_version": "mbti.cross_type_comparison.authority.v1",
+        "readmodel_contract_version": "mbti.cross_type_comparison.readmodel.v1",
         "public_api": "not_enabled_in_this_package",
         "write_mode": "draft_package_plan_only"
     },
@@ -17,6 +19,37 @@
     ],
     "missing_requested_assets": [
         "ISTJ_vs_ISFJ_Content_Asset_Package.zip"
+    ],
+    "pending_missing_slugs": [
+        {
+            "slug": "istj-vs-isfj",
+            "status": "pending_asset",
+            "expected_asset": "ISTJ_vs_ISFJ_Content_Asset_Package.zip",
+            "reason": "requested_cross_type_asset_not_available"
+        }
+    ],
+    "readmodel_projection_fields": [
+        "slug",
+        "comparison_type",
+        "locale",
+        "left_type",
+        "right_type",
+        "title",
+        "seo_title",
+        "seo_description",
+        "summary",
+        "section_count",
+        "faq_count",
+        "internal_link_count",
+        "claim_boundary_present",
+        "source_notes_count",
+        "review_status",
+        "publish_status",
+        "indexability_status",
+        "source_sha256",
+        "public_api_enabled",
+        "is_public",
+        "is_indexable"
     ],
     "dry_run_only": true,
     "write_supported_in_this_package": false,

--- a/backend/tests/Feature/Console/PersonalityMbti64CrossTypeComparisonAssetsDryRunCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CrossTypeComparisonAssetsDryRunCommandTest.php
@@ -33,6 +33,11 @@ final class PersonalityMbti64CrossTypeComparisonAssetsDryRunCommandTest extends 
         $this->assertSame(6, $payload['valid_count']);
         $this->assertSame(6, $payload['comparison_count']);
         $this->assertSame(6, $payload['rows_would_stage']);
+        $this->assertSame('mbti.cross_type_comparison.authority.v1', $payload['authority_contract']['contract_version']);
+        $this->assertSame('mbti.cross_type_comparison.readmodel.v1', $payload['readmodel_contract']['contract_version']);
+        $this->assertSame('backend_authority.mbti64_cross_type_comparison', $payload['authority_contract']['storage']);
+        $this->assertFalse($payload['authority_contract']['public_api_enabled']);
+        $this->assertFalse($payload['readmodel_contract']['public_api_enabled']);
 
         $slugs = array_column($payload['rows'], 'slug');
         sort($slugs);
@@ -44,12 +49,47 @@ final class PersonalityMbti64CrossTypeComparisonAssetsDryRunCommandTest extends 
             'intj-vs-intp',
             'isfp-vs-infp',
         ], $slugs);
+        $this->assertSame($slugs, $payload['available_slugs']);
+        $this->assertSame($slugs, $payload['expected_available_slugs']);
+        $this->assertSame([
+            [
+                'slug' => 'istj-vs-isfj',
+                'status' => 'pending_asset',
+                'expected_asset' => 'ISTJ_vs_ISFJ_Content_Asset_Package.zip',
+                'reason' => 'requested_cross_type_asset_not_available',
+            ],
+        ], $payload['pending_missing_slugs']);
+        $this->assertSame($payload['pending_missing_slugs'], $payload['authority_contract']['pending_missing_slugs']);
+        $this->assertNotContains('istj-vs-isfj', $payload['available_slugs']);
 
         foreach ($payload['rows'] as $row) {
             $this->assertSame('zh-CN', $row['locale']);
             $this->assertNotSame($row['left_type'], $row['right_type']);
-            $this->assertSame('future_backend_authority.mbti64_cross_type_comparison', $row['target']['storage']);
+            $this->assertSame('backend_authority.mbti64_cross_type_comparison', $row['target']['storage']);
             $this->assertFalse($row['target']['public_api_enabled']);
+            $this->assertSame('mbti.cross_type_comparison.authority.v1', $row['authority_contract_version']);
+            $this->assertSame('mbti.cross_type_comparison.readmodel.v1', $row['readmodel_contract_version']);
+            $this->assertSame($row['slug'], $row['projection']['slug']);
+            $this->assertSame('mbti_cross_type', $row['projection']['comparison_type']);
+            $this->assertSame('zh-CN', $row['projection']['locale']);
+            $this->assertSame($row['left_type'], $row['projection']['left_type']);
+            $this->assertSame($row['right_type'], $row['projection']['right_type']);
+            $this->assertSame('draft', $row['projection']['review_status']);
+            $this->assertSame('draft', $row['projection']['publish_status']);
+            $this->assertSame('pending_review', $row['projection']['indexability_status']);
+            $this->assertIsString($row['projection']['title']);
+            $this->assertIsString($row['projection']['seo_title']);
+            $this->assertIsString($row['projection']['seo_description']);
+            $this->assertIsString($row['projection']['summary']);
+            $this->assertGreaterThanOrEqual(5, $row['projection']['section_count']);
+            $this->assertGreaterThanOrEqual(4, $row['projection']['faq_count']);
+            $this->assertGreaterThanOrEqual(3, $row['projection']['internal_link_count']);
+            $this->assertTrue($row['projection']['claim_boundary_present']);
+            $this->assertGreaterThan(0, $row['projection']['source_notes_count']);
+            $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $row['projection']['source_sha256']);
+            $this->assertFalse($row['projection']['public_api_enabled']);
+            $this->assertFalse($row['projection']['is_public']);
+            $this->assertFalse($row['projection']['is_indexable']);
             $this->assertFalse($row['draft_state_after_import']['is_public']);
             $this->assertFalse($row['draft_state_after_import']['is_indexable']);
         }


### PR DESCRIPTION
## What changed
- Formalized the MBTI cross-type comparison dry-run package as an internal backend authority/readmodel contract.
- Added authority/readmodel contract versions, per-row readmodel projections, available slug evidence, and pending missing `istj-vs-isfj` tracking.
- Updated the package manifest/README to document the internal-only projection and missing asset boundary.

## Why
- API-02A needs a stable backend authority boundary before a future public cross-type comparison API.
- The current package has 6 valid cross-type assets and must explicitly avoid fabricating the missing ISTJ vs ISFJ asset.

## Validation
- `php artisan personality:mbti64-cross-type-comparison-assets-dry-run --source-dir=docs/seo/import-packages/mbti-cross-type-comparison-content-assets-draft-20260702 --json`
- `php artisan test --filter=PersonalityMbti64CrossTypeComparisonAssetsDryRunCommandTest --no-ansi`
- `./vendor/bin/pint --test app/Services/Cms/Mbti64CrossTypeComparisonAssetsDryRunPlanner.php tests/Feature/Console/PersonalityMbti64CrossTypeComparisonAssetsDryRunCommandTest.php`
- `git diff --check`

## Intentionally deferred
- No public API route in this PR.
- No CMS write/import/publish.
- No DB migration.
- No sitemap, llms, JSON-LD, canonical, hreflang, or search submission.
- `istj-vs-isfj` remains pending until a real asset package exists.

## Repository rule impact
This remains backend-authoritative baseline/dry-run package work. It does not add runtime frontend content, public indexing, or CMS publication behavior.