### PR TITLE
RIASEC-CONTENT-ACTIVITY-02 harden RIASEC activity explorer selection

### DIFF
--- a/backend/app/Services/Riasec/RiasecActivityExplorerService.php
+++ b/backend/app/Services/Riasec/RiasecActivityExplorerService.php
@@ -27,6 +27,11 @@ final class RiasecActivityExplorerService
         'commercial_expansion_candidate_not_runtime_imported',
     ];
 
+    public function __construct(
+        private readonly ?string $activityTaskAssetPath = null,
+        private readonly ?string $occupationExampleAssetPath = null,
+    ) {}
+
     /**
      * @var array<string,array{dimension:string,label:array{en:string,zh-CN:string},core_drive:array{en:string,zh-CN:string},activity_families:list<string>}>
      */
@@ -227,6 +232,17 @@ final class RiasecActivityExplorerService
                 static fn (array $activity): string => (string) ($activity['activity_key'] ?? ''),
                 $activities,
             )),
+            'selection_policy' => [
+                'ordering' => 'holland_code_order_then_asset_order',
+                'per_dimension_limit' => 3,
+                'source_status_required' => self::SOURCE_STATUS,
+                'commercial_expansion_rows_publicly_selectable' => false,
+                'dedupe_key' => 'activity_key',
+                'fail_closed_on_invalid_or_incomplete_asset' => true,
+                'not_a_recommendation' => true,
+                'ranking_allowed' => false,
+                'fit_score_allowed' => false,
+            ],
             'activities' => $activities,
             'occupation_examples' => [],
         ];
@@ -256,7 +272,11 @@ final class RiasecActivityExplorerService
                     break;
                 }
 
-                if (isset($seen[$row['activity_key']]) || ! in_array($dimension, $row['dimensions'], true)) {
+                if (
+                    isset($seen[$row['activity_key']])
+                    || ($row['source_status'] ?? null) !== self::SOURCE_STATUS
+                    || ! in_array($dimension, $row['dimensions'], true)
+                ) {
                     continue;
                 }
 
@@ -264,24 +284,30 @@ final class RiasecActivityExplorerService
                 $selected[] = $this->normalizeFileBackedActivity($row, $locale);
                 $perDimension++;
             }
+
+            if ($perDimension < 3) {
+                return [];
+            }
         }
 
-        return $selected;
+        return count($selected) === count($dimensions) * 3 ? $selected : [];
     }
 
     /**
-     * @return list<array{activity_key:string,dimensions:list<string>,activity_label:string,task_examples:list<string>,low_risk_validation:string,action_duration_options:array<string,string>}>
+     * @return list<array{activity_key:string,source_status:string,dimensions:list<string>,activity_label:string,task_examples:list<string>,low_risk_validation:string,action_duration_options:array<string,string>}>
      */
     private function loadActivityTaskAssetRows(): array
     {
-        static $cache = null;
-        if (is_array($cache)) {
-            return $cache;
+        static $cache = [];
+
+        $assetPath = $this->activityTaskAssetPath ?? self::ACTIVITY_TASK_ASSET_PATH;
+        if (array_key_exists($assetPath, $cache)) {
+            return $cache[$assetPath];
         }
 
-        $path = base_path(self::ACTIVITY_TASK_ASSET_PATH);
+        $path = $this->resolveAssetPath($assetPath);
         if (! is_file($path) || ! is_readable($path)) {
-            return $cache = [];
+            return $cache[$assetPath] = [];
         }
 
         $rows = [];
@@ -289,15 +315,16 @@ final class RiasecActivityExplorerService
             try {
                 $decoded = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
             } catch (\JsonException) {
-                return $cache = [];
+                return $cache[$assetPath] = [];
             }
 
             if (! is_array($decoded) || ! $this->isValidActivityTaskRow($decoded)) {
-                return $cache = [];
+                return $cache[$assetPath] = [];
             }
 
             $rows[] = [
                 'activity_key' => (string) $decoded['activity_key'],
+                'source_status' => (string) $decoded['source_status'],
                 'dimensions' => array_values(array_map('strval', (array) $decoded['dimensions'])),
                 'activity_label' => (string) $decoded['activity_label'],
                 'task_examples' => array_values(array_map('strval', (array) $decoded['task_examples'])),
@@ -306,7 +333,7 @@ final class RiasecActivityExplorerService
             ];
         }
 
-        return $cache = $rows;
+        return $cache[$assetPath] = $rows;
     }
 
     /**
@@ -343,11 +370,17 @@ final class RiasecActivityExplorerService
         return count((array) $row['task_examples']) >= 3
             && is_string($row['activity_label'] ?? null)
             && is_string($row['low_risk_validation'] ?? null)
-            && is_array($row['action_duration_options'] ?? null);
+            && is_array($row['action_duration_options'] ?? null)
+            && isset(
+                $row['action_duration_options']['15min'],
+                $row['action_duration_options']['30min'],
+                $row['action_duration_options']['2h'],
+                $row['action_duration_options']['1week'],
+            );
     }
 
     /**
-     * @param  array{activity_key:string,dimensions:list<string>,activity_label:string,task_examples:list<string>,low_risk_validation:string,action_duration_options:array<string,string>}  $row
+     * @param  array{activity_key:string,source_status:string,dimensions:list<string>,activity_label:string,task_examples:list<string>,low_risk_validation:string,action_duration_options:array<string,string>}  $row
      * @return array<string,mixed>
      */
     private function normalizeFileBackedActivity(array $row, string $locale): array
@@ -365,8 +398,12 @@ final class RiasecActivityExplorerService
             'activity_user_copy' => $row['low_risk_validation'],
             'content_version' => self::CONTENT_VERSION,
             'evidence_level' => 'backend_authoritative_activity_task_asset',
-            'source_status' => self::SOURCE_STATUS,
+            'source_status' => $row['source_status'],
             'source_name' => self::SOURCE_NAME,
+            'not_a_recommendation' => true,
+            'ranking_allowed' => false,
+            'fit_score_allowed' => false,
+            'selection_boundary' => 'activity_example_not_recommendation',
             'task_examples' => $row['task_examples'],
             'occupation_examples' => $this->occupationExamplesForActivityDimensions($row['dimensions']),
             'next_experiments' => $nextExperiments,
@@ -414,7 +451,7 @@ final class RiasecActivityExplorerService
             return $cache;
         }
 
-        $path = base_path(self::OCCUPATION_EXAMPLE_ASSET_PATH);
+        $path = $this->resolveAssetPath($this->occupationExampleAssetPath ?? self::OCCUPATION_EXAMPLE_ASSET_PATH);
         if (! is_file($path) || ! is_readable($path)) {
             return $cache = [];
         }
@@ -504,6 +541,11 @@ final class RiasecActivityExplorerService
             'not_a_recommendation' => true,
             'fit_score_allowed' => false,
         ];
+    }
+
+    private function resolveAssetPath(string $path): string
+    {
+        return str_starts_with($path, DIRECTORY_SEPARATOR) ? $path : base_path($path);
     }
 
     /**

--- a/backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php
@@ -73,14 +73,40 @@ final class RiasecActivityExplorerServiceTest extends TestCase
             ['r_field_observe_1', 'r_proto_1', 'r_debug_1'],
             array_slice((array) data_get($payload, 'code_activity_pack.activity_chain'), 0, 3),
         );
+        $this->assertSame(
+            [
+                'r_field_observe_1',
+                'r_proto_1',
+                'r_debug_1',
+                'c_sort_1',
+                'c_process_1',
+                'c_check_1',
+                'e_pitch_1',
+                'e_resource_1',
+                'e_goal_1',
+            ],
+            data_get($payload, 'code_activity_pack.activity_chain'),
+        );
+        $this->assertSame('holland_code_order_then_asset_order', data_get($payload, 'code_activity_pack.selection_policy.ordering'));
+        $this->assertSame(3, data_get($payload, 'code_activity_pack.selection_policy.per_dimension_limit'));
+        $this->assertSame('content_example_not_registry_match', data_get($payload, 'code_activity_pack.selection_policy.source_status_required'));
+        $this->assertFalse((bool) data_get($payload, 'code_activity_pack.selection_policy.commercial_expansion_rows_publicly_selectable'));
+        $this->assertFalse((bool) data_get($payload, 'code_activity_pack.selection_policy.ranking_allowed'));
+        $this->assertFalse((bool) data_get($payload, 'code_activity_pack.selection_policy.fit_score_allowed'));
         $this->assertSame('content_example_not_registry_match', data_get($payload, 'code_activity_pack.source_status'));
         $this->assertFalse((bool) data_get($payload, 'boundary.registry_source_connected'));
 
         $activities = (array) data_get($payload, 'code_activity_pack.activities', []);
         $this->assertCount(9, $activities);
+        $this->assertCount(9, array_unique(array_column($activities, 'activity_key')));
 
         foreach ($activities as $activity) {
             $this->assertSame('content_example_not_registry_match', data_get($activity, 'source_status'));
+            $this->assertStringNotContainsString('commercial_variant', (string) data_get($activity, 'activity_key'));
+            $this->assertTrue((bool) data_get($activity, 'not_a_recommendation'));
+            $this->assertFalse((bool) data_get($activity, 'ranking_allowed'));
+            $this->assertFalse((bool) data_get($activity, 'fit_score_allowed'));
+            $this->assertSame('activity_example_not_recommendation', data_get($activity, 'selection_boundary'));
             $this->assertNotEmpty(data_get($activity, 'task_examples'));
             $this->assertNotEmpty(data_get($activity, 'occupation_examples'));
         }
@@ -109,6 +135,36 @@ final class RiasecActivityExplorerServiceTest extends TestCase
         $this->assertSame('available', data_get($payload, 'code_activity_pack.status'));
         $this->assertCount(9, (array) data_get($payload, 'code_activity_pack.activities'));
         $this->assertSame([], data_get($payload, 'code_activity_pack.occupation_examples'));
+    }
+
+    public function test_activity_pack_fails_closed_when_asset_is_invalid_or_incomplete(): void
+    {
+        $invalidAsset = tempnam(sys_get_temp_dir(), 'riasec-activity-invalid-');
+        $this->assertIsString($invalidAsset);
+        file_put_contents($invalidAsset, json_encode([
+            'schema_version' => 'riasec.activity_task_example.v1',
+            'asset_version' => 'riasec_activity_task_examples_v1.zh-CN',
+            'activity_key' => 'r_invalid_1',
+            'dimensions' => ['R'],
+            'activity_label' => '坏资产行',
+            'task_examples' => ['只有一条'],
+            'low_risk_validation' => '无效行应 fail closed。',
+            'source_status' => 'content_example_not_registry_match',
+            'not_a_recommendation' => true,
+            'frontend_fallback_allowed' => false,
+            'action_duration_options' => ['15min' => '只提供一个时长'],
+        ], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR).PHP_EOL);
+
+        try {
+            $payload = (new RiasecActivityExplorerService($invalidAsset))->build('RIA', 'zh-CN');
+
+            $this->assertSame('not_available_for_code_v1', data_get($payload, 'code_activity_pack.status'));
+            $this->assertSame('activity_task_examples_not_available', data_get($payload, 'code_activity_pack.reason'));
+            $this->assertSame([], data_get($payload, 'code_activity_pack.activities'));
+            $this->assertSame([], data_get($payload, 'code_activity_pack.occupation_examples'));
+        } finally {
+            @unlink($invalidAsset);
+        }
     }
 
     public function test_activity_explorer_payload_does_not_emit_forbidden_claim_copy(): void

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69740,9 +69740,9 @@
     "depends_on": [
       "RIASEC-CONTENT-ACTIVITY-01"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "336e40fdc6b4b0ead7a7df3374c093363da9c809",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2617",
     "checks": {
       "phpunit_activity_explorer_service": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php --no-ansi --display-warnings",
@@ -69790,6 +69790,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Hardened ACTIVITY-02 activity explorer selection, source filtering, dedupe, and fail-closed behavior; local RIASEC unit subset and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T17:35:11Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2617 after ACTIVITY-02 local validation, latest-main rebase, and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69648,8 +69648,8 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "pr_opened",
-    "commit_sha": "07c497bec2d1e0c9cb066c685fe6befdf0d9bf25",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "71f6beb7f16ece11a4d9e967f6fd506b2f4f4f4a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2614",
     "checks": {
       "phpunit_activity_preflight": {
@@ -69674,24 +69674,33 @@
       "manifest_state_parse_and_diff_check": {
         "command": "ruby YAML parse; python JSON parse; git diff --check",
         "status": "passed"
+      },
+      "github_required_checks": {
+        "command": "gh pr view 2614 --json statusCheckRollup,mergeStateStatus",
+        "status": "passed",
+        "summary": "All reported GitHub CI and Code Scanning checks succeeded; mergeStateStatus CLEAN before squash merge."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T17:28:53Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/content_assets/riasec/activity_task_examples_v1.zh-CN.jsonl",
         "backend/docs/riasec/activity-task-examples-pack-05-preflight.md",
         "backend/tests/Fixtures/Riasec/activity_task_examples_v1.zh-CN.jsonl",
         "backend/tests/Unit/Services/Riasec/RiasecActivityTaskExamplesPreflightTest.php",
         "docs/codex/pr-train-state.json"
-      ]
+      ],
+      "origin_main_contains_merge_commit": true,
+      "local_main_synced": true,
+      "local_main_equals_origin_main": true,
+      "clean_worktree_after_cleanup": true
     },
     "transitions": [
       {
@@ -69711,8 +69720,15 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2614 after ACTIVITY-01 local validation, latest-main rebase, and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T17:33:06Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2614 merged; origin/main contains merge commit; local main synced; task branches cleaned. Recorded during ACTIVITY-02 ledger reconciliation."
       }
-    ]
+    ],
+    "merge_commit_sha": "3e48faa7e12ddcddd8b443e2c93ea40fb13722d5"
   },
   "RIASEC-CONTENT-ACTIVITY-02": {
     "id": "RIASEC-CONTENT-ACTIVITY-02",
@@ -69724,19 +69740,43 @@
     "depends_on": [
       "RIASEC-CONTENT-ACTIVITY-01"
     ],
-    "status": "authorized_pending_start",
+    "status": "local_validation_passed",
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "phpunit_activity_explorer_service": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "7 tests, 455 assertions"
+      },
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "168 tests, 98265 assertions"
+      },
+      "pint": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecActivityExplorerService.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php",
+        "status": "passed"
+      },
+      "manifest_state_parse_and_diff_check": {
+        "command": "ruby YAML parse; python JSON parse; git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecActivityExplorerService.php",
+        "backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -69744,6 +69784,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T17:33:06Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Hardened ACTIVITY-02 activity explorer selection, source filtering, dedupe, and fail-closed behavior; local RIASEC unit subset and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Hardened `RiasecActivityExplorerService` so public activity packs select only runtime-approved `content_example_not_registry_match` activity rows.
- Made selection deterministic: Holland code order, then asset order, three activities per dimension.
- Added explicit selection policy metadata, activity-level non-recommendation boundaries, ranking/fit-score false flags, and fail-closed behavior for invalid or incomplete activity assets.
- Added tests for deterministic order, dedupe, commercial expansion row exclusion, no recommendation flags, and invalid-asset fail-closed behavior.
- Reconciled ACTIVITY-01 post-merge ledger state and recorded ACTIVITY-02 local validation.

## Why
- Activity examples must not be read as recommendations or ranking output. The service should make that boundary explicit and avoid selecting commercial expansion rows before a scoped runtime decision exists.
- Missing or malformed backend assets should omit the activity pack instead of emitting partial or fallback copy.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php --no-ansi --display-warnings`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecActivityExplorerService.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check origin/main...HEAD`

## Intentionally deferred
- No activity content rewrite; completed in ACTIVITY-01.
- No occupation example content/projection boundary changes; those remain OCC PRs.
- No CMS writes, production import, database migration, frontend fallback copy, staging deploy wait, server verification, manual deploy, or production deploy.

## Repository rule impact
- Content authority remains backend. This PR only changes backend RIASEC service selection logic, unit tests, and PR-train ledger state within the authorized train scope.