### PR TITLE
PR-EQ-ASSET-SCI-05: reduce EQ core_formulation claim strength and increase depth

### DIFF
--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T17:18:52.198969Z",
+    "generated_at": "2026-07-02T17:49:08.361934Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -682,37 +682,37 @@
             "formulations": {
                 "balanced_integrated": {
                     "zh-CN": {
-                        "title": "自我报告模式：均衡整合型",
-                        "one_liner": "你不是只擅长某一项，而是较能把觉察、调节、共情和关系处理连起来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你通常能看见自己的状态，也能顾及他人的感受，并把情绪信息转成相对稳定的沟通和行动。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：均衡整合",
+                        "one_liner": "本次自我报告显示，你较少只靠单一优势应对情绪关系问题，而是倾向于把自我觉察、调节、共情和关系处理连在一起使用。",
+                        "core_claim": "这个结果提示你对自己和他人的情绪线索都有一定可用感，也认为自己能把这些线索转成相对稳定的沟通选择。它仍然需要用真实反馈和具体场景来校准。",
                         "evidence_basis": [
                             "Four dimensions high or upper-stable; no severe gap."
                         ],
-                        "primary_strength": "复杂对话里，你更容易同时顾及事实、情绪和关系目标。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "优势太均衡时，你可能低估持续恢复和边界维护的必要性。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把稳定优势转成可复用的沟通流程，而不是只靠当下状态。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你不是只擅长某一项，而是较能把觉察、调节、共情和关系处理连起来。"
+                        "primary_strength": "在需要同时处理事实、情绪和关系目标时，你可能更容易保持整体视角。",
+                        "likely_cost": "均衡感也可能让你低估恢复、边界和复盘的必要性，尤其在长期消耗的关系或团队环境里。",
+                        "development_lever": "把“整体稳定”拆成可复用流程：先识别情绪线索，再确认边界，最后选择沟通动作。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你倾向于把觉察、调节、共情和关系处理连起来使用。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Integrated Balance",
-                        "one_liner": "Your strength is not one isolated skill; it is how your self-reported awareness, regulation, empathy, and relationship-management signals appear to work together. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You usually notice your own state, register other people’s feelings, and turn emotional information into relatively steady communication and action. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Integrated balance",
+                        "one_liner": "In this self-report, your pattern is less about one standout strength and more about linking self-awareness, regulation, empathy, and relationship management together.",
+                        "core_claim": "The result suggests you experience both self-focused and other-focused emotional information as usable, and you see yourself as able to turn that information into steadier communication choices. It still needs calibration against real feedback and specific contexts.",
                         "evidence_basis": [
                             "Four dimensions high or upper-stable; no severe gap."
                         ],
-                        "primary_strength": "In complex conversations, you are more likely to hold the facts, the emotions, and the relationship goal at the same time. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "When things are going well, you may underestimate how much recovery and boundary maintenance still matter. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn your strengths into repeatable communication routines, rather than relying on being in a good state.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Your strength is not one isolated skill; it is how your self-reported awareness, regulation, empathy, and relationship-management signals appear to work together."
+                        "primary_strength": "When facts, feelings, and relationship goals all matter, you may be more likely to keep the whole situation in view.",
+                        "likely_cost": "A balanced self-view can make recovery, boundaries, and review feel less urgent than they are in long-running or high-demand settings.",
+                        "development_lever": "Translate “overall steadiness” into a repeatable sequence: notice the cue, check the boundary, then choose the communication move.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you tend to link awareness, regulation, empathy, and relationship handling rather than relying on one isolated strength."
                     },
                     "meta": {
                         "id": "balanced_integrated",
                         "asset_type": "core_formulation",
                         "v23_source_id": "balanced_integrated",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "balanced_strength",
                         "release_state": "stable",
                         "trigger_summary": "Four dimensions high or upper-stable; no severe gap.",
@@ -743,37 +743,37 @@
                 },
                 "high_empathy_low_recovery": {
                     "zh-CN": {
-                        "title": "自我报告模式：高共情，低恢复",
-                        "one_liner": "本次自我报告显示，你倾向于较快注意到他人的情绪线索，但在情绪负荷后可能需要更多恢复空间。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的共情不是问题；真正的杠杆是共情之后如何区分陪伴、责任和恢复。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：高共情线索，恢复负荷偏高",
+                        "one_liner": "本次自我报告显示，你较容易注意到他人的情绪线索，但在承接情绪后可能需要更多恢复空间。",
+                        "core_claim": "重点不是“共情太多”，而是你如何区分理解、责任、行动和恢复。真实关系中的权力差、亲密度和压力水平会显著影响这个模式。",
                         "evidence_basis": [
                             "EM high; ER low or medium-low."
                         ],
-                        "primary_strength": "你可能倾向于表达理解，尤其在对方情绪明显但没有说清楚时。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "你可能把“我理解你”滑向“我必须替你扛住”。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "练习共情后的边界句和恢复动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "本次自我报告显示，你倾向于较快注意到他人的情绪线索，但在情绪负荷后可能需要更多恢复空间。"
+                        "primary_strength": "你可能较快捕捉对方没有明说的情绪，并愿意用理解来维持连接。",
+                        "likely_cost": "如果边界不清，你可能把“我能理解”误变成“我必须承担”。",
+                        "development_lever": "练习共情后的边界句：先承认感受，再说明自己能承担和不能承担的部分。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你容易读到他人情绪，也需要更清楚的恢复和边界。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: High Empathy, Low Recovery",
-                        "one_liner": "Your self-report suggests you often notice emotional cues in others, but you may experience recovery as slower after emotionally loaded contact. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your empathy is not the problem. The leverage point is what happens after empathy: companionship, responsibility, and recovery need clearer separation. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Strong empathy cues, heavier recovery load",
+                        "one_liner": "In this self-report, you appear quick to notice emotional cues in others, while recovery after emotionally loaded contact may take more space.",
+                        "core_claim": "The issue is not “too much empathy.” The leverage point is separating understanding, responsibility, action, and recovery. Power dynamics, closeness, and stress level can change how this pattern shows up.",
                         "evidence_basis": [
                             "EM high; ER low or medium-low."
                         ],
-                        "primary_strength": "You may tend to communicate understanding, especially when their emotion is obvious but not clearly stated. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "You may slide from “I understand this” into “I have to carry this with you or for you.” Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Practice boundary language and recovery steps after empathic contact.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Your self-report suggests you often notice emotional cues in others, but you may experience recovery as slower after emotionally loaded contact."
+                        "primary_strength": "You may be quick to notice what someone is feeling before they state it directly, and you may use understanding to maintain connection.",
+                        "likely_cost": "Without a clear boundary, “I understand” can slide into “I have to carry this.”",
+                        "development_lever": "Practice a post-empathy boundary sentence: name the feeling, then state what you can and cannot take on.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you often notice others’ emotions and may need clearer recovery and boundaries afterward."
                     },
                     "meta": {
                         "id": "high_empathy_low_recovery",
                         "asset_type": "core_formulation",
                         "v23_source_id": "high_empathy_low_recovery",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "empathy_regulation_gap",
                         "release_state": "stable",
                         "trigger_summary": "EM high; ER low or medium-low.",
@@ -804,37 +804,37 @@
                 },
                 "aware_but_unregulated": {
                     "zh-CN": {
-                        "title": "自我报告模式：有觉察，调节不足",
-                        "one_liner": "你常常知道自己被触发了，但还没有总能把自己带回稳定状态。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的优势在于看见内在变化；发展点在于把“我知道”变成“我能暂停和恢复”。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：觉察较快，调节跟进不足",
+                        "one_liner": "本次自我报告显示，你较能意识到自己被触发了，但不一定能立刻把情绪强度降到适合行动的水平。",
+                        "core_claim": "这不是“知道也没用”的判断，而是提示觉察和调节之间可能有时间差。场景压力越高，这个时间差越需要被看见。",
                         "evidence_basis": [
                             "SA high; ER low or medium-low."
                         ],
-                        "primary_strength": "你能比很多人更快识别自己的情绪线索。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "觉察越清楚，若缺少调节步骤，越可能变成反复分析或内耗。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "给觉察配一个身体层面的暂停动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你常常知道自己被触发了，但还没有总能把自己带回稳定状态。"
+                        "primary_strength": "你可能比许多人更早发现自己的不适、紧张或防御反应。",
+                        "likely_cost": "如果缺少暂停，你可能在已经意识到情绪的情况下仍被情绪推动表达或决策。",
+                        "development_lever": "把觉察后面的 30 秒做实：暂停、命名、降速，再回应。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能很快知道自己怎么了，但还需要更稳定的恢复步骤。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Aware, Not Yet Settled",
-                        "one_liner": "You often know you have been triggered, but you may not always be able to bring yourself back to steadiness in time. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your strength is noticing the inner shift; the next step is turning “I know what is happening” into “I can pause and recover.” Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Fast awareness, slower regulation follow-through",
+                        "one_liner": "In this self-report, you seem able to notice when you are activated, but not always able to lower the intensity quickly enough for useful action.",
+                        "core_claim": "This is not a judgment that awareness “doesn’t help.” It suggests a possible lag between noticing emotion and regulating it, especially under pressure.",
                         "evidence_basis": [
                             "SA high; ER low or medium-low."
                         ],
-                        "primary_strength": "You can often identify your emotional cues faster than many people. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Clear awareness without regulation steps can turn into replaying, overanalyzing, or emotional fatigue. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Pair awareness with a physical pause that slows the next response.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You often know you have been triggered, but you may not always be able to bring yourself back to steadiness in time."
+                        "primary_strength": "You may catch discomfort, tension, or defensiveness relatively early.",
+                        "likely_cost": "Without a pause, you may still speak or decide from the emotion even after you have named it.",
+                        "development_lever": "Make the 30 seconds after awareness concrete: pause, label, slow down, then respond.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may know what is happening inside before you have a reliable recovery step."
                     },
                     "meta": {
                         "id": "aware_but_unregulated",
                         "asset_type": "core_formulation",
                         "v23_source_id": "aware_but_unregulated",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "awareness_regulation_gap",
                         "release_state": "stable",
                         "trigger_summary": "SA high; ER low or medium-low.",
@@ -865,37 +865,37 @@
                 },
                 "calm_but_distant": {
                     "zh-CN": {
-                        "title": "自我报告模式：冷静稳定，但情绪回应偏弱",
-                        "one_liner": "你能稳住局面，但别人不一定感到自己的情绪被你接住。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的调节能力能降低混乱，但如果少了情绪回应，稳定会被误读成疏离。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：自感稳定，情绪回应偏保留",
+                        "one_liner": "本次自我报告显示，你倾向于认为自己能保持稳定，但对他人情绪的回应可能更克制或更晚出现。",
+                        "core_claim": "这里的“稳定”不等于客观冷静能力，也不说明别人一定感到被支持；它提示你可以校准稳定与回应之间的距离。",
                         "evidence_basis": [
                             "ER high; EM low or medium-low."
                         ],
-                        "primary_strength": "压力高时，你更容易保持思路和节奏。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "别人可能听到了你的解决方案，却没有感到被理解。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在解决问题前先命名对方的感受。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能稳住局面，但别人不一定感到自己的情绪被你接住。"
+                        "primary_strength": "你可能在压力下不容易被情绪牵着走，能先保留判断空间。",
+                        "likely_cost": "他人可能需要的不只是稳定，也可能是被看见、被确认或被回应。",
+                        "development_lever": "练习把稳定转成可被感受到的回应：先复述对方关注点，再给出你的判断。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较重视稳定，但可以让回应更容易被他人感受到。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Calm, but Hard to Read Warmly",
-                        "one_liner": "You may keep the situation steady, while others may not always feel emotionally met. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your regulation can reduce chaos, but without emotional acknowledgment, steadiness can be mistaken for distance. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Steady self-view, reserved emotional response",
+                        "one_liner": "In this self-report, you see yourself as relatively steady, while your response to others’ emotions may be restrained or delayed.",
+                        "core_claim": "“Steady” here is not proof of objective calmness, and it does not mean others automatically feel supported. It points to a calibration question: how much response is visible?",
                         "evidence_basis": [
                             "ER high; EM low or medium-low."
                         ],
-                        "primary_strength": "Under pressure, you are more likely to keep your thinking and pacing intact. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "People may hear your solution without feeling that you understood the emotional weight of the moment. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Name the other person’s feeling before moving into problem-solving.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may keep the situation steady, while others may not always feel emotionally met."
+                        "primary_strength": "Under pressure, you may be less likely to get pulled immediately into emotional escalation.",
+                        "likely_cost": "Other people may need more than steadiness; they may need to feel seen, acknowledged, or answered.",
+                        "development_lever": "Turn steadiness into a visible response: reflect the concern first, then offer your view.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you value steadiness and may benefit from making emotional acknowledgment more visible."
                     },
                     "meta": {
                         "id": "calm_but_distant",
                         "asset_type": "core_formulation",
                         "v23_source_id": "calm_but_distant",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "regulation_empathy_gap",
                         "release_state": "stable",
                         "trigger_summary": "ER high; EM low or medium-low.",
@@ -926,37 +926,37 @@
                 },
                 "relationship_first_self_later": {
                     "zh-CN": {
-                        "title": "自我报告模式：关系优先，自我后置",
-                        "one_liner": "你很会维护关系，但有时把自己的真实感受排到太后面。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你会照顾气氛、流程和他人的反应；发展点是不要让关系稳定建立在自我忽略上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：关系优先，自我后置",
+                        "one_liner": "本次自我报告显示，你可能较快考虑关系氛围和他人感受，但自己的需要、限制或不满更晚才被表达。",
+                        "core_claim": "这不是“讨好型人格”诊断，而是一个自我报告线索：关系维护可能先于自我澄清。不同文化和权力关系会影响它是否是优势或负担。",
                         "evidence_basis": [
                             "RM high; SA low or medium-low."
                         ],
-                        "primary_strength": "你常能让对话继续进行，不轻易让场面崩掉。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "你可能很晚才发现自己其实已经不舒服。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在回应别人前先问自己一句：我现在真实需要什么？",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你很会维护关系，但有时把自己的真实感受排到太后面。"
+                        "primary_strength": "你可能擅长降低场面摩擦，避免让关系立即破裂。",
+                        "likely_cost": "长期后置自己可能让不满积累，并使边界表达变得突然或困难。",
+                        "development_lever": "在照顾关系前先补一句自我定位：我现在能接受什么，不能接受什么。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较先照顾关系，也需要更早把自己放进关系里。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Relationship First, Self Later",
-                        "one_liner": "You are often good at keeping relationships moving, but your own feelings may get pushed too far down the list. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can manage tone, flow, and other people’s reactions; the growth point is making sure relational stability does not depend on self-erasure. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Relationship first, self later",
+                        "one_liner": "In this self-report, you may consider the relationship climate and others’ feelings quickly, while your own needs, limits, or frustration appear later.",
+                        "core_claim": "This is not a diagnosis of people-pleasing. It is a self-report signal that relationship maintenance may come before self-clarification. Culture and power dynamics can determine whether this is useful or costly.",
                         "evidence_basis": [
                             "RM high; SA low or medium-low."
                         ],
-                        "primary_strength": "You often keep conversations going without letting the room collapse emotionally. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "You may realize late that you were uncomfortable much earlier. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Before responding to others, ask: what do I actually need right now?",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You are often good at keeping relationships moving, but your own feelings may get pushed too far down the list."
+                        "primary_strength": "You may be good at reducing immediate friction and keeping the relationship from breaking down too quickly.",
+                        "likely_cost": "Putting yourself last for too long can build resentment and make boundaries feel sudden or hard to state.",
+                        "development_lever": "Before protecting the relationship, add one self-positioning sentence: what you can accept and what you cannot.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you attend to the relationship early and may need to include yourself earlier too."
                     },
                     "meta": {
                         "id": "relationship_first_self_later",
                         "asset_type": "core_formulation",
                         "v23_source_id": "relationship_first_self_later",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "relationship_self_gap",
                         "release_state": "stable",
                         "trigger_summary": "RM high; SA low or medium-low.",
@@ -987,37 +987,37 @@
                 },
                 "self_clear_repair_weak": {
                     "zh-CN": {
-                        "title": "自我报告模式：自我清楚，修复不足",
-                        "one_liner": "你知道自己要表达什么，但关系修复的步骤可能还不够细。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的自我觉察让表达更清楚；发展点是让对方也能接住你的表达。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：自我较清楚，修复动作不足",
+                        "one_liner": "本次自我报告显示，你较知道自己的感受和立场，但在冲突后如何修复关系、重开对话或降低防御感上可能不够稳定。",
+                        "core_claim": "这不表示你“不会处理关系”，而是提示表达清楚和关系修复是两个不同环节。",
                         "evidence_basis": [
                             "SA high; RM low or medium-low."
                         ],
-                        "primary_strength": "你不容易完全失去自己的立场。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果缺少修复，清楚可能被听成强硬。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在表达后补上影响确认和关系修复。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你知道自己要表达什么，但关系修复的步骤可能还不够细。"
+                        "primary_strength": "你可能能较明确说出自己为什么不舒服、不同意或需要什么。",
+                        "likely_cost": "如果缺少修复动作，清楚表达可能被他人感受到为定案、拒绝或距离。",
+                        "development_lever": "给表达后加一个修复句：我想把问题说清楚，也想把关系留在可继续沟通的位置。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较清楚自己的立场，但冲突后的修复动作还可以更具体。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Clear About Self, Less Practiced at Repair",
-                        "one_liner": "You may know what you need to say, but the repair steps after impact may need more structure. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your self-awareness can make your expression clear; the next step is making that expression easier for another person to receive. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Clear self-position, weaker repair moves",
+                        "one_liner": "In this self-report, you seem relatively clear about your feelings and position, while post-conflict repair, reopening dialogue, or lowering defensiveness may be less consistent.",
+                        "core_claim": "This does not mean you “cannot handle relationships.” It separates clear expression from relational repair as two different steps.",
                         "evidence_basis": [
                             "SA high; RM low or medium-low."
                         ],
-                        "primary_strength": "You are less likely to lose track of your own position. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without repair, clarity can be heard as sharpness. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "After expressing yourself, add impact-checking and repair language.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may know what you need to say, but the repair steps after impact may need more structure."
+                        "primary_strength": "You may be able to state why something bothers you, where you disagree, or what you need.",
+                        "likely_cost": "Without repair, clear expression can be experienced by others as final, rejecting, or distant.",
+                        "development_lever": "Add a repair sentence after expression: I want to be clear about the issue and still keep the relationship open for dialogue.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may know your position clearly, while repair after tension can become more concrete."
                     },
                     "meta": {
                         "id": "self_clear_repair_weak",
                         "asset_type": "core_formulation",
                         "v23_source_id": "self_clear_repair_weak",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "expression_repair_gap",
                         "release_state": "stable",
                         "trigger_summary": "SA high; RM low or medium-low.",
@@ -1048,37 +1048,37 @@
                 },
                 "steady_collaborator": {
                     "zh-CN": {
-                        "title": "自我报告模式：稳定协作者",
-                        "one_liner": "你在压力下通常能把对话拉回问题本身，而不是被情绪完全带走。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的优势在于把稳定和关系推进结合起来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：协作稳定感较强",
+                        "one_liner": "本次自我报告显示，你较相信自己能在压力和协作中保持可沟通、可配合的状态。",
+                        "core_claim": "这不是团队能力证明，也不预测别人一定觉得你可靠；它提示你可以继续检验稳定感在高压和多方冲突里是否仍可维持。",
                         "evidence_basis": [
                             "ER high; RM high."
                         ],
-                        "primary_strength": "你适合做对话里的降温者和整理者。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "你可能低估别人还需要被情绪回应，而不只是被推进。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在推动下一步前，补一句情绪确认。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你在压力下通常能把对话拉回问题本身，而不是被情绪完全带走。"
+                        "primary_strength": "你可能能在多数协作情境中保持节奏，不轻易把压力转嫁给他人。",
+                        "likely_cost": "稳定也可能带来过度承担，尤其当团队默认你来兜底时。",
+                        "development_lever": "把稳定从“我来扛”转成“我们如何分配、同步和复盘”。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你对自己的协作稳定感较强，但仍需要边界和分工来支撑。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Steady Collaborator",
-                        "one_liner": "Under pressure, you can often bring the conversation back to the issue rather than letting emotion take over. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your strength is combining steadiness with relationship movement. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Collaborative steadiness",
+                        "one_liner": "In this self-report, you see yourself as able to stay communicative and cooperative under pressure and in group work.",
+                        "core_claim": "This is not proof of team performance, nor a prediction that others experience you as reliable. It suggests a stability pattern worth testing in high-pressure or multi-party conflict.",
                         "evidence_basis": [
                             "ER high; RM high."
                         ],
-                        "primary_strength": "You can be the person who cools the room down and organizes the next step. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "You may underestimate that others sometimes need emotional acknowledgment, not only forward motion. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Before moving the group forward, add one sentence of emotional acknowledgment.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Under pressure, you can often bring the conversation back to the issue rather than letting emotion take over."
+                        "primary_strength": "You may keep a workable rhythm in many collaborative settings without quickly displacing stress onto others.",
+                        "likely_cost": "Steadiness can turn into over-carrying when a team quietly expects you to absorb the strain.",
+                        "development_lever": "Shift from “I will hold this” to “how do we distribute, sync, and review this?”",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests stronger collaborative steadiness, with boundaries and role clarity still needed."
                     },
                     "meta": {
                         "id": "steady_collaborator",
                         "asset_type": "core_formulation",
                         "v23_source_id": "steady_collaborator",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "regulation_relationship_strength",
                         "release_state": "stable",
                         "trigger_summary": "ER high; RM high.",
@@ -1109,37 +1109,37 @@
                 },
                 "sensitive_absorber": {
                     "zh-CN": {
-                        "title": "自我报告模式：高敏感，易吸收",
-                        "one_liner": "你对自己和他人的情绪都很敏锐，但容易把太多信号带回身体里。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你捕捉细节的能力很强；真正要保护的是情绪能量的进出边界。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：敏感度高，吸收感偏强",
+                        "one_liner": "本次自我报告显示，你对自己和他人的情绪线索都较敏感，但也可能更容易把环境情绪带进自己身上。",
+                        "core_claim": "这不是高敏感诊断，也不是能力标签；它提示情绪线索对你的主观影响可能更强，需要区分信息、感受和责任。",
                         "evidence_basis": [
                             "SA high; EM high; ER medium-low."
                         ],
-                        "primary_strength": "你能注意到别人没说出口的变化。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "你可能在事情结束后还长时间停留在对方的情绪里。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "建立“接收—整理—放下”的结束仪式。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你对自己和他人的情绪都很敏锐，但容易把太多信号带回身体里。"
+                        "primary_strength": "你可能能捕捉细微信号，较早发现关系或氛围变化。",
+                        "likely_cost": "如果缺少筛选，你可能把别人的紧张、失望或期待当成自己的任务。",
+                        "development_lever": "练习三分法：这是我观察到的信息、我受到的影响、我真正需要承担的行动。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较敏感，也更需要筛选哪些情绪信息要进入行动。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Sensitive and Absorbing",
-                        "one_liner": "You are sensitive to both your own feelings and other people’s signals, but you may carry too much of that information in your body afterward. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your ability to catch subtle cues is strong; what needs protection is the boundary around emotional intake and recovery. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: High sensitivity, stronger absorption",
+                        "one_liner": "In this self-report, you appear sensitive to emotional cues in yourself and others, and you may also experience the emotional atmosphere as entering your own system more strongly.",
+                        "core_claim": "This is not a high-sensitivity diagnosis or an ability label. It suggests emotional information may have stronger subjective impact, making it useful to separate information, feeling, and responsibility.",
                         "evidence_basis": [
                             "SA high; EM high; ER medium-low."
                         ],
-                        "primary_strength": "You can notice shifts that other people have not put into words. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "After the moment is over, you may still be living inside someone else’s emotional weather. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Build a small closing ritual for receiving, sorting, and releasing emotional information.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You are sensitive to both your own feelings and other people’s signals, but you may carry too much of that information in your body afterward."
+                        "primary_strength": "You may notice subtle signals and changes in relationship tone earlier than you expect.",
+                        "likely_cost": "Without filtering, another person’s tension, disappointment, or expectation can start to feel like your task.",
+                        "development_lever": "Practice three-way sorting: what I observed, how it affected me, and what action is actually mine.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests higher sensitivity and a need to filter which emotional information should become action."
                     },
                     "meta": {
                         "id": "sensitive_absorber",
                         "asset_type": "core_formulation",
                         "v23_source_id": "sensitive_absorber",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "high_sensitivity",
                         "release_state": "stable",
                         "trigger_summary": "SA high; EM high; ER medium-low.",
@@ -1170,37 +1170,37 @@
                 },
                 "developing_foundation": {
                     "zh-CN": {
-                        "title": "自我报告模式：基础发展中",
-                        "one_liner": "你的结果更像在提示：先把情绪命名、暂停和基本沟通步骤搭起来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "现在不需要急着追求复杂技巧；先建立稳定的观察和回应习惯。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：基础线索仍在建立",
+                        "one_liner": "本次自我报告显示，你对情绪觉察、调节、共情或关系处理的信心可能还不稳定。",
+                        "core_claim": "这不是能力不足诊断，也不说明你在现实中一定表现差；它更可能说明当前自我感知里可用策略、语言和复盘经验还需要建立。",
                         "evidence_basis": [
                             "Multiple dimensions low or low-medium."
                         ],
-                        "primary_strength": "你有机会从很小的练习中看到明显变化。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果直接进入复杂关系策略，容易觉得抽象或挫败。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "从每天一次情绪命名和一个暂停句开始。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你的结果更像在提示：先把情绪命名、暂停和基本沟通步骤搭起来。"
+                        "primary_strength": "你已经有一个起点：能把这些维度放到同一张图里看，而不是只用“我情商高/低”概括。",
+                        "likely_cost": "如果过早给自己贴标签，可能会忽略具体场景里的可练习部分。",
+                        "development_lever": "先从一个低风险场景开始：命名情绪、确认需要、选择一个小回应。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，基础策略还在建立，适合从小场景和可复盘动作开始。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Building the Foundation",
-                        "one_liner": "Your result suggests that the first step is building the basics: naming emotion, pausing, and using simple communication steps. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "This result points first to simple, repeatable reflection steps rather than complex strategies. The report emphasizes stable habits for noticing, pausing, and responding. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Foundations still forming",
+                        "one_liner": "In this self-report, your confidence around emotional awareness, regulation, empathy, or relationship handling may be less stable.",
+                        "core_claim": "This is not a diagnosis of low ability, and it does not mean you necessarily perform poorly in real life. It more likely means your current self-view has fewer ready strategies, words, or review experiences to draw on.",
                         "evidence_basis": [
                             "Multiple dimensions low or low-medium."
                         ],
-                        "primary_strength": "Small practices may be a reasonable place to start because the foundation is still forming. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "If you jump straight into complex relationship strategies, the work may feel abstract or discouraging. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Start with one emotion label and one pause sentence each day.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Your result suggests that the first step is building the basics: naming emotion, pausing, and using simple communication steps."
+                        "primary_strength": "There is already a starting point: seeing these dimensions together instead of reducing yourself to “high EQ” or “low EQ.”",
+                        "likely_cost": "If you label yourself too quickly, you may miss the specific situations where practice is possible.",
+                        "development_lever": "Start with one low-risk scene: name the emotion, clarify the need, choose one small response.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests your foundation is still forming, best approached through small scenes and reviewable actions."
                     },
                     "meta": {
                         "id": "developing_foundation",
                         "asset_type": "core_formulation",
                         "v23_source_id": "developing_foundation",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "foundational_development",
                         "release_state": "stable",
                         "trigger_summary": "Multiple dimensions low or low-medium.",
@@ -1231,37 +1231,37 @@
                 },
                 "low_confidence_result": {
                     "zh-CN": {
-                        "title": "自我报告模式：本次结果需要谨慎阅读",
-                        "one_liner": "本次结果只适合作为低置信作答证据，不适合作为画像结论。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "由于本次作答质量较低，不应用这次结果得出人格结论、职业结论或行动处方。请把它作为复测准备提示。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次结果：解释置信度不足",
+                        "one_liner": "本次作答质量提示结果更适合作为初步参考，不适合输出强 formulation。",
+                        "core_claim": "当前最重要的信息不是“你是哪一类”，而是这次数据不足以支持细化解释。可能原因包括作答过快、答案模式过于单一或状态不稳定。",
                         "evidence_basis": [
                             "Quality C/D or severe response-quality flags."
                         ],
-                        "primary_strength": "可用信号是复盘作答质量，而不是人格优势判断。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "过度解读本次分数或画像语言可能造成误导。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在更稳定、不被打断的状态下复测后，再阅读报告模块。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "这次结果更适合作为初步参考，而不是强结论。"
+                        "primary_strength": "你仍可以用报告里的科学边界和维度说明做轻量反思。",
+                        "likely_cost": "不建议基于本次结果做关系、职业或自我判断。",
+                        "development_lever": "在更稳定、少干扰的状态下复测；复测前先回想 2-3 个真实情境。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次结果置信度不足，建议先复测，再阅读细化解释。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Read This Result Lightly",
-                        "one_liner": "This session should be treated as low-confidence response evidence, not a profile conclusion. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Because response quality is low, do not use this session to draw a personality conclusion, career conclusion, or action prescription. Treat it as a prompt to retake in a steadier setting. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Result status: Low interpretation confidence",
+                        "one_liner": "The response-quality signal suggests this result is best treated as a preliminary reference, not a strong formulation.",
+                        "core_claim": "The main message is not “which type you are.” It is that this session does not provide enough reliable signal for detailed interpretation. Possible reasons include very fast responding, overly uniform answers, or an unstable response state.",
                         "evidence_basis": [
                             "Quality C/D or severe response-quality flags."
                         ],
-                        "primary_strength": "The usable signal is response-quality review, not a personality strength. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Overreading scores or profile language from this session may be misleading. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Retake the assessment in a steadier, uninterrupted setting before using report modules.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Treat this session as a first pass, not a profile conclusion."
+                        "primary_strength": "You can still use the scientific boundary and dimension definitions for light reflection.",
+                        "likely_cost": "Avoid using this result for relationship, career, or self-labeling decisions.",
+                        "development_lever": "Retake in a steadier, less distracted state; before retaking, recall two or three real situations.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This result has low interpretation confidence; retaking before reading detailed interpretation is recommended."
                     },
                     "meta": {
                         "id": "low_confidence_result",
                         "asset_type": "core_formulation",
                         "v23_source_id": "low_confidence_result",
                         "claim_risk": "high",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "quality_caution",
                         "release_state": "stable",
                         "trigger_summary": "Quality C/D or severe response-quality flags.",
@@ -1292,37 +1292,37 @@
                 },
                 "underconfident_repairer": {
                     "zh-CN": {
-                        "title": "自我报告模式：低估自己的修复者",
-                        "one_liner": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：修复意愿在，信心偏低",
+                        "one_liner": "本次自我报告显示，你可能在意关系修复，但对自己是否能把话说好、把局面拉回可谈状态不够有把握。",
+                        "core_claim": "这不是社交能力判断，而是提示你对修复动作的自我效能感可能低于实际意愿。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。"
+                        "primary_strength": "你可能愿意承担一部分关系维护，而不是简单切断或逃离。",
+                        "likely_cost": "如果信心不足，你可能等太久才开口，或把修复留给对方先开始。",
+                        "development_lever": "准备一个低负担开场：我想把刚才那段说清楚，不急着马上解决。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能想修复关系，但需要更低门槛的开口方式。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Underconfident Repairer",
-                        "one_liner": "You may be more capable of repairing relationships than you give yourself credit for. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may be more capable of repairing relationships than you give yourself credit for. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Repair intention, lower confidence",
+                        "one_liner": "In this self-report, you may care about repair, while feeling less sure that you can say it well or move the situation back into dialogue.",
+                        "core_claim": "This is not a social-skill judgment. It suggests your self-efficacy around repair may be lower than your actual intention to repair.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may be more capable of repairing relationships than you give yourself credit for."
+                        "primary_strength": "You may be willing to carry part of the relationship maintenance rather than simply cut off or leave.",
+                        "likely_cost": "If confidence is low, you may wait too long to speak or hope the other person starts the repair first.",
+                        "development_lever": "Prepare a low-pressure opener: I want to clarify that moment, and we do not have to solve it all right now.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may want repair but need a lower-barrier way to begin."
                     },
                     "meta": {
                         "id": "underconfident_repairer",
                         "asset_type": "core_formulation",
                         "v23_source_id": "underconfident_repairer",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "repair_confidence_gap",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1348,37 +1348,37 @@
                 },
                 "over_responsible_helper": {
                     "zh-CN": {
-                        "title": "自我报告模式：过度负责的帮助者",
-                        "one_liner": "你很愿意帮忙，但容易把支持变成替别人承担。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你很愿意帮忙，但容易把支持变成替别人承担。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：帮助意愿强，责任边界需校准",
+                        "one_liner": "本次自我报告显示，你可能较快进入支持者位置，也较容易把他人的困难纳入自己的责任范围。",
+                        "core_claim": "这不是“拯救者”标签，而是提示帮助、支持和代替承担之间需要更清楚的边界。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你很愿意帮忙，但容易把支持变成替别人承担。"
+                        "primary_strength": "你可能愿意给出时间、注意力和实际支持。",
+                        "likely_cost": "过度负责可能让对方减少自主处理，也让你在关系中持续消耗。",
+                        "development_lever": "在帮助前先问：你希望我听你说、一起想办法，还是具体帮一个步骤？",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你愿意支持他人，也需要把支持和代替承担分开。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Over-Responsible Helper",
-                        "one_liner": "You want to be useful, but support can turn into carrying what is not yours. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You want to be useful, but support can turn into carrying what is not yours. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Strong helping impulse, responsibility boundary to calibrate",
+                        "one_liner": "In this self-report, you may move quickly into a support role and include other people’s difficulties within your own sense of responsibility.",
+                        "core_claim": "This is not a “rescuer” label. It points to a boundary between helping, supporting, and taking over.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You want to be useful, but support can turn into carrying what is not yours."
+                        "primary_strength": "You may be willing to offer time, attention, and practical support.",
+                        "likely_cost": "Over-responsibility can reduce the other person’s agency and leave you carrying ongoing strain.",
+                        "development_lever": "Before helping, ask: do you want me to listen, think this through with you, or help with one concrete step?",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests a strong support impulse and a need to separate support from taking over."
                     },
                     "meta": {
                         "id": "over_responsible_helper",
                         "asset_type": "core_formulation",
                         "v23_source_id": "over_responsible_helper",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "boundary_overhelping",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1404,37 +1404,37 @@
                 },
                 "fast_reactor": {
                     "zh-CN": {
-                        "title": "自我报告模式：反应快，暂停短",
-                        "one_liner": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：反应较快，缓冲不足",
+                        "one_liner": "本次自我报告显示，在反馈、冲突或压力情境里，你可能较快进入回应状态，缓冲时间不一定够。",
+                        "core_claim": "这不是冲动诊断，也不说明你一定会失控；它提示速度可能先于整理。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。"
+                        "primary_strength": "你可能能迅速捕捉问题并给出回应。",
+                        "likely_cost": "速度过快时，情绪、判断和表达可能混在一起，让对话更难回到重点。",
+                        "development_lever": "练习把第一反应变成内部草稿：先停一下，再选择是否说出来。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你回应速度较快，也需要给自己留出缓冲。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Fast Reactor",
-                        "one_liner": "You react quickly once something lands; the growth point is separating first reaction from final response. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You react quickly once something lands; the growth point is separating first reaction from final response. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Fast reaction, limited buffer",
+                        "one_liner": "In this self-report, you may move quickly into response mode in feedback, conflict, or pressure situations, with less buffer time than you need.",
+                        "core_claim": "This is not a diagnosis of impulsivity, and it does not mean you necessarily lose control. It suggests speed may arrive before sorting.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You react quickly once something lands; the growth point is separating first reaction from final response."
+                        "primary_strength": "You may notice the issue quickly and respond without much delay.",
+                        "likely_cost": "When speed is too high, emotion, judgment, and expression can merge and make the conversation harder to refocus.",
+                        "development_lever": "Turn the first reaction into an internal draft: pause first, then choose whether to say it.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests fast responding and a need for more buffer."
                     },
                     "meta": {
                         "id": "fast_reactor",
                         "asset_type": "core_formulation",
                         "v23_source_id": "fast_reactor",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "speed_under_pressure",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1460,37 +1460,37 @@
                 },
                 "analytical_under_feeling": {
                     "zh-CN": {
-                        "title": "自我报告模式：先分析，后感受",
-                        "one_liner": "你倾向先整理逻辑，情绪可能在之后才追上来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你倾向先整理逻辑，情绪可能在之后才追上来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：分析在前，感受在后",
+                        "one_liner": "本次自我报告显示，你可能倾向于先解释问题、找原因或给方案，而不是先停在感受本身。",
+                        "core_claim": "这不是缺乏情感能力的判断；它提示分析可能是你处理不确定情绪的一种方式。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你倾向先整理逻辑，情绪可能在之后才追上来。"
+                        "primary_strength": "你可能擅长把混乱问题结构化，帮助自己或他人看见逻辑。",
+                        "likely_cost": "如果分析来得太早，自己或他人的情绪需要可能会被跳过。",
+                        "development_lever": "在分析前加一句感受确认：这件事让我/你可能先有某种感受，然后再看原因。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较会分析，也可以给感受多一点停留时间。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Analytical Before Feeling",
-                        "one_liner": "You tend to organize the logic first; the feeling may arrive later. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You tend to organize the logic first; the feeling may arrive later. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Analysis first, feeling second",
+                        "one_liner": "In this self-report, you may explain, diagnose causes, or look for solutions before staying with the feeling itself.",
+                        "core_claim": "This is not a judgment that you lack emotional capacity. It suggests analysis may be one way you manage uncertain emotion.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You tend to organize the logic first; the feeling may arrive later."
+                        "primary_strength": "You may be good at structuring messy situations and seeing the logic.",
+                        "likely_cost": "If analysis comes too early, your own or another person’s emotional need may be skipped.",
+                        "development_lever": "Add one feeling check before analysis: this may first feel like ___, and then we can look at why.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests analytical strength and room to let feeling stay present a little longer."
                     },
                     "meta": {
                         "id": "analytical_under_feeling",
                         "asset_type": "core_formulation",
                         "v23_source_id": "analytical_under_feeling",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "analysis_feeling_gap",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1516,37 +1516,37 @@
                 },
                 "quiet_empathy": {
                     "zh-CN": {
-                        "title": "自我报告模式：安静共情型",
-                        "one_liner": "你会在心里理解别人，但不总把理解表达出来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你会在心里理解别人，但不总把理解表达出来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：共情在内，表达偏安静",
+                        "one_liner": "本次自我报告显示，你可能能感到或理解他人的状态，但不一定会明显表达出来。",
+                        "core_claim": "这不是冷漠判断，也不证明他人一定能感受到你的理解；它提示内在理解和外在回应之间可能有距离。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你会在心里理解别人，但不总把理解表达出来。"
+                        "primary_strength": "你可能在心里保留对他人感受的细腻观察。",
+                        "likely_cost": "如果表达过少，对方可能不知道你已经理解，关系支持也可能变得不可见。",
+                        "development_lever": "练习把内在理解外化成一句短回应：我听到你最在意的是……",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能有共情，但需要让共情更可被看见。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Quiet Empathy",
-                        "one_liner": "You may understand people quietly without always making that understanding visible. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may understand people quietly without always making that understanding visible. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Quiet empathy",
+                        "one_liner": "In this self-report, you may feel or understand another person’s state without making that understanding very visible.",
+                        "core_claim": "This is not a judgment of coldness, and it does not prove others can feel your understanding. It points to a gap between inner understanding and outward response.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may understand people quietly without always making that understanding visible."
+                        "primary_strength": "You may hold careful observations about what others are feeling.",
+                        "likely_cost": "If expression is too quiet, the other person may not know you understand, and support can become invisible.",
+                        "development_lever": "Externalize one piece of understanding: what I hear matters most to you is...",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests empathy may be present but could be made more visible."
                     },
                     "meta": {
                         "id": "quiet_empathy",
                         "asset_type": "core_formulation",
                         "v23_source_id": "quiet_empathy",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "quiet_empathy",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1572,37 +1572,37 @@
                 },
                 "direct_without_softening": {
                     "zh-CN": {
-                        "title": "自我报告模式：直接表达，柔化不足",
-                        "one_liner": "你能把话说清楚，但有时少了让对方接住的铺垫。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能把话说清楚，但有时少了让对方接住的铺垫。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：表达直接，缓冲偏少",
+                        "one_liner": "本次自我报告显示，你可能较快说出事实、观点或边界，但不一定先处理对方的情绪入口。",
+                        "core_claim": "这不是粗暴或低共情判断；它提示直接表达和关系缓冲需要分开设计。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能把话说清楚，但有时少了让对方接住的铺垫。"
+                        "primary_strength": "你可能能让问题更快进入实质讨论。",
+                        "likely_cost": "如果缺少情绪缓冲，对方可能先听到压力或否定，而不是信息本身。",
+                        "development_lever": "在直接表达前加一个缓冲：我想把问题说清楚，也会尽量不把它说成对你的否定。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你表达较直接，可以给重要对话加一点情绪缓冲。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Direct Without Softening",
-                        "one_liner": "You can say the thing clearly, but sometimes without enough landing space for the other person. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can say the thing clearly, but sometimes without enough landing space for the other person. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Direct expression, less softening",
+                        "one_liner": "In this self-report, you may state facts, opinions, or boundaries quickly, without always creating an emotional entry point for the other person.",
+                        "core_claim": "This is not a judgment of harshness or low empathy. It suggests direct expression and relational buffering may need to be designed separately.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can say the thing clearly, but sometimes without enough landing space for the other person."
+                        "primary_strength": "You may help conversations move more quickly toward the real issue.",
+                        "likely_cost": "Without a buffer, the other person may hear pressure or rejection before they can hear the information.",
+                        "development_lever": "Add a softening frame before directness: I want to be clear about the issue, and I do not mean this as a rejection of you.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests directness that may benefit from a little emotional buffering in important conversations."
                     },
                     "meta": {
                         "id": "direct_without_softening",
                         "asset_type": "core_formulation",
                         "v23_source_id": "direct_without_softening",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "direct_expression",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1628,37 +1628,37 @@
                 },
                 "relationship_masking": {
                     "zh-CN": {
-                        "title": "自我报告模式：用关系稳定掩盖真实感受",
-                        "one_liner": "你能让关系看起来稳定，但真实感受可能没有被看见。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能让关系看起来稳定，但真实感受可能没有被看见。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：关系维持下的自我遮蔽",
+                        "one_liner": "本次自我报告显示，你可能为了维持关系稳定而压低自己的不满、需求或真实反应。",
+                        "core_claim": "这不是人格诊断，也不能说明你总是在伪装；它提示在部分关系里，安全感和表达真实感受之间可能存在张力。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能让关系看起来稳定，但真实感受可能没有被看见。"
+                        "primary_strength": "你可能能敏锐判断什么话会影响氛围，并努力维持表面稳定。",
+                        "likely_cost": "长期遮蔽会让别人误判你的真实状态，也让你更难获得合适支持。",
+                        "development_lever": "先在低风险关系里练习小剂量真实表达，而不是一次性摊牌。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能用压低自己来维持关系，需要逐步恢复真实表达。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Relationship Masking",
-                        "one_liner": "You can keep the relationship looking stable while your real feeling stays hidden. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can keep the relationship looking stable while your real feeling stays hidden. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Self-masking to preserve the relationship",
+                        "one_liner": "In this self-report, you may reduce the visibility of your frustration, needs, or reactions to keep a relationship stable.",
+                        "core_claim": "This is not a personality diagnosis, and it does not mean you are always masking. It suggests tension between safety and honest expression in some relationships.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can keep the relationship looking stable while your real feeling stays hidden."
+                        "primary_strength": "You may be sensitive to what could disturb the atmosphere and work to keep things smooth.",
+                        "likely_cost": "Long-term masking can lead others to misread your actual state and make support harder to receive.",
+                        "development_lever": "Practice small-dose honesty in lower-risk relationships instead of waiting for a major disclosure.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may preserve relationships by lowering your own visibility, and gradual honest expression may help."
                     },
                     "meta": {
                         "id": "relationship_masking",
                         "asset_type": "core_formulation",
                         "v23_source_id": "relationship_masking",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "relationship_masking",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1684,37 +1684,37 @@
                 },
                 "feedback_absorber": {
                     "zh-CN": {
-                        "title": "自我报告模式：容易吸收反馈情绪",
-                        "one_liner": "你听反馈时可能先吸收对方的情绪，再处理信息。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你听反馈时可能先吸收对方的情绪，再处理信息。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：反馈吸收较深",
+                        "one_liner": "本次自我报告显示，你可能把反馈很快带入自我评价，而不是只把它当作信息。",
+                        "core_claim": "这不是脆弱诊断，也不说明你不能接受反馈；它提示反馈中的评价感可能比内容本身更容易被放大。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你听反馈时可能先吸收对方的情绪，再处理信息。"
+                        "primary_strength": "你可能愿意认真听取反馈，并尝试从中修正自己。",
+                        "likely_cost": "如果吸收过深，你可能把一个具体建议扩大成对自己的整体否定。",
+                        "development_lever": "把反馈拆成三栏：事实信息、对方偏好、我下一步可试的小动作。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你很认真对待反馈，也需要防止把反馈扩大成自我否定。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Feedback Absorber",
-                        "one_liner": "When receiving feedback, you may absorb the emotional tone before you can process the information. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "When receiving feedback, you may absorb the emotional tone before you can process the information. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Deep feedback absorption",
+                        "one_liner": "In this self-report, you may take feedback quickly into self-evaluation rather than treating it only as information.",
+                        "core_claim": "This is not a diagnosis of fragility, and it does not mean you cannot receive feedback. It suggests the evaluative tone of feedback may become louder than the content.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "When receiving feedback, you may absorb the emotional tone before you can process the information."
+                        "primary_strength": "You may listen carefully and try to use feedback to adjust.",
+                        "likely_cost": "If absorption is too deep, one concrete suggestion can expand into a global self-critique.",
+                        "development_lever": "Split feedback into three columns: factual information, the other person’s preference, and one next action to test.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you take feedback seriously and may need to keep it from becoming global self-judgment."
                     },
                     "meta": {
                         "id": "feedback_absorber",
                         "asset_type": "core_formulation",
                         "v23_source_id": "feedback_absorber",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "feedback_absorption",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1740,37 +1740,37 @@
                 },
                 "balanced_moderate": {
                     "zh-CN": {
-                        "title": "自我报告模式：均衡但仍在打磨",
-                        "one_liner": "你的四维没有明显短板，但也还没有形成特别稳定的优势。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的四维没有明显短板，但也还没有形成特别稳定的优势。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：中等均衡，可塑空间较大",
+                        "one_liner": "本次自我报告显示，四个维度没有明显极端，也没有特别突出的单一优势。",
+                        "core_claim": "这不代表“普通”或“没有特点”；它提示你的结果可能更依赖具体场景，适合通过场景记录来寻找真正的差异点。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你的四维没有明显短板，但也还没有形成特别稳定的优势。"
+                        "primary_strength": "你可能有一定基础，不容易被单一短板完全定义。",
+                        "likely_cost": "如果只看总分，可能错过具体场景中的波动：反馈、冲突、边界或压力恢复。",
+                        "development_lever": "选择一个最近反复出现的场景，记录触发点、反应和恢复方式。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你整体较均衡，关键差异可能藏在具体场景里。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Balanced, Still Sharpening",
-                        "one_liner": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Moderate balance, room for clearer differentiation",
+                        "one_liner": "In this self-report, the four dimensions are not highly extreme and no single strength dominates.",
+                        "core_claim": "This does not mean “average” or “without a pattern.” It suggests your result may depend more on context, and scene tracking can reveal the real differences.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits."
+                        "primary_strength": "You may have a workable base that is not defined by one clear weakness.",
+                        "likely_cost": "If you only look at the global score, you may miss variation across feedback, conflict, boundaries, or recovery.",
+                        "development_lever": "Choose one recurring recent scene and record the trigger, reaction, and recovery pattern.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests moderate balance, with the important differences likely hidden in specific situations."
                     },
                     "meta": {
                         "id": "balanced_moderate",
                         "asset_type": "core_formulation",
                         "v23_source_id": "balanced_moderate",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "balanced_moderate",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1796,37 +1796,37 @@
                 },
                 "regulated_but_private": {
                     "zh-CN": {
-                        "title": "自我报告模式：能稳住，但不易表达",
-                        "one_liner": "你能把自己稳住，但别人不一定知道你经历了什么。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能把自己稳住，但别人不一定知道你经历了什么。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：自我调节较私密",
+                        "one_liner": "本次自我报告显示，你可能认为自己能处理情绪，但处理过程多在内部完成，不太让别人参与。",
+                        "core_claim": "这不是独立能力证明，也不说明你不需要支持；它提示调节可能较私人化。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能把自己稳住，但别人不一定知道你经历了什么。"
+                        "primary_strength": "你可能能把情绪先收住，避免立即扩散到外部关系。",
+                        "likely_cost": "太私密的调节会让别人看不见你的压力，也可能减少及时支持。",
+                        "development_lever": "在不暴露过多细节的前提下，练习一句状态说明：我需要一点时间处理，但我没有退出沟通。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你倾向于自己处理情绪，也可以让他人知道你仍在沟通里。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Regulated but Private",
-                        "one_liner": "You can steady yourself, but others may not know what you went through internally. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can steady yourself, but others may not know what you went through internally. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Private regulation",
+                        "one_liner": "In this self-report, you may see yourself as able to manage emotion, while doing most of that processing internally.",
+                        "core_claim": "This is not proof of independent capacity, and it does not mean you never need support. It suggests regulation may be private.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can steady yourself, but others may not know what you went through internally."
+                        "primary_strength": "You may contain emotion before it spreads into the relationship.",
+                        "likely_cost": "Highly private regulation can make your pressure invisible and reduce timely support.",
+                        "development_lever": "Without over-explaining, practice one status sentence: I need a little time to process, but I am not leaving the conversation.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you tend to process emotion privately and may benefit from signaling that you are still engaged."
                     },
                     "meta": {
                         "id": "regulated_but_private",
                         "asset_type": "core_formulation",
                         "v23_source_id": "regulated_but_private",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "private_regulation",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1852,37 +1852,37 @@
                 },
                 "warm_but_avoidant": {
                     "zh-CN": {
-                        "title": "自我报告模式：温和但回避张力",
-                        "one_liner": "你愿意保持善意，但可能绕开真正紧张的话题。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你愿意保持善意，但可能绕开真正紧张的话题。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：温和连接，回避张力",
+                        "one_liner": "本次自我报告显示，你可能愿意保持温和和连接，但在需要面对分歧、边界或失望时会更谨慎。",
+                        "core_claim": "这不是回避型依恋诊断；它只是提示你可能更擅长维护温度，而不一定擅长进入张力。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你愿意保持善意，但可能绕开真正紧张的话题。"
+                        "primary_strength": "你可能能让关系保持友好、可接近。",
+                        "likely_cost": "如果张力一直被绕开，问题可能反复出现，关系也难以更新。",
+                        "development_lever": "选择一个低风险分歧练习：表达一处不同意，同时保留连接。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较能维持温和连接，但需要练习安全地进入分歧。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Warm but Avoidant",
-                        "one_liner": "You try to stay warm, but may sidestep the conversation that actually needs to happen. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You try to stay warm, but may sidestep the conversation that actually needs to happen. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Warm connection, tension avoidance",
+                        "one_liner": "In this self-report, you may want to stay warm and connected, while becoming more cautious when disagreement, boundaries, or disappointment need to be faced.",
+                        "core_claim": "This is not an attachment diagnosis. It suggests you may be better at preserving warmth than entering tension.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You try to stay warm, but may sidestep the conversation that actually needs to happen."
+                        "primary_strength": "You may help relationships feel friendly and approachable.",
+                        "likely_cost": "If tension is repeatedly bypassed, the same issue may return and the relationship may not update.",
+                        "development_lever": "Practice one low-risk disagreement: state one difference while keeping connection intact.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests warmth in connection and a need to practice entering disagreement safely."
                     },
                     "meta": {
                         "id": "warm_but_avoidant",
                         "asset_type": "core_formulation",
                         "v23_source_id": "warm_but_avoidant",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "warm_avoidance",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1908,37 +1908,37 @@
                 },
                 "strategic_listener": {
                     "zh-CN": {
-                        "title": "自我报告模式：策略型倾听者",
-                        "one_liner": "你能抓住对话线索，但需要确认自己不是只在收集信息。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能抓住对话线索，但需要确认自己不是只在收集信息。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：策略性倾听",
+                        "one_liner": "本次自我报告显示，你可能较会听出对方关注点，并用倾听来稳定局面或收集信息。",
+                        "core_claim": "这不是操控判断，也不是沟通能力证明；它提示倾听在你的自我感知里是一种重要工具。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能抓住对话线索，但需要确认自己不是只在收集信息。"
+                        "primary_strength": "你可能能在复杂对话中先让信息变清楚。",
+                        "likely_cost": "如果倾听停留在策略层，情感回应或真实立场可能不够可见。",
+                        "development_lever": "在总结对方后补一句自己的位置：我听到的是……我这边目前是……",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你会用倾听稳住局面，也需要让自己的位置同样清楚。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Strategic Listener",
-                        "one_liner": "You can track conversation cues well; the challenge is not turning listening into silent data collection. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can track conversation cues well; the challenge is not turning listening into silent data collection. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Strategic listening",
+                        "one_liner": "In this self-report, you may hear what the other person cares about and use listening to stabilize the situation or gather information.",
+                        "core_claim": "This is not a manipulation claim or proof of communication skill. It suggests listening is an important tool in your self-view.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can track conversation cues well; the challenge is not turning listening into silent data collection."
+                        "primary_strength": "You may help complex conversations become clearer before action is taken.",
+                        "likely_cost": "If listening stays only strategic, emotional acknowledgment or your own position may remain unclear.",
+                        "development_lever": "After summarizing them, add your position: what I hear is..., and where I am right now is...",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you use listening to steady the situation and may need to make your own position equally clear."
                     },
                     "meta": {
                         "id": "strategic_listener",
                         "asset_type": "core_formulation",
                         "v23_source_id": "strategic_listener",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "listening_strength",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1964,37 +1964,37 @@
                 },
                 "delayed_processor": {
                     "zh-CN": {
-                        "title": "自我报告模式：延迟处理型",
-                        "one_liner": "你常常事后才真正明白自己感受到了什么。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你常常事后才真正明白自己感受到了什么。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：延迟处理",
+                        "one_liner": "本次自我报告显示，你可能在当下不一定马上知道自己真正的感受，事后才更清楚。",
+                        "core_claim": "这不是迟钝或低觉察判断；它提示你的情绪加工可能需要时间和距离。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你常常事后才真正明白自己感受到了什么。"
+                        "primary_strength": "你可能能在事后复盘出更准确的感受和需求。",
+                        "likely_cost": "如果没有向对方说明延迟，你可能被误解为冷淡、同意或回避。",
+                        "development_lever": "建立延迟说明：我现在还没整理好，晚一点再回来回应。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能需要时间处理情绪，关键是让延迟变得可沟通。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Delayed Processor",
-                        "one_liner": "You may understand what you felt only after the conversation is over. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may understand what you felt only after the conversation is over. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Delayed processing",
+                        "one_liner": "In this self-report, you may not immediately know what you truly feel in the moment, with clarity arriving later.",
+                        "core_claim": "This is not a judgment of dullness or low awareness. It suggests emotional processing may need time and distance.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may understand what you felt only after the conversation is over."
+                        "primary_strength": "You may be able to review later and identify feelings or needs more accurately.",
+                        "likely_cost": "If you do not signal the delay, others may read it as coldness, agreement, or avoidance.",
+                        "development_lever": "Create a delay signal: I am not sorted yet; I will come back to this later.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may need time to process, and the key is making that delay communicable."
                     },
                     "meta": {
                         "id": "delayed_processor",
                         "asset_type": "core_formulation",
                         "v23_source_id": "delayed_processor",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "delayed_processing",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2020,37 +2020,37 @@
                 },
                 "pressure_contained": {
                     "zh-CN": {
-                        "title": "自我报告模式：压力内收型",
-                        "one_liner": "压力下你可能外表稳定，但内部承载很多。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "压力下你可能外表稳定，但内部承载很多。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：压力下先收住",
+                        "one_liner": "本次自我报告显示，你在压力下可能倾向于先把反应收住，而不是马上表达。",
+                        "core_claim": "这不是抗压能力证明；它提示你可能用控制外显反应来维持功能。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "压力下你可能外表稳定，但内部承载很多。"
+                        "primary_strength": "你可能能避免压力即时升级，给局面留出空间。",
+                        "likely_cost": "如果只收不排，压力可能在事后累积，或以疲惫、疏离、突然爆发出现。",
+                        "development_lever": "给压力一个出口：事后 10 分钟记录身体反应、想法和需要。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你压力下较会收住，也需要安排后续释放和复盘。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Contained Under Pressure",
-                        "one_liner": "Under pressure, you may look steady while carrying a lot internally. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Under pressure, you may look steady while carrying a lot internally. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Containment under pressure",
+                        "one_liner": "In this self-report, you may contain your reaction under pressure rather than expressing it immediately.",
+                        "core_claim": "This is not proof of resilience. It suggests you may maintain functioning by controlling visible reaction.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Under pressure, you may look steady while carrying a lot internally."
+                        "primary_strength": "You may prevent immediate escalation and leave the situation more room.",
+                        "likely_cost": "If you only contain and never discharge, pressure can accumulate as fatigue, distance, or sudden expression later.",
+                        "development_lever": "Give pressure an outlet: after the event, spend ten minutes noting body response, thoughts, and needs.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests pressure containment, with a need for later release and review."
                     },
                     "meta": {
                         "id": "pressure_contained",
                         "asset_type": "core_formulation",
                         "v23_source_id": "pressure_contained",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "pressure_containment",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2076,37 +2076,37 @@
                 },
                 "empathy_to_action_gap": {
                     "zh-CN": {
-                        "title": "自我报告模式：懂别人，但行动转化慢",
-                        "one_liner": "你能理解对方，但不一定马上知道下一步怎么做。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能理解对方，但不一定马上知道下一步怎么做。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：能理解，行动转换偏慢",
+                        "one_liner": "本次自我报告显示，你可能能理解他人的感受，但不一定马上知道下一步该怎么回应。",
+                        "core_claim": "这不是共情无效判断；它提示理解和行动之间需要桥接。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能理解对方，但不一定马上知道下一步怎么做。"
+                        "primary_strength": "你可能能准确听到对方的处境和情绪。",
+                        "likely_cost": "如果行动转换慢，对方可能感到你理解了但没有支持，或你自己陷入犹豫。",
+                        "development_lever": "把理解转成一个小动作：确认、提问、给选项，而不是立刻解决。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能理解得快，但需要把理解转成可见的小行动。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Empathy-to-Action Gap",
-                        "one_liner": "You may understand the feeling but need more structure to turn it into action. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may understand the feeling but need more structure to turn it into action. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Empathy-to-action gap",
+                        "one_liner": "In this self-report, you may understand what someone feels without immediately knowing what response to choose next.",
+                        "core_claim": "This is not a judgment that empathy is ineffective. It suggests understanding and action need a bridge.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may understand the feeling but need more structure to turn it into action."
+                        "primary_strength": "You may accurately hear the other person’s situation and emotion.",
+                        "likely_cost": "If action is delayed, the other person may feel understood but unsupported, while you may feel stuck.",
+                        "development_lever": "Turn understanding into one small move: acknowledge, ask, or offer options instead of trying to solve everything.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests fast understanding and a need to translate it into visible small action."
                     },
                     "meta": {
                         "id": "empathy_to_action_gap",
                         "asset_type": "core_formulation",
                         "v23_source_id": "empathy_to_action_gap",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "empathy_action_gap",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2132,37 +2132,37 @@
                 },
                 "self_protective_distance": {
                     "zh-CN": {
-                        "title": "自我报告模式：保护性距离",
-                        "one_liner": "你用距离保护自己，代价是别人可能读不到你的真实意图。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你用距离保护自己，代价是别人可能读不到你的真实意图。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：自我保护性距离",
+                        "one_liner": "本次自我报告显示，当关系或情绪压力变强时，你可能更倾向于拉开距离来保持稳定。",
+                        "core_claim": "这不是冷漠或回避诊断；它提示距离可能是一种保护策略。具体关系是否安全，会影响这个策略是否合适。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你用距离保护自己，代价是别人可能读不到你的真实意图。"
+                        "primary_strength": "你可能能防止自己被卷入过强情绪。",
+                        "likely_cost": "如果距离没有说明，对方可能感到被排除或被拒绝，你也可能失去必要支持。",
+                        "development_lever": "把距离说清楚：我需要一点空间整理，不是要结束这段沟通。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，距离可能是你的保护方式，关键是让距离有说明。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Protective Distance",
-                        "one_liner": "You use distance to protect yourself; the cost is that others may not read your intent. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You use distance to protect yourself; the cost is that others may not read your intent. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Self-protective distance",
+                        "one_liner": "In this self-report, when relational or emotional pressure rises, you may create distance to stay stable.",
+                        "core_claim": "This is not a diagnosis of coldness or avoidance. It suggests distance may function as protection. Whether that strategy is appropriate depends on safety in the specific relationship.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You use distance to protect yourself; the cost is that others may not read your intent."
+                        "primary_strength": "You may prevent yourself from being pulled into emotion that feels too strong.",
+                        "likely_cost": "If distance is unexplained, others may feel excluded or rejected, and you may lose needed support.",
+                        "development_lever": "Explain the distance: I need a little space to sort myself; I am not ending the conversation.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests distance may be protective, and the key is making it clear rather than silent."
                     },
                     "meta": {
                         "id": "self_protective_distance",
                         "asset_type": "core_formulation",
                         "v23_source_id": "self_protective_distance",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "protective_distance",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2188,37 +2188,37 @@
                 },
                 "values_sensitive": {
                     "zh-CN": {
-                        "title": "自我报告模式：价值敏感型",
-                        "one_liner": "当事情触碰你的原则时，情绪反应会更强。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "当事情触碰你的原则时，情绪反应会更强。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：价值敏感",
+                        "one_liner": "本次自我报告显示，当事件触及公平、尊重、责任或边界等价值时，你的情绪反应可能更明显。",
+                        "core_claim": "这不是道德优越或脆弱判断；它提示价值线索可能放大情绪强度。不同文化和组织规则会影响价值冲突的表达方式。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "当事情触碰你的原则时，情绪反应会更强。"
+                        "primary_strength": "你可能较快察觉某件事为什么“不只是小事”。",
+                        "likely_cost": "如果价值感太快进入评判，可能难以先弄清事实、意图和可行动空间。",
+                        "development_lever": "先把价值词说具体：我在意的是公平/尊重/边界中的哪一部分？",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你对价值线索较敏感，需要把价值感转成可讨论的具体语言。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Values-Sensitive Responder",
-                        "one_liner": "When something touches your values, your emotional response may intensify quickly. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "When something touches your values, your emotional response may intensify quickly. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Values sensitivity",
+                        "one_liner": "In this self-report, when a situation touches fairness, respect, responsibility, or boundaries, your emotional response may become more pronounced.",
+                        "core_claim": "This is not a claim of moral superiority or fragility. It suggests values cues may amplify emotional intensity. Culture and organizational norms can shape how values conflict is expressed.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "When something touches your values, your emotional response may intensify quickly."
+                        "primary_strength": "You may notice quickly why something feels like “more than a small issue.”",
+                        "likely_cost": "If values move too quickly into judgment, it can be harder to clarify facts, intent, and action options.",
+                        "development_lever": "Make the values word specific: which part of fairness, respect, or boundary is at stake?",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests sensitivity to values cues and a need to translate them into discussable language."
                     },
                     "meta": {
                         "id": "values_sensitive",
                         "asset_type": "core_formulation",
                         "v23_source_id": "values_sensitive",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "values_sensitivity",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2244,37 +2244,37 @@
                 },
                 "team_stabilizer": {
                     "zh-CN": {
-                        "title": "自我报告模式：团队稳定器",
-                        "one_liner": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：团队稳定器倾向",
+                        "one_liner": "本次自我报告显示，你可能倾向于在团队情绪波动时维持节奏、降低摩擦或帮助大家回到任务。",
+                        "core_claim": "这不是领导力或团队绩效证明；它提示你自认会承担一部分团队情绪管理。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。"
+                        "primary_strength": "你可能能帮助团队避免被短期情绪完全带偏。",
+                        "likely_cost": "如果这种角色变成默认，你可能被隐性分配过多协调和情绪劳动。",
+                        "development_lever": "把稳定角色显性化：我可以帮助整理问题，但需要大家共同承担下一步。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能会稳定团队氛围，但需要避免把团队情绪劳动都接到自己身上。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Team Stabilizer",
-                        "one_liner": "You can help a team stay steady, but you should not become the only stabilizing system. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can help a team stay steady, but you should not become the only stabilizing system. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Team stabilizer tendency",
+                        "one_liner": "In this self-report, you may try to maintain rhythm, reduce friction, or bring people back to the task when team emotion fluctuates.",
+                        "core_claim": "This is not proof of leadership or team performance. It suggests you see yourself as carrying part of the team’s emotional management.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can help a team stay steady, but you should not become the only stabilizing system."
+                        "primary_strength": "You may help a team avoid being fully derailed by short-term emotion.",
+                        "likely_cost": "If this role becomes assumed, you may receive too much invisible coordination or emotional labor.",
+                        "development_lever": "Make the stabilizing role explicit: I can help organize the issue, and we all need to carry the next step.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests a team-stabilizing tendency and a need not to absorb all team emotional labor."
                     },
                     "meta": {
                         "id": "team_stabilizer",
                         "asset_type": "core_formulation",
                         "v23_source_id": "team_stabilizer",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "team_stabilizing",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2300,37 +2300,37 @@
                 },
                 "listening_without_followthrough": {
                     "zh-CN": {
-                        "title": "自我报告模式：会听，但后续弱",
-                        "one_liner": "你能听见别人，但后续行动可能没有跟上。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能听见别人，但后续行动可能没有跟上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：能听见，跟进不足",
+                        "one_liner": "本次自我报告显示，你可能能认真听到他人的情绪和需要，但后续行动、确认或复盘不一定跟得上。",
+                        "core_claim": "这不是不真诚判断；它提示倾听和后续承诺之间可能需要更小、更明确的连接。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能听见别人，但后续行动可能没有跟上。"
+                        "primary_strength": "你可能能让对方在对话中感到被听见。",
+                        "likely_cost": "如果没有后续，对方可能觉得当下被理解了，但事情没有真正推进。",
+                        "development_lever": "每次倾听后只承诺一个小跟进：我会在明天前确认一件事。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能听得进去，但需要把倾听接到一个小而明确的跟进。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Listening Without Follow-Through",
-                        "one_liner": "You may hear people well, but the follow-through can lag behind the listening. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may hear people well, but the follow-through can lag behind the listening. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Listening without follow-through",
+                        "one_liner": "In this self-report, you may listen carefully to another person’s emotion or need, while follow-up action, confirmation, or review may be less consistent.",
+                        "core_claim": "This is not a judgment of insincerity. It suggests listening and commitment need a smaller, clearer connection.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may hear people well, but the follow-through can lag behind the listening."
+                        "primary_strength": "You may help someone feel heard in the conversation itself.",
+                        "likely_cost": "Without follow-through, the other person may feel understood in the moment but see little movement afterward.",
+                        "development_lever": "After listening, commit to one small follow-up: I will confirm one thing by tomorrow.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may listen well and need to connect listening to a small concrete follow-up."
                     },
                     "meta": {
                         "id": "listening_without_followthrough",
                         "asset_type": "core_formulation",
                         "v23_source_id": "listening_without_followthrough",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "listening_action_gap",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2356,37 +2356,37 @@
                 },
                 "conflict_avoider": {
                     "zh-CN": {
-                        "title": "自我报告模式：冲突回避者",
-                        "one_liner": "你可能用沉默换取平静，但未处理的问题会留在关系里。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你可能用沉默换取平静，但未处理的问题会留在关系里。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：冲突回避倾向",
+                        "one_liner": "本次自我报告显示，当分歧可能升级或伤害关系时，你可能更倾向于绕开、延后或淡化冲突。",
+                        "core_claim": "这不是人格诊断，也不说明回避一定错误；在不安全或权力差明显的关系里，降低冲突可能是必要策略。边界在于：它是否让重要问题长期无法被处理。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你可能用沉默换取平静，但未处理的问题会留在关系里。"
+                        "primary_strength": "你可能能避免不必要的即时升级。",
+                        "likely_cost": "如果所有冲突都被延后，真实问题可能积累，关系表面稳定但底层更紧。",
+                        "development_lever": "从低风险分歧开始练习：只表达一个事实、一个影响、一个请求。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能倾向于降低冲突，需要区分安全回避和长期拖延。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Conflict Avoider",
-                        "one_liner": "You may trade silence for calm, but the unaddressed issue remains in the relationship. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may trade silence for calm, but the unaddressed issue remains in the relationship. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Conflict-avoidance tendency",
+                        "one_liner": "In this self-report, when disagreement may escalate or damage the relationship, you may avoid, delay, or soften the conflict.",
+                        "core_claim": "This is not a personality diagnosis, and avoidance is not always wrong. In unsafe relationships or strong power differences, lowering conflict may be necessary. The question is whether important issues remain unaddressed for too long.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may trade silence for calm, but the unaddressed issue remains in the relationship."
+                        "primary_strength": "You may prevent unnecessary immediate escalation.",
+                        "likely_cost": "If every conflict is delayed, real issues can accumulate while the relationship looks stable on the surface.",
+                        "development_lever": "Practice with a low-risk disagreement: one fact, one impact, one request.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests a tendency to lower conflict and a need to distinguish safe avoidance from long-term delay."
                     },
                     "meta": {
                         "id": "conflict_avoider",
                         "asset_type": "core_formulation",
                         "v23_source_id": "conflict_avoider",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "conflict_avoidance",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/core_formulations.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/core_formulations.json
@@ -4,37 +4,37 @@
   "formulations": {
     "balanced_integrated": {
       "zh-CN": {
-        "title": "自我报告模式：均衡整合型",
-        "one_liner": "你不是只擅长某一项，而是较能把觉察、调节、共情和关系处理连起来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你通常能看见自己的状态，也能顾及他人的感受，并把情绪信息转成相对稳定的沟通和行动。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：均衡整合",
+        "one_liner": "本次自我报告显示，你较少只靠单一优势应对情绪关系问题，而是倾向于把自我觉察、调节、共情和关系处理连在一起使用。",
+        "core_claim": "这个结果提示你对自己和他人的情绪线索都有一定可用感，也认为自己能把这些线索转成相对稳定的沟通选择。它仍然需要用真实反馈和具体场景来校准。",
         "evidence_basis": [
           "Four dimensions high or upper-stable; no severe gap."
         ],
-        "primary_strength": "复杂对话里，你更容易同时顾及事实、情绪和关系目标。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "优势太均衡时，你可能低估持续恢复和边界维护的必要性。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把稳定优势转成可复用的沟通流程，而不是只靠当下状态。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你不是只擅长某一项，而是较能把觉察、调节、共情和关系处理连起来。"
+        "primary_strength": "在需要同时处理事实、情绪和关系目标时，你可能更容易保持整体视角。",
+        "likely_cost": "均衡感也可能让你低估恢复、边界和复盘的必要性，尤其在长期消耗的关系或团队环境里。",
+        "development_lever": "把“整体稳定”拆成可复用流程：先识别情绪线索，再确认边界，最后选择沟通动作。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你倾向于把觉察、调节、共情和关系处理连起来使用。"
       },
       "en": {
-        "title": "Self-reported pattern: Integrated Balance",
-        "one_liner": "Your strength is not one isolated skill; it is how your self-reported awareness, regulation, empathy, and relationship-management signals appear to work together. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You usually notice your own state, register other people’s feelings, and turn emotional information into relatively steady communication and action. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Integrated balance",
+        "one_liner": "In this self-report, your pattern is less about one standout strength and more about linking self-awareness, regulation, empathy, and relationship management together.",
+        "core_claim": "The result suggests you experience both self-focused and other-focused emotional information as usable, and you see yourself as able to turn that information into steadier communication choices. It still needs calibration against real feedback and specific contexts.",
         "evidence_basis": [
           "Four dimensions high or upper-stable; no severe gap."
         ],
-        "primary_strength": "In complex conversations, you are more likely to hold the facts, the emotions, and the relationship goal at the same time. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "When things are going well, you may underestimate how much recovery and boundary maintenance still matter. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn your strengths into repeatable communication routines, rather than relying on being in a good state.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Your strength is not one isolated skill; it is how your self-reported awareness, regulation, empathy, and relationship-management signals appear to work together."
+        "primary_strength": "When facts, feelings, and relationship goals all matter, you may be more likely to keep the whole situation in view.",
+        "likely_cost": "A balanced self-view can make recovery, boundaries, and review feel less urgent than they are in long-running or high-demand settings.",
+        "development_lever": "Translate “overall steadiness” into a repeatable sequence: notice the cue, check the boundary, then choose the communication move.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you tend to link awareness, regulation, empathy, and relationship handling rather than relying on one isolated strength."
       },
       "meta": {
         "id": "balanced_integrated",
         "asset_type": "core_formulation",
         "v23_source_id": "balanced_integrated",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "balanced_strength",
         "release_state": "stable",
         "trigger_summary": "Four dimensions high or upper-stable; no severe gap.",
@@ -65,37 +65,37 @@
     },
     "high_empathy_low_recovery": {
       "zh-CN": {
-        "title": "自我报告模式：高共情，低恢复",
-        "one_liner": "本次自我报告显示，你倾向于较快注意到他人的情绪线索，但在情绪负荷后可能需要更多恢复空间。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的共情不是问题；真正的杠杆是共情之后如何区分陪伴、责任和恢复。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：高共情线索，恢复负荷偏高",
+        "one_liner": "本次自我报告显示，你较容易注意到他人的情绪线索，但在承接情绪后可能需要更多恢复空间。",
+        "core_claim": "重点不是“共情太多”，而是你如何区分理解、责任、行动和恢复。真实关系中的权力差、亲密度和压力水平会显著影响这个模式。",
         "evidence_basis": [
           "EM high; ER low or medium-low."
         ],
-        "primary_strength": "你可能倾向于表达理解，尤其在对方情绪明显但没有说清楚时。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "你可能把“我理解你”滑向“我必须替你扛住”。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "练习共情后的边界句和恢复动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "本次自我报告显示，你倾向于较快注意到他人的情绪线索，但在情绪负荷后可能需要更多恢复空间。"
+        "primary_strength": "你可能较快捕捉对方没有明说的情绪，并愿意用理解来维持连接。",
+        "likely_cost": "如果边界不清，你可能把“我能理解”误变成“我必须承担”。",
+        "development_lever": "练习共情后的边界句：先承认感受，再说明自己能承担和不能承担的部分。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你容易读到他人情绪，也需要更清楚的恢复和边界。"
       },
       "en": {
-        "title": "Self-reported pattern: High Empathy, Low Recovery",
-        "one_liner": "Your self-report suggests you often notice emotional cues in others, but you may experience recovery as slower after emotionally loaded contact. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your empathy is not the problem. The leverage point is what happens after empathy: companionship, responsibility, and recovery need clearer separation. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Strong empathy cues, heavier recovery load",
+        "one_liner": "In this self-report, you appear quick to notice emotional cues in others, while recovery after emotionally loaded contact may take more space.",
+        "core_claim": "The issue is not “too much empathy.” The leverage point is separating understanding, responsibility, action, and recovery. Power dynamics, closeness, and stress level can change how this pattern shows up.",
         "evidence_basis": [
           "EM high; ER low or medium-low."
         ],
-        "primary_strength": "You may tend to communicate understanding, especially when their emotion is obvious but not clearly stated. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "You may slide from “I understand this” into “I have to carry this with you or for you.” Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Practice boundary language and recovery steps after empathic contact.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Your self-report suggests you often notice emotional cues in others, but you may experience recovery as slower after emotionally loaded contact."
+        "primary_strength": "You may be quick to notice what someone is feeling before they state it directly, and you may use understanding to maintain connection.",
+        "likely_cost": "Without a clear boundary, “I understand” can slide into “I have to carry this.”",
+        "development_lever": "Practice a post-empathy boundary sentence: name the feeling, then state what you can and cannot take on.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you often notice others’ emotions and may need clearer recovery and boundaries afterward."
       },
       "meta": {
         "id": "high_empathy_low_recovery",
         "asset_type": "core_formulation",
         "v23_source_id": "high_empathy_low_recovery",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "empathy_regulation_gap",
         "release_state": "stable",
         "trigger_summary": "EM high; ER low or medium-low.",
@@ -126,37 +126,37 @@
     },
     "aware_but_unregulated": {
       "zh-CN": {
-        "title": "自我报告模式：有觉察，调节不足",
-        "one_liner": "你常常知道自己被触发了，但还没有总能把自己带回稳定状态。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的优势在于看见内在变化；发展点在于把“我知道”变成“我能暂停和恢复”。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：觉察较快，调节跟进不足",
+        "one_liner": "本次自我报告显示，你较能意识到自己被触发了，但不一定能立刻把情绪强度降到适合行动的水平。",
+        "core_claim": "这不是“知道也没用”的判断，而是提示觉察和调节之间可能有时间差。场景压力越高，这个时间差越需要被看见。",
         "evidence_basis": [
           "SA high; ER low or medium-low."
         ],
-        "primary_strength": "你能比很多人更快识别自己的情绪线索。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "觉察越清楚，若缺少调节步骤，越可能变成反复分析或内耗。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "给觉察配一个身体层面的暂停动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你常常知道自己被触发了，但还没有总能把自己带回稳定状态。"
+        "primary_strength": "你可能比许多人更早发现自己的不适、紧张或防御反应。",
+        "likely_cost": "如果缺少暂停，你可能在已经意识到情绪的情况下仍被情绪推动表达或决策。",
+        "development_lever": "把觉察后面的 30 秒做实：暂停、命名、降速，再回应。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能很快知道自己怎么了，但还需要更稳定的恢复步骤。"
       },
       "en": {
-        "title": "Self-reported pattern: Aware, Not Yet Settled",
-        "one_liner": "You often know you have been triggered, but you may not always be able to bring yourself back to steadiness in time. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your strength is noticing the inner shift; the next step is turning “I know what is happening” into “I can pause and recover.” Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Fast awareness, slower regulation follow-through",
+        "one_liner": "In this self-report, you seem able to notice when you are activated, but not always able to lower the intensity quickly enough for useful action.",
+        "core_claim": "This is not a judgment that awareness “doesn’t help.” It suggests a possible lag between noticing emotion and regulating it, especially under pressure.",
         "evidence_basis": [
           "SA high; ER low or medium-low."
         ],
-        "primary_strength": "You can often identify your emotional cues faster than many people. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Clear awareness without regulation steps can turn into replaying, overanalyzing, or emotional fatigue. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Pair awareness with a physical pause that slows the next response.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You often know you have been triggered, but you may not always be able to bring yourself back to steadiness in time."
+        "primary_strength": "You may catch discomfort, tension, or defensiveness relatively early.",
+        "likely_cost": "Without a pause, you may still speak or decide from the emotion even after you have named it.",
+        "development_lever": "Make the 30 seconds after awareness concrete: pause, label, slow down, then respond.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may know what is happening inside before you have a reliable recovery step."
       },
       "meta": {
         "id": "aware_but_unregulated",
         "asset_type": "core_formulation",
         "v23_source_id": "aware_but_unregulated",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "awareness_regulation_gap",
         "release_state": "stable",
         "trigger_summary": "SA high; ER low or medium-low.",
@@ -187,37 +187,37 @@
     },
     "calm_but_distant": {
       "zh-CN": {
-        "title": "自我报告模式：冷静稳定，但情绪回应偏弱",
-        "one_liner": "你能稳住局面，但别人不一定感到自己的情绪被你接住。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的调节能力能降低混乱，但如果少了情绪回应，稳定会被误读成疏离。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：自感稳定，情绪回应偏保留",
+        "one_liner": "本次自我报告显示，你倾向于认为自己能保持稳定，但对他人情绪的回应可能更克制或更晚出现。",
+        "core_claim": "这里的“稳定”不等于客观冷静能力，也不说明别人一定感到被支持；它提示你可以校准稳定与回应之间的距离。",
         "evidence_basis": [
           "ER high; EM low or medium-low."
         ],
-        "primary_strength": "压力高时，你更容易保持思路和节奏。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "别人可能听到了你的解决方案，却没有感到被理解。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在解决问题前先命名对方的感受。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能稳住局面，但别人不一定感到自己的情绪被你接住。"
+        "primary_strength": "你可能在压力下不容易被情绪牵着走，能先保留判断空间。",
+        "likely_cost": "他人可能需要的不只是稳定，也可能是被看见、被确认或被回应。",
+        "development_lever": "练习把稳定转成可被感受到的回应：先复述对方关注点，再给出你的判断。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较重视稳定，但可以让回应更容易被他人感受到。"
       },
       "en": {
-        "title": "Self-reported pattern: Calm, but Hard to Read Warmly",
-        "one_liner": "You may keep the situation steady, while others may not always feel emotionally met. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your regulation can reduce chaos, but without emotional acknowledgment, steadiness can be mistaken for distance. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Steady self-view, reserved emotional response",
+        "one_liner": "In this self-report, you see yourself as relatively steady, while your response to others’ emotions may be restrained or delayed.",
+        "core_claim": "“Steady” here is not proof of objective calmness, and it does not mean others automatically feel supported. It points to a calibration question: how much response is visible?",
         "evidence_basis": [
           "ER high; EM low or medium-low."
         ],
-        "primary_strength": "Under pressure, you are more likely to keep your thinking and pacing intact. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "People may hear your solution without feeling that you understood the emotional weight of the moment. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Name the other person’s feeling before moving into problem-solving.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may keep the situation steady, while others may not always feel emotionally met."
+        "primary_strength": "Under pressure, you may be less likely to get pulled immediately into emotional escalation.",
+        "likely_cost": "Other people may need more than steadiness; they may need to feel seen, acknowledged, or answered.",
+        "development_lever": "Turn steadiness into a visible response: reflect the concern first, then offer your view.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you value steadiness and may benefit from making emotional acknowledgment more visible."
       },
       "meta": {
         "id": "calm_but_distant",
         "asset_type": "core_formulation",
         "v23_source_id": "calm_but_distant",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "regulation_empathy_gap",
         "release_state": "stable",
         "trigger_summary": "ER high; EM low or medium-low.",
@@ -248,37 +248,37 @@
     },
     "relationship_first_self_later": {
       "zh-CN": {
-        "title": "自我报告模式：关系优先，自我后置",
-        "one_liner": "你很会维护关系，但有时把自己的真实感受排到太后面。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你会照顾气氛、流程和他人的反应；发展点是不要让关系稳定建立在自我忽略上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：关系优先，自我后置",
+        "one_liner": "本次自我报告显示，你可能较快考虑关系氛围和他人感受，但自己的需要、限制或不满更晚才被表达。",
+        "core_claim": "这不是“讨好型人格”诊断，而是一个自我报告线索：关系维护可能先于自我澄清。不同文化和权力关系会影响它是否是优势或负担。",
         "evidence_basis": [
           "RM high; SA low or medium-low."
         ],
-        "primary_strength": "你常能让对话继续进行，不轻易让场面崩掉。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "你可能很晚才发现自己其实已经不舒服。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在回应别人前先问自己一句：我现在真实需要什么？",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你很会维护关系，但有时把自己的真实感受排到太后面。"
+        "primary_strength": "你可能擅长降低场面摩擦，避免让关系立即破裂。",
+        "likely_cost": "长期后置自己可能让不满积累，并使边界表达变得突然或困难。",
+        "development_lever": "在照顾关系前先补一句自我定位：我现在能接受什么，不能接受什么。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较先照顾关系，也需要更早把自己放进关系里。"
       },
       "en": {
-        "title": "Self-reported pattern: Relationship First, Self Later",
-        "one_liner": "You are often good at keeping relationships moving, but your own feelings may get pushed too far down the list. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can manage tone, flow, and other people’s reactions; the growth point is making sure relational stability does not depend on self-erasure. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Relationship first, self later",
+        "one_liner": "In this self-report, you may consider the relationship climate and others’ feelings quickly, while your own needs, limits, or frustration appear later.",
+        "core_claim": "This is not a diagnosis of people-pleasing. It is a self-report signal that relationship maintenance may come before self-clarification. Culture and power dynamics can determine whether this is useful or costly.",
         "evidence_basis": [
           "RM high; SA low or medium-low."
         ],
-        "primary_strength": "You often keep conversations going without letting the room collapse emotionally. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "You may realize late that you were uncomfortable much earlier. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Before responding to others, ask: what do I actually need right now?",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You are often good at keeping relationships moving, but your own feelings may get pushed too far down the list."
+        "primary_strength": "You may be good at reducing immediate friction and keeping the relationship from breaking down too quickly.",
+        "likely_cost": "Putting yourself last for too long can build resentment and make boundaries feel sudden or hard to state.",
+        "development_lever": "Before protecting the relationship, add one self-positioning sentence: what you can accept and what you cannot.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you attend to the relationship early and may need to include yourself earlier too."
       },
       "meta": {
         "id": "relationship_first_self_later",
         "asset_type": "core_formulation",
         "v23_source_id": "relationship_first_self_later",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "relationship_self_gap",
         "release_state": "stable",
         "trigger_summary": "RM high; SA low or medium-low.",
@@ -309,37 +309,37 @@
     },
     "self_clear_repair_weak": {
       "zh-CN": {
-        "title": "自我报告模式：自我清楚，修复不足",
-        "one_liner": "你知道自己要表达什么，但关系修复的步骤可能还不够细。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的自我觉察让表达更清楚；发展点是让对方也能接住你的表达。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：自我较清楚，修复动作不足",
+        "one_liner": "本次自我报告显示，你较知道自己的感受和立场，但在冲突后如何修复关系、重开对话或降低防御感上可能不够稳定。",
+        "core_claim": "这不表示你“不会处理关系”，而是提示表达清楚和关系修复是两个不同环节。",
         "evidence_basis": [
           "SA high; RM low or medium-low."
         ],
-        "primary_strength": "你不容易完全失去自己的立场。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果缺少修复，清楚可能被听成强硬。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在表达后补上影响确认和关系修复。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你知道自己要表达什么，但关系修复的步骤可能还不够细。"
+        "primary_strength": "你可能能较明确说出自己为什么不舒服、不同意或需要什么。",
+        "likely_cost": "如果缺少修复动作，清楚表达可能被他人感受到为定案、拒绝或距离。",
+        "development_lever": "给表达后加一个修复句：我想把问题说清楚，也想把关系留在可继续沟通的位置。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较清楚自己的立场，但冲突后的修复动作还可以更具体。"
       },
       "en": {
-        "title": "Self-reported pattern: Clear About Self, Less Practiced at Repair",
-        "one_liner": "You may know what you need to say, but the repair steps after impact may need more structure. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your self-awareness can make your expression clear; the next step is making that expression easier for another person to receive. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Clear self-position, weaker repair moves",
+        "one_liner": "In this self-report, you seem relatively clear about your feelings and position, while post-conflict repair, reopening dialogue, or lowering defensiveness may be less consistent.",
+        "core_claim": "This does not mean you “cannot handle relationships.” It separates clear expression from relational repair as two different steps.",
         "evidence_basis": [
           "SA high; RM low or medium-low."
         ],
-        "primary_strength": "You are less likely to lose track of your own position. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without repair, clarity can be heard as sharpness. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "After expressing yourself, add impact-checking and repair language.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may know what you need to say, but the repair steps after impact may need more structure."
+        "primary_strength": "You may be able to state why something bothers you, where you disagree, or what you need.",
+        "likely_cost": "Without repair, clear expression can be experienced by others as final, rejecting, or distant.",
+        "development_lever": "Add a repair sentence after expression: I want to be clear about the issue and still keep the relationship open for dialogue.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may know your position clearly, while repair after tension can become more concrete."
       },
       "meta": {
         "id": "self_clear_repair_weak",
         "asset_type": "core_formulation",
         "v23_source_id": "self_clear_repair_weak",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "expression_repair_gap",
         "release_state": "stable",
         "trigger_summary": "SA high; RM low or medium-low.",
@@ -370,37 +370,37 @@
     },
     "steady_collaborator": {
       "zh-CN": {
-        "title": "自我报告模式：稳定协作者",
-        "one_liner": "你在压力下通常能把对话拉回问题本身，而不是被情绪完全带走。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的优势在于把稳定和关系推进结合起来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：协作稳定感较强",
+        "one_liner": "本次自我报告显示，你较相信自己能在压力和协作中保持可沟通、可配合的状态。",
+        "core_claim": "这不是团队能力证明，也不预测别人一定觉得你可靠；它提示你可以继续检验稳定感在高压和多方冲突里是否仍可维持。",
         "evidence_basis": [
           "ER high; RM high."
         ],
-        "primary_strength": "你适合做对话里的降温者和整理者。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "你可能低估别人还需要被情绪回应，而不只是被推进。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在推动下一步前，补一句情绪确认。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你在压力下通常能把对话拉回问题本身，而不是被情绪完全带走。"
+        "primary_strength": "你可能能在多数协作情境中保持节奏，不轻易把压力转嫁给他人。",
+        "likely_cost": "稳定也可能带来过度承担，尤其当团队默认你来兜底时。",
+        "development_lever": "把稳定从“我来扛”转成“我们如何分配、同步和复盘”。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你对自己的协作稳定感较强，但仍需要边界和分工来支撑。"
       },
       "en": {
-        "title": "Self-reported pattern: Steady Collaborator",
-        "one_liner": "Under pressure, you can often bring the conversation back to the issue rather than letting emotion take over. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your strength is combining steadiness with relationship movement. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Collaborative steadiness",
+        "one_liner": "In this self-report, you see yourself as able to stay communicative and cooperative under pressure and in group work.",
+        "core_claim": "This is not proof of team performance, nor a prediction that others experience you as reliable. It suggests a stability pattern worth testing in high-pressure or multi-party conflict.",
         "evidence_basis": [
           "ER high; RM high."
         ],
-        "primary_strength": "You can be the person who cools the room down and organizes the next step. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "You may underestimate that others sometimes need emotional acknowledgment, not only forward motion. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Before moving the group forward, add one sentence of emotional acknowledgment.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Under pressure, you can often bring the conversation back to the issue rather than letting emotion take over."
+        "primary_strength": "You may keep a workable rhythm in many collaborative settings without quickly displacing stress onto others.",
+        "likely_cost": "Steadiness can turn into over-carrying when a team quietly expects you to absorb the strain.",
+        "development_lever": "Shift from “I will hold this” to “how do we distribute, sync, and review this?”",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests stronger collaborative steadiness, with boundaries and role clarity still needed."
       },
       "meta": {
         "id": "steady_collaborator",
         "asset_type": "core_formulation",
         "v23_source_id": "steady_collaborator",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "regulation_relationship_strength",
         "release_state": "stable",
         "trigger_summary": "ER high; RM high.",
@@ -431,37 +431,37 @@
     },
     "sensitive_absorber": {
       "zh-CN": {
-        "title": "自我报告模式：高敏感，易吸收",
-        "one_liner": "你对自己和他人的情绪都很敏锐，但容易把太多信号带回身体里。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你捕捉细节的能力很强；真正要保护的是情绪能量的进出边界。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：敏感度高，吸收感偏强",
+        "one_liner": "本次自我报告显示，你对自己和他人的情绪线索都较敏感，但也可能更容易把环境情绪带进自己身上。",
+        "core_claim": "这不是高敏感诊断，也不是能力标签；它提示情绪线索对你的主观影响可能更强，需要区分信息、感受和责任。",
         "evidence_basis": [
           "SA high; EM high; ER medium-low."
         ],
-        "primary_strength": "你能注意到别人没说出口的变化。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "你可能在事情结束后还长时间停留在对方的情绪里。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "建立“接收—整理—放下”的结束仪式。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你对自己和他人的情绪都很敏锐，但容易把太多信号带回身体里。"
+        "primary_strength": "你可能能捕捉细微信号，较早发现关系或氛围变化。",
+        "likely_cost": "如果缺少筛选，你可能把别人的紧张、失望或期待当成自己的任务。",
+        "development_lever": "练习三分法：这是我观察到的信息、我受到的影响、我真正需要承担的行动。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较敏感，也更需要筛选哪些情绪信息要进入行动。"
       },
       "en": {
-        "title": "Self-reported pattern: Sensitive and Absorbing",
-        "one_liner": "You are sensitive to both your own feelings and other people’s signals, but you may carry too much of that information in your body afterward. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your ability to catch subtle cues is strong; what needs protection is the boundary around emotional intake and recovery. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: High sensitivity, stronger absorption",
+        "one_liner": "In this self-report, you appear sensitive to emotional cues in yourself and others, and you may also experience the emotional atmosphere as entering your own system more strongly.",
+        "core_claim": "This is not a high-sensitivity diagnosis or an ability label. It suggests emotional information may have stronger subjective impact, making it useful to separate information, feeling, and responsibility.",
         "evidence_basis": [
           "SA high; EM high; ER medium-low."
         ],
-        "primary_strength": "You can notice shifts that other people have not put into words. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "After the moment is over, you may still be living inside someone else’s emotional weather. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Build a small closing ritual for receiving, sorting, and releasing emotional information.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You are sensitive to both your own feelings and other people’s signals, but you may carry too much of that information in your body afterward."
+        "primary_strength": "You may notice subtle signals and changes in relationship tone earlier than you expect.",
+        "likely_cost": "Without filtering, another person’s tension, disappointment, or expectation can start to feel like your task.",
+        "development_lever": "Practice three-way sorting: what I observed, how it affected me, and what action is actually mine.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests higher sensitivity and a need to filter which emotional information should become action."
       },
       "meta": {
         "id": "sensitive_absorber",
         "asset_type": "core_formulation",
         "v23_source_id": "sensitive_absorber",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "high_sensitivity",
         "release_state": "stable",
         "trigger_summary": "SA high; EM high; ER medium-low.",
@@ -492,37 +492,37 @@
     },
     "developing_foundation": {
       "zh-CN": {
-        "title": "自我报告模式：基础发展中",
-        "one_liner": "你的结果更像在提示：先把情绪命名、暂停和基本沟通步骤搭起来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "现在不需要急着追求复杂技巧；先建立稳定的观察和回应习惯。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：基础线索仍在建立",
+        "one_liner": "本次自我报告显示，你对情绪觉察、调节、共情或关系处理的信心可能还不稳定。",
+        "core_claim": "这不是能力不足诊断，也不说明你在现实中一定表现差；它更可能说明当前自我感知里可用策略、语言和复盘经验还需要建立。",
         "evidence_basis": [
           "Multiple dimensions low or low-medium."
         ],
-        "primary_strength": "你有机会从很小的练习中看到明显变化。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果直接进入复杂关系策略，容易觉得抽象或挫败。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "从每天一次情绪命名和一个暂停句开始。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你的结果更像在提示：先把情绪命名、暂停和基本沟通步骤搭起来。"
+        "primary_strength": "你已经有一个起点：能把这些维度放到同一张图里看，而不是只用“我情商高/低”概括。",
+        "likely_cost": "如果过早给自己贴标签，可能会忽略具体场景里的可练习部分。",
+        "development_lever": "先从一个低风险场景开始：命名情绪、确认需要、选择一个小回应。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，基础策略还在建立，适合从小场景和可复盘动作开始。"
       },
       "en": {
-        "title": "Self-reported pattern: Building the Foundation",
-        "one_liner": "Your result suggests that the first step is building the basics: naming emotion, pausing, and using simple communication steps. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "This result points first to simple, repeatable reflection steps rather than complex strategies. The report emphasizes stable habits for noticing, pausing, and responding. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Foundations still forming",
+        "one_liner": "In this self-report, your confidence around emotional awareness, regulation, empathy, or relationship handling may be less stable.",
+        "core_claim": "This is not a diagnosis of low ability, and it does not mean you necessarily perform poorly in real life. It more likely means your current self-view has fewer ready strategies, words, or review experiences to draw on.",
         "evidence_basis": [
           "Multiple dimensions low or low-medium."
         ],
-        "primary_strength": "Small practices may be a reasonable place to start because the foundation is still forming. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "If you jump straight into complex relationship strategies, the work may feel abstract or discouraging. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Start with one emotion label and one pause sentence each day.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Your result suggests that the first step is building the basics: naming emotion, pausing, and using simple communication steps."
+        "primary_strength": "There is already a starting point: seeing these dimensions together instead of reducing yourself to “high EQ” or “low EQ.”",
+        "likely_cost": "If you label yourself too quickly, you may miss the specific situations where practice is possible.",
+        "development_lever": "Start with one low-risk scene: name the emotion, clarify the need, choose one small response.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests your foundation is still forming, best approached through small scenes and reviewable actions."
       },
       "meta": {
         "id": "developing_foundation",
         "asset_type": "core_formulation",
         "v23_source_id": "developing_foundation",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "foundational_development",
         "release_state": "stable",
         "trigger_summary": "Multiple dimensions low or low-medium.",
@@ -553,37 +553,37 @@
     },
     "low_confidence_result": {
       "zh-CN": {
-        "title": "自我报告模式：本次结果需要谨慎阅读",
-        "one_liner": "本次结果只适合作为低置信作答证据，不适合作为画像结论。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "由于本次作答质量较低，不应用这次结果得出人格结论、职业结论或行动处方。请把它作为复测准备提示。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次结果：解释置信度不足",
+        "one_liner": "本次作答质量提示结果更适合作为初步参考，不适合输出强 formulation。",
+        "core_claim": "当前最重要的信息不是“你是哪一类”，而是这次数据不足以支持细化解释。可能原因包括作答过快、答案模式过于单一或状态不稳定。",
         "evidence_basis": [
           "Quality C/D or severe response-quality flags."
         ],
-        "primary_strength": "可用信号是复盘作答质量，而不是人格优势判断。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "过度解读本次分数或画像语言可能造成误导。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在更稳定、不被打断的状态下复测后，再阅读报告模块。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "这次结果更适合作为初步参考，而不是强结论。"
+        "primary_strength": "你仍可以用报告里的科学边界和维度说明做轻量反思。",
+        "likely_cost": "不建议基于本次结果做关系、职业或自我判断。",
+        "development_lever": "在更稳定、少干扰的状态下复测；复测前先回想 2-3 个真实情境。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次结果置信度不足，建议先复测，再阅读细化解释。"
       },
       "en": {
-        "title": "Self-reported pattern: Read This Result Lightly",
-        "one_liner": "This session should be treated as low-confidence response evidence, not a profile conclusion. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Because response quality is low, do not use this session to draw a personality conclusion, career conclusion, or action prescription. Treat it as a prompt to retake in a steadier setting. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Result status: Low interpretation confidence",
+        "one_liner": "The response-quality signal suggests this result is best treated as a preliminary reference, not a strong formulation.",
+        "core_claim": "The main message is not “which type you are.” It is that this session does not provide enough reliable signal for detailed interpretation. Possible reasons include very fast responding, overly uniform answers, or an unstable response state.",
         "evidence_basis": [
           "Quality C/D or severe response-quality flags."
         ],
-        "primary_strength": "The usable signal is response-quality review, not a personality strength. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Overreading scores or profile language from this session may be misleading. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Retake the assessment in a steadier, uninterrupted setting before using report modules.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Treat this session as a first pass, not a profile conclusion."
+        "primary_strength": "You can still use the scientific boundary and dimension definitions for light reflection.",
+        "likely_cost": "Avoid using this result for relationship, career, or self-labeling decisions.",
+        "development_lever": "Retake in a steadier, less distracted state; before retaking, recall two or three real situations.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This result has low interpretation confidence; retaking before reading detailed interpretation is recommended."
       },
       "meta": {
         "id": "low_confidence_result",
         "asset_type": "core_formulation",
         "v23_source_id": "low_confidence_result",
         "claim_risk": "high",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "quality_caution",
         "release_state": "stable",
         "trigger_summary": "Quality C/D or severe response-quality flags.",
@@ -614,37 +614,37 @@
     },
     "underconfident_repairer": {
       "zh-CN": {
-        "title": "自我报告模式：低估自己的修复者",
-        "one_liner": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：修复意愿在，信心偏低",
+        "one_liner": "本次自我报告显示，你可能在意关系修复，但对自己是否能把话说好、把局面拉回可谈状态不够有把握。",
+        "core_claim": "这不是社交能力判断，而是提示你对修复动作的自我效能感可能低于实际意愿。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。"
+        "primary_strength": "你可能愿意承担一部分关系维护，而不是简单切断或逃离。",
+        "likely_cost": "如果信心不足，你可能等太久才开口，或把修复留给对方先开始。",
+        "development_lever": "准备一个低负担开场：我想把刚才那段说清楚，不急着马上解决。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能想修复关系，但需要更低门槛的开口方式。"
       },
       "en": {
-        "title": "Self-reported pattern: Underconfident Repairer",
-        "one_liner": "You may be more capable of repairing relationships than you give yourself credit for. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may be more capable of repairing relationships than you give yourself credit for. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Repair intention, lower confidence",
+        "one_liner": "In this self-report, you may care about repair, while feeling less sure that you can say it well or move the situation back into dialogue.",
+        "core_claim": "This is not a social-skill judgment. It suggests your self-efficacy around repair may be lower than your actual intention to repair.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may be more capable of repairing relationships than you give yourself credit for."
+        "primary_strength": "You may be willing to carry part of the relationship maintenance rather than simply cut off or leave.",
+        "likely_cost": "If confidence is low, you may wait too long to speak or hope the other person starts the repair first.",
+        "development_lever": "Prepare a low-pressure opener: I want to clarify that moment, and we do not have to solve it all right now.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may want repair but need a lower-barrier way to begin."
       },
       "meta": {
         "id": "underconfident_repairer",
         "asset_type": "core_formulation",
         "v23_source_id": "underconfident_repairer",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "repair_confidence_gap",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -670,37 +670,37 @@
     },
     "over_responsible_helper": {
       "zh-CN": {
-        "title": "自我报告模式：过度负责的帮助者",
-        "one_liner": "你很愿意帮忙，但容易把支持变成替别人承担。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你很愿意帮忙，但容易把支持变成替别人承担。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：帮助意愿强，责任边界需校准",
+        "one_liner": "本次自我报告显示，你可能较快进入支持者位置，也较容易把他人的困难纳入自己的责任范围。",
+        "core_claim": "这不是“拯救者”标签，而是提示帮助、支持和代替承担之间需要更清楚的边界。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你很愿意帮忙，但容易把支持变成替别人承担。"
+        "primary_strength": "你可能愿意给出时间、注意力和实际支持。",
+        "likely_cost": "过度负责可能让对方减少自主处理，也让你在关系中持续消耗。",
+        "development_lever": "在帮助前先问：你希望我听你说、一起想办法，还是具体帮一个步骤？",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你愿意支持他人，也需要把支持和代替承担分开。"
       },
       "en": {
-        "title": "Self-reported pattern: Over-Responsible Helper",
-        "one_liner": "You want to be useful, but support can turn into carrying what is not yours. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You want to be useful, but support can turn into carrying what is not yours. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Strong helping impulse, responsibility boundary to calibrate",
+        "one_liner": "In this self-report, you may move quickly into a support role and include other people’s difficulties within your own sense of responsibility.",
+        "core_claim": "This is not a “rescuer” label. It points to a boundary between helping, supporting, and taking over.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You want to be useful, but support can turn into carrying what is not yours."
+        "primary_strength": "You may be willing to offer time, attention, and practical support.",
+        "likely_cost": "Over-responsibility can reduce the other person’s agency and leave you carrying ongoing strain.",
+        "development_lever": "Before helping, ask: do you want me to listen, think this through with you, or help with one concrete step?",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests a strong support impulse and a need to separate support from taking over."
       },
       "meta": {
         "id": "over_responsible_helper",
         "asset_type": "core_formulation",
         "v23_source_id": "over_responsible_helper",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "boundary_overhelping",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -726,37 +726,37 @@
     },
     "fast_reactor": {
       "zh-CN": {
-        "title": "自我报告模式：反应快，暂停短",
-        "one_liner": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：反应较快，缓冲不足",
+        "one_liner": "本次自我报告显示，在反馈、冲突或压力情境里，你可能较快进入回应状态，缓冲时间不一定够。",
+        "core_claim": "这不是冲动诊断，也不说明你一定会失控；它提示速度可能先于整理。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。"
+        "primary_strength": "你可能能迅速捕捉问题并给出回应。",
+        "likely_cost": "速度过快时，情绪、判断和表达可能混在一起，让对话更难回到重点。",
+        "development_lever": "练习把第一反应变成内部草稿：先停一下，再选择是否说出来。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你回应速度较快，也需要给自己留出缓冲。"
       },
       "en": {
-        "title": "Self-reported pattern: Fast Reactor",
-        "one_liner": "You react quickly once something lands; the growth point is separating first reaction from final response. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You react quickly once something lands; the growth point is separating first reaction from final response. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Fast reaction, limited buffer",
+        "one_liner": "In this self-report, you may move quickly into response mode in feedback, conflict, or pressure situations, with less buffer time than you need.",
+        "core_claim": "This is not a diagnosis of impulsivity, and it does not mean you necessarily lose control. It suggests speed may arrive before sorting.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You react quickly once something lands; the growth point is separating first reaction from final response."
+        "primary_strength": "You may notice the issue quickly and respond without much delay.",
+        "likely_cost": "When speed is too high, emotion, judgment, and expression can merge and make the conversation harder to refocus.",
+        "development_lever": "Turn the first reaction into an internal draft: pause first, then choose whether to say it.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests fast responding and a need for more buffer."
       },
       "meta": {
         "id": "fast_reactor",
         "asset_type": "core_formulation",
         "v23_source_id": "fast_reactor",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "speed_under_pressure",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -782,37 +782,37 @@
     },
     "analytical_under_feeling": {
       "zh-CN": {
-        "title": "自我报告模式：先分析，后感受",
-        "one_liner": "你倾向先整理逻辑，情绪可能在之后才追上来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你倾向先整理逻辑，情绪可能在之后才追上来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：分析在前，感受在后",
+        "one_liner": "本次自我报告显示，你可能倾向于先解释问题、找原因或给方案，而不是先停在感受本身。",
+        "core_claim": "这不是缺乏情感能力的判断；它提示分析可能是你处理不确定情绪的一种方式。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你倾向先整理逻辑，情绪可能在之后才追上来。"
+        "primary_strength": "你可能擅长把混乱问题结构化，帮助自己或他人看见逻辑。",
+        "likely_cost": "如果分析来得太早，自己或他人的情绪需要可能会被跳过。",
+        "development_lever": "在分析前加一句感受确认：这件事让我/你可能先有某种感受，然后再看原因。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较会分析，也可以给感受多一点停留时间。"
       },
       "en": {
-        "title": "Self-reported pattern: Analytical Before Feeling",
-        "one_liner": "You tend to organize the logic first; the feeling may arrive later. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You tend to organize the logic first; the feeling may arrive later. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Analysis first, feeling second",
+        "one_liner": "In this self-report, you may explain, diagnose causes, or look for solutions before staying with the feeling itself.",
+        "core_claim": "This is not a judgment that you lack emotional capacity. It suggests analysis may be one way you manage uncertain emotion.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You tend to organize the logic first; the feeling may arrive later."
+        "primary_strength": "You may be good at structuring messy situations and seeing the logic.",
+        "likely_cost": "If analysis comes too early, your own or another person’s emotional need may be skipped.",
+        "development_lever": "Add one feeling check before analysis: this may first feel like ___, and then we can look at why.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests analytical strength and room to let feeling stay present a little longer."
       },
       "meta": {
         "id": "analytical_under_feeling",
         "asset_type": "core_formulation",
         "v23_source_id": "analytical_under_feeling",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "analysis_feeling_gap",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -838,37 +838,37 @@
     },
     "quiet_empathy": {
       "zh-CN": {
-        "title": "自我报告模式：安静共情型",
-        "one_liner": "你会在心里理解别人，但不总把理解表达出来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你会在心里理解别人，但不总把理解表达出来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：共情在内，表达偏安静",
+        "one_liner": "本次自我报告显示，你可能能感到或理解他人的状态，但不一定会明显表达出来。",
+        "core_claim": "这不是冷漠判断，也不证明他人一定能感受到你的理解；它提示内在理解和外在回应之间可能有距离。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你会在心里理解别人，但不总把理解表达出来。"
+        "primary_strength": "你可能在心里保留对他人感受的细腻观察。",
+        "likely_cost": "如果表达过少，对方可能不知道你已经理解，关系支持也可能变得不可见。",
+        "development_lever": "练习把内在理解外化成一句短回应：我听到你最在意的是……",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能有共情，但需要让共情更可被看见。"
       },
       "en": {
-        "title": "Self-reported pattern: Quiet Empathy",
-        "one_liner": "You may understand people quietly without always making that understanding visible. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may understand people quietly without always making that understanding visible. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Quiet empathy",
+        "one_liner": "In this self-report, you may feel or understand another person’s state without making that understanding very visible.",
+        "core_claim": "This is not a judgment of coldness, and it does not prove others can feel your understanding. It points to a gap between inner understanding and outward response.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may understand people quietly without always making that understanding visible."
+        "primary_strength": "You may hold careful observations about what others are feeling.",
+        "likely_cost": "If expression is too quiet, the other person may not know you understand, and support can become invisible.",
+        "development_lever": "Externalize one piece of understanding: what I hear matters most to you is...",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests empathy may be present but could be made more visible."
       },
       "meta": {
         "id": "quiet_empathy",
         "asset_type": "core_formulation",
         "v23_source_id": "quiet_empathy",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "quiet_empathy",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -894,37 +894,37 @@
     },
     "direct_without_softening": {
       "zh-CN": {
-        "title": "自我报告模式：直接表达，柔化不足",
-        "one_liner": "你能把话说清楚，但有时少了让对方接住的铺垫。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能把话说清楚，但有时少了让对方接住的铺垫。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：表达直接，缓冲偏少",
+        "one_liner": "本次自我报告显示，你可能较快说出事实、观点或边界，但不一定先处理对方的情绪入口。",
+        "core_claim": "这不是粗暴或低共情判断；它提示直接表达和关系缓冲需要分开设计。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能把话说清楚，但有时少了让对方接住的铺垫。"
+        "primary_strength": "你可能能让问题更快进入实质讨论。",
+        "likely_cost": "如果缺少情绪缓冲，对方可能先听到压力或否定，而不是信息本身。",
+        "development_lever": "在直接表达前加一个缓冲：我想把问题说清楚，也会尽量不把它说成对你的否定。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你表达较直接，可以给重要对话加一点情绪缓冲。"
       },
       "en": {
-        "title": "Self-reported pattern: Direct Without Softening",
-        "one_liner": "You can say the thing clearly, but sometimes without enough landing space for the other person. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can say the thing clearly, but sometimes without enough landing space for the other person. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Direct expression, less softening",
+        "one_liner": "In this self-report, you may state facts, opinions, or boundaries quickly, without always creating an emotional entry point for the other person.",
+        "core_claim": "This is not a judgment of harshness or low empathy. It suggests direct expression and relational buffering may need to be designed separately.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can say the thing clearly, but sometimes without enough landing space for the other person."
+        "primary_strength": "You may help conversations move more quickly toward the real issue.",
+        "likely_cost": "Without a buffer, the other person may hear pressure or rejection before they can hear the information.",
+        "development_lever": "Add a softening frame before directness: I want to be clear about the issue, and I do not mean this as a rejection of you.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests directness that may benefit from a little emotional buffering in important conversations."
       },
       "meta": {
         "id": "direct_without_softening",
         "asset_type": "core_formulation",
         "v23_source_id": "direct_without_softening",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "direct_expression",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -950,37 +950,37 @@
     },
     "relationship_masking": {
       "zh-CN": {
-        "title": "自我报告模式：用关系稳定掩盖真实感受",
-        "one_liner": "你能让关系看起来稳定，但真实感受可能没有被看见。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能让关系看起来稳定，但真实感受可能没有被看见。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：关系维持下的自我遮蔽",
+        "one_liner": "本次自我报告显示，你可能为了维持关系稳定而压低自己的不满、需求或真实反应。",
+        "core_claim": "这不是人格诊断，也不能说明你总是在伪装；它提示在部分关系里，安全感和表达真实感受之间可能存在张力。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能让关系看起来稳定，但真实感受可能没有被看见。"
+        "primary_strength": "你可能能敏锐判断什么话会影响氛围，并努力维持表面稳定。",
+        "likely_cost": "长期遮蔽会让别人误判你的真实状态，也让你更难获得合适支持。",
+        "development_lever": "先在低风险关系里练习小剂量真实表达，而不是一次性摊牌。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能用压低自己来维持关系，需要逐步恢复真实表达。"
       },
       "en": {
-        "title": "Self-reported pattern: Relationship Masking",
-        "one_liner": "You can keep the relationship looking stable while your real feeling stays hidden. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can keep the relationship looking stable while your real feeling stays hidden. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Self-masking to preserve the relationship",
+        "one_liner": "In this self-report, you may reduce the visibility of your frustration, needs, or reactions to keep a relationship stable.",
+        "core_claim": "This is not a personality diagnosis, and it does not mean you are always masking. It suggests tension between safety and honest expression in some relationships.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can keep the relationship looking stable while your real feeling stays hidden."
+        "primary_strength": "You may be sensitive to what could disturb the atmosphere and work to keep things smooth.",
+        "likely_cost": "Long-term masking can lead others to misread your actual state and make support harder to receive.",
+        "development_lever": "Practice small-dose honesty in lower-risk relationships instead of waiting for a major disclosure.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may preserve relationships by lowering your own visibility, and gradual honest expression may help."
       },
       "meta": {
         "id": "relationship_masking",
         "asset_type": "core_formulation",
         "v23_source_id": "relationship_masking",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "relationship_masking",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1006,37 +1006,37 @@
     },
     "feedback_absorber": {
       "zh-CN": {
-        "title": "自我报告模式：容易吸收反馈情绪",
-        "one_liner": "你听反馈时可能先吸收对方的情绪，再处理信息。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你听反馈时可能先吸收对方的情绪，再处理信息。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：反馈吸收较深",
+        "one_liner": "本次自我报告显示，你可能把反馈很快带入自我评价，而不是只把它当作信息。",
+        "core_claim": "这不是脆弱诊断，也不说明你不能接受反馈；它提示反馈中的评价感可能比内容本身更容易被放大。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你听反馈时可能先吸收对方的情绪，再处理信息。"
+        "primary_strength": "你可能愿意认真听取反馈，并尝试从中修正自己。",
+        "likely_cost": "如果吸收过深，你可能把一个具体建议扩大成对自己的整体否定。",
+        "development_lever": "把反馈拆成三栏：事实信息、对方偏好、我下一步可试的小动作。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你很认真对待反馈，也需要防止把反馈扩大成自我否定。"
       },
       "en": {
-        "title": "Self-reported pattern: Feedback Absorber",
-        "one_liner": "When receiving feedback, you may absorb the emotional tone before you can process the information. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "When receiving feedback, you may absorb the emotional tone before you can process the information. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Deep feedback absorption",
+        "one_liner": "In this self-report, you may take feedback quickly into self-evaluation rather than treating it only as information.",
+        "core_claim": "This is not a diagnosis of fragility, and it does not mean you cannot receive feedback. It suggests the evaluative tone of feedback may become louder than the content.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "When receiving feedback, you may absorb the emotional tone before you can process the information."
+        "primary_strength": "You may listen carefully and try to use feedback to adjust.",
+        "likely_cost": "If absorption is too deep, one concrete suggestion can expand into a global self-critique.",
+        "development_lever": "Split feedback into three columns: factual information, the other person’s preference, and one next action to test.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you take feedback seriously and may need to keep it from becoming global self-judgment."
       },
       "meta": {
         "id": "feedback_absorber",
         "asset_type": "core_formulation",
         "v23_source_id": "feedback_absorber",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "feedback_absorption",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1062,37 +1062,37 @@
     },
     "balanced_moderate": {
       "zh-CN": {
-        "title": "自我报告模式：均衡但仍在打磨",
-        "one_liner": "你的四维没有明显短板，但也还没有形成特别稳定的优势。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的四维没有明显短板，但也还没有形成特别稳定的优势。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：中等均衡，可塑空间较大",
+        "one_liner": "本次自我报告显示，四个维度没有明显极端，也没有特别突出的单一优势。",
+        "core_claim": "这不代表“普通”或“没有特点”；它提示你的结果可能更依赖具体场景，适合通过场景记录来寻找真正的差异点。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你的四维没有明显短板，但也还没有形成特别稳定的优势。"
+        "primary_strength": "你可能有一定基础，不容易被单一短板完全定义。",
+        "likely_cost": "如果只看总分，可能错过具体场景中的波动：反馈、冲突、边界或压力恢复。",
+        "development_lever": "选择一个最近反复出现的场景，记录触发点、反应和恢复方式。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你整体较均衡，关键差异可能藏在具体场景里。"
       },
       "en": {
-        "title": "Self-reported pattern: Balanced, Still Sharpening",
-        "one_liner": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Moderate balance, room for clearer differentiation",
+        "one_liner": "In this self-report, the four dimensions are not highly extreme and no single strength dominates.",
+        "core_claim": "This does not mean “average” or “without a pattern.” It suggests your result may depend more on context, and scene tracking can reveal the real differences.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits."
+        "primary_strength": "You may have a workable base that is not defined by one clear weakness.",
+        "likely_cost": "If you only look at the global score, you may miss variation across feedback, conflict, boundaries, or recovery.",
+        "development_lever": "Choose one recurring recent scene and record the trigger, reaction, and recovery pattern.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests moderate balance, with the important differences likely hidden in specific situations."
       },
       "meta": {
         "id": "balanced_moderate",
         "asset_type": "core_formulation",
         "v23_source_id": "balanced_moderate",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "balanced_moderate",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1118,37 +1118,37 @@
     },
     "regulated_but_private": {
       "zh-CN": {
-        "title": "自我报告模式：能稳住，但不易表达",
-        "one_liner": "你能把自己稳住，但别人不一定知道你经历了什么。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能把自己稳住，但别人不一定知道你经历了什么。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：自我调节较私密",
+        "one_liner": "本次自我报告显示，你可能认为自己能处理情绪，但处理过程多在内部完成，不太让别人参与。",
+        "core_claim": "这不是独立能力证明，也不说明你不需要支持；它提示调节可能较私人化。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能把自己稳住，但别人不一定知道你经历了什么。"
+        "primary_strength": "你可能能把情绪先收住，避免立即扩散到外部关系。",
+        "likely_cost": "太私密的调节会让别人看不见你的压力，也可能减少及时支持。",
+        "development_lever": "在不暴露过多细节的前提下，练习一句状态说明：我需要一点时间处理，但我没有退出沟通。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你倾向于自己处理情绪，也可以让他人知道你仍在沟通里。"
       },
       "en": {
-        "title": "Self-reported pattern: Regulated but Private",
-        "one_liner": "You can steady yourself, but others may not know what you went through internally. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can steady yourself, but others may not know what you went through internally. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Private regulation",
+        "one_liner": "In this self-report, you may see yourself as able to manage emotion, while doing most of that processing internally.",
+        "core_claim": "This is not proof of independent capacity, and it does not mean you never need support. It suggests regulation may be private.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can steady yourself, but others may not know what you went through internally."
+        "primary_strength": "You may contain emotion before it spreads into the relationship.",
+        "likely_cost": "Highly private regulation can make your pressure invisible and reduce timely support.",
+        "development_lever": "Without over-explaining, practice one status sentence: I need a little time to process, but I am not leaving the conversation.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you tend to process emotion privately and may benefit from signaling that you are still engaged."
       },
       "meta": {
         "id": "regulated_but_private",
         "asset_type": "core_formulation",
         "v23_source_id": "regulated_but_private",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "private_regulation",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1174,37 +1174,37 @@
     },
     "warm_but_avoidant": {
       "zh-CN": {
-        "title": "自我报告模式：温和但回避张力",
-        "one_liner": "你愿意保持善意，但可能绕开真正紧张的话题。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你愿意保持善意，但可能绕开真正紧张的话题。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：温和连接，回避张力",
+        "one_liner": "本次自我报告显示，你可能愿意保持温和和连接，但在需要面对分歧、边界或失望时会更谨慎。",
+        "core_claim": "这不是回避型依恋诊断；它只是提示你可能更擅长维护温度，而不一定擅长进入张力。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你愿意保持善意，但可能绕开真正紧张的话题。"
+        "primary_strength": "你可能能让关系保持友好、可接近。",
+        "likely_cost": "如果张力一直被绕开，问题可能反复出现，关系也难以更新。",
+        "development_lever": "选择一个低风险分歧练习：表达一处不同意，同时保留连接。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较能维持温和连接，但需要练习安全地进入分歧。"
       },
       "en": {
-        "title": "Self-reported pattern: Warm but Avoidant",
-        "one_liner": "You try to stay warm, but may sidestep the conversation that actually needs to happen. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You try to stay warm, but may sidestep the conversation that actually needs to happen. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Warm connection, tension avoidance",
+        "one_liner": "In this self-report, you may want to stay warm and connected, while becoming more cautious when disagreement, boundaries, or disappointment need to be faced.",
+        "core_claim": "This is not an attachment diagnosis. It suggests you may be better at preserving warmth than entering tension.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You try to stay warm, but may sidestep the conversation that actually needs to happen."
+        "primary_strength": "You may help relationships feel friendly and approachable.",
+        "likely_cost": "If tension is repeatedly bypassed, the same issue may return and the relationship may not update.",
+        "development_lever": "Practice one low-risk disagreement: state one difference while keeping connection intact.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests warmth in connection and a need to practice entering disagreement safely."
       },
       "meta": {
         "id": "warm_but_avoidant",
         "asset_type": "core_formulation",
         "v23_source_id": "warm_but_avoidant",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "warm_avoidance",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1230,37 +1230,37 @@
     },
     "strategic_listener": {
       "zh-CN": {
-        "title": "自我报告模式：策略型倾听者",
-        "one_liner": "你能抓住对话线索，但需要确认自己不是只在收集信息。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能抓住对话线索，但需要确认自己不是只在收集信息。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：策略性倾听",
+        "one_liner": "本次自我报告显示，你可能较会听出对方关注点，并用倾听来稳定局面或收集信息。",
+        "core_claim": "这不是操控判断，也不是沟通能力证明；它提示倾听在你的自我感知里是一种重要工具。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能抓住对话线索，但需要确认自己不是只在收集信息。"
+        "primary_strength": "你可能能在复杂对话中先让信息变清楚。",
+        "likely_cost": "如果倾听停留在策略层，情感回应或真实立场可能不够可见。",
+        "development_lever": "在总结对方后补一句自己的位置：我听到的是……我这边目前是……",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你会用倾听稳住局面，也需要让自己的位置同样清楚。"
       },
       "en": {
-        "title": "Self-reported pattern: Strategic Listener",
-        "one_liner": "You can track conversation cues well; the challenge is not turning listening into silent data collection. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can track conversation cues well; the challenge is not turning listening into silent data collection. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Strategic listening",
+        "one_liner": "In this self-report, you may hear what the other person cares about and use listening to stabilize the situation or gather information.",
+        "core_claim": "This is not a manipulation claim or proof of communication skill. It suggests listening is an important tool in your self-view.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can track conversation cues well; the challenge is not turning listening into silent data collection."
+        "primary_strength": "You may help complex conversations become clearer before action is taken.",
+        "likely_cost": "If listening stays only strategic, emotional acknowledgment or your own position may remain unclear.",
+        "development_lever": "After summarizing them, add your position: what I hear is..., and where I am right now is...",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you use listening to steady the situation and may need to make your own position equally clear."
       },
       "meta": {
         "id": "strategic_listener",
         "asset_type": "core_formulation",
         "v23_source_id": "strategic_listener",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "listening_strength",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1286,37 +1286,37 @@
     },
     "delayed_processor": {
       "zh-CN": {
-        "title": "自我报告模式：延迟处理型",
-        "one_liner": "你常常事后才真正明白自己感受到了什么。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你常常事后才真正明白自己感受到了什么。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：延迟处理",
+        "one_liner": "本次自我报告显示，你可能在当下不一定马上知道自己真正的感受，事后才更清楚。",
+        "core_claim": "这不是迟钝或低觉察判断；它提示你的情绪加工可能需要时间和距离。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你常常事后才真正明白自己感受到了什么。"
+        "primary_strength": "你可能能在事后复盘出更准确的感受和需求。",
+        "likely_cost": "如果没有向对方说明延迟，你可能被误解为冷淡、同意或回避。",
+        "development_lever": "建立延迟说明：我现在还没整理好，晚一点再回来回应。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能需要时间处理情绪，关键是让延迟变得可沟通。"
       },
       "en": {
-        "title": "Self-reported pattern: Delayed Processor",
-        "one_liner": "You may understand what you felt only after the conversation is over. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may understand what you felt only after the conversation is over. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Delayed processing",
+        "one_liner": "In this self-report, you may not immediately know what you truly feel in the moment, with clarity arriving later.",
+        "core_claim": "This is not a judgment of dullness or low awareness. It suggests emotional processing may need time and distance.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may understand what you felt only after the conversation is over."
+        "primary_strength": "You may be able to review later and identify feelings or needs more accurately.",
+        "likely_cost": "If you do not signal the delay, others may read it as coldness, agreement, or avoidance.",
+        "development_lever": "Create a delay signal: I am not sorted yet; I will come back to this later.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may need time to process, and the key is making that delay communicable."
       },
       "meta": {
         "id": "delayed_processor",
         "asset_type": "core_formulation",
         "v23_source_id": "delayed_processor",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "delayed_processing",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1342,37 +1342,37 @@
     },
     "pressure_contained": {
       "zh-CN": {
-        "title": "自我报告模式：压力内收型",
-        "one_liner": "压力下你可能外表稳定，但内部承载很多。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "压力下你可能外表稳定，但内部承载很多。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：压力下先收住",
+        "one_liner": "本次自我报告显示，你在压力下可能倾向于先把反应收住，而不是马上表达。",
+        "core_claim": "这不是抗压能力证明；它提示你可能用控制外显反应来维持功能。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "压力下你可能外表稳定，但内部承载很多。"
+        "primary_strength": "你可能能避免压力即时升级，给局面留出空间。",
+        "likely_cost": "如果只收不排，压力可能在事后累积，或以疲惫、疏离、突然爆发出现。",
+        "development_lever": "给压力一个出口：事后 10 分钟记录身体反应、想法和需要。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你压力下较会收住，也需要安排后续释放和复盘。"
       },
       "en": {
-        "title": "Self-reported pattern: Contained Under Pressure",
-        "one_liner": "Under pressure, you may look steady while carrying a lot internally. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Under pressure, you may look steady while carrying a lot internally. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Containment under pressure",
+        "one_liner": "In this self-report, you may contain your reaction under pressure rather than expressing it immediately.",
+        "core_claim": "This is not proof of resilience. It suggests you may maintain functioning by controlling visible reaction.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Under pressure, you may look steady while carrying a lot internally."
+        "primary_strength": "You may prevent immediate escalation and leave the situation more room.",
+        "likely_cost": "If you only contain and never discharge, pressure can accumulate as fatigue, distance, or sudden expression later.",
+        "development_lever": "Give pressure an outlet: after the event, spend ten minutes noting body response, thoughts, and needs.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests pressure containment, with a need for later release and review."
       },
       "meta": {
         "id": "pressure_contained",
         "asset_type": "core_formulation",
         "v23_source_id": "pressure_contained",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "pressure_containment",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1398,37 +1398,37 @@
     },
     "empathy_to_action_gap": {
       "zh-CN": {
-        "title": "自我报告模式：懂别人，但行动转化慢",
-        "one_liner": "你能理解对方，但不一定马上知道下一步怎么做。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能理解对方，但不一定马上知道下一步怎么做。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：能理解，行动转换偏慢",
+        "one_liner": "本次自我报告显示，你可能能理解他人的感受，但不一定马上知道下一步该怎么回应。",
+        "core_claim": "这不是共情无效判断；它提示理解和行动之间需要桥接。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能理解对方，但不一定马上知道下一步怎么做。"
+        "primary_strength": "你可能能准确听到对方的处境和情绪。",
+        "likely_cost": "如果行动转换慢，对方可能感到你理解了但没有支持，或你自己陷入犹豫。",
+        "development_lever": "把理解转成一个小动作：确认、提问、给选项，而不是立刻解决。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能理解得快，但需要把理解转成可见的小行动。"
       },
       "en": {
-        "title": "Self-reported pattern: Empathy-to-Action Gap",
-        "one_liner": "You may understand the feeling but need more structure to turn it into action. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may understand the feeling but need more structure to turn it into action. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Empathy-to-action gap",
+        "one_liner": "In this self-report, you may understand what someone feels without immediately knowing what response to choose next.",
+        "core_claim": "This is not a judgment that empathy is ineffective. It suggests understanding and action need a bridge.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may understand the feeling but need more structure to turn it into action."
+        "primary_strength": "You may accurately hear the other person’s situation and emotion.",
+        "likely_cost": "If action is delayed, the other person may feel understood but unsupported, while you may feel stuck.",
+        "development_lever": "Turn understanding into one small move: acknowledge, ask, or offer options instead of trying to solve everything.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests fast understanding and a need to translate it into visible small action."
       },
       "meta": {
         "id": "empathy_to_action_gap",
         "asset_type": "core_formulation",
         "v23_source_id": "empathy_to_action_gap",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "empathy_action_gap",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1454,37 +1454,37 @@
     },
     "self_protective_distance": {
       "zh-CN": {
-        "title": "自我报告模式：保护性距离",
-        "one_liner": "你用距离保护自己，代价是别人可能读不到你的真实意图。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你用距离保护自己，代价是别人可能读不到你的真实意图。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：自我保护性距离",
+        "one_liner": "本次自我报告显示，当关系或情绪压力变强时，你可能更倾向于拉开距离来保持稳定。",
+        "core_claim": "这不是冷漠或回避诊断；它提示距离可能是一种保护策略。具体关系是否安全，会影响这个策略是否合适。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你用距离保护自己，代价是别人可能读不到你的真实意图。"
+        "primary_strength": "你可能能防止自己被卷入过强情绪。",
+        "likely_cost": "如果距离没有说明，对方可能感到被排除或被拒绝，你也可能失去必要支持。",
+        "development_lever": "把距离说清楚：我需要一点空间整理，不是要结束这段沟通。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，距离可能是你的保护方式，关键是让距离有说明。"
       },
       "en": {
-        "title": "Self-reported pattern: Protective Distance",
-        "one_liner": "You use distance to protect yourself; the cost is that others may not read your intent. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You use distance to protect yourself; the cost is that others may not read your intent. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Self-protective distance",
+        "one_liner": "In this self-report, when relational or emotional pressure rises, you may create distance to stay stable.",
+        "core_claim": "This is not a diagnosis of coldness or avoidance. It suggests distance may function as protection. Whether that strategy is appropriate depends on safety in the specific relationship.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You use distance to protect yourself; the cost is that others may not read your intent."
+        "primary_strength": "You may prevent yourself from being pulled into emotion that feels too strong.",
+        "likely_cost": "If distance is unexplained, others may feel excluded or rejected, and you may lose needed support.",
+        "development_lever": "Explain the distance: I need a little space to sort myself; I am not ending the conversation.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests distance may be protective, and the key is making it clear rather than silent."
       },
       "meta": {
         "id": "self_protective_distance",
         "asset_type": "core_formulation",
         "v23_source_id": "self_protective_distance",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "protective_distance",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1510,37 +1510,37 @@
     },
     "values_sensitive": {
       "zh-CN": {
-        "title": "自我报告模式：价值敏感型",
-        "one_liner": "当事情触碰你的原则时，情绪反应会更强。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "当事情触碰你的原则时，情绪反应会更强。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：价值敏感",
+        "one_liner": "本次自我报告显示，当事件触及公平、尊重、责任或边界等价值时，你的情绪反应可能更明显。",
+        "core_claim": "这不是道德优越或脆弱判断；它提示价值线索可能放大情绪强度。不同文化和组织规则会影响价值冲突的表达方式。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "当事情触碰你的原则时，情绪反应会更强。"
+        "primary_strength": "你可能较快察觉某件事为什么“不只是小事”。",
+        "likely_cost": "如果价值感太快进入评判，可能难以先弄清事实、意图和可行动空间。",
+        "development_lever": "先把价值词说具体：我在意的是公平/尊重/边界中的哪一部分？",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你对价值线索较敏感，需要把价值感转成可讨论的具体语言。"
       },
       "en": {
-        "title": "Self-reported pattern: Values-Sensitive Responder",
-        "one_liner": "When something touches your values, your emotional response may intensify quickly. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "When something touches your values, your emotional response may intensify quickly. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Values sensitivity",
+        "one_liner": "In this self-report, when a situation touches fairness, respect, responsibility, or boundaries, your emotional response may become more pronounced.",
+        "core_claim": "This is not a claim of moral superiority or fragility. It suggests values cues may amplify emotional intensity. Culture and organizational norms can shape how values conflict is expressed.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "When something touches your values, your emotional response may intensify quickly."
+        "primary_strength": "You may notice quickly why something feels like “more than a small issue.”",
+        "likely_cost": "If values move too quickly into judgment, it can be harder to clarify facts, intent, and action options.",
+        "development_lever": "Make the values word specific: which part of fairness, respect, or boundary is at stake?",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests sensitivity to values cues and a need to translate them into discussable language."
       },
       "meta": {
         "id": "values_sensitive",
         "asset_type": "core_formulation",
         "v23_source_id": "values_sensitive",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "values_sensitivity",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1566,37 +1566,37 @@
     },
     "team_stabilizer": {
       "zh-CN": {
-        "title": "自我报告模式：团队稳定器",
-        "one_liner": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：团队稳定器倾向",
+        "one_liner": "本次自我报告显示，你可能倾向于在团队情绪波动时维持节奏、降低摩擦或帮助大家回到任务。",
+        "core_claim": "这不是领导力或团队绩效证明；它提示你自认会承担一部分团队情绪管理。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。"
+        "primary_strength": "你可能能帮助团队避免被短期情绪完全带偏。",
+        "likely_cost": "如果这种角色变成默认，你可能被隐性分配过多协调和情绪劳动。",
+        "development_lever": "把稳定角色显性化：我可以帮助整理问题，但需要大家共同承担下一步。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能会稳定团队氛围，但需要避免把团队情绪劳动都接到自己身上。"
       },
       "en": {
-        "title": "Self-reported pattern: Team Stabilizer",
-        "one_liner": "You can help a team stay steady, but you should not become the only stabilizing system. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can help a team stay steady, but you should not become the only stabilizing system. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Team stabilizer tendency",
+        "one_liner": "In this self-report, you may try to maintain rhythm, reduce friction, or bring people back to the task when team emotion fluctuates.",
+        "core_claim": "This is not proof of leadership or team performance. It suggests you see yourself as carrying part of the team’s emotional management.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can help a team stay steady, but you should not become the only stabilizing system."
+        "primary_strength": "You may help a team avoid being fully derailed by short-term emotion.",
+        "likely_cost": "If this role becomes assumed, you may receive too much invisible coordination or emotional labor.",
+        "development_lever": "Make the stabilizing role explicit: I can help organize the issue, and we all need to carry the next step.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests a team-stabilizing tendency and a need not to absorb all team emotional labor."
       },
       "meta": {
         "id": "team_stabilizer",
         "asset_type": "core_formulation",
         "v23_source_id": "team_stabilizer",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "team_stabilizing",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1622,37 +1622,37 @@
     },
     "listening_without_followthrough": {
       "zh-CN": {
-        "title": "自我报告模式：会听，但后续弱",
-        "one_liner": "你能听见别人，但后续行动可能没有跟上。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能听见别人，但后续行动可能没有跟上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：能听见，跟进不足",
+        "one_liner": "本次自我报告显示，你可能能认真听到他人的情绪和需要，但后续行动、确认或复盘不一定跟得上。",
+        "core_claim": "这不是不真诚判断；它提示倾听和后续承诺之间可能需要更小、更明确的连接。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能听见别人，但后续行动可能没有跟上。"
+        "primary_strength": "你可能能让对方在对话中感到被听见。",
+        "likely_cost": "如果没有后续，对方可能觉得当下被理解了，但事情没有真正推进。",
+        "development_lever": "每次倾听后只承诺一个小跟进：我会在明天前确认一件事。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能听得进去，但需要把倾听接到一个小而明确的跟进。"
       },
       "en": {
-        "title": "Self-reported pattern: Listening Without Follow-Through",
-        "one_liner": "You may hear people well, but the follow-through can lag behind the listening. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may hear people well, but the follow-through can lag behind the listening. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Listening without follow-through",
+        "one_liner": "In this self-report, you may listen carefully to another person’s emotion or need, while follow-up action, confirmation, or review may be less consistent.",
+        "core_claim": "This is not a judgment of insincerity. It suggests listening and commitment need a smaller, clearer connection.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may hear people well, but the follow-through can lag behind the listening."
+        "primary_strength": "You may help someone feel heard in the conversation itself.",
+        "likely_cost": "Without follow-through, the other person may feel understood in the moment but see little movement afterward.",
+        "development_lever": "After listening, commit to one small follow-up: I will confirm one thing by tomorrow.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may listen well and need to connect listening to a small concrete follow-up."
       },
       "meta": {
         "id": "listening_without_followthrough",
         "asset_type": "core_formulation",
         "v23_source_id": "listening_without_followthrough",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "listening_action_gap",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1678,37 +1678,37 @@
     },
     "conflict_avoider": {
       "zh-CN": {
-        "title": "自我报告模式：冲突回避者",
-        "one_liner": "你可能用沉默换取平静，但未处理的问题会留在关系里。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你可能用沉默换取平静，但未处理的问题会留在关系里。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：冲突回避倾向",
+        "one_liner": "本次自我报告显示，当分歧可能升级或伤害关系时，你可能更倾向于绕开、延后或淡化冲突。",
+        "core_claim": "这不是人格诊断，也不说明回避一定错误；在不安全或权力差明显的关系里，降低冲突可能是必要策略。边界在于：它是否让重要问题长期无法被处理。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你可能用沉默换取平静，但未处理的问题会留在关系里。"
+        "primary_strength": "你可能能避免不必要的即时升级。",
+        "likely_cost": "如果所有冲突都被延后，真实问题可能积累，关系表面稳定但底层更紧。",
+        "development_lever": "从低风险分歧开始练习：只表达一个事实、一个影响、一个请求。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能倾向于降低冲突，需要区分安全回避和长期拖延。"
       },
       "en": {
-        "title": "Self-reported pattern: Conflict Avoider",
-        "one_liner": "You may trade silence for calm, but the unaddressed issue remains in the relationship. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may trade silence for calm, but the unaddressed issue remains in the relationship. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Conflict-avoidance tendency",
+        "one_liner": "In this self-report, when disagreement may escalate or damage the relationship, you may avoid, delay, or soften the conflict.",
+        "core_claim": "This is not a personality diagnosis, and avoidance is not always wrong. In unsafe relationships or strong power differences, lowering conflict may be necessary. The question is whether important issues remain unaddressed for too long.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may trade silence for calm, but the unaddressed issue remains in the relationship."
+        "primary_strength": "You may prevent unnecessary immediate escalation.",
+        "likely_cost": "If every conflict is delayed, real issues can accumulate while the relationship looks stable on the surface.",
+        "development_lever": "Practice with a low-risk disagreement: one fact, one impact, one request.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests a tendency to lower conflict and a need to distinguish safe avoidance from long-term delay."
       },
       "meta": {
         "id": "conflict_avoider",
         "asset_type": "core_formulation",
         "v23_source_id": "conflict_avoider",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "conflict_avoidance",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T17:18:52.198969Z",
+    "generated_at": "2026-07-02T17:49:08.361934Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -682,37 +682,37 @@
             "formulations": {
                 "balanced_integrated": {
                     "zh-CN": {
-                        "title": "自我报告模式：均衡整合型",
-                        "one_liner": "你不是只擅长某一项，而是较能把觉察、调节、共情和关系处理连起来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你通常能看见自己的状态，也能顾及他人的感受，并把情绪信息转成相对稳定的沟通和行动。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：均衡整合",
+                        "one_liner": "本次自我报告显示，你较少只靠单一优势应对情绪关系问题，而是倾向于把自我觉察、调节、共情和关系处理连在一起使用。",
+                        "core_claim": "这个结果提示你对自己和他人的情绪线索都有一定可用感，也认为自己能把这些线索转成相对稳定的沟通选择。它仍然需要用真实反馈和具体场景来校准。",
                         "evidence_basis": [
                             "Four dimensions high or upper-stable; no severe gap."
                         ],
-                        "primary_strength": "复杂对话里，你更容易同时顾及事实、情绪和关系目标。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "优势太均衡时，你可能低估持续恢复和边界维护的必要性。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把稳定优势转成可复用的沟通流程，而不是只靠当下状态。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你不是只擅长某一项，而是较能把觉察、调节、共情和关系处理连起来。"
+                        "primary_strength": "在需要同时处理事实、情绪和关系目标时，你可能更容易保持整体视角。",
+                        "likely_cost": "均衡感也可能让你低估恢复、边界和复盘的必要性，尤其在长期消耗的关系或团队环境里。",
+                        "development_lever": "把“整体稳定”拆成可复用流程：先识别情绪线索，再确认边界，最后选择沟通动作。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你倾向于把觉察、调节、共情和关系处理连起来使用。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Integrated Balance",
-                        "one_liner": "Your strength is not one isolated skill; it is how your self-reported awareness, regulation, empathy, and relationship-management signals appear to work together. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You usually notice your own state, register other people’s feelings, and turn emotional information into relatively steady communication and action. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Integrated balance",
+                        "one_liner": "In this self-report, your pattern is less about one standout strength and more about linking self-awareness, regulation, empathy, and relationship management together.",
+                        "core_claim": "The result suggests you experience both self-focused and other-focused emotional information as usable, and you see yourself as able to turn that information into steadier communication choices. It still needs calibration against real feedback and specific contexts.",
                         "evidence_basis": [
                             "Four dimensions high or upper-stable; no severe gap."
                         ],
-                        "primary_strength": "In complex conversations, you are more likely to hold the facts, the emotions, and the relationship goal at the same time. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "When things are going well, you may underestimate how much recovery and boundary maintenance still matter. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn your strengths into repeatable communication routines, rather than relying on being in a good state.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Your strength is not one isolated skill; it is how your self-reported awareness, regulation, empathy, and relationship-management signals appear to work together."
+                        "primary_strength": "When facts, feelings, and relationship goals all matter, you may be more likely to keep the whole situation in view.",
+                        "likely_cost": "A balanced self-view can make recovery, boundaries, and review feel less urgent than they are in long-running or high-demand settings.",
+                        "development_lever": "Translate “overall steadiness” into a repeatable sequence: notice the cue, check the boundary, then choose the communication move.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you tend to link awareness, regulation, empathy, and relationship handling rather than relying on one isolated strength."
                     },
                     "meta": {
                         "id": "balanced_integrated",
                         "asset_type": "core_formulation",
                         "v23_source_id": "balanced_integrated",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "balanced_strength",
                         "release_state": "stable",
                         "trigger_summary": "Four dimensions high or upper-stable; no severe gap.",
@@ -743,37 +743,37 @@
                 },
                 "high_empathy_low_recovery": {
                     "zh-CN": {
-                        "title": "自我报告模式：高共情，低恢复",
-                        "one_liner": "本次自我报告显示，你倾向于较快注意到他人的情绪线索，但在情绪负荷后可能需要更多恢复空间。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的共情不是问题；真正的杠杆是共情之后如何区分陪伴、责任和恢复。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：高共情线索，恢复负荷偏高",
+                        "one_liner": "本次自我报告显示，你较容易注意到他人的情绪线索，但在承接情绪后可能需要更多恢复空间。",
+                        "core_claim": "重点不是“共情太多”，而是你如何区分理解、责任、行动和恢复。真实关系中的权力差、亲密度和压力水平会显著影响这个模式。",
                         "evidence_basis": [
                             "EM high; ER low or medium-low."
                         ],
-                        "primary_strength": "你可能倾向于表达理解，尤其在对方情绪明显但没有说清楚时。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "你可能把“我理解你”滑向“我必须替你扛住”。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "练习共情后的边界句和恢复动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "本次自我报告显示，你倾向于较快注意到他人的情绪线索，但在情绪负荷后可能需要更多恢复空间。"
+                        "primary_strength": "你可能较快捕捉对方没有明说的情绪，并愿意用理解来维持连接。",
+                        "likely_cost": "如果边界不清，你可能把“我能理解”误变成“我必须承担”。",
+                        "development_lever": "练习共情后的边界句：先承认感受，再说明自己能承担和不能承担的部分。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你容易读到他人情绪，也需要更清楚的恢复和边界。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: High Empathy, Low Recovery",
-                        "one_liner": "Your self-report suggests you often notice emotional cues in others, but you may experience recovery as slower after emotionally loaded contact. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your empathy is not the problem. The leverage point is what happens after empathy: companionship, responsibility, and recovery need clearer separation. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Strong empathy cues, heavier recovery load",
+                        "one_liner": "In this self-report, you appear quick to notice emotional cues in others, while recovery after emotionally loaded contact may take more space.",
+                        "core_claim": "The issue is not “too much empathy.” The leverage point is separating understanding, responsibility, action, and recovery. Power dynamics, closeness, and stress level can change how this pattern shows up.",
                         "evidence_basis": [
                             "EM high; ER low or medium-low."
                         ],
-                        "primary_strength": "You may tend to communicate understanding, especially when their emotion is obvious but not clearly stated. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "You may slide from “I understand this” into “I have to carry this with you or for you.” Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Practice boundary language and recovery steps after empathic contact.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Your self-report suggests you often notice emotional cues in others, but you may experience recovery as slower after emotionally loaded contact."
+                        "primary_strength": "You may be quick to notice what someone is feeling before they state it directly, and you may use understanding to maintain connection.",
+                        "likely_cost": "Without a clear boundary, “I understand” can slide into “I have to carry this.”",
+                        "development_lever": "Practice a post-empathy boundary sentence: name the feeling, then state what you can and cannot take on.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you often notice others’ emotions and may need clearer recovery and boundaries afterward."
                     },
                     "meta": {
                         "id": "high_empathy_low_recovery",
                         "asset_type": "core_formulation",
                         "v23_source_id": "high_empathy_low_recovery",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "empathy_regulation_gap",
                         "release_state": "stable",
                         "trigger_summary": "EM high; ER low or medium-low.",
@@ -804,37 +804,37 @@
                 },
                 "aware_but_unregulated": {
                     "zh-CN": {
-                        "title": "自我报告模式：有觉察，调节不足",
-                        "one_liner": "你常常知道自己被触发了，但还没有总能把自己带回稳定状态。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的优势在于看见内在变化；发展点在于把“我知道”变成“我能暂停和恢复”。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：觉察较快，调节跟进不足",
+                        "one_liner": "本次自我报告显示，你较能意识到自己被触发了，但不一定能立刻把情绪强度降到适合行动的水平。",
+                        "core_claim": "这不是“知道也没用”的判断，而是提示觉察和调节之间可能有时间差。场景压力越高，这个时间差越需要被看见。",
                         "evidence_basis": [
                             "SA high; ER low or medium-low."
                         ],
-                        "primary_strength": "你能比很多人更快识别自己的情绪线索。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "觉察越清楚，若缺少调节步骤，越可能变成反复分析或内耗。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "给觉察配一个身体层面的暂停动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你常常知道自己被触发了，但还没有总能把自己带回稳定状态。"
+                        "primary_strength": "你可能比许多人更早发现自己的不适、紧张或防御反应。",
+                        "likely_cost": "如果缺少暂停，你可能在已经意识到情绪的情况下仍被情绪推动表达或决策。",
+                        "development_lever": "把觉察后面的 30 秒做实：暂停、命名、降速，再回应。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能很快知道自己怎么了，但还需要更稳定的恢复步骤。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Aware, Not Yet Settled",
-                        "one_liner": "You often know you have been triggered, but you may not always be able to bring yourself back to steadiness in time. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your strength is noticing the inner shift; the next step is turning “I know what is happening” into “I can pause and recover.” Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Fast awareness, slower regulation follow-through",
+                        "one_liner": "In this self-report, you seem able to notice when you are activated, but not always able to lower the intensity quickly enough for useful action.",
+                        "core_claim": "This is not a judgment that awareness “doesn’t help.” It suggests a possible lag between noticing emotion and regulating it, especially under pressure.",
                         "evidence_basis": [
                             "SA high; ER low or medium-low."
                         ],
-                        "primary_strength": "You can often identify your emotional cues faster than many people. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Clear awareness without regulation steps can turn into replaying, overanalyzing, or emotional fatigue. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Pair awareness with a physical pause that slows the next response.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You often know you have been triggered, but you may not always be able to bring yourself back to steadiness in time."
+                        "primary_strength": "You may catch discomfort, tension, or defensiveness relatively early.",
+                        "likely_cost": "Without a pause, you may still speak or decide from the emotion even after you have named it.",
+                        "development_lever": "Make the 30 seconds after awareness concrete: pause, label, slow down, then respond.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may know what is happening inside before you have a reliable recovery step."
                     },
                     "meta": {
                         "id": "aware_but_unregulated",
                         "asset_type": "core_formulation",
                         "v23_source_id": "aware_but_unregulated",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "awareness_regulation_gap",
                         "release_state": "stable",
                         "trigger_summary": "SA high; ER low or medium-low.",
@@ -865,37 +865,37 @@
                 },
                 "calm_but_distant": {
                     "zh-CN": {
-                        "title": "自我报告模式：冷静稳定，但情绪回应偏弱",
-                        "one_liner": "你能稳住局面，但别人不一定感到自己的情绪被你接住。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的调节能力能降低混乱，但如果少了情绪回应，稳定会被误读成疏离。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：自感稳定，情绪回应偏保留",
+                        "one_liner": "本次自我报告显示，你倾向于认为自己能保持稳定，但对他人情绪的回应可能更克制或更晚出现。",
+                        "core_claim": "这里的“稳定”不等于客观冷静能力，也不说明别人一定感到被支持；它提示你可以校准稳定与回应之间的距离。",
                         "evidence_basis": [
                             "ER high; EM low or medium-low."
                         ],
-                        "primary_strength": "压力高时，你更容易保持思路和节奏。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "别人可能听到了你的解决方案，却没有感到被理解。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在解决问题前先命名对方的感受。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能稳住局面，但别人不一定感到自己的情绪被你接住。"
+                        "primary_strength": "你可能在压力下不容易被情绪牵着走，能先保留判断空间。",
+                        "likely_cost": "他人可能需要的不只是稳定，也可能是被看见、被确认或被回应。",
+                        "development_lever": "练习把稳定转成可被感受到的回应：先复述对方关注点，再给出你的判断。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较重视稳定，但可以让回应更容易被他人感受到。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Calm, but Hard to Read Warmly",
-                        "one_liner": "You may keep the situation steady, while others may not always feel emotionally met. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your regulation can reduce chaos, but without emotional acknowledgment, steadiness can be mistaken for distance. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Steady self-view, reserved emotional response",
+                        "one_liner": "In this self-report, you see yourself as relatively steady, while your response to others’ emotions may be restrained or delayed.",
+                        "core_claim": "“Steady” here is not proof of objective calmness, and it does not mean others automatically feel supported. It points to a calibration question: how much response is visible?",
                         "evidence_basis": [
                             "ER high; EM low or medium-low."
                         ],
-                        "primary_strength": "Under pressure, you are more likely to keep your thinking and pacing intact. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "People may hear your solution without feeling that you understood the emotional weight of the moment. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Name the other person’s feeling before moving into problem-solving.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may keep the situation steady, while others may not always feel emotionally met."
+                        "primary_strength": "Under pressure, you may be less likely to get pulled immediately into emotional escalation.",
+                        "likely_cost": "Other people may need more than steadiness; they may need to feel seen, acknowledged, or answered.",
+                        "development_lever": "Turn steadiness into a visible response: reflect the concern first, then offer your view.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you value steadiness and may benefit from making emotional acknowledgment more visible."
                     },
                     "meta": {
                         "id": "calm_but_distant",
                         "asset_type": "core_formulation",
                         "v23_source_id": "calm_but_distant",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "regulation_empathy_gap",
                         "release_state": "stable",
                         "trigger_summary": "ER high; EM low or medium-low.",
@@ -926,37 +926,37 @@
                 },
                 "relationship_first_self_later": {
                     "zh-CN": {
-                        "title": "自我报告模式：关系优先，自我后置",
-                        "one_liner": "你很会维护关系，但有时把自己的真实感受排到太后面。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你会照顾气氛、流程和他人的反应；发展点是不要让关系稳定建立在自我忽略上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：关系优先，自我后置",
+                        "one_liner": "本次自我报告显示，你可能较快考虑关系氛围和他人感受，但自己的需要、限制或不满更晚才被表达。",
+                        "core_claim": "这不是“讨好型人格”诊断，而是一个自我报告线索：关系维护可能先于自我澄清。不同文化和权力关系会影响它是否是优势或负担。",
                         "evidence_basis": [
                             "RM high; SA low or medium-low."
                         ],
-                        "primary_strength": "你常能让对话继续进行，不轻易让场面崩掉。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "你可能很晚才发现自己其实已经不舒服。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在回应别人前先问自己一句：我现在真实需要什么？",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你很会维护关系，但有时把自己的真实感受排到太后面。"
+                        "primary_strength": "你可能擅长降低场面摩擦，避免让关系立即破裂。",
+                        "likely_cost": "长期后置自己可能让不满积累，并使边界表达变得突然或困难。",
+                        "development_lever": "在照顾关系前先补一句自我定位：我现在能接受什么，不能接受什么。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较先照顾关系，也需要更早把自己放进关系里。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Relationship First, Self Later",
-                        "one_liner": "You are often good at keeping relationships moving, but your own feelings may get pushed too far down the list. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can manage tone, flow, and other people’s reactions; the growth point is making sure relational stability does not depend on self-erasure. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Relationship first, self later",
+                        "one_liner": "In this self-report, you may consider the relationship climate and others’ feelings quickly, while your own needs, limits, or frustration appear later.",
+                        "core_claim": "This is not a diagnosis of people-pleasing. It is a self-report signal that relationship maintenance may come before self-clarification. Culture and power dynamics can determine whether this is useful or costly.",
                         "evidence_basis": [
                             "RM high; SA low or medium-low."
                         ],
-                        "primary_strength": "You often keep conversations going without letting the room collapse emotionally. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "You may realize late that you were uncomfortable much earlier. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Before responding to others, ask: what do I actually need right now?",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You are often good at keeping relationships moving, but your own feelings may get pushed too far down the list."
+                        "primary_strength": "You may be good at reducing immediate friction and keeping the relationship from breaking down too quickly.",
+                        "likely_cost": "Putting yourself last for too long can build resentment and make boundaries feel sudden or hard to state.",
+                        "development_lever": "Before protecting the relationship, add one self-positioning sentence: what you can accept and what you cannot.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you attend to the relationship early and may need to include yourself earlier too."
                     },
                     "meta": {
                         "id": "relationship_first_self_later",
                         "asset_type": "core_formulation",
                         "v23_source_id": "relationship_first_self_later",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "relationship_self_gap",
                         "release_state": "stable",
                         "trigger_summary": "RM high; SA low or medium-low.",
@@ -987,37 +987,37 @@
                 },
                 "self_clear_repair_weak": {
                     "zh-CN": {
-                        "title": "自我报告模式：自我清楚，修复不足",
-                        "one_liner": "你知道自己要表达什么，但关系修复的步骤可能还不够细。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的自我觉察让表达更清楚；发展点是让对方也能接住你的表达。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：自我较清楚，修复动作不足",
+                        "one_liner": "本次自我报告显示，你较知道自己的感受和立场，但在冲突后如何修复关系、重开对话或降低防御感上可能不够稳定。",
+                        "core_claim": "这不表示你“不会处理关系”，而是提示表达清楚和关系修复是两个不同环节。",
                         "evidence_basis": [
                             "SA high; RM low or medium-low."
                         ],
-                        "primary_strength": "你不容易完全失去自己的立场。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果缺少修复，清楚可能被听成强硬。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在表达后补上影响确认和关系修复。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你知道自己要表达什么，但关系修复的步骤可能还不够细。"
+                        "primary_strength": "你可能能较明确说出自己为什么不舒服、不同意或需要什么。",
+                        "likely_cost": "如果缺少修复动作，清楚表达可能被他人感受到为定案、拒绝或距离。",
+                        "development_lever": "给表达后加一个修复句：我想把问题说清楚，也想把关系留在可继续沟通的位置。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较清楚自己的立场，但冲突后的修复动作还可以更具体。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Clear About Self, Less Practiced at Repair",
-                        "one_liner": "You may know what you need to say, but the repair steps after impact may need more structure. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your self-awareness can make your expression clear; the next step is making that expression easier for another person to receive. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Clear self-position, weaker repair moves",
+                        "one_liner": "In this self-report, you seem relatively clear about your feelings and position, while post-conflict repair, reopening dialogue, or lowering defensiveness may be less consistent.",
+                        "core_claim": "This does not mean you “cannot handle relationships.” It separates clear expression from relational repair as two different steps.",
                         "evidence_basis": [
                             "SA high; RM low or medium-low."
                         ],
-                        "primary_strength": "You are less likely to lose track of your own position. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without repair, clarity can be heard as sharpness. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "After expressing yourself, add impact-checking and repair language.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may know what you need to say, but the repair steps after impact may need more structure."
+                        "primary_strength": "You may be able to state why something bothers you, where you disagree, or what you need.",
+                        "likely_cost": "Without repair, clear expression can be experienced by others as final, rejecting, or distant.",
+                        "development_lever": "Add a repair sentence after expression: I want to be clear about the issue and still keep the relationship open for dialogue.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may know your position clearly, while repair after tension can become more concrete."
                     },
                     "meta": {
                         "id": "self_clear_repair_weak",
                         "asset_type": "core_formulation",
                         "v23_source_id": "self_clear_repair_weak",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "expression_repair_gap",
                         "release_state": "stable",
                         "trigger_summary": "SA high; RM low or medium-low.",
@@ -1048,37 +1048,37 @@
                 },
                 "steady_collaborator": {
                     "zh-CN": {
-                        "title": "自我报告模式：稳定协作者",
-                        "one_liner": "你在压力下通常能把对话拉回问题本身，而不是被情绪完全带走。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的优势在于把稳定和关系推进结合起来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：协作稳定感较强",
+                        "one_liner": "本次自我报告显示，你较相信自己能在压力和协作中保持可沟通、可配合的状态。",
+                        "core_claim": "这不是团队能力证明，也不预测别人一定觉得你可靠；它提示你可以继续检验稳定感在高压和多方冲突里是否仍可维持。",
                         "evidence_basis": [
                             "ER high; RM high."
                         ],
-                        "primary_strength": "你适合做对话里的降温者和整理者。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "你可能低估别人还需要被情绪回应，而不只是被推进。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在推动下一步前，补一句情绪确认。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你在压力下通常能把对话拉回问题本身，而不是被情绪完全带走。"
+                        "primary_strength": "你可能能在多数协作情境中保持节奏，不轻易把压力转嫁给他人。",
+                        "likely_cost": "稳定也可能带来过度承担，尤其当团队默认你来兜底时。",
+                        "development_lever": "把稳定从“我来扛”转成“我们如何分配、同步和复盘”。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你对自己的协作稳定感较强，但仍需要边界和分工来支撑。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Steady Collaborator",
-                        "one_liner": "Under pressure, you can often bring the conversation back to the issue rather than letting emotion take over. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your strength is combining steadiness with relationship movement. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Collaborative steadiness",
+                        "one_liner": "In this self-report, you see yourself as able to stay communicative and cooperative under pressure and in group work.",
+                        "core_claim": "This is not proof of team performance, nor a prediction that others experience you as reliable. It suggests a stability pattern worth testing in high-pressure or multi-party conflict.",
                         "evidence_basis": [
                             "ER high; RM high."
                         ],
-                        "primary_strength": "You can be the person who cools the room down and organizes the next step. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "You may underestimate that others sometimes need emotional acknowledgment, not only forward motion. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Before moving the group forward, add one sentence of emotional acknowledgment.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Under pressure, you can often bring the conversation back to the issue rather than letting emotion take over."
+                        "primary_strength": "You may keep a workable rhythm in many collaborative settings without quickly displacing stress onto others.",
+                        "likely_cost": "Steadiness can turn into over-carrying when a team quietly expects you to absorb the strain.",
+                        "development_lever": "Shift from “I will hold this” to “how do we distribute, sync, and review this?”",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests stronger collaborative steadiness, with boundaries and role clarity still needed."
                     },
                     "meta": {
                         "id": "steady_collaborator",
                         "asset_type": "core_formulation",
                         "v23_source_id": "steady_collaborator",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "regulation_relationship_strength",
                         "release_state": "stable",
                         "trigger_summary": "ER high; RM high.",
@@ -1109,37 +1109,37 @@
                 },
                 "sensitive_absorber": {
                     "zh-CN": {
-                        "title": "自我报告模式：高敏感，易吸收",
-                        "one_liner": "你对自己和他人的情绪都很敏锐，但容易把太多信号带回身体里。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你捕捉细节的能力很强；真正要保护的是情绪能量的进出边界。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：敏感度高，吸收感偏强",
+                        "one_liner": "本次自我报告显示，你对自己和他人的情绪线索都较敏感，但也可能更容易把环境情绪带进自己身上。",
+                        "core_claim": "这不是高敏感诊断，也不是能力标签；它提示情绪线索对你的主观影响可能更强，需要区分信息、感受和责任。",
                         "evidence_basis": [
                             "SA high; EM high; ER medium-low."
                         ],
-                        "primary_strength": "你能注意到别人没说出口的变化。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "你可能在事情结束后还长时间停留在对方的情绪里。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "建立“接收—整理—放下”的结束仪式。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你对自己和他人的情绪都很敏锐，但容易把太多信号带回身体里。"
+                        "primary_strength": "你可能能捕捉细微信号，较早发现关系或氛围变化。",
+                        "likely_cost": "如果缺少筛选，你可能把别人的紧张、失望或期待当成自己的任务。",
+                        "development_lever": "练习三分法：这是我观察到的信息、我受到的影响、我真正需要承担的行动。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较敏感，也更需要筛选哪些情绪信息要进入行动。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Sensitive and Absorbing",
-                        "one_liner": "You are sensitive to both your own feelings and other people’s signals, but you may carry too much of that information in your body afterward. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your ability to catch subtle cues is strong; what needs protection is the boundary around emotional intake and recovery. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: High sensitivity, stronger absorption",
+                        "one_liner": "In this self-report, you appear sensitive to emotional cues in yourself and others, and you may also experience the emotional atmosphere as entering your own system more strongly.",
+                        "core_claim": "This is not a high-sensitivity diagnosis or an ability label. It suggests emotional information may have stronger subjective impact, making it useful to separate information, feeling, and responsibility.",
                         "evidence_basis": [
                             "SA high; EM high; ER medium-low."
                         ],
-                        "primary_strength": "You can notice shifts that other people have not put into words. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "After the moment is over, you may still be living inside someone else’s emotional weather. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Build a small closing ritual for receiving, sorting, and releasing emotional information.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You are sensitive to both your own feelings and other people’s signals, but you may carry too much of that information in your body afterward."
+                        "primary_strength": "You may notice subtle signals and changes in relationship tone earlier than you expect.",
+                        "likely_cost": "Without filtering, another person’s tension, disappointment, or expectation can start to feel like your task.",
+                        "development_lever": "Practice three-way sorting: what I observed, how it affected me, and what action is actually mine.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests higher sensitivity and a need to filter which emotional information should become action."
                     },
                     "meta": {
                         "id": "sensitive_absorber",
                         "asset_type": "core_formulation",
                         "v23_source_id": "sensitive_absorber",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "high_sensitivity",
                         "release_state": "stable",
                         "trigger_summary": "SA high; EM high; ER medium-low.",
@@ -1170,37 +1170,37 @@
                 },
                 "developing_foundation": {
                     "zh-CN": {
-                        "title": "自我报告模式：基础发展中",
-                        "one_liner": "你的结果更像在提示：先把情绪命名、暂停和基本沟通步骤搭起来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "现在不需要急着追求复杂技巧；先建立稳定的观察和回应习惯。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：基础线索仍在建立",
+                        "one_liner": "本次自我报告显示，你对情绪觉察、调节、共情或关系处理的信心可能还不稳定。",
+                        "core_claim": "这不是能力不足诊断，也不说明你在现实中一定表现差；它更可能说明当前自我感知里可用策略、语言和复盘经验还需要建立。",
                         "evidence_basis": [
                             "Multiple dimensions low or low-medium."
                         ],
-                        "primary_strength": "你有机会从很小的练习中看到明显变化。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果直接进入复杂关系策略，容易觉得抽象或挫败。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "从每天一次情绪命名和一个暂停句开始。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你的结果更像在提示：先把情绪命名、暂停和基本沟通步骤搭起来。"
+                        "primary_strength": "你已经有一个起点：能把这些维度放到同一张图里看，而不是只用“我情商高/低”概括。",
+                        "likely_cost": "如果过早给自己贴标签，可能会忽略具体场景里的可练习部分。",
+                        "development_lever": "先从一个低风险场景开始：命名情绪、确认需要、选择一个小回应。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，基础策略还在建立，适合从小场景和可复盘动作开始。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Building the Foundation",
-                        "one_liner": "Your result suggests that the first step is building the basics: naming emotion, pausing, and using simple communication steps. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "This result points first to simple, repeatable reflection steps rather than complex strategies. The report emphasizes stable habits for noticing, pausing, and responding. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Foundations still forming",
+                        "one_liner": "In this self-report, your confidence around emotional awareness, regulation, empathy, or relationship handling may be less stable.",
+                        "core_claim": "This is not a diagnosis of low ability, and it does not mean you necessarily perform poorly in real life. It more likely means your current self-view has fewer ready strategies, words, or review experiences to draw on.",
                         "evidence_basis": [
                             "Multiple dimensions low or low-medium."
                         ],
-                        "primary_strength": "Small practices may be a reasonable place to start because the foundation is still forming. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "If you jump straight into complex relationship strategies, the work may feel abstract or discouraging. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Start with one emotion label and one pause sentence each day.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Your result suggests that the first step is building the basics: naming emotion, pausing, and using simple communication steps."
+                        "primary_strength": "There is already a starting point: seeing these dimensions together instead of reducing yourself to “high EQ” or “low EQ.”",
+                        "likely_cost": "If you label yourself too quickly, you may miss the specific situations where practice is possible.",
+                        "development_lever": "Start with one low-risk scene: name the emotion, clarify the need, choose one small response.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests your foundation is still forming, best approached through small scenes and reviewable actions."
                     },
                     "meta": {
                         "id": "developing_foundation",
                         "asset_type": "core_formulation",
                         "v23_source_id": "developing_foundation",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "foundational_development",
                         "release_state": "stable",
                         "trigger_summary": "Multiple dimensions low or low-medium.",
@@ -1231,37 +1231,37 @@
                 },
                 "low_confidence_result": {
                     "zh-CN": {
-                        "title": "自我报告模式：本次结果需要谨慎阅读",
-                        "one_liner": "本次结果只适合作为低置信作答证据，不适合作为画像结论。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "由于本次作答质量较低，不应用这次结果得出人格结论、职业结论或行动处方。请把它作为复测准备提示。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次结果：解释置信度不足",
+                        "one_liner": "本次作答质量提示结果更适合作为初步参考，不适合输出强 formulation。",
+                        "core_claim": "当前最重要的信息不是“你是哪一类”，而是这次数据不足以支持细化解释。可能原因包括作答过快、答案模式过于单一或状态不稳定。",
                         "evidence_basis": [
                             "Quality C/D or severe response-quality flags."
                         ],
-                        "primary_strength": "可用信号是复盘作答质量，而不是人格优势判断。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "过度解读本次分数或画像语言可能造成误导。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "在更稳定、不被打断的状态下复测后，再阅读报告模块。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "这次结果更适合作为初步参考，而不是强结论。"
+                        "primary_strength": "你仍可以用报告里的科学边界和维度说明做轻量反思。",
+                        "likely_cost": "不建议基于本次结果做关系、职业或自我判断。",
+                        "development_lever": "在更稳定、少干扰的状态下复测；复测前先回想 2-3 个真实情境。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次结果置信度不足，建议先复测，再阅读细化解释。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Read This Result Lightly",
-                        "one_liner": "This session should be treated as low-confidence response evidence, not a profile conclusion. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Because response quality is low, do not use this session to draw a personality conclusion, career conclusion, or action prescription. Treat it as a prompt to retake in a steadier setting. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Result status: Low interpretation confidence",
+                        "one_liner": "The response-quality signal suggests this result is best treated as a preliminary reference, not a strong formulation.",
+                        "core_claim": "The main message is not “which type you are.” It is that this session does not provide enough reliable signal for detailed interpretation. Possible reasons include very fast responding, overly uniform answers, or an unstable response state.",
                         "evidence_basis": [
                             "Quality C/D or severe response-quality flags."
                         ],
-                        "primary_strength": "The usable signal is response-quality review, not a personality strength. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Overreading scores or profile language from this session may be misleading. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Retake the assessment in a steadier, uninterrupted setting before using report modules.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Treat this session as a first pass, not a profile conclusion."
+                        "primary_strength": "You can still use the scientific boundary and dimension definitions for light reflection.",
+                        "likely_cost": "Avoid using this result for relationship, career, or self-labeling decisions.",
+                        "development_lever": "Retake in a steadier, less distracted state; before retaking, recall two or three real situations.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This result has low interpretation confidence; retaking before reading detailed interpretation is recommended."
                     },
                     "meta": {
                         "id": "low_confidence_result",
                         "asset_type": "core_formulation",
                         "v23_source_id": "low_confidence_result",
                         "claim_risk": "high",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "quality_caution",
                         "release_state": "stable",
                         "trigger_summary": "Quality C/D or severe response-quality flags.",
@@ -1292,37 +1292,37 @@
                 },
                 "underconfident_repairer": {
                     "zh-CN": {
-                        "title": "自我报告模式：低估自己的修复者",
-                        "one_liner": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：修复意愿在，信心偏低",
+                        "one_liner": "本次自我报告显示，你可能在意关系修复，但对自己是否能把话说好、把局面拉回可谈状态不够有把握。",
+                        "core_claim": "这不是社交能力判断，而是提示你对修复动作的自我效能感可能低于实际意愿。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。"
+                        "primary_strength": "你可能愿意承担一部分关系维护，而不是简单切断或逃离。",
+                        "likely_cost": "如果信心不足，你可能等太久才开口，或把修复留给对方先开始。",
+                        "development_lever": "准备一个低负担开场：我想把刚才那段说清楚，不急着马上解决。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能想修复关系，但需要更低门槛的开口方式。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Underconfident Repairer",
-                        "one_liner": "You may be more capable of repairing relationships than you give yourself credit for. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may be more capable of repairing relationships than you give yourself credit for. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Repair intention, lower confidence",
+                        "one_liner": "In this self-report, you may care about repair, while feeling less sure that you can say it well or move the situation back into dialogue.",
+                        "core_claim": "This is not a social-skill judgment. It suggests your self-efficacy around repair may be lower than your actual intention to repair.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may be more capable of repairing relationships than you give yourself credit for."
+                        "primary_strength": "You may be willing to carry part of the relationship maintenance rather than simply cut off or leave.",
+                        "likely_cost": "If confidence is low, you may wait too long to speak or hope the other person starts the repair first.",
+                        "development_lever": "Prepare a low-pressure opener: I want to clarify that moment, and we do not have to solve it all right now.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may want repair but need a lower-barrier way to begin."
                     },
                     "meta": {
                         "id": "underconfident_repairer",
                         "asset_type": "core_formulation",
                         "v23_source_id": "underconfident_repairer",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "repair_confidence_gap",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1348,37 +1348,37 @@
                 },
                 "over_responsible_helper": {
                     "zh-CN": {
-                        "title": "自我报告模式：过度负责的帮助者",
-                        "one_liner": "你很愿意帮忙，但容易把支持变成替别人承担。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你很愿意帮忙，但容易把支持变成替别人承担。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：帮助意愿强，责任边界需校准",
+                        "one_liner": "本次自我报告显示，你可能较快进入支持者位置，也较容易把他人的困难纳入自己的责任范围。",
+                        "core_claim": "这不是“拯救者”标签，而是提示帮助、支持和代替承担之间需要更清楚的边界。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你很愿意帮忙，但容易把支持变成替别人承担。"
+                        "primary_strength": "你可能愿意给出时间、注意力和实际支持。",
+                        "likely_cost": "过度负责可能让对方减少自主处理，也让你在关系中持续消耗。",
+                        "development_lever": "在帮助前先问：你希望我听你说、一起想办法，还是具体帮一个步骤？",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你愿意支持他人，也需要把支持和代替承担分开。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Over-Responsible Helper",
-                        "one_liner": "You want to be useful, but support can turn into carrying what is not yours. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You want to be useful, but support can turn into carrying what is not yours. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Strong helping impulse, responsibility boundary to calibrate",
+                        "one_liner": "In this self-report, you may move quickly into a support role and include other people’s difficulties within your own sense of responsibility.",
+                        "core_claim": "This is not a “rescuer” label. It points to a boundary between helping, supporting, and taking over.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You want to be useful, but support can turn into carrying what is not yours."
+                        "primary_strength": "You may be willing to offer time, attention, and practical support.",
+                        "likely_cost": "Over-responsibility can reduce the other person’s agency and leave you carrying ongoing strain.",
+                        "development_lever": "Before helping, ask: do you want me to listen, think this through with you, or help with one concrete step?",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests a strong support impulse and a need to separate support from taking over."
                     },
                     "meta": {
                         "id": "over_responsible_helper",
                         "asset_type": "core_formulation",
                         "v23_source_id": "over_responsible_helper",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "boundary_overhelping",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1404,37 +1404,37 @@
                 },
                 "fast_reactor": {
                     "zh-CN": {
-                        "title": "自我报告模式：反应快，暂停短",
-                        "one_liner": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：反应较快，缓冲不足",
+                        "one_liner": "本次自我报告显示，在反馈、冲突或压力情境里，你可能较快进入回应状态，缓冲时间不一定够。",
+                        "core_claim": "这不是冲动诊断，也不说明你一定会失控；它提示速度可能先于整理。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。"
+                        "primary_strength": "你可能能迅速捕捉问题并给出回应。",
+                        "likely_cost": "速度过快时，情绪、判断和表达可能混在一起，让对话更难回到重点。",
+                        "development_lever": "练习把第一反应变成内部草稿：先停一下，再选择是否说出来。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你回应速度较快，也需要给自己留出缓冲。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Fast Reactor",
-                        "one_liner": "You react quickly once something lands; the growth point is separating first reaction from final response. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You react quickly once something lands; the growth point is separating first reaction from final response. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Fast reaction, limited buffer",
+                        "one_liner": "In this self-report, you may move quickly into response mode in feedback, conflict, or pressure situations, with less buffer time than you need.",
+                        "core_claim": "This is not a diagnosis of impulsivity, and it does not mean you necessarily lose control. It suggests speed may arrive before sorting.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You react quickly once something lands; the growth point is separating first reaction from final response."
+                        "primary_strength": "You may notice the issue quickly and respond without much delay.",
+                        "likely_cost": "When speed is too high, emotion, judgment, and expression can merge and make the conversation harder to refocus.",
+                        "development_lever": "Turn the first reaction into an internal draft: pause first, then choose whether to say it.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests fast responding and a need for more buffer."
                     },
                     "meta": {
                         "id": "fast_reactor",
                         "asset_type": "core_formulation",
                         "v23_source_id": "fast_reactor",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "speed_under_pressure",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1460,37 +1460,37 @@
                 },
                 "analytical_under_feeling": {
                     "zh-CN": {
-                        "title": "自我报告模式：先分析，后感受",
-                        "one_liner": "你倾向先整理逻辑，情绪可能在之后才追上来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你倾向先整理逻辑，情绪可能在之后才追上来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：分析在前，感受在后",
+                        "one_liner": "本次自我报告显示，你可能倾向于先解释问题、找原因或给方案，而不是先停在感受本身。",
+                        "core_claim": "这不是缺乏情感能力的判断；它提示分析可能是你处理不确定情绪的一种方式。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你倾向先整理逻辑，情绪可能在之后才追上来。"
+                        "primary_strength": "你可能擅长把混乱问题结构化，帮助自己或他人看见逻辑。",
+                        "likely_cost": "如果分析来得太早，自己或他人的情绪需要可能会被跳过。",
+                        "development_lever": "在分析前加一句感受确认：这件事让我/你可能先有某种感受，然后再看原因。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较会分析，也可以给感受多一点停留时间。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Analytical Before Feeling",
-                        "one_liner": "You tend to organize the logic first; the feeling may arrive later. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You tend to organize the logic first; the feeling may arrive later. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Analysis first, feeling second",
+                        "one_liner": "In this self-report, you may explain, diagnose causes, or look for solutions before staying with the feeling itself.",
+                        "core_claim": "This is not a judgment that you lack emotional capacity. It suggests analysis may be one way you manage uncertain emotion.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You tend to organize the logic first; the feeling may arrive later."
+                        "primary_strength": "You may be good at structuring messy situations and seeing the logic.",
+                        "likely_cost": "If analysis comes too early, your own or another person’s emotional need may be skipped.",
+                        "development_lever": "Add one feeling check before analysis: this may first feel like ___, and then we can look at why.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests analytical strength and room to let feeling stay present a little longer."
                     },
                     "meta": {
                         "id": "analytical_under_feeling",
                         "asset_type": "core_formulation",
                         "v23_source_id": "analytical_under_feeling",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "analysis_feeling_gap",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1516,37 +1516,37 @@
                 },
                 "quiet_empathy": {
                     "zh-CN": {
-                        "title": "自我报告模式：安静共情型",
-                        "one_liner": "你会在心里理解别人，但不总把理解表达出来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你会在心里理解别人，但不总把理解表达出来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：共情在内，表达偏安静",
+                        "one_liner": "本次自我报告显示，你可能能感到或理解他人的状态，但不一定会明显表达出来。",
+                        "core_claim": "这不是冷漠判断，也不证明他人一定能感受到你的理解；它提示内在理解和外在回应之间可能有距离。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你会在心里理解别人，但不总把理解表达出来。"
+                        "primary_strength": "你可能在心里保留对他人感受的细腻观察。",
+                        "likely_cost": "如果表达过少，对方可能不知道你已经理解，关系支持也可能变得不可见。",
+                        "development_lever": "练习把内在理解外化成一句短回应：我听到你最在意的是……",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能有共情，但需要让共情更可被看见。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Quiet Empathy",
-                        "one_liner": "You may understand people quietly without always making that understanding visible. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may understand people quietly without always making that understanding visible. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Quiet empathy",
+                        "one_liner": "In this self-report, you may feel or understand another person’s state without making that understanding very visible.",
+                        "core_claim": "This is not a judgment of coldness, and it does not prove others can feel your understanding. It points to a gap between inner understanding and outward response.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may understand people quietly without always making that understanding visible."
+                        "primary_strength": "You may hold careful observations about what others are feeling.",
+                        "likely_cost": "If expression is too quiet, the other person may not know you understand, and support can become invisible.",
+                        "development_lever": "Externalize one piece of understanding: what I hear matters most to you is...",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests empathy may be present but could be made more visible."
                     },
                     "meta": {
                         "id": "quiet_empathy",
                         "asset_type": "core_formulation",
                         "v23_source_id": "quiet_empathy",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "quiet_empathy",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1572,37 +1572,37 @@
                 },
                 "direct_without_softening": {
                     "zh-CN": {
-                        "title": "自我报告模式：直接表达，柔化不足",
-                        "one_liner": "你能把话说清楚，但有时少了让对方接住的铺垫。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能把话说清楚，但有时少了让对方接住的铺垫。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：表达直接，缓冲偏少",
+                        "one_liner": "本次自我报告显示，你可能较快说出事实、观点或边界，但不一定先处理对方的情绪入口。",
+                        "core_claim": "这不是粗暴或低共情判断；它提示直接表达和关系缓冲需要分开设计。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能把话说清楚，但有时少了让对方接住的铺垫。"
+                        "primary_strength": "你可能能让问题更快进入实质讨论。",
+                        "likely_cost": "如果缺少情绪缓冲，对方可能先听到压力或否定，而不是信息本身。",
+                        "development_lever": "在直接表达前加一个缓冲：我想把问题说清楚，也会尽量不把它说成对你的否定。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你表达较直接，可以给重要对话加一点情绪缓冲。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Direct Without Softening",
-                        "one_liner": "You can say the thing clearly, but sometimes without enough landing space for the other person. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can say the thing clearly, but sometimes without enough landing space for the other person. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Direct expression, less softening",
+                        "one_liner": "In this self-report, you may state facts, opinions, or boundaries quickly, without always creating an emotional entry point for the other person.",
+                        "core_claim": "This is not a judgment of harshness or low empathy. It suggests direct expression and relational buffering may need to be designed separately.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can say the thing clearly, but sometimes without enough landing space for the other person."
+                        "primary_strength": "You may help conversations move more quickly toward the real issue.",
+                        "likely_cost": "Without a buffer, the other person may hear pressure or rejection before they can hear the information.",
+                        "development_lever": "Add a softening frame before directness: I want to be clear about the issue, and I do not mean this as a rejection of you.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests directness that may benefit from a little emotional buffering in important conversations."
                     },
                     "meta": {
                         "id": "direct_without_softening",
                         "asset_type": "core_formulation",
                         "v23_source_id": "direct_without_softening",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "direct_expression",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1628,37 +1628,37 @@
                 },
                 "relationship_masking": {
                     "zh-CN": {
-                        "title": "自我报告模式：用关系稳定掩盖真实感受",
-                        "one_liner": "你能让关系看起来稳定，但真实感受可能没有被看见。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能让关系看起来稳定，但真实感受可能没有被看见。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：关系维持下的自我遮蔽",
+                        "one_liner": "本次自我报告显示，你可能为了维持关系稳定而压低自己的不满、需求或真实反应。",
+                        "core_claim": "这不是人格诊断，也不能说明你总是在伪装；它提示在部分关系里，安全感和表达真实感受之间可能存在张力。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能让关系看起来稳定，但真实感受可能没有被看见。"
+                        "primary_strength": "你可能能敏锐判断什么话会影响氛围，并努力维持表面稳定。",
+                        "likely_cost": "长期遮蔽会让别人误判你的真实状态，也让你更难获得合适支持。",
+                        "development_lever": "先在低风险关系里练习小剂量真实表达，而不是一次性摊牌。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能用压低自己来维持关系，需要逐步恢复真实表达。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Relationship Masking",
-                        "one_liner": "You can keep the relationship looking stable while your real feeling stays hidden. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can keep the relationship looking stable while your real feeling stays hidden. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Self-masking to preserve the relationship",
+                        "one_liner": "In this self-report, you may reduce the visibility of your frustration, needs, or reactions to keep a relationship stable.",
+                        "core_claim": "This is not a personality diagnosis, and it does not mean you are always masking. It suggests tension between safety and honest expression in some relationships.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can keep the relationship looking stable while your real feeling stays hidden."
+                        "primary_strength": "You may be sensitive to what could disturb the atmosphere and work to keep things smooth.",
+                        "likely_cost": "Long-term masking can lead others to misread your actual state and make support harder to receive.",
+                        "development_lever": "Practice small-dose honesty in lower-risk relationships instead of waiting for a major disclosure.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may preserve relationships by lowering your own visibility, and gradual honest expression may help."
                     },
                     "meta": {
                         "id": "relationship_masking",
                         "asset_type": "core_formulation",
                         "v23_source_id": "relationship_masking",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "relationship_masking",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1684,37 +1684,37 @@
                 },
                 "feedback_absorber": {
                     "zh-CN": {
-                        "title": "自我报告模式：容易吸收反馈情绪",
-                        "one_liner": "你听反馈时可能先吸收对方的情绪，再处理信息。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你听反馈时可能先吸收对方的情绪，再处理信息。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：反馈吸收较深",
+                        "one_liner": "本次自我报告显示，你可能把反馈很快带入自我评价，而不是只把它当作信息。",
+                        "core_claim": "这不是脆弱诊断，也不说明你不能接受反馈；它提示反馈中的评价感可能比内容本身更容易被放大。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你听反馈时可能先吸收对方的情绪，再处理信息。"
+                        "primary_strength": "你可能愿意认真听取反馈，并尝试从中修正自己。",
+                        "likely_cost": "如果吸收过深，你可能把一个具体建议扩大成对自己的整体否定。",
+                        "development_lever": "把反馈拆成三栏：事实信息、对方偏好、我下一步可试的小动作。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你很认真对待反馈，也需要防止把反馈扩大成自我否定。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Feedback Absorber",
-                        "one_liner": "When receiving feedback, you may absorb the emotional tone before you can process the information. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "When receiving feedback, you may absorb the emotional tone before you can process the information. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Deep feedback absorption",
+                        "one_liner": "In this self-report, you may take feedback quickly into self-evaluation rather than treating it only as information.",
+                        "core_claim": "This is not a diagnosis of fragility, and it does not mean you cannot receive feedback. It suggests the evaluative tone of feedback may become louder than the content.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "When receiving feedback, you may absorb the emotional tone before you can process the information."
+                        "primary_strength": "You may listen carefully and try to use feedback to adjust.",
+                        "likely_cost": "If absorption is too deep, one concrete suggestion can expand into a global self-critique.",
+                        "development_lever": "Split feedback into three columns: factual information, the other person’s preference, and one next action to test.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you take feedback seriously and may need to keep it from becoming global self-judgment."
                     },
                     "meta": {
                         "id": "feedback_absorber",
                         "asset_type": "core_formulation",
                         "v23_source_id": "feedback_absorber",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "feedback_absorption",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1740,37 +1740,37 @@
                 },
                 "balanced_moderate": {
                     "zh-CN": {
-                        "title": "自我报告模式：均衡但仍在打磨",
-                        "one_liner": "你的四维没有明显短板，但也还没有形成特别稳定的优势。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你的四维没有明显短板，但也还没有形成特别稳定的优势。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：中等均衡，可塑空间较大",
+                        "one_liner": "本次自我报告显示，四个维度没有明显极端，也没有特别突出的单一优势。",
+                        "core_claim": "这不代表“普通”或“没有特点”；它提示你的结果可能更依赖具体场景，适合通过场景记录来寻找真正的差异点。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你的四维没有明显短板，但也还没有形成特别稳定的优势。"
+                        "primary_strength": "你可能有一定基础，不容易被单一短板完全定义。",
+                        "likely_cost": "如果只看总分，可能错过具体场景中的波动：反馈、冲突、边界或压力恢复。",
+                        "development_lever": "选择一个最近反复出现的场景，记录触发点、反应和恢复方式。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你整体较均衡，关键差异可能藏在具体场景里。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Balanced, Still Sharpening",
-                        "one_liner": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Moderate balance, room for clearer differentiation",
+                        "one_liner": "In this self-report, the four dimensions are not highly extreme and no single strength dominates.",
+                        "core_claim": "This does not mean “average” or “without a pattern.” It suggests your result may depend more on context, and scene tracking can reveal the real differences.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits."
+                        "primary_strength": "You may have a workable base that is not defined by one clear weakness.",
+                        "likely_cost": "If you only look at the global score, you may miss variation across feedback, conflict, boundaries, or recovery.",
+                        "development_lever": "Choose one recurring recent scene and record the trigger, reaction, and recovery pattern.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests moderate balance, with the important differences likely hidden in specific situations."
                     },
                     "meta": {
                         "id": "balanced_moderate",
                         "asset_type": "core_formulation",
                         "v23_source_id": "balanced_moderate",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "balanced_moderate",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1796,37 +1796,37 @@
                 },
                 "regulated_but_private": {
                     "zh-CN": {
-                        "title": "自我报告模式：能稳住，但不易表达",
-                        "one_liner": "你能把自己稳住，但别人不一定知道你经历了什么。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能把自己稳住，但别人不一定知道你经历了什么。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：自我调节较私密",
+                        "one_liner": "本次自我报告显示，你可能认为自己能处理情绪，但处理过程多在内部完成，不太让别人参与。",
+                        "core_claim": "这不是独立能力证明，也不说明你不需要支持；它提示调节可能较私人化。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能把自己稳住，但别人不一定知道你经历了什么。"
+                        "primary_strength": "你可能能把情绪先收住，避免立即扩散到外部关系。",
+                        "likely_cost": "太私密的调节会让别人看不见你的压力，也可能减少及时支持。",
+                        "development_lever": "在不暴露过多细节的前提下，练习一句状态说明：我需要一点时间处理，但我没有退出沟通。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你倾向于自己处理情绪，也可以让他人知道你仍在沟通里。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Regulated but Private",
-                        "one_liner": "You can steady yourself, but others may not know what you went through internally. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can steady yourself, but others may not know what you went through internally. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Private regulation",
+                        "one_liner": "In this self-report, you may see yourself as able to manage emotion, while doing most of that processing internally.",
+                        "core_claim": "This is not proof of independent capacity, and it does not mean you never need support. It suggests regulation may be private.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can steady yourself, but others may not know what you went through internally."
+                        "primary_strength": "You may contain emotion before it spreads into the relationship.",
+                        "likely_cost": "Highly private regulation can make your pressure invisible and reduce timely support.",
+                        "development_lever": "Without over-explaining, practice one status sentence: I need a little time to process, but I am not leaving the conversation.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you tend to process emotion privately and may benefit from signaling that you are still engaged."
                     },
                     "meta": {
                         "id": "regulated_but_private",
                         "asset_type": "core_formulation",
                         "v23_source_id": "regulated_but_private",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "private_regulation",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1852,37 +1852,37 @@
                 },
                 "warm_but_avoidant": {
                     "zh-CN": {
-                        "title": "自我报告模式：温和但回避张力",
-                        "one_liner": "你愿意保持善意，但可能绕开真正紧张的话题。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你愿意保持善意，但可能绕开真正紧张的话题。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：温和连接，回避张力",
+                        "one_liner": "本次自我报告显示，你可能愿意保持温和和连接，但在需要面对分歧、边界或失望时会更谨慎。",
+                        "core_claim": "这不是回避型依恋诊断；它只是提示你可能更擅长维护温度，而不一定擅长进入张力。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你愿意保持善意，但可能绕开真正紧张的话题。"
+                        "primary_strength": "你可能能让关系保持友好、可接近。",
+                        "likely_cost": "如果张力一直被绕开，问题可能反复出现，关系也难以更新。",
+                        "development_lever": "选择一个低风险分歧练习：表达一处不同意，同时保留连接。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你较能维持温和连接，但需要练习安全地进入分歧。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Warm but Avoidant",
-                        "one_liner": "You try to stay warm, but may sidestep the conversation that actually needs to happen. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You try to stay warm, but may sidestep the conversation that actually needs to happen. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Warm connection, tension avoidance",
+                        "one_liner": "In this self-report, you may want to stay warm and connected, while becoming more cautious when disagreement, boundaries, or disappointment need to be faced.",
+                        "core_claim": "This is not an attachment diagnosis. It suggests you may be better at preserving warmth than entering tension.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You try to stay warm, but may sidestep the conversation that actually needs to happen."
+                        "primary_strength": "You may help relationships feel friendly and approachable.",
+                        "likely_cost": "If tension is repeatedly bypassed, the same issue may return and the relationship may not update.",
+                        "development_lever": "Practice one low-risk disagreement: state one difference while keeping connection intact.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests warmth in connection and a need to practice entering disagreement safely."
                     },
                     "meta": {
                         "id": "warm_but_avoidant",
                         "asset_type": "core_formulation",
                         "v23_source_id": "warm_but_avoidant",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "warm_avoidance",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1908,37 +1908,37 @@
                 },
                 "strategic_listener": {
                     "zh-CN": {
-                        "title": "自我报告模式：策略型倾听者",
-                        "one_liner": "你能抓住对话线索，但需要确认自己不是只在收集信息。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能抓住对话线索，但需要确认自己不是只在收集信息。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：策略性倾听",
+                        "one_liner": "本次自我报告显示，你可能较会听出对方关注点，并用倾听来稳定局面或收集信息。",
+                        "core_claim": "这不是操控判断，也不是沟通能力证明；它提示倾听在你的自我感知里是一种重要工具。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能抓住对话线索，但需要确认自己不是只在收集信息。"
+                        "primary_strength": "你可能能在复杂对话中先让信息变清楚。",
+                        "likely_cost": "如果倾听停留在策略层，情感回应或真实立场可能不够可见。",
+                        "development_lever": "在总结对方后补一句自己的位置：我听到的是……我这边目前是……",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你会用倾听稳住局面，也需要让自己的位置同样清楚。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Strategic Listener",
-                        "one_liner": "You can track conversation cues well; the challenge is not turning listening into silent data collection. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can track conversation cues well; the challenge is not turning listening into silent data collection. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Strategic listening",
+                        "one_liner": "In this self-report, you may hear what the other person cares about and use listening to stabilize the situation or gather information.",
+                        "core_claim": "This is not a manipulation claim or proof of communication skill. It suggests listening is an important tool in your self-view.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can track conversation cues well; the challenge is not turning listening into silent data collection."
+                        "primary_strength": "You may help complex conversations become clearer before action is taken.",
+                        "likely_cost": "If listening stays only strategic, emotional acknowledgment or your own position may remain unclear.",
+                        "development_lever": "After summarizing them, add your position: what I hear is..., and where I am right now is...",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you use listening to steady the situation and may need to make your own position equally clear."
                     },
                     "meta": {
                         "id": "strategic_listener",
                         "asset_type": "core_formulation",
                         "v23_source_id": "strategic_listener",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "listening_strength",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1964,37 +1964,37 @@
                 },
                 "delayed_processor": {
                     "zh-CN": {
-                        "title": "自我报告模式：延迟处理型",
-                        "one_liner": "你常常事后才真正明白自己感受到了什么。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你常常事后才真正明白自己感受到了什么。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：延迟处理",
+                        "one_liner": "本次自我报告显示，你可能在当下不一定马上知道自己真正的感受，事后才更清楚。",
+                        "core_claim": "这不是迟钝或低觉察判断；它提示你的情绪加工可能需要时间和距离。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你常常事后才真正明白自己感受到了什么。"
+                        "primary_strength": "你可能能在事后复盘出更准确的感受和需求。",
+                        "likely_cost": "如果没有向对方说明延迟，你可能被误解为冷淡、同意或回避。",
+                        "development_lever": "建立延迟说明：我现在还没整理好，晚一点再回来回应。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能需要时间处理情绪，关键是让延迟变得可沟通。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Delayed Processor",
-                        "one_liner": "You may understand what you felt only after the conversation is over. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may understand what you felt only after the conversation is over. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Delayed processing",
+                        "one_liner": "In this self-report, you may not immediately know what you truly feel in the moment, with clarity arriving later.",
+                        "core_claim": "This is not a judgment of dullness or low awareness. It suggests emotional processing may need time and distance.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may understand what you felt only after the conversation is over."
+                        "primary_strength": "You may be able to review later and identify feelings or needs more accurately.",
+                        "likely_cost": "If you do not signal the delay, others may read it as coldness, agreement, or avoidance.",
+                        "development_lever": "Create a delay signal: I am not sorted yet; I will come back to this later.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may need time to process, and the key is making that delay communicable."
                     },
                     "meta": {
                         "id": "delayed_processor",
                         "asset_type": "core_formulation",
                         "v23_source_id": "delayed_processor",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "delayed_processing",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2020,37 +2020,37 @@
                 },
                 "pressure_contained": {
                     "zh-CN": {
-                        "title": "自我报告模式：压力内收型",
-                        "one_liner": "压力下你可能外表稳定，但内部承载很多。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "压力下你可能外表稳定，但内部承载很多。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：压力下先收住",
+                        "one_liner": "本次自我报告显示，你在压力下可能倾向于先把反应收住，而不是马上表达。",
+                        "core_claim": "这不是抗压能力证明；它提示你可能用控制外显反应来维持功能。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "压力下你可能外表稳定，但内部承载很多。"
+                        "primary_strength": "你可能能避免压力即时升级，给局面留出空间。",
+                        "likely_cost": "如果只收不排，压力可能在事后累积，或以疲惫、疏离、突然爆发出现。",
+                        "development_lever": "给压力一个出口：事后 10 分钟记录身体反应、想法和需要。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你压力下较会收住，也需要安排后续释放和复盘。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Contained Under Pressure",
-                        "one_liner": "Under pressure, you may look steady while carrying a lot internally. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "Under pressure, you may look steady while carrying a lot internally. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Containment under pressure",
+                        "one_liner": "In this self-report, you may contain your reaction under pressure rather than expressing it immediately.",
+                        "core_claim": "This is not proof of resilience. It suggests you may maintain functioning by controlling visible reaction.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "Under pressure, you may look steady while carrying a lot internally."
+                        "primary_strength": "You may prevent immediate escalation and leave the situation more room.",
+                        "likely_cost": "If you only contain and never discharge, pressure can accumulate as fatigue, distance, or sudden expression later.",
+                        "development_lever": "Give pressure an outlet: after the event, spend ten minutes noting body response, thoughts, and needs.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests pressure containment, with a need for later release and review."
                     },
                     "meta": {
                         "id": "pressure_contained",
                         "asset_type": "core_formulation",
                         "v23_source_id": "pressure_contained",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "pressure_containment",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2076,37 +2076,37 @@
                 },
                 "empathy_to_action_gap": {
                     "zh-CN": {
-                        "title": "自我报告模式：懂别人，但行动转化慢",
-                        "one_liner": "你能理解对方，但不一定马上知道下一步怎么做。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能理解对方，但不一定马上知道下一步怎么做。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：能理解，行动转换偏慢",
+                        "one_liner": "本次自我报告显示，你可能能理解他人的感受，但不一定马上知道下一步该怎么回应。",
+                        "core_claim": "这不是共情无效判断；它提示理解和行动之间需要桥接。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能理解对方，但不一定马上知道下一步怎么做。"
+                        "primary_strength": "你可能能准确听到对方的处境和情绪。",
+                        "likely_cost": "如果行动转换慢，对方可能感到你理解了但没有支持，或你自己陷入犹豫。",
+                        "development_lever": "把理解转成一个小动作：确认、提问、给选项，而不是立刻解决。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能理解得快，但需要把理解转成可见的小行动。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Empathy-to-Action Gap",
-                        "one_liner": "You may understand the feeling but need more structure to turn it into action. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may understand the feeling but need more structure to turn it into action. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Empathy-to-action gap",
+                        "one_liner": "In this self-report, you may understand what someone feels without immediately knowing what response to choose next.",
+                        "core_claim": "This is not a judgment that empathy is ineffective. It suggests understanding and action need a bridge.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may understand the feeling but need more structure to turn it into action."
+                        "primary_strength": "You may accurately hear the other person’s situation and emotion.",
+                        "likely_cost": "If action is delayed, the other person may feel understood but unsupported, while you may feel stuck.",
+                        "development_lever": "Turn understanding into one small move: acknowledge, ask, or offer options instead of trying to solve everything.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests fast understanding and a need to translate it into visible small action."
                     },
                     "meta": {
                         "id": "empathy_to_action_gap",
                         "asset_type": "core_formulation",
                         "v23_source_id": "empathy_to_action_gap",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "empathy_action_gap",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2132,37 +2132,37 @@
                 },
                 "self_protective_distance": {
                     "zh-CN": {
-                        "title": "自我报告模式：保护性距离",
-                        "one_liner": "你用距离保护自己，代价是别人可能读不到你的真实意图。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你用距离保护自己，代价是别人可能读不到你的真实意图。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：自我保护性距离",
+                        "one_liner": "本次自我报告显示，当关系或情绪压力变强时，你可能更倾向于拉开距离来保持稳定。",
+                        "core_claim": "这不是冷漠或回避诊断；它提示距离可能是一种保护策略。具体关系是否安全，会影响这个策略是否合适。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你用距离保护自己，代价是别人可能读不到你的真实意图。"
+                        "primary_strength": "你可能能防止自己被卷入过强情绪。",
+                        "likely_cost": "如果距离没有说明，对方可能感到被排除或被拒绝，你也可能失去必要支持。",
+                        "development_lever": "把距离说清楚：我需要一点空间整理，不是要结束这段沟通。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，距离可能是你的保护方式，关键是让距离有说明。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Protective Distance",
-                        "one_liner": "You use distance to protect yourself; the cost is that others may not read your intent. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You use distance to protect yourself; the cost is that others may not read your intent. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Self-protective distance",
+                        "one_liner": "In this self-report, when relational or emotional pressure rises, you may create distance to stay stable.",
+                        "core_claim": "This is not a diagnosis of coldness or avoidance. It suggests distance may function as protection. Whether that strategy is appropriate depends on safety in the specific relationship.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You use distance to protect yourself; the cost is that others may not read your intent."
+                        "primary_strength": "You may prevent yourself from being pulled into emotion that feels too strong.",
+                        "likely_cost": "If distance is unexplained, others may feel excluded or rejected, and you may lose needed support.",
+                        "development_lever": "Explain the distance: I need a little space to sort myself; I am not ending the conversation.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests distance may be protective, and the key is making it clear rather than silent."
                     },
                     "meta": {
                         "id": "self_protective_distance",
                         "asset_type": "core_formulation",
                         "v23_source_id": "self_protective_distance",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "protective_distance",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2188,37 +2188,37 @@
                 },
                 "values_sensitive": {
                     "zh-CN": {
-                        "title": "自我报告模式：价值敏感型",
-                        "one_liner": "当事情触碰你的原则时，情绪反应会更强。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "当事情触碰你的原则时，情绪反应会更强。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：价值敏感",
+                        "one_liner": "本次自我报告显示，当事件触及公平、尊重、责任或边界等价值时，你的情绪反应可能更明显。",
+                        "core_claim": "这不是道德优越或脆弱判断；它提示价值线索可能放大情绪强度。不同文化和组织规则会影响价值冲突的表达方式。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "当事情触碰你的原则时，情绪反应会更强。"
+                        "primary_strength": "你可能较快察觉某件事为什么“不只是小事”。",
+                        "likely_cost": "如果价值感太快进入评判，可能难以先弄清事实、意图和可行动空间。",
+                        "development_lever": "先把价值词说具体：我在意的是公平/尊重/边界中的哪一部分？",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你对价值线索较敏感，需要把价值感转成可讨论的具体语言。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Values-Sensitive Responder",
-                        "one_liner": "When something touches your values, your emotional response may intensify quickly. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "When something touches your values, your emotional response may intensify quickly. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Values sensitivity",
+                        "one_liner": "In this self-report, when a situation touches fairness, respect, responsibility, or boundaries, your emotional response may become more pronounced.",
+                        "core_claim": "This is not a claim of moral superiority or fragility. It suggests values cues may amplify emotional intensity. Culture and organizational norms can shape how values conflict is expressed.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "When something touches your values, your emotional response may intensify quickly."
+                        "primary_strength": "You may notice quickly why something feels like “more than a small issue.”",
+                        "likely_cost": "If values move too quickly into judgment, it can be harder to clarify facts, intent, and action options.",
+                        "development_lever": "Make the values word specific: which part of fairness, respect, or boundary is at stake?",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests sensitivity to values cues and a need to translate them into discussable language."
                     },
                     "meta": {
                         "id": "values_sensitive",
                         "asset_type": "core_formulation",
                         "v23_source_id": "values_sensitive",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "values_sensitivity",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2244,37 +2244,37 @@
                 },
                 "team_stabilizer": {
                     "zh-CN": {
-                        "title": "自我报告模式：团队稳定器",
-                        "one_liner": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：团队稳定器倾向",
+                        "one_liner": "本次自我报告显示，你可能倾向于在团队情绪波动时维持节奏、降低摩擦或帮助大家回到任务。",
+                        "core_claim": "这不是领导力或团队绩效证明；它提示你自认会承担一部分团队情绪管理。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。"
+                        "primary_strength": "你可能能帮助团队避免被短期情绪完全带偏。",
+                        "likely_cost": "如果这种角色变成默认，你可能被隐性分配过多协调和情绪劳动。",
+                        "development_lever": "把稳定角色显性化：我可以帮助整理问题，但需要大家共同承担下一步。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能会稳定团队氛围，但需要避免把团队情绪劳动都接到自己身上。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Team Stabilizer",
-                        "one_liner": "You can help a team stay steady, but you should not become the only stabilizing system. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You can help a team stay steady, but you should not become the only stabilizing system. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Team stabilizer tendency",
+                        "one_liner": "In this self-report, you may try to maintain rhythm, reduce friction, or bring people back to the task when team emotion fluctuates.",
+                        "core_claim": "This is not proof of leadership or team performance. It suggests you see yourself as carrying part of the team’s emotional management.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You can help a team stay steady, but you should not become the only stabilizing system."
+                        "primary_strength": "You may help a team avoid being fully derailed by short-term emotion.",
+                        "likely_cost": "If this role becomes assumed, you may receive too much invisible coordination or emotional labor.",
+                        "development_lever": "Make the stabilizing role explicit: I can help organize the issue, and we all need to carry the next step.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests a team-stabilizing tendency and a need not to absorb all team emotional labor."
                     },
                     "meta": {
                         "id": "team_stabilizer",
                         "asset_type": "core_formulation",
                         "v23_source_id": "team_stabilizer",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "team_stabilizing",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2300,37 +2300,37 @@
                 },
                 "listening_without_followthrough": {
                     "zh-CN": {
-                        "title": "自我报告模式：会听，但后续弱",
-                        "one_liner": "你能听见别人，但后续行动可能没有跟上。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你能听见别人，但后续行动可能没有跟上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：能听见，跟进不足",
+                        "one_liner": "本次自我报告显示，你可能能认真听到他人的情绪和需要，但后续行动、确认或复盘不一定跟得上。",
+                        "core_claim": "这不是不真诚判断；它提示倾听和后续承诺之间可能需要更小、更明确的连接。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你能听见别人，但后续行动可能没有跟上。"
+                        "primary_strength": "你可能能让对方在对话中感到被听见。",
+                        "likely_cost": "如果没有后续，对方可能觉得当下被理解了，但事情没有真正推进。",
+                        "development_lever": "每次倾听后只承诺一个小跟进：我会在明天前确认一件事。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能听得进去，但需要把倾听接到一个小而明确的跟进。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Listening Without Follow-Through",
-                        "one_liner": "You may hear people well, but the follow-through can lag behind the listening. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may hear people well, but the follow-through can lag behind the listening. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Listening without follow-through",
+                        "one_liner": "In this self-report, you may listen carefully to another person’s emotion or need, while follow-up action, confirmation, or review may be less consistent.",
+                        "core_claim": "This is not a judgment of insincerity. It suggests listening and commitment need a smaller, clearer connection.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may hear people well, but the follow-through can lag behind the listening."
+                        "primary_strength": "You may help someone feel heard in the conversation itself.",
+                        "likely_cost": "Without follow-through, the other person may feel understood in the moment but see little movement afterward.",
+                        "development_lever": "After listening, commit to one small follow-up: I will confirm one thing by tomorrow.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests you may listen well and need to connect listening to a small concrete follow-up."
                     },
                     "meta": {
                         "id": "listening_without_followthrough",
                         "asset_type": "core_formulation",
                         "v23_source_id": "listening_without_followthrough",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "listening_action_gap",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -2356,37 +2356,37 @@
                 },
                 "conflict_avoider": {
                     "zh-CN": {
-                        "title": "自我报告模式：冲突回避者",
-                        "one_liner": "你可能用沉默换取平静，但未处理的问题会留在关系里。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "core_claim": "你可能用沉默换取平静，但未处理的问题会留在关系里。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+                        "title": "本次作答模式：冲突回避倾向",
+                        "one_liner": "本次自我报告显示，当分歧可能升级或伤害关系时，你可能更倾向于绕开、延后或淡化冲突。",
+                        "core_claim": "这不是人格诊断，也不说明回避一定错误；在不安全或权力差明显的关系里，降低冲突可能是必要策略。边界在于：它是否让重要问题长期无法被处理。",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-                        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-                        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-                        "share_line": "你可能用沉默换取平静，但未处理的问题会留在关系里。"
+                        "primary_strength": "你可能能避免不必要的即时升级。",
+                        "likely_cost": "如果所有冲突都被延后，真实问题可能积累，关系表面稳定但底层更紧。",
+                        "development_lever": "从低风险分歧开始练习：只表达一个事实、一个影响、一个请求。",
+                        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+                        "share_line": "本次自我报告显示，你可能倾向于降低冲突，需要区分安全回避和长期拖延。"
                     },
                     "en": {
-                        "title": "Self-reported pattern: Conflict Avoider",
-                        "one_liner": "You may trade silence for calm, but the unaddressed issue remains in the relationship. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "core_claim": "You may trade silence for calm, but the unaddressed issue remains in the relationship. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+                        "title": "Self-reported pattern: Conflict-avoidance tendency",
+                        "one_liner": "In this self-report, when disagreement may escalate or damage the relationship, you may avoid, delay, or soften the conflict.",
+                        "core_claim": "This is not a personality diagnosis, and avoidance is not always wrong. In unsafe relationships or strong power differences, lowering conflict may be necessary. The question is whether important issues remain unaddressed for too long.",
                         "evidence_basis": [
                             "Specific score pattern or route-level pattern match."
                         ],
-                        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-                        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-                        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-                        "share_line": "You may trade silence for calm, but the unaddressed issue remains in the relationship."
+                        "primary_strength": "You may prevent unnecessary immediate escalation.",
+                        "likely_cost": "If every conflict is delayed, real issues can accumulate while the relationship looks stable on the surface.",
+                        "development_lever": "Practice with a low-risk disagreement: one fact, one impact, one request.",
+                        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+                        "share_line": "This self-report suggests a tendency to lower conflict and a need to distinguish safe avoidance from long-term delay."
                     },
                     "meta": {
                         "id": "conflict_avoider",
                         "asset_type": "core_formulation",
                         "v23_source_id": "conflict_avoider",
                         "claim_risk": "medium",
-                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
                         "category": "conflict_avoidance",
                         "release_state": "production_candidate",
                         "trigger_summary": "Specific score pattern or route-level pattern match.",

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/core_formulations.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/core_formulations.json
@@ -4,37 +4,37 @@
   "formulations": {
     "balanced_integrated": {
       "zh-CN": {
-        "title": "自我报告模式：均衡整合型",
-        "one_liner": "你不是只擅长某一项，而是较能把觉察、调节、共情和关系处理连起来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你通常能看见自己的状态，也能顾及他人的感受，并把情绪信息转成相对稳定的沟通和行动。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：均衡整合",
+        "one_liner": "本次自我报告显示，你较少只靠单一优势应对情绪关系问题，而是倾向于把自我觉察、调节、共情和关系处理连在一起使用。",
+        "core_claim": "这个结果提示你对自己和他人的情绪线索都有一定可用感，也认为自己能把这些线索转成相对稳定的沟通选择。它仍然需要用真实反馈和具体场景来校准。",
         "evidence_basis": [
           "Four dimensions high or upper-stable; no severe gap."
         ],
-        "primary_strength": "复杂对话里，你更容易同时顾及事实、情绪和关系目标。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "优势太均衡时，你可能低估持续恢复和边界维护的必要性。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把稳定优势转成可复用的沟通流程，而不是只靠当下状态。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你不是只擅长某一项，而是较能把觉察、调节、共情和关系处理连起来。"
+        "primary_strength": "在需要同时处理事实、情绪和关系目标时，你可能更容易保持整体视角。",
+        "likely_cost": "均衡感也可能让你低估恢复、边界和复盘的必要性，尤其在长期消耗的关系或团队环境里。",
+        "development_lever": "把“整体稳定”拆成可复用流程：先识别情绪线索，再确认边界，最后选择沟通动作。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你倾向于把觉察、调节、共情和关系处理连起来使用。"
       },
       "en": {
-        "title": "Self-reported pattern: Integrated Balance",
-        "one_liner": "Your strength is not one isolated skill; it is how your self-reported awareness, regulation, empathy, and relationship-management signals appear to work together. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You usually notice your own state, register other people’s feelings, and turn emotional information into relatively steady communication and action. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Integrated balance",
+        "one_liner": "In this self-report, your pattern is less about one standout strength and more about linking self-awareness, regulation, empathy, and relationship management together.",
+        "core_claim": "The result suggests you experience both self-focused and other-focused emotional information as usable, and you see yourself as able to turn that information into steadier communication choices. It still needs calibration against real feedback and specific contexts.",
         "evidence_basis": [
           "Four dimensions high or upper-stable; no severe gap."
         ],
-        "primary_strength": "In complex conversations, you are more likely to hold the facts, the emotions, and the relationship goal at the same time. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "When things are going well, you may underestimate how much recovery and boundary maintenance still matter. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn your strengths into repeatable communication routines, rather than relying on being in a good state.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Your strength is not one isolated skill; it is how your self-reported awareness, regulation, empathy, and relationship-management signals appear to work together."
+        "primary_strength": "When facts, feelings, and relationship goals all matter, you may be more likely to keep the whole situation in view.",
+        "likely_cost": "A balanced self-view can make recovery, boundaries, and review feel less urgent than they are in long-running or high-demand settings.",
+        "development_lever": "Translate “overall steadiness” into a repeatable sequence: notice the cue, check the boundary, then choose the communication move.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you tend to link awareness, regulation, empathy, and relationship handling rather than relying on one isolated strength."
       },
       "meta": {
         "id": "balanced_integrated",
         "asset_type": "core_formulation",
         "v23_source_id": "balanced_integrated",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "balanced_strength",
         "release_state": "stable",
         "trigger_summary": "Four dimensions high or upper-stable; no severe gap.",
@@ -65,37 +65,37 @@
     },
     "high_empathy_low_recovery": {
       "zh-CN": {
-        "title": "自我报告模式：高共情，低恢复",
-        "one_liner": "本次自我报告显示，你倾向于较快注意到他人的情绪线索，但在情绪负荷后可能需要更多恢复空间。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的共情不是问题；真正的杠杆是共情之后如何区分陪伴、责任和恢复。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：高共情线索，恢复负荷偏高",
+        "one_liner": "本次自我报告显示，你较容易注意到他人的情绪线索，但在承接情绪后可能需要更多恢复空间。",
+        "core_claim": "重点不是“共情太多”，而是你如何区分理解、责任、行动和恢复。真实关系中的权力差、亲密度和压力水平会显著影响这个模式。",
         "evidence_basis": [
           "EM high; ER low or medium-low."
         ],
-        "primary_strength": "你可能倾向于表达理解，尤其在对方情绪明显但没有说清楚时。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "你可能把“我理解你”滑向“我必须替你扛住”。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "练习共情后的边界句和恢复动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "本次自我报告显示，你倾向于较快注意到他人的情绪线索，但在情绪负荷后可能需要更多恢复空间。"
+        "primary_strength": "你可能较快捕捉对方没有明说的情绪，并愿意用理解来维持连接。",
+        "likely_cost": "如果边界不清，你可能把“我能理解”误变成“我必须承担”。",
+        "development_lever": "练习共情后的边界句：先承认感受，再说明自己能承担和不能承担的部分。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你容易读到他人情绪，也需要更清楚的恢复和边界。"
       },
       "en": {
-        "title": "Self-reported pattern: High Empathy, Low Recovery",
-        "one_liner": "Your self-report suggests you often notice emotional cues in others, but you may experience recovery as slower after emotionally loaded contact. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your empathy is not the problem. The leverage point is what happens after empathy: companionship, responsibility, and recovery need clearer separation. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Strong empathy cues, heavier recovery load",
+        "one_liner": "In this self-report, you appear quick to notice emotional cues in others, while recovery after emotionally loaded contact may take more space.",
+        "core_claim": "The issue is not “too much empathy.” The leverage point is separating understanding, responsibility, action, and recovery. Power dynamics, closeness, and stress level can change how this pattern shows up.",
         "evidence_basis": [
           "EM high; ER low or medium-low."
         ],
-        "primary_strength": "You may tend to communicate understanding, especially when their emotion is obvious but not clearly stated. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "You may slide from “I understand this” into “I have to carry this with you or for you.” Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Practice boundary language and recovery steps after empathic contact.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Your self-report suggests you often notice emotional cues in others, but you may experience recovery as slower after emotionally loaded contact."
+        "primary_strength": "You may be quick to notice what someone is feeling before they state it directly, and you may use understanding to maintain connection.",
+        "likely_cost": "Without a clear boundary, “I understand” can slide into “I have to carry this.”",
+        "development_lever": "Practice a post-empathy boundary sentence: name the feeling, then state what you can and cannot take on.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you often notice others’ emotions and may need clearer recovery and boundaries afterward."
       },
       "meta": {
         "id": "high_empathy_low_recovery",
         "asset_type": "core_formulation",
         "v23_source_id": "high_empathy_low_recovery",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "empathy_regulation_gap",
         "release_state": "stable",
         "trigger_summary": "EM high; ER low or medium-low.",
@@ -126,37 +126,37 @@
     },
     "aware_but_unregulated": {
       "zh-CN": {
-        "title": "自我报告模式：有觉察，调节不足",
-        "one_liner": "你常常知道自己被触发了，但还没有总能把自己带回稳定状态。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的优势在于看见内在变化；发展点在于把“我知道”变成“我能暂停和恢复”。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：觉察较快，调节跟进不足",
+        "one_liner": "本次自我报告显示，你较能意识到自己被触发了，但不一定能立刻把情绪强度降到适合行动的水平。",
+        "core_claim": "这不是“知道也没用”的判断，而是提示觉察和调节之间可能有时间差。场景压力越高，这个时间差越需要被看见。",
         "evidence_basis": [
           "SA high; ER low or medium-low."
         ],
-        "primary_strength": "你能比很多人更快识别自己的情绪线索。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "觉察越清楚，若缺少调节步骤，越可能变成反复分析或内耗。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "给觉察配一个身体层面的暂停动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你常常知道自己被触发了，但还没有总能把自己带回稳定状态。"
+        "primary_strength": "你可能比许多人更早发现自己的不适、紧张或防御反应。",
+        "likely_cost": "如果缺少暂停，你可能在已经意识到情绪的情况下仍被情绪推动表达或决策。",
+        "development_lever": "把觉察后面的 30 秒做实：暂停、命名、降速，再回应。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能很快知道自己怎么了，但还需要更稳定的恢复步骤。"
       },
       "en": {
-        "title": "Self-reported pattern: Aware, Not Yet Settled",
-        "one_liner": "You often know you have been triggered, but you may not always be able to bring yourself back to steadiness in time. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your strength is noticing the inner shift; the next step is turning “I know what is happening” into “I can pause and recover.” Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Fast awareness, slower regulation follow-through",
+        "one_liner": "In this self-report, you seem able to notice when you are activated, but not always able to lower the intensity quickly enough for useful action.",
+        "core_claim": "This is not a judgment that awareness “doesn’t help.” It suggests a possible lag between noticing emotion and regulating it, especially under pressure.",
         "evidence_basis": [
           "SA high; ER low or medium-low."
         ],
-        "primary_strength": "You can often identify your emotional cues faster than many people. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Clear awareness without regulation steps can turn into replaying, overanalyzing, or emotional fatigue. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Pair awareness with a physical pause that slows the next response.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You often know you have been triggered, but you may not always be able to bring yourself back to steadiness in time."
+        "primary_strength": "You may catch discomfort, tension, or defensiveness relatively early.",
+        "likely_cost": "Without a pause, you may still speak or decide from the emotion even after you have named it.",
+        "development_lever": "Make the 30 seconds after awareness concrete: pause, label, slow down, then respond.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may know what is happening inside before you have a reliable recovery step."
       },
       "meta": {
         "id": "aware_but_unregulated",
         "asset_type": "core_formulation",
         "v23_source_id": "aware_but_unregulated",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "awareness_regulation_gap",
         "release_state": "stable",
         "trigger_summary": "SA high; ER low or medium-low.",
@@ -187,37 +187,37 @@
     },
     "calm_but_distant": {
       "zh-CN": {
-        "title": "自我报告模式：冷静稳定，但情绪回应偏弱",
-        "one_liner": "你能稳住局面，但别人不一定感到自己的情绪被你接住。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的调节能力能降低混乱，但如果少了情绪回应，稳定会被误读成疏离。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：自感稳定，情绪回应偏保留",
+        "one_liner": "本次自我报告显示，你倾向于认为自己能保持稳定，但对他人情绪的回应可能更克制或更晚出现。",
+        "core_claim": "这里的“稳定”不等于客观冷静能力，也不说明别人一定感到被支持；它提示你可以校准稳定与回应之间的距离。",
         "evidence_basis": [
           "ER high; EM low or medium-low."
         ],
-        "primary_strength": "压力高时，你更容易保持思路和节奏。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "别人可能听到了你的解决方案，却没有感到被理解。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在解决问题前先命名对方的感受。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能稳住局面，但别人不一定感到自己的情绪被你接住。"
+        "primary_strength": "你可能在压力下不容易被情绪牵着走，能先保留判断空间。",
+        "likely_cost": "他人可能需要的不只是稳定，也可能是被看见、被确认或被回应。",
+        "development_lever": "练习把稳定转成可被感受到的回应：先复述对方关注点，再给出你的判断。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较重视稳定，但可以让回应更容易被他人感受到。"
       },
       "en": {
-        "title": "Self-reported pattern: Calm, but Hard to Read Warmly",
-        "one_liner": "You may keep the situation steady, while others may not always feel emotionally met. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your regulation can reduce chaos, but without emotional acknowledgment, steadiness can be mistaken for distance. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Steady self-view, reserved emotional response",
+        "one_liner": "In this self-report, you see yourself as relatively steady, while your response to others’ emotions may be restrained or delayed.",
+        "core_claim": "“Steady” here is not proof of objective calmness, and it does not mean others automatically feel supported. It points to a calibration question: how much response is visible?",
         "evidence_basis": [
           "ER high; EM low or medium-low."
         ],
-        "primary_strength": "Under pressure, you are more likely to keep your thinking and pacing intact. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "People may hear your solution without feeling that you understood the emotional weight of the moment. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Name the other person’s feeling before moving into problem-solving.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may keep the situation steady, while others may not always feel emotionally met."
+        "primary_strength": "Under pressure, you may be less likely to get pulled immediately into emotional escalation.",
+        "likely_cost": "Other people may need more than steadiness; they may need to feel seen, acknowledged, or answered.",
+        "development_lever": "Turn steadiness into a visible response: reflect the concern first, then offer your view.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you value steadiness and may benefit from making emotional acknowledgment more visible."
       },
       "meta": {
         "id": "calm_but_distant",
         "asset_type": "core_formulation",
         "v23_source_id": "calm_but_distant",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "regulation_empathy_gap",
         "release_state": "stable",
         "trigger_summary": "ER high; EM low or medium-low.",
@@ -248,37 +248,37 @@
     },
     "relationship_first_self_later": {
       "zh-CN": {
-        "title": "自我报告模式：关系优先，自我后置",
-        "one_liner": "你很会维护关系，但有时把自己的真实感受排到太后面。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你会照顾气氛、流程和他人的反应；发展点是不要让关系稳定建立在自我忽略上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：关系优先，自我后置",
+        "one_liner": "本次自我报告显示，你可能较快考虑关系氛围和他人感受，但自己的需要、限制或不满更晚才被表达。",
+        "core_claim": "这不是“讨好型人格”诊断，而是一个自我报告线索：关系维护可能先于自我澄清。不同文化和权力关系会影响它是否是优势或负担。",
         "evidence_basis": [
           "RM high; SA low or medium-low."
         ],
-        "primary_strength": "你常能让对话继续进行，不轻易让场面崩掉。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "你可能很晚才发现自己其实已经不舒服。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在回应别人前先问自己一句：我现在真实需要什么？",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你很会维护关系，但有时把自己的真实感受排到太后面。"
+        "primary_strength": "你可能擅长降低场面摩擦，避免让关系立即破裂。",
+        "likely_cost": "长期后置自己可能让不满积累，并使边界表达变得突然或困难。",
+        "development_lever": "在照顾关系前先补一句自我定位：我现在能接受什么，不能接受什么。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较先照顾关系，也需要更早把自己放进关系里。"
       },
       "en": {
-        "title": "Self-reported pattern: Relationship First, Self Later",
-        "one_liner": "You are often good at keeping relationships moving, but your own feelings may get pushed too far down the list. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can manage tone, flow, and other people’s reactions; the growth point is making sure relational stability does not depend on self-erasure. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Relationship first, self later",
+        "one_liner": "In this self-report, you may consider the relationship climate and others’ feelings quickly, while your own needs, limits, or frustration appear later.",
+        "core_claim": "This is not a diagnosis of people-pleasing. It is a self-report signal that relationship maintenance may come before self-clarification. Culture and power dynamics can determine whether this is useful or costly.",
         "evidence_basis": [
           "RM high; SA low or medium-low."
         ],
-        "primary_strength": "You often keep conversations going without letting the room collapse emotionally. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "You may realize late that you were uncomfortable much earlier. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Before responding to others, ask: what do I actually need right now?",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You are often good at keeping relationships moving, but your own feelings may get pushed too far down the list."
+        "primary_strength": "You may be good at reducing immediate friction and keeping the relationship from breaking down too quickly.",
+        "likely_cost": "Putting yourself last for too long can build resentment and make boundaries feel sudden or hard to state.",
+        "development_lever": "Before protecting the relationship, add one self-positioning sentence: what you can accept and what you cannot.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you attend to the relationship early and may need to include yourself earlier too."
       },
       "meta": {
         "id": "relationship_first_self_later",
         "asset_type": "core_formulation",
         "v23_source_id": "relationship_first_self_later",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "relationship_self_gap",
         "release_state": "stable",
         "trigger_summary": "RM high; SA low or medium-low.",
@@ -309,37 +309,37 @@
     },
     "self_clear_repair_weak": {
       "zh-CN": {
-        "title": "自我报告模式：自我清楚，修复不足",
-        "one_liner": "你知道自己要表达什么，但关系修复的步骤可能还不够细。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的自我觉察让表达更清楚；发展点是让对方也能接住你的表达。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：自我较清楚，修复动作不足",
+        "one_liner": "本次自我报告显示，你较知道自己的感受和立场，但在冲突后如何修复关系、重开对话或降低防御感上可能不够稳定。",
+        "core_claim": "这不表示你“不会处理关系”，而是提示表达清楚和关系修复是两个不同环节。",
         "evidence_basis": [
           "SA high; RM low or medium-low."
         ],
-        "primary_strength": "你不容易完全失去自己的立场。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果缺少修复，清楚可能被听成强硬。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在表达后补上影响确认和关系修复。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你知道自己要表达什么，但关系修复的步骤可能还不够细。"
+        "primary_strength": "你可能能较明确说出自己为什么不舒服、不同意或需要什么。",
+        "likely_cost": "如果缺少修复动作，清楚表达可能被他人感受到为定案、拒绝或距离。",
+        "development_lever": "给表达后加一个修复句：我想把问题说清楚，也想把关系留在可继续沟通的位置。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较清楚自己的立场，但冲突后的修复动作还可以更具体。"
       },
       "en": {
-        "title": "Self-reported pattern: Clear About Self, Less Practiced at Repair",
-        "one_liner": "You may know what you need to say, but the repair steps after impact may need more structure. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your self-awareness can make your expression clear; the next step is making that expression easier for another person to receive. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Clear self-position, weaker repair moves",
+        "one_liner": "In this self-report, you seem relatively clear about your feelings and position, while post-conflict repair, reopening dialogue, or lowering defensiveness may be less consistent.",
+        "core_claim": "This does not mean you “cannot handle relationships.” It separates clear expression from relational repair as two different steps.",
         "evidence_basis": [
           "SA high; RM low or medium-low."
         ],
-        "primary_strength": "You are less likely to lose track of your own position. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without repair, clarity can be heard as sharpness. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "After expressing yourself, add impact-checking and repair language.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may know what you need to say, but the repair steps after impact may need more structure."
+        "primary_strength": "You may be able to state why something bothers you, where you disagree, or what you need.",
+        "likely_cost": "Without repair, clear expression can be experienced by others as final, rejecting, or distant.",
+        "development_lever": "Add a repair sentence after expression: I want to be clear about the issue and still keep the relationship open for dialogue.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may know your position clearly, while repair after tension can become more concrete."
       },
       "meta": {
         "id": "self_clear_repair_weak",
         "asset_type": "core_formulation",
         "v23_source_id": "self_clear_repair_weak",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "expression_repair_gap",
         "release_state": "stable",
         "trigger_summary": "SA high; RM low or medium-low.",
@@ -370,37 +370,37 @@
     },
     "steady_collaborator": {
       "zh-CN": {
-        "title": "自我报告模式：稳定协作者",
-        "one_liner": "你在压力下通常能把对话拉回问题本身，而不是被情绪完全带走。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的优势在于把稳定和关系推进结合起来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：协作稳定感较强",
+        "one_liner": "本次自我报告显示，你较相信自己能在压力和协作中保持可沟通、可配合的状态。",
+        "core_claim": "这不是团队能力证明，也不预测别人一定觉得你可靠；它提示你可以继续检验稳定感在高压和多方冲突里是否仍可维持。",
         "evidence_basis": [
           "ER high; RM high."
         ],
-        "primary_strength": "你适合做对话里的降温者和整理者。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "你可能低估别人还需要被情绪回应，而不只是被推进。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在推动下一步前，补一句情绪确认。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你在压力下通常能把对话拉回问题本身，而不是被情绪完全带走。"
+        "primary_strength": "你可能能在多数协作情境中保持节奏，不轻易把压力转嫁给他人。",
+        "likely_cost": "稳定也可能带来过度承担，尤其当团队默认你来兜底时。",
+        "development_lever": "把稳定从“我来扛”转成“我们如何分配、同步和复盘”。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你对自己的协作稳定感较强，但仍需要边界和分工来支撑。"
       },
       "en": {
-        "title": "Self-reported pattern: Steady Collaborator",
-        "one_liner": "Under pressure, you can often bring the conversation back to the issue rather than letting emotion take over. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your strength is combining steadiness with relationship movement. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Collaborative steadiness",
+        "one_liner": "In this self-report, you see yourself as able to stay communicative and cooperative under pressure and in group work.",
+        "core_claim": "This is not proof of team performance, nor a prediction that others experience you as reliable. It suggests a stability pattern worth testing in high-pressure or multi-party conflict.",
         "evidence_basis": [
           "ER high; RM high."
         ],
-        "primary_strength": "You can be the person who cools the room down and organizes the next step. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "You may underestimate that others sometimes need emotional acknowledgment, not only forward motion. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Before moving the group forward, add one sentence of emotional acknowledgment.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Under pressure, you can often bring the conversation back to the issue rather than letting emotion take over."
+        "primary_strength": "You may keep a workable rhythm in many collaborative settings without quickly displacing stress onto others.",
+        "likely_cost": "Steadiness can turn into over-carrying when a team quietly expects you to absorb the strain.",
+        "development_lever": "Shift from “I will hold this” to “how do we distribute, sync, and review this?”",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests stronger collaborative steadiness, with boundaries and role clarity still needed."
       },
       "meta": {
         "id": "steady_collaborator",
         "asset_type": "core_formulation",
         "v23_source_id": "steady_collaborator",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "regulation_relationship_strength",
         "release_state": "stable",
         "trigger_summary": "ER high; RM high.",
@@ -431,37 +431,37 @@
     },
     "sensitive_absorber": {
       "zh-CN": {
-        "title": "自我报告模式：高敏感，易吸收",
-        "one_liner": "你对自己和他人的情绪都很敏锐，但容易把太多信号带回身体里。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你捕捉细节的能力很强；真正要保护的是情绪能量的进出边界。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：敏感度高，吸收感偏强",
+        "one_liner": "本次自我报告显示，你对自己和他人的情绪线索都较敏感，但也可能更容易把环境情绪带进自己身上。",
+        "core_claim": "这不是高敏感诊断，也不是能力标签；它提示情绪线索对你的主观影响可能更强，需要区分信息、感受和责任。",
         "evidence_basis": [
           "SA high; EM high; ER medium-low."
         ],
-        "primary_strength": "你能注意到别人没说出口的变化。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "你可能在事情结束后还长时间停留在对方的情绪里。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "建立“接收—整理—放下”的结束仪式。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你对自己和他人的情绪都很敏锐，但容易把太多信号带回身体里。"
+        "primary_strength": "你可能能捕捉细微信号，较早发现关系或氛围变化。",
+        "likely_cost": "如果缺少筛选，你可能把别人的紧张、失望或期待当成自己的任务。",
+        "development_lever": "练习三分法：这是我观察到的信息、我受到的影响、我真正需要承担的行动。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较敏感，也更需要筛选哪些情绪信息要进入行动。"
       },
       "en": {
-        "title": "Self-reported pattern: Sensitive and Absorbing",
-        "one_liner": "You are sensitive to both your own feelings and other people’s signals, but you may carry too much of that information in your body afterward. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your ability to catch subtle cues is strong; what needs protection is the boundary around emotional intake and recovery. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: High sensitivity, stronger absorption",
+        "one_liner": "In this self-report, you appear sensitive to emotional cues in yourself and others, and you may also experience the emotional atmosphere as entering your own system more strongly.",
+        "core_claim": "This is not a high-sensitivity diagnosis or an ability label. It suggests emotional information may have stronger subjective impact, making it useful to separate information, feeling, and responsibility.",
         "evidence_basis": [
           "SA high; EM high; ER medium-low."
         ],
-        "primary_strength": "You can notice shifts that other people have not put into words. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "After the moment is over, you may still be living inside someone else’s emotional weather. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Build a small closing ritual for receiving, sorting, and releasing emotional information.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You are sensitive to both your own feelings and other people’s signals, but you may carry too much of that information in your body afterward."
+        "primary_strength": "You may notice subtle signals and changes in relationship tone earlier than you expect.",
+        "likely_cost": "Without filtering, another person’s tension, disappointment, or expectation can start to feel like your task.",
+        "development_lever": "Practice three-way sorting: what I observed, how it affected me, and what action is actually mine.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests higher sensitivity and a need to filter which emotional information should become action."
       },
       "meta": {
         "id": "sensitive_absorber",
         "asset_type": "core_formulation",
         "v23_source_id": "sensitive_absorber",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "high_sensitivity",
         "release_state": "stable",
         "trigger_summary": "SA high; EM high; ER medium-low.",
@@ -492,37 +492,37 @@
     },
     "developing_foundation": {
       "zh-CN": {
-        "title": "自我报告模式：基础发展中",
-        "one_liner": "你的结果更像在提示：先把情绪命名、暂停和基本沟通步骤搭起来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "现在不需要急着追求复杂技巧；先建立稳定的观察和回应习惯。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：基础线索仍在建立",
+        "one_liner": "本次自我报告显示，你对情绪觉察、调节、共情或关系处理的信心可能还不稳定。",
+        "core_claim": "这不是能力不足诊断，也不说明你在现实中一定表现差；它更可能说明当前自我感知里可用策略、语言和复盘经验还需要建立。",
         "evidence_basis": [
           "Multiple dimensions low or low-medium."
         ],
-        "primary_strength": "你有机会从很小的练习中看到明显变化。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果直接进入复杂关系策略，容易觉得抽象或挫败。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "从每天一次情绪命名和一个暂停句开始。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你的结果更像在提示：先把情绪命名、暂停和基本沟通步骤搭起来。"
+        "primary_strength": "你已经有一个起点：能把这些维度放到同一张图里看，而不是只用“我情商高/低”概括。",
+        "likely_cost": "如果过早给自己贴标签，可能会忽略具体场景里的可练习部分。",
+        "development_lever": "先从一个低风险场景开始：命名情绪、确认需要、选择一个小回应。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，基础策略还在建立，适合从小场景和可复盘动作开始。"
       },
       "en": {
-        "title": "Self-reported pattern: Building the Foundation",
-        "one_liner": "Your result suggests that the first step is building the basics: naming emotion, pausing, and using simple communication steps. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "This result points first to simple, repeatable reflection steps rather than complex strategies. The report emphasizes stable habits for noticing, pausing, and responding. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Foundations still forming",
+        "one_liner": "In this self-report, your confidence around emotional awareness, regulation, empathy, or relationship handling may be less stable.",
+        "core_claim": "This is not a diagnosis of low ability, and it does not mean you necessarily perform poorly in real life. It more likely means your current self-view has fewer ready strategies, words, or review experiences to draw on.",
         "evidence_basis": [
           "Multiple dimensions low or low-medium."
         ],
-        "primary_strength": "Small practices may be a reasonable place to start because the foundation is still forming. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "If you jump straight into complex relationship strategies, the work may feel abstract or discouraging. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Start with one emotion label and one pause sentence each day.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Your result suggests that the first step is building the basics: naming emotion, pausing, and using simple communication steps."
+        "primary_strength": "There is already a starting point: seeing these dimensions together instead of reducing yourself to “high EQ” or “low EQ.”",
+        "likely_cost": "If you label yourself too quickly, you may miss the specific situations where practice is possible.",
+        "development_lever": "Start with one low-risk scene: name the emotion, clarify the need, choose one small response.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests your foundation is still forming, best approached through small scenes and reviewable actions."
       },
       "meta": {
         "id": "developing_foundation",
         "asset_type": "core_formulation",
         "v23_source_id": "developing_foundation",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "foundational_development",
         "release_state": "stable",
         "trigger_summary": "Multiple dimensions low or low-medium.",
@@ -553,37 +553,37 @@
     },
     "low_confidence_result": {
       "zh-CN": {
-        "title": "自我报告模式：本次结果需要谨慎阅读",
-        "one_liner": "本次结果只适合作为低置信作答证据，不适合作为画像结论。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "由于本次作答质量较低，不应用这次结果得出人格结论、职业结论或行动处方。请把它作为复测准备提示。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次结果：解释置信度不足",
+        "one_liner": "本次作答质量提示结果更适合作为初步参考，不适合输出强 formulation。",
+        "core_claim": "当前最重要的信息不是“你是哪一类”，而是这次数据不足以支持细化解释。可能原因包括作答过快、答案模式过于单一或状态不稳定。",
         "evidence_basis": [
           "Quality C/D or severe response-quality flags."
         ],
-        "primary_strength": "可用信号是复盘作答质量，而不是人格优势判断。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "过度解读本次分数或画像语言可能造成误导。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "在更稳定、不被打断的状态下复测后，再阅读报告模块。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "这次结果更适合作为初步参考，而不是强结论。"
+        "primary_strength": "你仍可以用报告里的科学边界和维度说明做轻量反思。",
+        "likely_cost": "不建议基于本次结果做关系、职业或自我判断。",
+        "development_lever": "在更稳定、少干扰的状态下复测；复测前先回想 2-3 个真实情境。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次结果置信度不足，建议先复测，再阅读细化解释。"
       },
       "en": {
-        "title": "Self-reported pattern: Read This Result Lightly",
-        "one_liner": "This session should be treated as low-confidence response evidence, not a profile conclusion. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Because response quality is low, do not use this session to draw a personality conclusion, career conclusion, or action prescription. Treat it as a prompt to retake in a steadier setting. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Result status: Low interpretation confidence",
+        "one_liner": "The response-quality signal suggests this result is best treated as a preliminary reference, not a strong formulation.",
+        "core_claim": "The main message is not “which type you are.” It is that this session does not provide enough reliable signal for detailed interpretation. Possible reasons include very fast responding, overly uniform answers, or an unstable response state.",
         "evidence_basis": [
           "Quality C/D or severe response-quality flags."
         ],
-        "primary_strength": "The usable signal is response-quality review, not a personality strength. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Overreading scores or profile language from this session may be misleading. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Retake the assessment in a steadier, uninterrupted setting before using report modules.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Treat this session as a first pass, not a profile conclusion."
+        "primary_strength": "You can still use the scientific boundary and dimension definitions for light reflection.",
+        "likely_cost": "Avoid using this result for relationship, career, or self-labeling decisions.",
+        "development_lever": "Retake in a steadier, less distracted state; before retaking, recall two or three real situations.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This result has low interpretation confidence; retaking before reading detailed interpretation is recommended."
       },
       "meta": {
         "id": "low_confidence_result",
         "asset_type": "core_formulation",
         "v23_source_id": "low_confidence_result",
         "claim_risk": "high",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "quality_caution",
         "release_state": "stable",
         "trigger_summary": "Quality C/D or severe response-quality flags.",
@@ -614,37 +614,37 @@
     },
     "underconfident_repairer": {
       "zh-CN": {
-        "title": "自我报告模式：低估自己的修复者",
-        "one_liner": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：修复意愿在，信心偏低",
+        "one_liner": "本次自我报告显示，你可能在意关系修复，但对自己是否能把话说好、把局面拉回可谈状态不够有把握。",
+        "core_claim": "这不是社交能力判断，而是提示你对修复动作的自我效能感可能低于实际意愿。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你可能比自己以为的更能修复关系，只是对自己的关系处理信心不足。"
+        "primary_strength": "你可能愿意承担一部分关系维护，而不是简单切断或逃离。",
+        "likely_cost": "如果信心不足，你可能等太久才开口，或把修复留给对方先开始。",
+        "development_lever": "准备一个低负担开场：我想把刚才那段说清楚，不急着马上解决。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能想修复关系，但需要更低门槛的开口方式。"
       },
       "en": {
-        "title": "Self-reported pattern: Underconfident Repairer",
-        "one_liner": "You may be more capable of repairing relationships than you give yourself credit for. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may be more capable of repairing relationships than you give yourself credit for. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Repair intention, lower confidence",
+        "one_liner": "In this self-report, you may care about repair, while feeling less sure that you can say it well or move the situation back into dialogue.",
+        "core_claim": "This is not a social-skill judgment. It suggests your self-efficacy around repair may be lower than your actual intention to repair.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may be more capable of repairing relationships than you give yourself credit for."
+        "primary_strength": "You may be willing to carry part of the relationship maintenance rather than simply cut off or leave.",
+        "likely_cost": "If confidence is low, you may wait too long to speak or hope the other person starts the repair first.",
+        "development_lever": "Prepare a low-pressure opener: I want to clarify that moment, and we do not have to solve it all right now.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may want repair but need a lower-barrier way to begin."
       },
       "meta": {
         "id": "underconfident_repairer",
         "asset_type": "core_formulation",
         "v23_source_id": "underconfident_repairer",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "repair_confidence_gap",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -670,37 +670,37 @@
     },
     "over_responsible_helper": {
       "zh-CN": {
-        "title": "自我报告模式：过度负责的帮助者",
-        "one_liner": "你很愿意帮忙，但容易把支持变成替别人承担。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你很愿意帮忙，但容易把支持变成替别人承担。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：帮助意愿强，责任边界需校准",
+        "one_liner": "本次自我报告显示，你可能较快进入支持者位置，也较容易把他人的困难纳入自己的责任范围。",
+        "core_claim": "这不是“拯救者”标签，而是提示帮助、支持和代替承担之间需要更清楚的边界。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你很愿意帮忙，但容易把支持变成替别人承担。"
+        "primary_strength": "你可能愿意给出时间、注意力和实际支持。",
+        "likely_cost": "过度负责可能让对方减少自主处理，也让你在关系中持续消耗。",
+        "development_lever": "在帮助前先问：你希望我听你说、一起想办法，还是具体帮一个步骤？",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你愿意支持他人，也需要把支持和代替承担分开。"
       },
       "en": {
-        "title": "Self-reported pattern: Over-Responsible Helper",
-        "one_liner": "You want to be useful, but support can turn into carrying what is not yours. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You want to be useful, but support can turn into carrying what is not yours. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Strong helping impulse, responsibility boundary to calibrate",
+        "one_liner": "In this self-report, you may move quickly into a support role and include other people’s difficulties within your own sense of responsibility.",
+        "core_claim": "This is not a “rescuer” label. It points to a boundary between helping, supporting, and taking over.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You want to be useful, but support can turn into carrying what is not yours."
+        "primary_strength": "You may be willing to offer time, attention, and practical support.",
+        "likely_cost": "Over-responsibility can reduce the other person’s agency and leave you carrying ongoing strain.",
+        "development_lever": "Before helping, ask: do you want me to listen, think this through with you, or help with one concrete step?",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests a strong support impulse and a need to separate support from taking over."
       },
       "meta": {
         "id": "over_responsible_helper",
         "asset_type": "core_formulation",
         "v23_source_id": "over_responsible_helper",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "boundary_overhelping",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -726,37 +726,37 @@
     },
     "fast_reactor": {
       "zh-CN": {
-        "title": "自我报告模式：反应快，暂停短",
-        "one_liner": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：反应较快，缓冲不足",
+        "one_liner": "本次自我报告显示，在反馈、冲突或压力情境里，你可能较快进入回应状态，缓冲时间不一定够。",
+        "core_claim": "这不是冲动诊断，也不说明你一定会失控；它提示速度可能先于整理。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你捕捉到刺激后反应很快，发展点是把第一反应和正式回应分开。"
+        "primary_strength": "你可能能迅速捕捉问题并给出回应。",
+        "likely_cost": "速度过快时，情绪、判断和表达可能混在一起，让对话更难回到重点。",
+        "development_lever": "练习把第一反应变成内部草稿：先停一下，再选择是否说出来。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你回应速度较快，也需要给自己留出缓冲。"
       },
       "en": {
-        "title": "Self-reported pattern: Fast Reactor",
-        "one_liner": "You react quickly once something lands; the growth point is separating first reaction from final response. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You react quickly once something lands; the growth point is separating first reaction from final response. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Fast reaction, limited buffer",
+        "one_liner": "In this self-report, you may move quickly into response mode in feedback, conflict, or pressure situations, with less buffer time than you need.",
+        "core_claim": "This is not a diagnosis of impulsivity, and it does not mean you necessarily lose control. It suggests speed may arrive before sorting.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You react quickly once something lands; the growth point is separating first reaction from final response."
+        "primary_strength": "You may notice the issue quickly and respond without much delay.",
+        "likely_cost": "When speed is too high, emotion, judgment, and expression can merge and make the conversation harder to refocus.",
+        "development_lever": "Turn the first reaction into an internal draft: pause first, then choose whether to say it.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests fast responding and a need for more buffer."
       },
       "meta": {
         "id": "fast_reactor",
         "asset_type": "core_formulation",
         "v23_source_id": "fast_reactor",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "speed_under_pressure",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -782,37 +782,37 @@
     },
     "analytical_under_feeling": {
       "zh-CN": {
-        "title": "自我报告模式：先分析，后感受",
-        "one_liner": "你倾向先整理逻辑，情绪可能在之后才追上来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你倾向先整理逻辑，情绪可能在之后才追上来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：分析在前，感受在后",
+        "one_liner": "本次自我报告显示，你可能倾向于先解释问题、找原因或给方案，而不是先停在感受本身。",
+        "core_claim": "这不是缺乏情感能力的判断；它提示分析可能是你处理不确定情绪的一种方式。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你倾向先整理逻辑，情绪可能在之后才追上来。"
+        "primary_strength": "你可能擅长把混乱问题结构化，帮助自己或他人看见逻辑。",
+        "likely_cost": "如果分析来得太早，自己或他人的情绪需要可能会被跳过。",
+        "development_lever": "在分析前加一句感受确认：这件事让我/你可能先有某种感受，然后再看原因。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较会分析，也可以给感受多一点停留时间。"
       },
       "en": {
-        "title": "Self-reported pattern: Analytical Before Feeling",
-        "one_liner": "You tend to organize the logic first; the feeling may arrive later. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You tend to organize the logic first; the feeling may arrive later. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Analysis first, feeling second",
+        "one_liner": "In this self-report, you may explain, diagnose causes, or look for solutions before staying with the feeling itself.",
+        "core_claim": "This is not a judgment that you lack emotional capacity. It suggests analysis may be one way you manage uncertain emotion.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You tend to organize the logic first; the feeling may arrive later."
+        "primary_strength": "You may be good at structuring messy situations and seeing the logic.",
+        "likely_cost": "If analysis comes too early, your own or another person’s emotional need may be skipped.",
+        "development_lever": "Add one feeling check before analysis: this may first feel like ___, and then we can look at why.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests analytical strength and room to let feeling stay present a little longer."
       },
       "meta": {
         "id": "analytical_under_feeling",
         "asset_type": "core_formulation",
         "v23_source_id": "analytical_under_feeling",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "analysis_feeling_gap",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -838,37 +838,37 @@
     },
     "quiet_empathy": {
       "zh-CN": {
-        "title": "自我报告模式：安静共情型",
-        "one_liner": "你会在心里理解别人，但不总把理解表达出来。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你会在心里理解别人，但不总把理解表达出来。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：共情在内，表达偏安静",
+        "one_liner": "本次自我报告显示，你可能能感到或理解他人的状态，但不一定会明显表达出来。",
+        "core_claim": "这不是冷漠判断，也不证明他人一定能感受到你的理解；它提示内在理解和外在回应之间可能有距离。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你会在心里理解别人，但不总把理解表达出来。"
+        "primary_strength": "你可能在心里保留对他人感受的细腻观察。",
+        "likely_cost": "如果表达过少，对方可能不知道你已经理解，关系支持也可能变得不可见。",
+        "development_lever": "练习把内在理解外化成一句短回应：我听到你最在意的是……",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能有共情，但需要让共情更可被看见。"
       },
       "en": {
-        "title": "Self-reported pattern: Quiet Empathy",
-        "one_liner": "You may understand people quietly without always making that understanding visible. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may understand people quietly without always making that understanding visible. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Quiet empathy",
+        "one_liner": "In this self-report, you may feel or understand another person’s state without making that understanding very visible.",
+        "core_claim": "This is not a judgment of coldness, and it does not prove others can feel your understanding. It points to a gap between inner understanding and outward response.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may understand people quietly without always making that understanding visible."
+        "primary_strength": "You may hold careful observations about what others are feeling.",
+        "likely_cost": "If expression is too quiet, the other person may not know you understand, and support can become invisible.",
+        "development_lever": "Externalize one piece of understanding: what I hear matters most to you is...",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests empathy may be present but could be made more visible."
       },
       "meta": {
         "id": "quiet_empathy",
         "asset_type": "core_formulation",
         "v23_source_id": "quiet_empathy",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "quiet_empathy",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -894,37 +894,37 @@
     },
     "direct_without_softening": {
       "zh-CN": {
-        "title": "自我报告模式：直接表达，柔化不足",
-        "one_liner": "你能把话说清楚，但有时少了让对方接住的铺垫。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能把话说清楚，但有时少了让对方接住的铺垫。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：表达直接，缓冲偏少",
+        "one_liner": "本次自我报告显示，你可能较快说出事实、观点或边界，但不一定先处理对方的情绪入口。",
+        "core_claim": "这不是粗暴或低共情判断；它提示直接表达和关系缓冲需要分开设计。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能把话说清楚，但有时少了让对方接住的铺垫。"
+        "primary_strength": "你可能能让问题更快进入实质讨论。",
+        "likely_cost": "如果缺少情绪缓冲，对方可能先听到压力或否定，而不是信息本身。",
+        "development_lever": "在直接表达前加一个缓冲：我想把问题说清楚，也会尽量不把它说成对你的否定。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你表达较直接，可以给重要对话加一点情绪缓冲。"
       },
       "en": {
-        "title": "Self-reported pattern: Direct Without Softening",
-        "one_liner": "You can say the thing clearly, but sometimes without enough landing space for the other person. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can say the thing clearly, but sometimes without enough landing space for the other person. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Direct expression, less softening",
+        "one_liner": "In this self-report, you may state facts, opinions, or boundaries quickly, without always creating an emotional entry point for the other person.",
+        "core_claim": "This is not a judgment of harshness or low empathy. It suggests direct expression and relational buffering may need to be designed separately.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can say the thing clearly, but sometimes without enough landing space for the other person."
+        "primary_strength": "You may help conversations move more quickly toward the real issue.",
+        "likely_cost": "Without a buffer, the other person may hear pressure or rejection before they can hear the information.",
+        "development_lever": "Add a softening frame before directness: I want to be clear about the issue, and I do not mean this as a rejection of you.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests directness that may benefit from a little emotional buffering in important conversations."
       },
       "meta": {
         "id": "direct_without_softening",
         "asset_type": "core_formulation",
         "v23_source_id": "direct_without_softening",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "direct_expression",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -950,37 +950,37 @@
     },
     "relationship_masking": {
       "zh-CN": {
-        "title": "自我报告模式：用关系稳定掩盖真实感受",
-        "one_liner": "你能让关系看起来稳定，但真实感受可能没有被看见。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能让关系看起来稳定，但真实感受可能没有被看见。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：关系维持下的自我遮蔽",
+        "one_liner": "本次自我报告显示，你可能为了维持关系稳定而压低自己的不满、需求或真实反应。",
+        "core_claim": "这不是人格诊断，也不能说明你总是在伪装；它提示在部分关系里，安全感和表达真实感受之间可能存在张力。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能让关系看起来稳定，但真实感受可能没有被看见。"
+        "primary_strength": "你可能能敏锐判断什么话会影响氛围，并努力维持表面稳定。",
+        "likely_cost": "长期遮蔽会让别人误判你的真实状态，也让你更难获得合适支持。",
+        "development_lever": "先在低风险关系里练习小剂量真实表达，而不是一次性摊牌。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能用压低自己来维持关系，需要逐步恢复真实表达。"
       },
       "en": {
-        "title": "Self-reported pattern: Relationship Masking",
-        "one_liner": "You can keep the relationship looking stable while your real feeling stays hidden. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can keep the relationship looking stable while your real feeling stays hidden. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Self-masking to preserve the relationship",
+        "one_liner": "In this self-report, you may reduce the visibility of your frustration, needs, or reactions to keep a relationship stable.",
+        "core_claim": "This is not a personality diagnosis, and it does not mean you are always masking. It suggests tension between safety and honest expression in some relationships.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can keep the relationship looking stable while your real feeling stays hidden."
+        "primary_strength": "You may be sensitive to what could disturb the atmosphere and work to keep things smooth.",
+        "likely_cost": "Long-term masking can lead others to misread your actual state and make support harder to receive.",
+        "development_lever": "Practice small-dose honesty in lower-risk relationships instead of waiting for a major disclosure.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may preserve relationships by lowering your own visibility, and gradual honest expression may help."
       },
       "meta": {
         "id": "relationship_masking",
         "asset_type": "core_formulation",
         "v23_source_id": "relationship_masking",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "relationship_masking",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1006,37 +1006,37 @@
     },
     "feedback_absorber": {
       "zh-CN": {
-        "title": "自我报告模式：容易吸收反馈情绪",
-        "one_liner": "你听反馈时可能先吸收对方的情绪，再处理信息。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你听反馈时可能先吸收对方的情绪，再处理信息。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：反馈吸收较深",
+        "one_liner": "本次自我报告显示，你可能把反馈很快带入自我评价，而不是只把它当作信息。",
+        "core_claim": "这不是脆弱诊断，也不说明你不能接受反馈；它提示反馈中的评价感可能比内容本身更容易被放大。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你听反馈时可能先吸收对方的情绪，再处理信息。"
+        "primary_strength": "你可能愿意认真听取反馈，并尝试从中修正自己。",
+        "likely_cost": "如果吸收过深，你可能把一个具体建议扩大成对自己的整体否定。",
+        "development_lever": "把反馈拆成三栏：事实信息、对方偏好、我下一步可试的小动作。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你很认真对待反馈，也需要防止把反馈扩大成自我否定。"
       },
       "en": {
-        "title": "Self-reported pattern: Feedback Absorber",
-        "one_liner": "When receiving feedback, you may absorb the emotional tone before you can process the information. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "When receiving feedback, you may absorb the emotional tone before you can process the information. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Deep feedback absorption",
+        "one_liner": "In this self-report, you may take feedback quickly into self-evaluation rather than treating it only as information.",
+        "core_claim": "This is not a diagnosis of fragility, and it does not mean you cannot receive feedback. It suggests the evaluative tone of feedback may become louder than the content.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "When receiving feedback, you may absorb the emotional tone before you can process the information."
+        "primary_strength": "You may listen carefully and try to use feedback to adjust.",
+        "likely_cost": "If absorption is too deep, one concrete suggestion can expand into a global self-critique.",
+        "development_lever": "Split feedback into three columns: factual information, the other person’s preference, and one next action to test.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you take feedback seriously and may need to keep it from becoming global self-judgment."
       },
       "meta": {
         "id": "feedback_absorber",
         "asset_type": "core_formulation",
         "v23_source_id": "feedback_absorber",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "feedback_absorption",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1062,37 +1062,37 @@
     },
     "balanced_moderate": {
       "zh-CN": {
-        "title": "自我报告模式：均衡但仍在打磨",
-        "one_liner": "你的四维没有明显短板，但也还没有形成特别稳定的优势。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你的四维没有明显短板，但也还没有形成特别稳定的优势。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：中等均衡，可塑空间较大",
+        "one_liner": "本次自我报告显示，四个维度没有明显极端，也没有特别突出的单一优势。",
+        "core_claim": "这不代表“普通”或“没有特点”；它提示你的结果可能更依赖具体场景，适合通过场景记录来寻找真正的差异点。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你的四维没有明显短板，但也还没有形成特别稳定的优势。"
+        "primary_strength": "你可能有一定基础，不容易被单一短板完全定义。",
+        "likely_cost": "如果只看总分，可能错过具体场景中的波动：反馈、冲突、边界或压力恢复。",
+        "development_lever": "选择一个最近反复出现的场景，记录触发点、反应和恢复方式。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你整体较均衡，关键差异可能藏在具体场景里。"
       },
       "en": {
-        "title": "Self-reported pattern: Balanced, Still Sharpening",
-        "one_liner": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Moderate balance, room for clearer differentiation",
+        "one_liner": "In this self-report, the four dimensions are not highly extreme and no single strength dominates.",
+        "core_claim": "This does not mean “average” or “without a pattern.” It suggests your result may depend more on context, and scene tracking can reveal the real differences.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Your four areas are relatively even, but the strengths may still need sharpening into repeatable habits."
+        "primary_strength": "You may have a workable base that is not defined by one clear weakness.",
+        "likely_cost": "If you only look at the global score, you may miss variation across feedback, conflict, boundaries, or recovery.",
+        "development_lever": "Choose one recurring recent scene and record the trigger, reaction, and recovery pattern.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests moderate balance, with the important differences likely hidden in specific situations."
       },
       "meta": {
         "id": "balanced_moderate",
         "asset_type": "core_formulation",
         "v23_source_id": "balanced_moderate",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "balanced_moderate",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1118,37 +1118,37 @@
     },
     "regulated_but_private": {
       "zh-CN": {
-        "title": "自我报告模式：能稳住，但不易表达",
-        "one_liner": "你能把自己稳住，但别人不一定知道你经历了什么。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能把自己稳住，但别人不一定知道你经历了什么。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：自我调节较私密",
+        "one_liner": "本次自我报告显示，你可能认为自己能处理情绪，但处理过程多在内部完成，不太让别人参与。",
+        "core_claim": "这不是独立能力证明，也不说明你不需要支持；它提示调节可能较私人化。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能把自己稳住，但别人不一定知道你经历了什么。"
+        "primary_strength": "你可能能把情绪先收住，避免立即扩散到外部关系。",
+        "likely_cost": "太私密的调节会让别人看不见你的压力，也可能减少及时支持。",
+        "development_lever": "在不暴露过多细节的前提下，练习一句状态说明：我需要一点时间处理，但我没有退出沟通。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你倾向于自己处理情绪，也可以让他人知道你仍在沟通里。"
       },
       "en": {
-        "title": "Self-reported pattern: Regulated but Private",
-        "one_liner": "You can steady yourself, but others may not know what you went through internally. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can steady yourself, but others may not know what you went through internally. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Private regulation",
+        "one_liner": "In this self-report, you may see yourself as able to manage emotion, while doing most of that processing internally.",
+        "core_claim": "This is not proof of independent capacity, and it does not mean you never need support. It suggests regulation may be private.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can steady yourself, but others may not know what you went through internally."
+        "primary_strength": "You may contain emotion before it spreads into the relationship.",
+        "likely_cost": "Highly private regulation can make your pressure invisible and reduce timely support.",
+        "development_lever": "Without over-explaining, practice one status sentence: I need a little time to process, but I am not leaving the conversation.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you tend to process emotion privately and may benefit from signaling that you are still engaged."
       },
       "meta": {
         "id": "regulated_but_private",
         "asset_type": "core_formulation",
         "v23_source_id": "regulated_but_private",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "private_regulation",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1174,37 +1174,37 @@
     },
     "warm_but_avoidant": {
       "zh-CN": {
-        "title": "自我报告模式：温和但回避张力",
-        "one_liner": "你愿意保持善意，但可能绕开真正紧张的话题。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你愿意保持善意，但可能绕开真正紧张的话题。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：温和连接，回避张力",
+        "one_liner": "本次自我报告显示，你可能愿意保持温和和连接，但在需要面对分歧、边界或失望时会更谨慎。",
+        "core_claim": "这不是回避型依恋诊断；它只是提示你可能更擅长维护温度，而不一定擅长进入张力。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你愿意保持善意，但可能绕开真正紧张的话题。"
+        "primary_strength": "你可能能让关系保持友好、可接近。",
+        "likely_cost": "如果张力一直被绕开，问题可能反复出现，关系也难以更新。",
+        "development_lever": "选择一个低风险分歧练习：表达一处不同意，同时保留连接。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你较能维持温和连接，但需要练习安全地进入分歧。"
       },
       "en": {
-        "title": "Self-reported pattern: Warm but Avoidant",
-        "one_liner": "You try to stay warm, but may sidestep the conversation that actually needs to happen. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You try to stay warm, but may sidestep the conversation that actually needs to happen. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Warm connection, tension avoidance",
+        "one_liner": "In this self-report, you may want to stay warm and connected, while becoming more cautious when disagreement, boundaries, or disappointment need to be faced.",
+        "core_claim": "This is not an attachment diagnosis. It suggests you may be better at preserving warmth than entering tension.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You try to stay warm, but may sidestep the conversation that actually needs to happen."
+        "primary_strength": "You may help relationships feel friendly and approachable.",
+        "likely_cost": "If tension is repeatedly bypassed, the same issue may return and the relationship may not update.",
+        "development_lever": "Practice one low-risk disagreement: state one difference while keeping connection intact.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests warmth in connection and a need to practice entering disagreement safely."
       },
       "meta": {
         "id": "warm_but_avoidant",
         "asset_type": "core_formulation",
         "v23_source_id": "warm_but_avoidant",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "warm_avoidance",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1230,37 +1230,37 @@
     },
     "strategic_listener": {
       "zh-CN": {
-        "title": "自我报告模式：策略型倾听者",
-        "one_liner": "你能抓住对话线索，但需要确认自己不是只在收集信息。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能抓住对话线索，但需要确认自己不是只在收集信息。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：策略性倾听",
+        "one_liner": "本次自我报告显示，你可能较会听出对方关注点，并用倾听来稳定局面或收集信息。",
+        "core_claim": "这不是操控判断，也不是沟通能力证明；它提示倾听在你的自我感知里是一种重要工具。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能抓住对话线索，但需要确认自己不是只在收集信息。"
+        "primary_strength": "你可能能在复杂对话中先让信息变清楚。",
+        "likely_cost": "如果倾听停留在策略层，情感回应或真实立场可能不够可见。",
+        "development_lever": "在总结对方后补一句自己的位置：我听到的是……我这边目前是……",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你会用倾听稳住局面，也需要让自己的位置同样清楚。"
       },
       "en": {
-        "title": "Self-reported pattern: Strategic Listener",
-        "one_liner": "You can track conversation cues well; the challenge is not turning listening into silent data collection. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can track conversation cues well; the challenge is not turning listening into silent data collection. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Strategic listening",
+        "one_liner": "In this self-report, you may hear what the other person cares about and use listening to stabilize the situation or gather information.",
+        "core_claim": "This is not a manipulation claim or proof of communication skill. It suggests listening is an important tool in your self-view.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can track conversation cues well; the challenge is not turning listening into silent data collection."
+        "primary_strength": "You may help complex conversations become clearer before action is taken.",
+        "likely_cost": "If listening stays only strategic, emotional acknowledgment or your own position may remain unclear.",
+        "development_lever": "After summarizing them, add your position: what I hear is..., and where I am right now is...",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you use listening to steady the situation and may need to make your own position equally clear."
       },
       "meta": {
         "id": "strategic_listener",
         "asset_type": "core_formulation",
         "v23_source_id": "strategic_listener",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "listening_strength",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1286,37 +1286,37 @@
     },
     "delayed_processor": {
       "zh-CN": {
-        "title": "自我报告模式：延迟处理型",
-        "one_liner": "你常常事后才真正明白自己感受到了什么。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你常常事后才真正明白自己感受到了什么。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：延迟处理",
+        "one_liner": "本次自我报告显示，你可能在当下不一定马上知道自己真正的感受，事后才更清楚。",
+        "core_claim": "这不是迟钝或低觉察判断；它提示你的情绪加工可能需要时间和距离。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你常常事后才真正明白自己感受到了什么。"
+        "primary_strength": "你可能能在事后复盘出更准确的感受和需求。",
+        "likely_cost": "如果没有向对方说明延迟，你可能被误解为冷淡、同意或回避。",
+        "development_lever": "建立延迟说明：我现在还没整理好，晚一点再回来回应。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能需要时间处理情绪，关键是让延迟变得可沟通。"
       },
       "en": {
-        "title": "Self-reported pattern: Delayed Processor",
-        "one_liner": "You may understand what you felt only after the conversation is over. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may understand what you felt only after the conversation is over. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Delayed processing",
+        "one_liner": "In this self-report, you may not immediately know what you truly feel in the moment, with clarity arriving later.",
+        "core_claim": "This is not a judgment of dullness or low awareness. It suggests emotional processing may need time and distance.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may understand what you felt only after the conversation is over."
+        "primary_strength": "You may be able to review later and identify feelings or needs more accurately.",
+        "likely_cost": "If you do not signal the delay, others may read it as coldness, agreement, or avoidance.",
+        "development_lever": "Create a delay signal: I am not sorted yet; I will come back to this later.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may need time to process, and the key is making that delay communicable."
       },
       "meta": {
         "id": "delayed_processor",
         "asset_type": "core_formulation",
         "v23_source_id": "delayed_processor",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "delayed_processing",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1342,37 +1342,37 @@
     },
     "pressure_contained": {
       "zh-CN": {
-        "title": "自我报告模式：压力内收型",
-        "one_liner": "压力下你可能外表稳定，但内部承载很多。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "压力下你可能外表稳定，但内部承载很多。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：压力下先收住",
+        "one_liner": "本次自我报告显示，你在压力下可能倾向于先把反应收住，而不是马上表达。",
+        "core_claim": "这不是抗压能力证明；它提示你可能用控制外显反应来维持功能。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "压力下你可能外表稳定，但内部承载很多。"
+        "primary_strength": "你可能能避免压力即时升级，给局面留出空间。",
+        "likely_cost": "如果只收不排，压力可能在事后累积，或以疲惫、疏离、突然爆发出现。",
+        "development_lever": "给压力一个出口：事后 10 分钟记录身体反应、想法和需要。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你压力下较会收住，也需要安排后续释放和复盘。"
       },
       "en": {
-        "title": "Self-reported pattern: Contained Under Pressure",
-        "one_liner": "Under pressure, you may look steady while carrying a lot internally. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "Under pressure, you may look steady while carrying a lot internally. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Containment under pressure",
+        "one_liner": "In this self-report, you may contain your reaction under pressure rather than expressing it immediately.",
+        "core_claim": "This is not proof of resilience. It suggests you may maintain functioning by controlling visible reaction.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "Under pressure, you may look steady while carrying a lot internally."
+        "primary_strength": "You may prevent immediate escalation and leave the situation more room.",
+        "likely_cost": "If you only contain and never discharge, pressure can accumulate as fatigue, distance, or sudden expression later.",
+        "development_lever": "Give pressure an outlet: after the event, spend ten minutes noting body response, thoughts, and needs.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests pressure containment, with a need for later release and review."
       },
       "meta": {
         "id": "pressure_contained",
         "asset_type": "core_formulation",
         "v23_source_id": "pressure_contained",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "pressure_containment",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1398,37 +1398,37 @@
     },
     "empathy_to_action_gap": {
       "zh-CN": {
-        "title": "自我报告模式：懂别人，但行动转化慢",
-        "one_liner": "你能理解对方，但不一定马上知道下一步怎么做。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能理解对方，但不一定马上知道下一步怎么做。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：能理解，行动转换偏慢",
+        "one_liner": "本次自我报告显示，你可能能理解他人的感受，但不一定马上知道下一步该怎么回应。",
+        "core_claim": "这不是共情无效判断；它提示理解和行动之间需要桥接。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能理解对方，但不一定马上知道下一步怎么做。"
+        "primary_strength": "你可能能准确听到对方的处境和情绪。",
+        "likely_cost": "如果行动转换慢，对方可能感到你理解了但没有支持，或你自己陷入犹豫。",
+        "development_lever": "把理解转成一个小动作：确认、提问、给选项，而不是立刻解决。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能理解得快，但需要把理解转成可见的小行动。"
       },
       "en": {
-        "title": "Self-reported pattern: Empathy-to-Action Gap",
-        "one_liner": "You may understand the feeling but need more structure to turn it into action. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may understand the feeling but need more structure to turn it into action. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Empathy-to-action gap",
+        "one_liner": "In this self-report, you may understand what someone feels without immediately knowing what response to choose next.",
+        "core_claim": "This is not a judgment that empathy is ineffective. It suggests understanding and action need a bridge.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may understand the feeling but need more structure to turn it into action."
+        "primary_strength": "You may accurately hear the other person’s situation and emotion.",
+        "likely_cost": "If action is delayed, the other person may feel understood but unsupported, while you may feel stuck.",
+        "development_lever": "Turn understanding into one small move: acknowledge, ask, or offer options instead of trying to solve everything.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests fast understanding and a need to translate it into visible small action."
       },
       "meta": {
         "id": "empathy_to_action_gap",
         "asset_type": "core_formulation",
         "v23_source_id": "empathy_to_action_gap",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "empathy_action_gap",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1454,37 +1454,37 @@
     },
     "self_protective_distance": {
       "zh-CN": {
-        "title": "自我报告模式：保护性距离",
-        "one_liner": "你用距离保护自己，代价是别人可能读不到你的真实意图。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你用距离保护自己，代价是别人可能读不到你的真实意图。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：自我保护性距离",
+        "one_liner": "本次自我报告显示，当关系或情绪压力变强时，你可能更倾向于拉开距离来保持稳定。",
+        "core_claim": "这不是冷漠或回避诊断；它提示距离可能是一种保护策略。具体关系是否安全，会影响这个策略是否合适。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你用距离保护自己，代价是别人可能读不到你的真实意图。"
+        "primary_strength": "你可能能防止自己被卷入过强情绪。",
+        "likely_cost": "如果距离没有说明，对方可能感到被排除或被拒绝，你也可能失去必要支持。",
+        "development_lever": "把距离说清楚：我需要一点空间整理，不是要结束这段沟通。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，距离可能是你的保护方式，关键是让距离有说明。"
       },
       "en": {
-        "title": "Self-reported pattern: Protective Distance",
-        "one_liner": "You use distance to protect yourself; the cost is that others may not read your intent. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You use distance to protect yourself; the cost is that others may not read your intent. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Self-protective distance",
+        "one_liner": "In this self-report, when relational or emotional pressure rises, you may create distance to stay stable.",
+        "core_claim": "This is not a diagnosis of coldness or avoidance. It suggests distance may function as protection. Whether that strategy is appropriate depends on safety in the specific relationship.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You use distance to protect yourself; the cost is that others may not read your intent."
+        "primary_strength": "You may prevent yourself from being pulled into emotion that feels too strong.",
+        "likely_cost": "If distance is unexplained, others may feel excluded or rejected, and you may lose needed support.",
+        "development_lever": "Explain the distance: I need a little space to sort myself; I am not ending the conversation.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests distance may be protective, and the key is making it clear rather than silent."
       },
       "meta": {
         "id": "self_protective_distance",
         "asset_type": "core_formulation",
         "v23_source_id": "self_protective_distance",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "protective_distance",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1510,37 +1510,37 @@
     },
     "values_sensitive": {
       "zh-CN": {
-        "title": "自我报告模式：价值敏感型",
-        "one_liner": "当事情触碰你的原则时，情绪反应会更强。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "当事情触碰你的原则时，情绪反应会更强。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：价值敏感",
+        "one_liner": "本次自我报告显示，当事件触及公平、尊重、责任或边界等价值时，你的情绪反应可能更明显。",
+        "core_claim": "这不是道德优越或脆弱判断；它提示价值线索可能放大情绪强度。不同文化和组织规则会影响价值冲突的表达方式。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "当事情触碰你的原则时，情绪反应会更强。"
+        "primary_strength": "你可能较快察觉某件事为什么“不只是小事”。",
+        "likely_cost": "如果价值感太快进入评判，可能难以先弄清事实、意图和可行动空间。",
+        "development_lever": "先把价值词说具体：我在意的是公平/尊重/边界中的哪一部分？",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你对价值线索较敏感，需要把价值感转成可讨论的具体语言。"
       },
       "en": {
-        "title": "Self-reported pattern: Values-Sensitive Responder",
-        "one_liner": "When something touches your values, your emotional response may intensify quickly. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "When something touches your values, your emotional response may intensify quickly. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Values sensitivity",
+        "one_liner": "In this self-report, when a situation touches fairness, respect, responsibility, or boundaries, your emotional response may become more pronounced.",
+        "core_claim": "This is not a claim of moral superiority or fragility. It suggests values cues may amplify emotional intensity. Culture and organizational norms can shape how values conflict is expressed.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "When something touches your values, your emotional response may intensify quickly."
+        "primary_strength": "You may notice quickly why something feels like “more than a small issue.”",
+        "likely_cost": "If values move too quickly into judgment, it can be harder to clarify facts, intent, and action options.",
+        "development_lever": "Make the values word specific: which part of fairness, respect, or boundary is at stake?",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests sensitivity to values cues and a need to translate them into discussable language."
       },
       "meta": {
         "id": "values_sensitive",
         "asset_type": "core_formulation",
         "v23_source_id": "values_sensitive",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "values_sensitivity",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1566,37 +1566,37 @@
     },
     "team_stabilizer": {
       "zh-CN": {
-        "title": "自我报告模式：团队稳定器",
-        "one_liner": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：团队稳定器倾向",
+        "one_liner": "本次自我报告显示，你可能倾向于在团队情绪波动时维持节奏、降低摩擦或帮助大家回到任务。",
+        "core_claim": "这不是领导力或团队绩效证明；它提示你自认会承担一部分团队情绪管理。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能帮助团队保持节奏，但要避免把稳定责任都放到自己身上。"
+        "primary_strength": "你可能能帮助团队避免被短期情绪完全带偏。",
+        "likely_cost": "如果这种角色变成默认，你可能被隐性分配过多协调和情绪劳动。",
+        "development_lever": "把稳定角色显性化：我可以帮助整理问题，但需要大家共同承担下一步。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能会稳定团队氛围，但需要避免把团队情绪劳动都接到自己身上。"
       },
       "en": {
-        "title": "Self-reported pattern: Team Stabilizer",
-        "one_liner": "You can help a team stay steady, but you should not become the only stabilizing system. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You can help a team stay steady, but you should not become the only stabilizing system. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Team stabilizer tendency",
+        "one_liner": "In this self-report, you may try to maintain rhythm, reduce friction, or bring people back to the task when team emotion fluctuates.",
+        "core_claim": "This is not proof of leadership or team performance. It suggests you see yourself as carrying part of the team’s emotional management.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You can help a team stay steady, but you should not become the only stabilizing system."
+        "primary_strength": "You may help a team avoid being fully derailed by short-term emotion.",
+        "likely_cost": "If this role becomes assumed, you may receive too much invisible coordination or emotional labor.",
+        "development_lever": "Make the stabilizing role explicit: I can help organize the issue, and we all need to carry the next step.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests a team-stabilizing tendency and a need not to absorb all team emotional labor."
       },
       "meta": {
         "id": "team_stabilizer",
         "asset_type": "core_formulation",
         "v23_source_id": "team_stabilizer",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "team_stabilizing",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1622,37 +1622,37 @@
     },
     "listening_without_followthrough": {
       "zh-CN": {
-        "title": "自我报告模式：会听，但后续弱",
-        "one_liner": "你能听见别人，但后续行动可能没有跟上。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你能听见别人，但后续行动可能没有跟上。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：能听见，跟进不足",
+        "one_liner": "本次自我报告显示，你可能能认真听到他人的情绪和需要，但后续行动、确认或复盘不一定跟得上。",
+        "core_claim": "这不是不真诚判断；它提示倾听和后续承诺之间可能需要更小、更明确的连接。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你能听见别人，但后续行动可能没有跟上。"
+        "primary_strength": "你可能能让对方在对话中感到被听见。",
+        "likely_cost": "如果没有后续，对方可能觉得当下被理解了，但事情没有真正推进。",
+        "development_lever": "每次倾听后只承诺一个小跟进：我会在明天前确认一件事。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能听得进去，但需要把倾听接到一个小而明确的跟进。"
       },
       "en": {
-        "title": "Self-reported pattern: Listening Without Follow-Through",
-        "one_liner": "You may hear people well, but the follow-through can lag behind the listening. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may hear people well, but the follow-through can lag behind the listening. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Listening without follow-through",
+        "one_liner": "In this self-report, you may listen carefully to another person’s emotion or need, while follow-up action, confirmation, or review may be less consistent.",
+        "core_claim": "This is not a judgment of insincerity. It suggests listening and commitment need a smaller, clearer connection.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may hear people well, but the follow-through can lag behind the listening."
+        "primary_strength": "You may help someone feel heard in the conversation itself.",
+        "likely_cost": "Without follow-through, the other person may feel understood in the moment but see little movement afterward.",
+        "development_lever": "After listening, commit to one small follow-up: I will confirm one thing by tomorrow.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests you may listen well and need to connect listening to a small concrete follow-up."
       },
       "meta": {
         "id": "listening_without_followthrough",
         "asset_type": "core_formulation",
         "v23_source_id": "listening_without_followthrough",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "listening_action_gap",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",
@@ -1678,37 +1678,37 @@
     },
     "conflict_avoider": {
       "zh-CN": {
-        "title": "自我报告模式：冲突回避者",
-        "one_liner": "你可能用沉默换取平静，但未处理的问题会留在关系里。 这是自我报告结果，不是外部观察能力。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "core_claim": "你可能用沉默换取平静，但未处理的问题会留在关系里。 请把它当作本次作答形成的模式假设。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
+        "title": "本次作答模式：冲突回避倾向",
+        "one_liner": "本次自我报告显示，当分歧可能升级或伤害关系时，你可能更倾向于绕开、延后或淡化冲突。",
+        "core_claim": "这不是人格诊断，也不说明回避一定错误；在不安全或权力差明显的关系里，降低冲突可能是必要策略。边界在于：它是否让重要问题长期无法被处理。",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "这一路径的优势在于你已经有一个可观察的情绪或关系资源。 这是自我感知倾向，不是对他人影响的证明。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "likely_cost": "如果没有明确练习，这个自我报告线索可能在压力下变形。 真实情境可能因文化、关系和压力而改变。 这是本次作答的自我感知线索，不是稳定人格类型或能力判断。",
-        "development_lever": "把这个模式转成一个具体、可重复的沟通动作。",
-        "do_not_overread": "这是结果解释的组织方式，不是固定人格标签，也不是能力凭证。 这是基于本次 60 题自我报告形成的模式解释，不是外部观察、客观能力分、临床结论、招聘信号或工作表现预测。 请把它作为本次自我报告形成的解释线索，而不是外部观察、客观能力分、临床判断、招聘信号或工作表现预测。",
-        "share_line": "你可能用沉默换取平静，但未处理的问题会留在关系里。"
+        "primary_strength": "你可能能避免不必要的即时升级。",
+        "likely_cost": "如果所有冲突都被延后，真实问题可能积累，关系表面稳定但底层更紧。",
+        "development_lever": "从低风险分歧开始练习：只表达一个事实、一个影响、一个请求。",
+        "do_not_overread": "请不要把这条 formulation 当成固定人格类型、客观情商能力、临床结论、招聘信号或工作表现预测；它只是本次 60 题自我报告的解释框架。",
+        "share_line": "本次自我报告显示，你可能倾向于降低冲突，需要区分安全回避和长期拖延。"
       },
       "en": {
-        "title": "Self-reported pattern: Conflict Avoider",
-        "one_liner": "You may trade silence for calm, but the unaddressed issue remains in the relationship. This is based on self-report, not observed ability. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "core_claim": "You may trade silence for calm, but the unaddressed issue remains in the relationship. Treat it as a pattern hypothesis from this session. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
+        "title": "Self-reported pattern: Conflict-avoidance tendency",
+        "one_liner": "In this self-report, when disagreement may escalate or damage the relationship, you may avoid, delay, or soften the conflict.",
+        "core_claim": "This is not a personality diagnosis, and avoidance is not always wrong. In unsafe relationships or strong power differences, lowering conflict may be necessary. The question is whether important issues remain unaddressed for too long.",
         "evidence_basis": [
           "Specific score pattern or route-level pattern match."
         ],
-        "primary_strength": "The useful signal in this pattern is a self-reported emotional or relational resource. This is a self-perceived tendency, not proof of impact on others. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "likely_cost": "Without a clear practice, that resource can shift under pressure. Context may change whether this appears in real situations. This is a self-perception signal from this response session, not a fixed personality type or ability judgment.",
-        "development_lever": "Turn the pattern into one concrete, repeatable communication move.",
-        "do_not_overread": "This is an interpretive pattern, not a fixed identity label or capability credential. This is a self-report pattern from this 60-item session, not an external observation, objective ability score, clinical finding, hiring signal, or prediction of job performance. Use this as a self-report interpretation from this session, not as external observation, an objective ability score, a clinical finding, a hiring signal, or a prediction of job performance.",
-        "share_line": "You may trade silence for calm, but the unaddressed issue remains in the relationship."
+        "primary_strength": "You may prevent unnecessary immediate escalation.",
+        "likely_cost": "If every conflict is delayed, real issues can accumulate while the relationship looks stable on the surface.",
+        "development_lever": "Practice with a low-risk disagreement: one fact, one impact, one request.",
+        "do_not_overread": "Do not treat this formulation as a fixed personality type, objective emotional ability, clinical finding, hiring signal, or job-performance prediction; it is an interpretive frame for this 60-item self-report session.",
+        "share_line": "This self-report suggests a tendency to lower conflict and a need to distinguish safe avoidance from long-term delay."
       },
       "meta": {
         "id": "conflict_avoider",
         "asset_type": "core_formulation",
         "v23_source_id": "conflict_avoider",
         "claim_risk": "medium",
-        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Core formulation must remain a self-report pattern hypothesis. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries. Maintain as self-report formulation only; avoid ability, clinical, hiring, or performance claims.",
         "category": "conflict_avoidance",
         "release_state": "production_candidate",
         "trigger_summary": "Specific score pattern or route-level pattern match.",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -68828,8 +68828,8 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-03"
     ],
-    "status": "pr_open",
-    "commit_sha": "295a1c7fee94a6c62f18997d835cdad96e3f19d5",
+    "status": "merged",
+    "commit_sha": "03e828762c05b30435d456792ff9f0fca4670e49",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2613",
     "checks": [
       {
@@ -68879,14 +68879,14 @@
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T17:29:46Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -68905,8 +68905,15 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "summary": "Opened PR #2613 for scoped score_system science-boundary repair; awaiting GitHub checks."
+      },
+      {
+        "at": "2026-07-02T17:38:02.409315Z",
+        "from": "pr_open",
+        "to": "merged",
+        "summary": "Reconciled PR #2613 as merged; merge commit 6751f425d5ca556267b76b1a8a4bf212a36db713 is in origin/main and local/remote task branches were cleaned."
       }
-    ]
+    ],
+    "merge_commit_sha": "6751f425d5ca556267b76b1a8a4bf212a36db713"
   },
   "PR-EQ-ASSET-SCI-05": {
     "id": "PR-EQ-ASSET-SCI-05",
@@ -68918,17 +68925,63 @@
       "PR-EQ-ASSET-SCI-03",
       "PR-EQ-ASSET-SCI-04"
     ],
-    "status": "user_authorized",
-    "commit_sha": null,
-    "pr_url": null,
-    "checks": [],
+    "status": "pr_open",
+    "commit_sha": "fe9f7f9d9c7d6d13cec9071fdaa69e51b7817aa5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2618",
+    "checks": [
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed after core formulation updates."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; only scoped report_assets compiled output retained and alias mirror synchronized."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 432 assertions; PHPUnit reported existing environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed_with_warnings",
+        "summary": "12 tests passed, 683 assertions; PHPUnit reported existing environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 208 assertions; PHPUnit reported existing environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed_with_warnings",
+        "summary": "4 tests passed, 130 assertions; PHPUnit reported existing environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 16 assertions; PHPUnit reported existing environment file_get_contents warning only."
+      },
+      {
+        "command": "core_formulations forbidden claim and repeated suffix scan",
+        "status": "passed",
+        "summary": "Scoped user-visible formulation fields have no old repeated suffixes and no commerce/ability/MSCEIT/clinical/hiring exact forbidden phrases."
+      },
+      {
+        "command": "cmp EQ_60 and EQ_EMOTIONAL_INTELLIGENCE core_formulations raw and compiled assets",
+        "status": "passed",
+        "summary": "Raw core_formulations and compiled report_assets mirrors are byte-for-byte synchronized."
+      }
+    ],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -68937,6 +68990,24 @@
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      },
+      {
+        "at": "2026-07-02T17:38:02.409315Z",
+        "from": "user_authorized",
+        "to": "local_checks_passed",
+        "summary": "Reduced claim strength and increased specificity across all 30 EQ core formulations while preserving self-report boundaries and existing scoring/composer behavior."
+      },
+      {
+        "at": "2026-07-02T17:40:33.870507Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "summary": "Opened PR #2618 for scoped core_formulations science-boundary repair; awaiting GitHub checks."
+      },
+      {
+        "at": "2026-07-02T17:49:25.769269Z",
+        "from": "pr_open",
+        "to": "pr_open",
+        "summary": "Rebased PR #2618 onto latest origin/main after external merges and reran local EQ validation successfully."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Reworked all 30 EQ `core_formulations` entries in `EQ_60/v1/raw/report_assets/core_formulations.json`.
- Mirrored the raw asset into `EQ_EMOTIONAL_INTELLIGENCE/v1` and refreshed scoped `report_assets.compiled.json` mirrors.
- Reconciled `PR-EQ-ASSET-SCI-04` merge facts in the PR-train state ledger and recorded local validation for `PR-EQ-ASSET-SCI-05`.

## Why
The previous core formulation copy relied on repeated safety suffixes and still read like stable type or ability interpretation in places. This PR makes each formulation more specific, less mechanical, and consistently framed as a 60-item self-report interpretation rather than an objective ability, clinical, hiring, or performance claim.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest`
- JSON/YAML parse, `git diff --check`, `git diff --cached --check`
- raw and compiled mirror `cmp` checks
- scoped forbidden-claim / repeated-suffix scan

## Intentionally deferred
- No scoring, norm, question, reverse-key, composer-selection, frontend, commerce, or SJT changes.
- No production deploy or server verification.

## Repository rule impact
Backend content pack remains the EQ report content authority. This PR does not move report prose into the frontend or CMS fallback logic.
