### PR TITLE
feat(personality): expose cross-type comparison public API

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -12,6 +12,7 @@ use App\Models\PersonalityProfileSeoMeta;
 use App\Models\PersonalityProfileVariant;
 use App\Models\PersonalityProfileVariantSection;
 use App\Models\PersonalityProfileVariantSeoMeta;
+use App\Services\Cms\Mbti64CrossTypeComparisonPublicReadModel;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\PersonalityProfileService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
@@ -52,6 +53,7 @@ class PersonalityController extends Controller
     public function __construct(
         private readonly PersonalityProfileService $personalityProfileService,
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
+        private readonly Mbti64CrossTypeComparisonPublicReadModel $crossTypeComparisonReadModel,
         private readonly AnswerSurfaceContractService $answerSurfaceContractService,
         private readonly LandingSurfaceContractService $landingSurfaceContractService,
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
@@ -258,6 +260,7 @@ class PersonalityController extends Controller
             $items[] = $this->comparisonListItemPayload($baseTypeCode, $validated['locale'], $profile);
         }
 
+        $crossTypeItems = $this->crossTypeComparisonReadModel->list($validated['locale']);
         $projection = [
             'comparison_list_contract_version' => 'mbti.comparison_list.v1',
             'locale' => $validated['locale'],
@@ -272,6 +275,15 @@ class PersonalityController extends Controller
                         : 'Compare A and T variants within the same 16-type personality core across stress feedback, self-confirmation, and action rhythm.',
                     'items' => $items,
                 ],
+                [
+                    'key' => 'cross_type_comparisons',
+                    'comparison_type' => 'mbti_cross_type',
+                    'title' => $validated['locale'] === 'zh-CN' ? '易混淆人格对比' : 'Commonly confused personality types',
+                    'description' => $validated['locale'] === 'zh-CN'
+                        ? '比较容易混淆的 16 型人格组合，帮助用户从思维入口、行动节奏和协作方式上做区分。'
+                        : 'Compare commonly confused 16-type personality pairs through thinking patterns, action rhythm, and collaboration style.',
+                    'items' => $crossTypeItems,
+                ],
             ],
         ];
 
@@ -279,6 +291,7 @@ class PersonalityController extends Controller
             'ok' => true,
             'comparison_list_public_projection_v1' => $projection,
             'at_comparisons' => $items,
+            'cross_type_comparisons' => $crossTypeItems,
         ]);
     }
 
@@ -287,6 +300,15 @@ class PersonalityController extends Controller
         $validated = $this->validateReadQuery($request);
         if ($validated instanceof JsonResponse) {
             return $validated;
+        }
+
+        $crossTypeComparison = $this->crossTypeComparisonReadModel->find($comparison, $validated['locale']);
+        if ($crossTypeComparison !== null) {
+            return response()->json([
+                'ok' => true,
+                'comparison' => $crossTypeComparison,
+                'comparison_public_projection_v1' => $crossTypeComparison,
+            ]);
         }
 
         $baseTypeCode = $this->comparisonBaseTypeCode($comparison);

--- a/backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php
+++ b/backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Support\CanonicalFrontendUrl;
+use Illuminate\Support\Facades\File;
+
+final class Mbti64CrossTypeComparisonPublicReadModel
+{
+    private const SOURCE_DIR = 'docs/seo/import-packages/mbti-cross-type-comparison-content-assets-draft-20260702';
+
+    private const CONTRACT_VERSION = 'mbti.cross_type_comparison.public.v1';
+
+    private const AUTHORITY_CONTRACT_VERSION = 'mbti.cross_type_comparison.authority.v1';
+
+    private const READMODEL_CONTRACT_VERSION = 'mbti.cross_type_comparison.readmodel.v1';
+
+    private const COMPARISON_TYPE = 'mbti_cross_type';
+
+    private const LOCALE = 'zh-CN';
+
+    /**
+     * @var array<string,array<string,mixed>>|null
+     */
+    private ?array $assetsBySlug = null;
+
+    public function __construct(
+        private readonly Mbti64CrossTypeComparisonAssetsDryRunPlanner $planner,
+    ) {}
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function list(string $locale): array
+    {
+        if ($locale !== self::LOCALE) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($this->assetsBySlug() as $asset) {
+            $item = $this->listItem($asset, $locale);
+            if ($item !== null) {
+                $items[] = $item;
+            }
+        }
+
+        usort($items, static fn (array $left, array $right): int => strcmp((string) $left['slug'], (string) $right['slug']));
+
+        return $items;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function find(string $slug, string $locale): ?array
+    {
+        $normalizedSlug = strtolower(trim($slug));
+        if ($locale !== self::LOCALE || ! $this->isCrossTypeSlug($normalizedSlug)) {
+            return null;
+        }
+
+        $asset = $this->assetsBySlug()[$normalizedSlug] ?? null;
+        if (! is_array($asset)) {
+            return null;
+        }
+
+        return $this->detail($asset, $locale);
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function assetsBySlug(): array
+    {
+        if ($this->assetsBySlug !== null) {
+            return $this->assetsBySlug;
+        }
+
+        $plan = $this->planner->planSourceDir(self::SOURCE_DIR);
+        if (($plan['ok'] ?? false) !== true) {
+            return $this->assetsBySlug = [];
+        }
+
+        $assets = [];
+        foreach ((array) ($plan['rows'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->stringValue($row['slug'] ?? null);
+            $sourceFile = $this->stringValue($row['source_file'] ?? null);
+            if ($slug === null || $sourceFile === null) {
+                continue;
+            }
+
+            $path = base_path($sourceFile);
+            if (! File::isFile($path)) {
+                continue;
+            }
+
+            $asset = json_decode((string) File::get($path), true);
+            if (! is_array($asset) || $this->stringValue($asset['slug'] ?? null) !== $slug) {
+                continue;
+            }
+
+            $asset['_source_sha256'] = (string) ($row['source_sha256'] ?? hash('sha256', (string) File::get($path)));
+            $assets[$slug] = $asset;
+        }
+
+        ksort($assets);
+
+        return $this->assetsBySlug = $assets;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return array<string,mixed>|null
+     */
+    private function listItem(array $asset, string $locale): ?array
+    {
+        $slug = $this->stringValue($asset['slug'] ?? null);
+        if ($slug === null || ! $this->isCrossTypeSlug($slug)) {
+            return null;
+        }
+
+        $leftType = strtoupper((string) ($asset['left_type'] ?? ''));
+        $rightType = strtoupper((string) ($asset['right_type'] ?? ''));
+        if (! in_array($leftType, PersonalityProfile::BASE_TYPE_CODES, true)
+            || ! in_array($rightType, PersonalityProfile::BASE_TYPE_CODES, true)
+            || $leftType === $rightType
+        ) {
+            return null;
+        }
+
+        return [
+            'slug' => $slug,
+            'comparison_type' => self::COMPARISON_TYPE,
+            'left_type' => $leftType,
+            'right_type' => $rightType,
+            'base_type_codes' => [$leftType, $rightType],
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'locale' => $locale,
+            'public_route_type' => 'cross-type-comparison',
+            'title' => (string) $asset['title'],
+            'seo_title' => (string) $asset['seo_title'],
+            'description' => (string) $asset['seo_description'],
+            'summary' => (string) $asset['summary'],
+            'public_url' => $this->canonicalUrl($slug, $locale),
+            'canonical_url' => $this->canonicalUrl($slug, $locale),
+            'is_public' => true,
+            'is_indexable' => false,
+            'status' => 'authority_ready',
+            'review_status' => (string) $asset['review_status'],
+            'publish_status' => (string) $asset['publish_status'],
+            'indexability_status' => (string) $asset['indexability_status'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return array<string,mixed>
+     */
+    private function detail(array $asset, string $locale): array
+    {
+        $slug = (string) $asset['slug'];
+        $leftType = strtoupper((string) $asset['left_type']);
+        $rightType = strtoupper((string) $asset['right_type']);
+        $sections = $this->sections($asset);
+        $faq = $this->faq($asset);
+        $internalLinks = $this->internalLinks($asset);
+        $canonicalUrl = $this->canonicalUrl($slug, $locale);
+
+        return [
+            'comparison_contract_version' => self::CONTRACT_VERSION,
+            'authority_contract_version' => self::AUTHORITY_CONTRACT_VERSION,
+            'readmodel_contract_version' => self::READMODEL_CONTRACT_VERSION,
+            'comparison_slug' => $slug,
+            'comparison_type' => self::COMPARISON_TYPE,
+            'public_route_type' => 'cross-type-comparison',
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'locale' => $locale,
+            'left_type' => $leftType,
+            'right_type' => $rightType,
+            'base_type_codes' => [$leftType, $rightType],
+            'title' => (string) $asset['title'],
+            'description' => (string) $asset['seo_description'],
+            'seo_title' => (string) $asset['seo_title'],
+            'seo_description' => (string) $asset['seo_description'],
+            'summary' => (string) $asset['summary'],
+            'canonical_url' => $canonicalUrl,
+            'alternates' => [
+                self::LOCALE => $canonicalUrl,
+            ],
+            'sections' => $sections,
+            'faq' => $faq,
+            'internal_links' => $internalLinks,
+            'claim_boundary' => (string) $asset['claim_boundary'],
+            'source_notes' => $this->sourceNotes($asset),
+            'source_refs' => [
+                'mbti-cross-type-comparison-content-assets-draft-20260702',
+                self::AUTHORITY_CONTRACT_VERSION,
+                self::READMODEL_CONTRACT_VERSION,
+            ],
+            'source_sha256' => (string) ($asset['_source_sha256'] ?? ''),
+            'is_public' => true,
+            'is_indexable' => false,
+            'review_status' => (string) $asset['review_status'],
+            'publish_status' => (string) $asset['publish_status'],
+            'indexability_status' => (string) $asset['indexability_status'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return list<array<string,mixed>>
+     */
+    private function sections(array $asset): array
+    {
+        $sections = [];
+        foreach (array_values((array) ($asset['sections'] ?? [])) as $index => $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            $id = $this->stringValue($section['id'] ?? null) ?? 'section-'.($index + 1);
+            $title = $this->stringValue($section['title'] ?? null);
+            $body = array_values(array_filter(array_map(
+                fn (mixed $line): ?string => $this->stringValue($line),
+                (array) ($section['body'] ?? [])
+            )));
+
+            if ($title === null || $body === []) {
+                continue;
+            }
+
+            $sections[] = [
+                'id' => $id,
+                'title' => $title,
+                'body' => $body,
+            ];
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return list<array<string,string>>
+     */
+    private function faq(array $asset): array
+    {
+        $faq = [];
+        foreach (array_values((array) ($asset['faq'] ?? [])) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $question = $this->stringValue($item['question'] ?? null);
+            $answer = $this->stringValue($item['answer'] ?? null);
+            if ($question === null || $answer === null) {
+                continue;
+            }
+
+            $faq[] = [
+                'question' => $question,
+                'answer' => $answer,
+            ];
+        }
+
+        return $faq;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return list<array<string,string>>
+     */
+    private function internalLinks(array $asset): array
+    {
+        $links = [];
+        foreach (array_values((array) ($asset['internal_links'] ?? [])) as $link) {
+            if (! is_array($link)) {
+                continue;
+            }
+
+            $href = $this->stringValue($link['href'] ?? null);
+            $anchor = $this->stringValue($link['anchor_text'] ?? null);
+            if ($href === null || $anchor === null || ! $this->isSafePublicHref($href)) {
+                continue;
+            }
+
+            $links[] = [
+                'href' => $href,
+                'anchor_text' => $anchor,
+                'link_intent' => $this->stringValue($link['link_intent'] ?? null) ?? 'related_public_page',
+            ];
+        }
+
+        return $links;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return array<string,mixed>
+     */
+    private function sourceNotes(array $asset): array
+    {
+        $sourceNotes = $asset['source_notes'] ?? [];
+
+        return is_array($sourceNotes) ? $sourceNotes : [];
+    }
+
+    private function canonicalUrl(string $slug, string $locale): ?string
+    {
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
+        if ($baseUrl === '') {
+            return null;
+        }
+
+        return $baseUrl.'/'.$this->frontendLocaleSegment($locale).'/personality/'.$slug;
+    }
+
+    private function frontendLocaleSegment(string $locale): string
+    {
+        return $locale === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    private function isCrossTypeSlug(string $slug): bool
+    {
+        if (preg_match('/^(?<left>[a-z]{4})-vs-(?<right>[a-z]{4})$/', $slug, $matches) !== 1) {
+            return false;
+        }
+
+        return $matches['left'] !== $matches['right'];
+    }
+
+    private function isSafePublicHref(string $href): bool
+    {
+        if (! str_starts_with($href, '/')) {
+            return false;
+        }
+
+        if (preg_match('~^/(?:[a-z]{2}(?:-[A-Z]{2})?/)?(?:result|results|orders|order|share|pay|payment|history|private|account)(?:/|[?#]|$)~i', $href) === 1) {
+            return false;
+        }
+
+        if (preg_match('/(?:[?&]|^)(?:token|session|user|result_id|report_id|order_no)=/i', $href) === 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -722,6 +722,90 @@ final class PersonalityPublicApiTest extends TestCase
         self::assertStringNotContainsString('token', (string) $response->getContent());
     }
 
+    public function test_personality_comparison_index_returns_cross_type_group_from_backend_authority(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $response = $this->getJson('/api/v0.5/personality/comparisons?locale=zh-CN');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.1.key', 'cross_type_comparisons')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.1.comparison_type', 'mbti_cross_type')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.1.items.0.slug', 'enfp-vs-entp')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.1.items.0.public_route_type', 'cross-type-comparison')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.1.items.0.public_url', 'https://fermatmind.com/zh/personality/enfp-vs-entp')
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.1.items.0.is_public', true)
+            ->assertJsonPath('comparison_list_public_projection_v1.groups.1.items.0.is_indexable', false)
+            ->assertJsonPath('cross_type_comparisons.0.slug', 'enfp-vs-entp');
+
+        $slugs = collect($response->json('cross_type_comparisons'))->pluck('slug')->sort()->values()->all();
+        self::assertSame([
+            'enfp-vs-entp',
+            'entj-vs-intj',
+            'estj-vs-entj',
+            'infj-vs-infp',
+            'intj-vs-intp',
+            'isfp-vs-infp',
+        ], $slugs);
+        self::assertNotContains('istj-vs-isfj', $slugs);
+        self::assertStringNotContainsString('/zh/result', (string) $response->getContent());
+        self::assertStringNotContainsString('/zh/orders', (string) $response->getContent());
+        self::assertStringNotContainsString('token=', (string) $response->getContent());
+        self::assertStringNotContainsString('order_no=', (string) $response->getContent());
+    }
+
+    public function test_personality_comparison_endpoint_returns_cross_type_detail_from_backend_authority(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $response = $this->getJson('/api/v0.5/personality/comparisons/intj-vs-intp?locale=zh-CN');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('comparison_public_projection_v1.comparison_contract_version', 'mbti.cross_type_comparison.public.v1')
+            ->assertJsonPath('comparison_public_projection_v1.authority_contract_version', 'mbti.cross_type_comparison.authority.v1')
+            ->assertJsonPath('comparison_public_projection_v1.readmodel_contract_version', 'mbti.cross_type_comparison.readmodel.v1')
+            ->assertJsonPath('comparison_public_projection_v1.comparison_slug', 'intj-vs-intp')
+            ->assertJsonPath('comparison_public_projection_v1.comparison_type', 'mbti_cross_type')
+            ->assertJsonPath('comparison_public_projection_v1.public_route_type', 'cross-type-comparison')
+            ->assertJsonPath('comparison_public_projection_v1.left_type', 'INTJ')
+            ->assertJsonPath('comparison_public_projection_v1.right_type', 'INTP')
+            ->assertJsonPath('comparison_public_projection_v1.canonical_url', 'https://fermatmind.com/zh/personality/intj-vs-intp')
+            ->assertJsonPath('comparison_public_projection_v1.is_public', true)
+            ->assertJsonPath('comparison_public_projection_v1.is_indexable', false)
+            ->assertJsonPath('comparison_public_projection_v1.sections.0.id', 'quick_answer')
+            ->assertJsonPath('comparison_public_projection_v1.sections.0.title', '快速结论：INTJ 和 INTP 最大区别是什么')
+            ->assertJsonPath('comparison_public_projection_v1.faq.0.question', 'INTJ 和 INTP 最大区别是什么？')
+            ->assertJsonPath('comparison_public_projection_v1.internal_links.0.href', '/zh/personality/intj')
+            ->assertJsonPath('comparison_public_projection_v1.source_refs.0', 'mbti-cross-type-comparison-content-assets-draft-20260702');
+
+        self::assertGreaterThanOrEqual(5, count((array) $response->json('comparison_public_projection_v1.sections')));
+        self::assertGreaterThanOrEqual(4, count((array) $response->json('comparison_public_projection_v1.faq')));
+        self::assertGreaterThanOrEqual(3, count((array) $response->json('comparison_public_projection_v1.internal_links')));
+        self::assertStringContainsString(
+            '战略收敛',
+            (string) $response->json('comparison_public_projection_v1.summary'),
+        );
+        self::assertStringNotContainsString('/zh/result', (string) $response->getContent());
+        self::assertStringNotContainsString('/zh/orders', (string) $response->getContent());
+        self::assertStringNotContainsString('token=', (string) $response->getContent());
+        self::assertStringNotContainsString('order_no=', (string) $response->getContent());
+    }
+
+    public function test_personality_cross_type_comparison_endpoint_fails_closed_for_missing_or_unavailable_assets(): void
+    {
+        $this->getJson('/api/v0.5/personality/comparisons/istj-vs-isfj?locale=zh-CN')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/personality/comparisons/intj-vs-intp?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
     public function test_personality_comparison_endpoint_returns_backend_authoritative_at_pair(): void
     {
         config(['app.frontend_url' => 'https://www.fermatmind.com']);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -289,6 +289,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_cross_type_comparison_public_read_model(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php',
+            'backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_result_page_pdf_export_route_changes(): void
     {
         $changed = [
@@ -4879,6 +4889,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiCrossTypeComparisonPublicReadModelFile($file)) {
+                continue;
+            }
+
             if ($this->isPersonalityPublicAssetContractFile($file)) {
                 continue;
             }
@@ -6320,6 +6334,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php',
             'backend/app/Services/Cms/PersonalityProfileService.php',
         ], true);
+    }
+
+    private function isMbtiCrossTypeComparisonPublicReadModelFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php';
     }
 
     private function isPersonalityPublicAssetContractFile(string $file): bool


### PR DESCRIPTION
## What changed
- Added a backend read-only cross-type comparison public read model backed by the approved internal authority package.
- Extended `/api/v0.5/personality/comparisons` with a separate `cross_type_comparisons` group.
- Added `/api/v0.5/personality/comparisons/{slug}` support for cross-type slugs such as `intj-vs-intp`.
- Kept `istj-vs-isfj` unavailable until a real authority asset exists and passes the gate.

## Why
- WEB-02 needs a backend-authoritative public list/detail contract for the six available cross-type comparison assets.
- The API must expose safe readability fields without opening sitemap, llms, JSON-LD, search submission, CMS write, or DB write behavior.

## Validation
- `php artisan test --filter=PersonalityPublicApiTest --no-ansi`
- `php artisan personality:mbti64-cross-type-comparison-assets-dry-run --source-dir=docs/seo/import-packages/mbti-cross-type-comparison-content-assets-draft-20260702 --json`
- `php artisan route:list --path=api/v0.5/personality --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=test_runtime_paths_have_no_uncommitted_diff --no-ansi`
- `./vendor/bin/pint --test app/Http/Controllers/API/V0_5/Cms/PersonalityController.php app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php tests/Feature/V0_5/PersonalityPublicApiTest.php`
- `git diff --check`

## Intentionally deferred
- No CMS write/import/publish.
- No DB migration.
- No sitemap, llms, JSON-LD, canonical, hreflang, or search submission changes.
- No English fallback or machine-translated cross-type content.
- SEO discoverability remains gated for SEO-01.

## Repository rule impact
This adds a backend-authoritative read-only API surface for existing internal authority package assets. It does not add frontend fallback content, CMS mutation, or SEO release behavior.