### PR TITLE
SECURITY-169-API-02: harden career import workflow staging trust

### DIFF
--- a/.github/workflows/career-content-production-import.yml
+++ b/.github/workflows/career-content-production-import.yml
@@ -106,6 +106,12 @@ jobs:
       AI_IMPACT_APPROVAL_MANIFEST_SHA256: ${{ github.event.inputs.ai_impact_approval_manifest_sha256 }}
       AI_IMPACT_STAGING_EDITORIAL_REVIEW_REPORT: ${{ github.event.inputs.ai_impact_staging_editorial_review_report }}
       AI_IMPACT_EDITORIAL_REVIEW_SHA256: ${{ github.event.inputs.ai_impact_editorial_review_sha256 }}
+      APPROVED_PAGE_ASSEMBLY_STAGING_ASSET_FILE: "/tmp/career-content-approved-transition/career_page_assembly_1046_v1.matching_staging_rows.jsonl"
+      APPROVED_PAGE_ASSEMBLY_STAGING_APPROVAL_MANIFEST: "/tmp/career-content-approved-transition/page_assembly_approval_manifest.matching_staging_rows.json"
+      APPROVED_PAGE_ASSEMBLY_STAGING_EDITORIAL_REVIEW_REPORT: "/tmp/career-content-approved-transition/page_assembly_editorial_review.matching_staging_rows.json"
+      APPROVED_AI_IMPACT_STAGING_ASSET_FILE: "/tmp/career-ai-impact-v5-approved-transition/career_risk_future_ai_impact_1046_v5_final_repaired_assets.jsonl"
+      APPROVED_AI_IMPACT_STAGING_APPROVAL_MANIFEST: "/tmp/career-ai-impact-v5-approved-transition/approval_manifest.json"
+      APPROVED_AI_IMPACT_STAGING_EDITORIAL_REVIEW_REPORT: "/tmp/career-ai-impact-v5-approved-transition/editorial_review.json"
 
     steps:
       - name: Checkout code
@@ -138,18 +144,30 @@ jobs:
             fi
           }
 
+          validate_approved_remote_path() {
+            local name="$1"
+            local value="$2"
+            local approved="$3"
+            validate_remote_path "$name" "$value"
+            if [ "$value" != "$approved" ]; then
+              echo "$name must match the approved staging artifact path for this production import."
+              echo "Expected: $approved"
+              exit 2
+            fi
+          }
+
           validate_sha PAGE_ASSEMBLY_EXPECTED_SHA256 "$PAGE_ASSEMBLY_EXPECTED_SHA256"
           validate_sha PAGE_ASSEMBLY_APPROVAL_MANIFEST_SHA256 "$PAGE_ASSEMBLY_APPROVAL_MANIFEST_SHA256"
           validate_sha PAGE_ASSEMBLY_EDITORIAL_REVIEW_SHA256 "$PAGE_ASSEMBLY_EDITORIAL_REVIEW_SHA256"
           validate_sha AI_IMPACT_EXPECTED_SHA256 "$AI_IMPACT_EXPECTED_SHA256"
           validate_sha AI_IMPACT_APPROVAL_MANIFEST_SHA256 "$AI_IMPACT_APPROVAL_MANIFEST_SHA256"
           validate_sha AI_IMPACT_EDITORIAL_REVIEW_SHA256 "$AI_IMPACT_EDITORIAL_REVIEW_SHA256"
-          validate_remote_path PAGE_ASSEMBLY_STAGING_ASSET_FILE "$PAGE_ASSEMBLY_STAGING_ASSET_FILE"
-          validate_remote_path PAGE_ASSEMBLY_STAGING_APPROVAL_MANIFEST "$PAGE_ASSEMBLY_STAGING_APPROVAL_MANIFEST"
-          validate_remote_path PAGE_ASSEMBLY_STAGING_EDITORIAL_REVIEW_REPORT "$PAGE_ASSEMBLY_STAGING_EDITORIAL_REVIEW_REPORT"
-          validate_remote_path AI_IMPACT_STAGING_ASSET_FILE "$AI_IMPACT_STAGING_ASSET_FILE"
-          validate_remote_path AI_IMPACT_STAGING_APPROVAL_MANIFEST "$AI_IMPACT_STAGING_APPROVAL_MANIFEST"
-          validate_remote_path AI_IMPACT_STAGING_EDITORIAL_REVIEW_REPORT "$AI_IMPACT_STAGING_EDITORIAL_REVIEW_REPORT"
+          validate_approved_remote_path PAGE_ASSEMBLY_STAGING_ASSET_FILE "$PAGE_ASSEMBLY_STAGING_ASSET_FILE" "$APPROVED_PAGE_ASSEMBLY_STAGING_ASSET_FILE"
+          validate_approved_remote_path PAGE_ASSEMBLY_STAGING_APPROVAL_MANIFEST "$PAGE_ASSEMBLY_STAGING_APPROVAL_MANIFEST" "$APPROVED_PAGE_ASSEMBLY_STAGING_APPROVAL_MANIFEST"
+          validate_approved_remote_path PAGE_ASSEMBLY_STAGING_EDITORIAL_REVIEW_REPORT "$PAGE_ASSEMBLY_STAGING_EDITORIAL_REVIEW_REPORT" "$APPROVED_PAGE_ASSEMBLY_STAGING_EDITORIAL_REVIEW_REPORT"
+          validate_approved_remote_path AI_IMPACT_STAGING_ASSET_FILE "$AI_IMPACT_STAGING_ASSET_FILE" "$APPROVED_AI_IMPACT_STAGING_ASSET_FILE"
+          validate_approved_remote_path AI_IMPACT_STAGING_APPROVAL_MANIFEST "$AI_IMPACT_STAGING_APPROVAL_MANIFEST" "$APPROVED_AI_IMPACT_STAGING_APPROVAL_MANIFEST"
+          validate_approved_remote_path AI_IMPACT_STAGING_EDITORIAL_REVIEW_REPORT "$AI_IMPACT_STAGING_EDITORIAL_REVIEW_REPORT" "$APPROVED_AI_IMPACT_STAGING_EDITORIAL_REVIEW_REPORT"
 
           expected_phrase="批准 career content 1046 production import, using page assembly SHA ${PAGE_ASSEMBLY_EXPECTED_SHA256} and AI Impact SHA ${AI_IMPACT_EXPECTED_SHA256}"
           if [ "$OPERATOR_APPROVAL_PHRASE" != "$expected_phrase" ]; then
@@ -174,12 +192,19 @@ jobs:
           printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
 
-      - name: Add staging host key for approved artifact transfer
-        shell: bash
-        run: |
-          set -euo pipefail
-          ssh-keyscan -p "$STAGING_PORT" -H "$STAGING_HOST" >> ~/.ssh/known_hosts
-          chmod 600 ~/.ssh/known_hosts
+          require_known_host() {
+            local host="$1"
+            local port="$2"
+            if [ "$port" = "22" ]; then
+              ssh-keygen -F "$host" -f ~/.ssh/known_hosts >/dev/null \
+                || ssh-keygen -F "[$host]:$port" -f ~/.ssh/known_hosts >/dev/null
+            else
+              ssh-keygen -F "[$host]:$port" -f ~/.ssh/known_hosts >/dev/null
+            fi
+          }
+
+          require_known_host "$STAGING_HOST" "$STAGING_PORT"
+          require_known_host "$PRODUCTION_HOST" "$PRODUCTION_PORT"
 
       - name: Copy approved artifacts from staging to production
         shell: bash

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
@@ -228,37 +228,38 @@ final class CareerAiImpactAssetImportService
         $updatedCount = 0;
         $writtenRows = [];
 
-        $handle = fopen($file, 'rb');
-        if ($handle === false) {
+        $targetRowErrors = [];
+        $targetRows = $this->targetRowsFromFile($file, array_keys($targetKeys), $sourceFileSha256, $targetRowErrors);
+        $existingProductionRows = CareerJobAiImpactAsset::query()
+            ->where('asset_version', CareerJobAiImpactAsset::ASSET_VERSION_V5)
+            ->whereIn('career_job_slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->where('status', CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED)
+            ->get(['career_job_slug', 'locale']);
+        foreach ($existingProductionRows as $existingProductionRow) {
+            $targetRowErrors[] = "{$existingProductionRow->career_job_slug}/{$existingProductionRow->locale}: staging preview import must not overwrite production_imported rows.";
+        }
+
+        $expectedWriteCount = (int) ($validation['expected_preview_rows'] ?? 0);
+        if (count($targetRows) !== $expectedWriteCount) {
+            $targetRowErrors[] = 'Verified source JSONL target row count '.count($targetRows)." did not match expected row count {$expectedWriteCount}.";
+        }
+        if ($targetRowErrors !== []) {
             return array_merge($validation, [
                 'mode' => 'write',
                 'status' => $status,
                 'decision' => 'fail',
                 'staging_write_performed' => false,
-                'errors' => ['Source JSONL file could not be opened for staging write.'],
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'written_count' => 0,
+                'errors' => array_values(array_unique($targetRowErrors)),
             ]);
         }
 
-        while (($line = fgets($handle)) !== false) {
-            if (trim($line) === '') {
-                continue;
-            }
-
-            try {
-                $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-            } catch (Throwable) {
-                continue;
-            }
-
-            if (! is_array($row)) {
-                continue;
-            }
-
+        foreach ($targetRows as $row) {
             $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
             $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
-            if (! isset($targetKeys[$slug.'|'.$locale])) {
-                continue;
-            }
 
             $occupation = Occupation::query()->where('canonical_slug', $slug)->first();
             if (! $occupation instanceof Occupation) {
@@ -312,9 +313,6 @@ final class CareerAiImpactAssetImportService
             ];
         }
 
-        fclose($handle);
-
-        $expectedWriteCount = (int) ($validation['expected_preview_rows'] ?? 0);
         if ($writtenCount !== $expectedWriteCount) {
             return array_merge($validation, [
                 'mode' => 'write',
@@ -706,7 +704,31 @@ final class CareerAiImpactAssetImportService
             ]);
         }
 
-        $targetRows = $this->targetRowsFromFile($file, array_keys($targetKeys));
+        $targetRowErrors = [];
+        $targetRows = $this->targetRowsFromFile($file, array_keys($targetKeys), $sourceFileSha256, $targetRowErrors);
+        if (count($targetRows) !== $expectedRows) {
+            $targetRowErrors[] = 'Verified source JSONL target row count does not match expected production rows.';
+        }
+        if ($targetRowErrors !== []) {
+            return array_merge($validation, [
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
+                'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+                'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+                'production_rows_touched' => 0,
+                'rollback_report' => [
+                    'available' => true,
+                    'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                    'previous_status_counts' => $previousStatusCounts,
+                    'rows' => $rollbackRows,
+                ],
+                'errors' => array_values(array_unique($targetRowErrors)),
+            ]);
+        }
         $importRunId = (string) Str::uuid();
         $writtenCount = 0;
         $createdCount = 0;
@@ -1074,8 +1096,15 @@ final class CareerAiImpactAssetImportService
             $errors[] = ucfirst($label).' SHA-256 does not match expected artifact SHA.';
         }
 
+        $contents = (string) file_get_contents($file);
+        if (! str_starts_with(ltrim($contents), '{')) {
+            $errors[] = ucfirst($label).' JSON must be an object.';
+
+            return ['payload' => null, 'sha256' => $sha256];
+        }
+
         try {
-            $payload = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+            $payload = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
         } catch (Throwable) {
             $errors[] = ucfirst($label).' file must be valid JSON.';
 
@@ -1098,6 +1127,8 @@ final class CareerAiImpactAssetImportService
     private function validateApprovalManifest(array $manifest, ?string $assetSha256, int $expectedRows, int $expectedSlugs, array &$errors): void
     {
         if ($manifest === []) {
+            $errors[] = 'Approval manifest must be a non-empty JSON object.';
+
             return;
         }
 
@@ -1152,6 +1183,8 @@ final class CareerAiImpactAssetImportService
     private function validateEditorialReviewReport(array $report, ?string $assetSha256, int $expectedRows, int $expectedSlugs, array &$errors): void
     {
         if ($report === []) {
+            $errors[] = 'Editorial review report must be a non-empty JSON object.';
+
             return;
         }
 
@@ -1246,16 +1279,38 @@ final class CareerAiImpactAssetImportService
      * @param  list<string>  $targetKeys
      * @return array<string, array<string, mixed>>
      */
-    private function targetRowsFromFile(string $file, array $targetKeys): array
+    private function targetRowsFromFile(string $file, array $targetKeys, ?string $expectedSha256, array &$errors): array
     {
-        $targetKeyMap = array_fill_keys($targetKeys, true);
-        $rows = [];
-        $handle = fopen($file, 'rb');
-        if ($handle === false) {
-            return $rows;
+        $contents = file_get_contents($file);
+        if (! is_string($contents)) {
+            $errors[] = 'Source JSONL file could not be read for verified import.';
+
+            return [];
         }
 
+        $actualSha256 = hash('sha256', $contents);
+        $expectedSha256 = $this->normalizeSha256($expectedSha256);
+        if ($expectedSha256 !== null && $actualSha256 !== $expectedSha256) {
+            $errors[] = 'Source JSONL changed after validation; verified import requires immutable SHA-matched bytes.';
+
+            return [];
+        }
+
+        $targetKeyMap = array_fill_keys($targetKeys, true);
+        $rows = [];
+
+        $handle = fopen('php://temp', 'rb+');
+        if ($handle === false) {
+            $errors[] = 'Source JSONL could not be buffered for verified import.';
+
+            return [];
+        }
+        fwrite($handle, $contents);
+        rewind($handle);
+
+        $lineNumber = 0;
         while (($line = fgets($handle)) !== false) {
+            $lineNumber++;
             if (trim($line) === '') {
                 continue;
             }
@@ -1263,21 +1318,36 @@ final class CareerAiImpactAssetImportService
             try {
                 $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
             } catch (Throwable) {
+                $errors[] = "Source JSONL changed after validation; line {$lineNumber} is invalid JSON.";
+
                 continue;
             }
 
             if (! is_array($row)) {
+                $errors[] = "Source JSONL changed after validation; line {$lineNumber} is not an object.";
+
                 continue;
             }
 
             $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
             $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+            if ($slug === '' || ! in_array($locale, ['zh-CN', 'en'], true)) {
+                $errors[] = "Source JSONL changed after validation; line {$lineNumber} is missing slug or locale.";
+
+                continue;
+            }
+
             $key = $slug.'|'.$locale;
             if (isset($targetKeyMap[$key])) {
+                if (isset($rows[$key])) {
+                    $errors[] = "Source JSONL changed after validation; duplicate slug/locale row {$key}.";
+
+                    continue;
+                }
+
                 $rows[$key] = $row;
             }
         }
-
         fclose($handle);
 
         return $rows;

--- a/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php
+++ b/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php
@@ -164,7 +164,32 @@ final class CareerPageAssemblyImportService
             $targetKeys[] = (string) $slug.'|zh-CN';
             $targetKeys[] = (string) $slug.'|en';
         }
-        $rowsByKey = $this->targetRowsFromFile($file, $targetKeys);
+        $targetRowErrors = [];
+        $rowsByKey = $this->targetRowsFromFile($file, $targetKeys, $sourceSha, $targetRowErrors);
+        $existingProductionRows = CareerJobPageAssemblyAsset::query()
+            ->where('asset_version', CareerJobPageAssemblyAsset::ASSET_VERSION_V1)
+            ->whereIn('career_job_slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->where('status', CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED)
+            ->get(['career_job_slug', 'locale']);
+        foreach ($existingProductionRows as $existingProductionRow) {
+            $targetRowErrors[] = "{$existingProductionRow->career_job_slug}/{$existingProductionRow->locale}: staging preview import must not overwrite production_imported rows.";
+        }
+        if (count($rowsByKey) !== (int) ($validation['expected_preview_rows'] ?? 0)) {
+            $targetRowErrors[] = 'Verified source JSONL target row count does not match expected preview rows.';
+        }
+        if ($targetRowErrors !== []) {
+            return array_merge($validation, [
+                'mode' => 'write',
+                'status' => CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW,
+                'decision' => 'fail',
+                'staging_write_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'written_count' => 0,
+                'errors' => array_values(array_unique($targetRowErrors)),
+            ]);
+        }
         $importRunId = (string) Str::uuid();
 
         $writtenRows = DB::transaction(function () use ($rowsByKey, $sourceSha, $importRunId): array {
@@ -608,7 +633,31 @@ final class CareerPageAssemblyImportService
             ]);
         }
 
-        $targetRows = $this->targetRowsFromFile($file, array_keys($targetKeys));
+        $targetRowErrors = [];
+        $targetRows = $this->targetRowsFromFile($file, array_keys($targetKeys), $sourceFileSha256, $targetRowErrors);
+        if (count($targetRows) !== $expectedRows) {
+            $targetRowErrors[] = 'Verified source JSONL target row count does not match expected production rows.';
+        }
+        if ($targetRowErrors !== []) {
+            return array_merge($validation, [
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
+                'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+                'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+                'production_rows_touched' => 0,
+                'rollback_report' => [
+                    'available' => true,
+                    'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                    'previous_status_counts' => $previousStatusCounts,
+                    'rows' => $rollbackRows,
+                ],
+                'errors' => array_values(array_unique($targetRowErrors)),
+            ]);
+        }
         $importRunId = (string) Str::uuid();
         $writtenRows = [];
 
@@ -970,9 +1019,73 @@ final class CareerPageAssemblyImportService
      * @param  list<string>  $targetKeys
      * @return array<string, array<string, mixed>>
      */
-    private function targetRowsFromFile(string $file, array $targetKeys): array
+    private function targetRowsFromFile(string $file, array $targetKeys, ?string $expectedSha256, array &$errors): array
     {
-        [$rowsByKey] = $this->readRowsByKey($file);
+        $contents = file_get_contents($file);
+        if (! is_string($contents)) {
+            $errors[] = 'Source JSONL file could not be read for verified import.';
+
+            return [];
+        }
+
+        $actualSha256 = hash('sha256', $contents);
+        $expectedSha256 = $this->normalizeSha256($expectedSha256);
+        if ($expectedSha256 !== null && $actualSha256 !== $expectedSha256) {
+            $errors[] = 'Source JSONL changed after validation; verified import requires immutable SHA-matched bytes.';
+
+            return [];
+        }
+
+        $handle = fopen('php://temp', 'rb+');
+        if ($handle === false) {
+            $errors[] = 'Source JSONL could not be buffered for verified import.';
+
+            return [];
+        }
+        fwrite($handle, $contents);
+        rewind($handle);
+
+        $rowsByKey = [];
+        $lineNumber = 0;
+        while (($line = fgets($handle)) !== false) {
+            $lineNumber++;
+            if (trim($line) === '') {
+                continue;
+            }
+
+            try {
+                $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            } catch (Throwable) {
+                $errors[] = "Source JSONL changed after validation; line {$lineNumber} is invalid JSON.";
+
+                continue;
+            }
+
+            if (! is_array($row)) {
+                $errors[] = "Source JSONL changed after validation; line {$lineNumber} is not an object.";
+
+                continue;
+            }
+
+            $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+            $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+            if ($slug === '' || ! in_array($locale, ['zh-CN', 'en'], true)) {
+                $errors[] = "Source JSONL changed after validation; line {$lineNumber} is missing slug or locale.";
+
+                continue;
+            }
+
+            $key = $slug.'|'.$locale;
+            if (isset($rowsByKey[$key])) {
+                $errors[] = "Source JSONL changed after validation; duplicate slug/locale row {$key}.";
+
+                continue;
+            }
+
+            $rowsByKey[$key] = $row;
+        }
+        fclose($handle);
+
         $targetKeyMap = array_fill_keys($targetKeys, true);
 
         return array_intersect_key($rowsByKey, $targetKeyMap);
@@ -1003,8 +1116,15 @@ final class CareerPageAssemblyImportService
             $errors[] = ucfirst($label).' SHA-256 does not match expected artifact SHA.';
         }
 
+        $contents = (string) file_get_contents($file);
+        if (! str_starts_with(ltrim($contents), '{')) {
+            $errors[] = ucfirst($label).' JSON must be an object.';
+
+            return ['payload' => null, 'sha256' => $sha256];
+        }
+
         try {
-            $payload = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+            $payload = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
         } catch (Throwable) {
             $errors[] = ucfirst($label).' file must be valid JSON.';
 
@@ -1027,6 +1147,8 @@ final class CareerPageAssemblyImportService
     private function validateApprovalManifest(array $manifest, ?string $assetSha256, int $expectedRows, int $expectedSlugs, array &$errors): void
     {
         if ($manifest === []) {
+            $errors[] = 'Approval manifest must be a non-empty JSON object.';
+
             return;
         }
 
@@ -1094,6 +1216,8 @@ final class CareerPageAssemblyImportService
     private function validateEditorialReviewReport(array $report, ?string $assetSha256, int $expectedRows, int $expectedSlugs, array &$errors): void
     {
         if ($report === []) {
+            $errors[] = 'Editorial review report must be a non-empty JSON object.';
+
             return;
         }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70353,11 +70353,59 @@
     "depends_on": [
       "SECURITY-169-API-01"
     ],
-    "status": "planned",
+    "status": "local_checks_passed",
     "checks": {
       "authorization": {
         "status": "pass",
         "evidence": "Authorized by the 2026-07-03 SECURITY-169 attached /goal."
+      },
+      "dependency_SECURITY_169_API_01": {
+        "status": "pass",
+        "evidence": "SECURITY-169-API-01 merged via PR #2605 and ledger closeout PR #2612; origin/main includes the prior deploy policy guard restore."
+      },
+      "base_sync": {
+        "status": "pass",
+        "evidence": "Started from latest origin/main at de7d31836999a2f35513fae326ba49b4e34da629 in isolated worktree /private/tmp/fap-api-security-169-api-02."
+      },
+      "workflow_yaml_and_bash_syntax": {
+        "status": "pass",
+        "evidence": "ruby parsed .github/workflows/career-content-production-import.yml and extracted run scripts passed bash -n."
+      },
+      "php_lint": {
+        "status": "pass",
+        "evidence": "php -l passed for CareerPageAssemblyImportService.php and CareerAiImpactAssetImportService.php."
+      },
+      "pint": {
+        "status": "pass",
+        "evidence": "cd backend && ./vendor/bin/pint --test app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php passed after scoped formatting."
+      },
+      "focused_career_import_tests": {
+        "status": "pass",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php --no-ansi passed (38 warnings, 558 assertions)."
+      },
+      "route_list": {
+        "status": "pass",
+        "evidence": "cd backend && php artisan route:list --no-ansi passed."
+      },
+      "sqlite_migrate": {
+        "status": "pass",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-02.sqlite php artisan migrate --force --no-ansi passed."
+      },
+      "ci_verify_mbti": {
+        "status": "pass",
+        "evidence": "bash backend/scripts/ci_verify_mbti.sh passed in the isolated API-02 worktree; generated BIG5_OCEAN compiled artifacts were restored because they were test side effects outside scope."
+      },
+      "json_yaml_diff": {
+        "status": "pass",
+        "evidence": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); YAML.load_file('.github/workflows/career-content-production-import.yml')\" && git diff --check passed after API-02 implementation and ledger updates."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "git diff --name-only contains only .github/workflows/career-content-production-import.yml, the two scoped career import services, and docs/codex/pr-train-state.json."
+      },
+      "deployment": {
+        "status": "not_run",
+        "evidence": "No staging wait, manual deploy, server deploy, production import, production deploy, CMS mutation, search submission, sitemap, llms, canonical, noindex, JSON-LD, or SEO runtime action executed."
       }
     },
     "pr_url": null,
@@ -70379,6 +70427,16 @@
         "at": "2026-07-03T00:00:00+08:00",
         "status": "planned",
         "note": "Registered authorized SECURITY-169-API-02; execution waits for declared dependency merge."
+      },
+      {
+        "at": "2026-07-03T01:40:40+08:00",
+        "status": "local_checks_passed",
+        "note": "API-02 scoped implementation completed and local validation passed; final scope validation, commit, push, PR, GitHub checks, merge, and post-merge revalidation remain."
+      },
+      {
+        "at": "2026-07-03T01:41:05+08:00",
+        "status": "scope_validation_passed",
+        "note": "Final changed-file validation passed for API-02 allowed paths; ready to stage path-limited files."
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Constrain the career production import workflow to the approved staging artifact paths and pinned known_hosts trust for staging and production hosts.
- Re-read career import target rows from SHA-matched immutable JSONL bytes before staging preview or production transition writes.
- Reject empty approval/review artifacts and block staging preview writes over existing production-imported rows.
- Update the SECURITY-169 train state for API-02 local validation and scope validation.

## Validation
- `php -l backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php && php -l backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/career-content-production-import.yml'); puts 'workflow yaml ok'"`
- extracted workflow `run:` scripts with Ruby and checked them with `bash -n`
- `cd backend && ./vendor/bin/pint --test app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-02.sqlite php artisan migrate --force --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); YAML.load_file('.github/workflows/career-content-production-import.yml')" && git diff --check`
- scope validation: `git diff --name-only` contains only API-02 allowed paths

## Train Protocol Notes
- No staging wait, manual server deploy, production deploy, production import, CMS mutation, search submission, sitemap, llms, canonical/noindex/JSON-LD, or SEO runtime action was executed.
- Generated BIG5_OCEAN compiled artifacts from `ci_verify_mbti.sh` were restored as test side effects outside API-02 scope.
- SECURITY-169-API-01 dependency is merged and origin/main includes its closeout state.
