### PR TITLE
RIASEC-CONTENT-OCC-02 harden RIASEC occupation example projection

### DIFF
--- a/backend/app/Services/Riasec/RiasecActivityExplorerService.php
+++ b/backend/app/Services/Riasec/RiasecActivityExplorerService.php
@@ -152,6 +152,9 @@ final class RiasecActivityExplorerService
                 'fit_score_allowed' => false,
                 'success_prediction_allowed' => false,
                 'qualification_judgment_allowed' => false,
+                'occupation_examples_share_card_allowed' => false,
+                'occupation_examples_pdf_default_visible' => false,
+                'occupation_examples_history_default_visible' => false,
                 'registry_source_connected' => false,
             ],
             'dimension_activity_families' => $this->dimensionFamilies($dimensions, $normalizedLocale),
@@ -539,7 +542,17 @@ final class RiasecActivityExplorerService
             'user_visible_boundary' => (string) $row['user_visible_boundary'],
             'reality_check' => (string) $row['reality_check'],
             'not_a_recommendation' => true,
+            'examples_only' => true,
+            'ranking_allowed' => false,
             'fit_score_allowed' => false,
+            'success_prediction_allowed' => false,
+            'qualification_judgment_allowed' => false,
+            'public_surfaces' => [
+                'result_page_allowed' => true,
+                'share_card_allowed' => false,
+                'pdf_default_visible' => false,
+                'history_default_visible' => false,
+            ],
         ];
     }
 

--- a/backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php
@@ -49,7 +49,15 @@ final class RiasecActivityExplorerServiceTest extends TestCase
                 $this->assertSame('活动场景例子，不是结果答案', data_get($example, 'display_label'));
                 $this->assertSame('occupation_examples_boundary_v1.zh-CN', data_get($example, 'content_version'));
                 $this->assertTrue((bool) data_get($example, 'not_a_recommendation'));
+                $this->assertTrue((bool) data_get($example, 'examples_only'));
+                $this->assertFalse((bool) data_get($example, 'ranking_allowed'));
                 $this->assertFalse((bool) data_get($example, 'fit_score_allowed'));
+                $this->assertFalse((bool) data_get($example, 'success_prediction_allowed'));
+                $this->assertFalse((bool) data_get($example, 'qualification_judgment_allowed'));
+                $this->assertTrue((bool) data_get($example, 'public_surfaces.result_page_allowed'));
+                $this->assertFalse((bool) data_get($example, 'public_surfaces.share_card_allowed'));
+                $this->assertFalse((bool) data_get($example, 'public_surfaces.pdf_default_visible'));
+                $this->assertFalse((bool) data_get($example, 'public_surfaces.history_default_visible'));
                 $this->assertNotEmpty(data_get($example, 'education_boundary'));
                 $this->assertNotEmpty(data_get($example, 'skill_boundary'));
                 $this->assertNotEmpty(data_get($example, 'qualification_boundary'));
@@ -135,6 +143,47 @@ final class RiasecActivityExplorerServiceTest extends TestCase
         $this->assertSame('available', data_get($payload, 'code_activity_pack.status'));
         $this->assertCount(9, (array) data_get($payload, 'code_activity_pack.activities'));
         $this->assertSame([], data_get($payload, 'code_activity_pack.occupation_examples'));
+    }
+
+    public function test_occupation_examples_are_public_safe_examples_not_ranked_recommendations(): void
+    {
+        $service = new RiasecActivityExplorerService;
+
+        foreach (['IAS', 'RCE', 'EAS', 'CRI', 'SIC', 'ERC', 'AIR', 'CSE', 'RES'] as $code) {
+            $payload = $service->build($code, 'zh-CN');
+
+            $this->assertFalse((bool) data_get($payload, 'boundary.ranking_allowed'));
+            $this->assertFalse((bool) data_get($payload, 'boundary.fit_score_allowed'));
+            $this->assertFalse((bool) data_get($payload, 'boundary.success_prediction_allowed'));
+            $this->assertFalse((bool) data_get($payload, 'boundary.qualification_judgment_allowed'));
+            $this->assertFalse((bool) data_get($payload, 'boundary.occupation_examples_share_card_allowed'));
+            $this->assertFalse((bool) data_get($payload, 'boundary.occupation_examples_pdf_default_visible'));
+            $this->assertFalse((bool) data_get($payload, 'boundary.occupation_examples_history_default_visible'));
+            $this->assertSame([], data_get($payload, 'code_activity_pack.occupation_examples'));
+
+            foreach ((array) data_get($payload, 'code_activity_pack.activities', []) as $activity) {
+                foreach ((array) data_get($activity, 'occupation_examples', []) as $example) {
+                    $this->assertSame('活动场景例子，不是结果答案', data_get($example, 'display_label'));
+                    $this->assertTrue((bool) data_get($example, 'not_a_recommendation'));
+                    $this->assertTrue((bool) data_get($example, 'examples_only'));
+                    $this->assertFalse((bool) data_get($example, 'ranking_allowed'));
+                    $this->assertFalse((bool) data_get($example, 'fit_score_allowed'));
+                    $this->assertFalse((bool) data_get($example, 'success_prediction_allowed'));
+                    $this->assertFalse((bool) data_get($example, 'qualification_judgment_allowed'));
+                    $this->assertTrue((bool) data_get($example, 'public_surfaces.result_page_allowed'));
+                    $this->assertFalse((bool) data_get($example, 'public_surfaces.share_card_allowed'));
+                    $this->assertFalse((bool) data_get($example, 'public_surfaces.pdf_default_visible'));
+                    $this->assertFalse((bool) data_get($example, 'public_surfaces.history_default_visible'));
+
+                    $this->assertArrayNotHasKey('source_url', (array) $example);
+                    $this->assertArrayNotHasKey('onet_code', (array) $example);
+                    $this->assertArrayNotHasKey('soc_code', (array) $example);
+                    $this->assertArrayNotHasKey('fit_score', (array) $example);
+                    $this->assertArrayNotHasKey('rank', (array) $example);
+                    $this->assertArrayNotHasKey('success_prediction', (array) $example);
+                }
+            }
+        }
     }
 
     public function test_activity_pack_fails_closed_when_asset_is_invalid_or_incomplete(): void

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69973,8 +69973,8 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "pr_opened",
-    "commit_sha": "af4aecd2187512a160c248e8408b809a8b8c34de",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "dd0f52428a49679297b828461d07c5d3b77e0192",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2621",
     "checks": {
       "phpunit_occupation_preflight": {
@@ -70002,14 +70002,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T17:55:02Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/content_assets/riasec/occupation_examples_boundary_v1.zh-CN.jsonl",
         "backend/docs/riasec/occupation-examples-pack-06-preflight.md",
@@ -70036,8 +70036,15 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2621 after OCC-01 local validation, latest-main rebase, and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:00:39Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2621 merged; origin/main contains merge commit; local main synced; task branch cleaned. Recorded during OCC-02 ledger reconciliation."
       }
-    ]
+    ],
+    "merge_commit_sha": "87f021660b31e46d2efb5c1f2c05dee0738e690a"
   },
   "RIASEC-CONTENT-OCC-02": {
     "id": "RIASEC-CONTENT-OCC-02",
@@ -70049,19 +70056,44 @@
     "depends_on": [
       "RIASEC-CONTENT-OCC-01"
     ],
-    "status": "authorized_pending_start",
-    "commit_sha": null,
+    "status": "local_validation_passed",
+    "commit_sha": "7edceffc52fa3fa83f44441765a9c84b67db0072",
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "phpunit_activity_explorer_and_occupation_projection": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecOccupationExamplesPreflightTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "12 tests, 39442 assertions"
+      },
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "170 tests, 103041 assertions"
+      },
+      "pint": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecActivityExplorerService.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecOccupationExamplesPreflightTest.php",
+        "status": "passed",
+        "summary": "3 files passed"
+      },
+      "manifest_state_parse_and_diff_check": {
+        "command": "ruby YAML parse; python JSON parse; git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecActivityExplorerService.php",
+        "backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -70069,6 +70101,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T18:00:39Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Hardened occupation example projection boundaries and public surface flags; local RIASEC unit subset and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70056,9 +70056,9 @@
     "depends_on": [
       "RIASEC-CONTENT-OCC-01"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": "7edceffc52fa3fa83f44441765a9c84b67db0072",
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "527269ead2939ccdf5c109a31d83ce63fb0f7420",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2624",
     "checks": {
       "phpunit_activity_explorer_and_occupation_projection": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecOccupationExamplesPreflightTest.php --no-ansi --display-warnings",
@@ -70107,6 +70107,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Hardened occupation example projection boundaries and public surface flags; local RIASEC unit subset and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:02:40Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2624 after OCC-02 local validation, latest-main ancestry check, and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Hardened RIASEC occupation example projection with explicit examples-only, no-ranking, no-success-prediction, and no-qualification-judgment flags.
- Added public surface policy flags so occupation examples remain result-page examples and are not exposed as share card, default PDF, or history recommendation material.
- Added service tests covering public-safe occupation examples across representative Holland codes and confirming source/fit/rank/private fields are absent from projected output.
- Reconciled prior OCC-01 post-merge ledger facts and recorded OCC-02 local validation in the PR train state.

## Why
Occupation examples are high-risk if they read like recommendations, fit rankings, success predictions, or qualification judgments. This PR keeps them scoped to activity examples while preserving the content repair from OCC-01.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecOccupationExamplesPreflightTest.php --no-ansi --display-warnings` — 12 tests, 39442 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings` — 170 tests, 103041 assertions
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecActivityExplorerService.php tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php tests/Unit/Services/Riasec/RiasecOccupationExamplesPreflightTest.php` — pass
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No occupation content rewrite here; OCC-01 repaired the asset text.
- No share/PDF/history implementation changes beyond explicit projection boundary flags.
- No CMS write, production import, manual server mutation, staging wait, or deploy.
