### PR TITLE
RIASEC-CONTENT-140CTA-01 repair RIASEC 60Q and 140Q CTA boundaries

### DIFF
--- a/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+++ b/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
@@ -365,13 +365,20 @@ final class RiasecDeepCopySlotRegistry
             ]),
             'layer_unavailable' => $this->layer140qSlot('140q_layer_unavailable_copy', 'layer_unavailable', [
                 'title' => '工作日常三张卡暂不可用',
-                'summary' => '当前结果可以看基础兴趣方向。任务、环境和角色责任三张卡需要完成 140Q 后才会显示；它们只会让工作日常线索更具体。',
+                'summary' => '当前 60Q 结果已经可以阅读基础兴趣结构。任务、环境和角色责任三张卡需要完成 140Q 后才会显示；它们只补充工作日常观察角度，不修正或覆盖 60Q。',
+                'applicable_form_codes' => ['riasec_60'],
+                'contextual_detail_only' => true,
+                'overrides_60q_result' => false,
                 'layer_state' => 'not_applicable_60q_only',
             ]),
             '140q_cta' => $this->layer140qSlot('140q_cta_copy', '140q_cta', [
                 'title' => '你喜欢的是任务本身，还是这份工作的真实日常？',
-                'summary' => '60Q 看兴趣方向；140Q 看工作日常。140Q 提供更具体的情境线索，不代表正确性更高，也不会覆盖 60Q。',
-                'button_label' => '查看 140Q 工作日常三张卡',
+                'summary' => '60Q 已经给出本次兴趣结构。140Q 只是把观察拆到任务、环境和角色责任三层，让你多看工作日常线索；它不是用来修正本次结果的版本，也不会修复、推翻或覆盖 60Q。',
+                'button_label' => '查看 140Q 情境线索',
+                'applicable_form_codes' => ['riasec_60'],
+                'contextual_detail_only' => true,
+                'accuracy_upgrade_claim_allowed' => false,
+                'overrides_60q_result' => false,
                 'layer_state' => 'unavailable',
             ]),
             '140q_not_recommended' => $this->layer140qSlot('140q_not_recommended_copy', '140q_not_recommended', [

--- a/backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php
+++ b/backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php
@@ -50,6 +50,36 @@ final class Riasec140qLayerSlotRegistryTest extends TestCase
         $this->assertSame('insufficient_quality', $registry->resolve140qLayerSlot('140q_not_recommended')['layer_state']);
     }
 
+    public function test_140q_cta_is_contextual_detail_not_accuracy_upgrade_or_60q_repair(): void
+    {
+        $registry = new RiasecDeepCopySlotRegistry;
+        $slot = $registry->resolve140qLayerSlot('140q_cta');
+        $serialized = json_encode($slot, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        $this->assertSame(['riasec_60'], $slot['applicable_form_codes']);
+        $this->assertTrue($slot['contextual_detail_only']);
+        $this->assertFalse($slot['accuracy_upgrade_claim_allowed']);
+        $this->assertFalse($slot['overrides_60q_result']);
+        $this->assertStringContainsString('任务、环境和角色责任三层', $slot['summary']);
+        $this->assertStringContainsString('不会修复、推翻或覆盖 60Q', $slot['summary']);
+        $this->assertStringContainsString('情境线索', $slot['button_label']);
+
+        foreach (['更准', '更准确', '最终答案', '岗位胜任', 'raw delta', '分数差异'] as $phrase) {
+            $this->assertStringNotContainsString($phrase, $serialized);
+        }
+    }
+
+    public function test_60q_unavailable_layer_does_not_downgrade_the_60q_result(): void
+    {
+        $slot = (new RiasecDeepCopySlotRegistry)->resolve140qLayerSlot('layer_unavailable');
+
+        $this->assertSame(['riasec_60'], $slot['applicable_form_codes']);
+        $this->assertTrue($slot['contextual_detail_only']);
+        $this->assertFalse($slot['overrides_60q_result']);
+        $this->assertStringContainsString('60Q 结果已经可以阅读基础兴趣结构', $slot['summary']);
+        $this->assertStringContainsString('不修正或覆盖 60Q', $slot['summary']);
+    }
+
     public function test_140q_copy_rejects_accuracy_override_job_and_raw_delta_claims(): void
     {
         $registry = new RiasecDeepCopySlotRegistry;

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70133,9 +70133,9 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": "a1d68df7ccb34dbe6d6bfb1e5d0dfab7f9542fa7",
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "1bac0bfc6a0597005f31df62832acfdaaf804b81",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2626",
     "checks": {
       "phpunit_140q_slot_and_selector_tests": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php --no-ansi --display-warnings",
@@ -70184,6 +70184,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Reframed 60Q/140Q CTA as contextual daily-work detail only; local RIASEC unit subset and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:07:40Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2626 after 140CTA-01 local validation, latest-main ancestry check, and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70056,8 +70056,8 @@
     "depends_on": [
       "RIASEC-CONTENT-OCC-01"
     ],
-    "status": "pr_opened",
-    "commit_sha": "527269ead2939ccdf5c109a31d83ce63fb0f7420",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "777a36fb568c6c7d483d106775b04269b6059468",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2624",
     "checks": {
       "phpunit_activity_explorer_and_occupation_projection": {
@@ -70081,14 +70081,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T18:02:42Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/app/Services/Riasec/RiasecActivityExplorerService.php",
         "backend/tests/Unit/Services/Riasec/RiasecActivityExplorerServiceTest.php",
@@ -70113,8 +70113,15 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2624 after OCC-02 local validation, latest-main ancestry check, and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:05:46Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2624 merged; origin/main contains merge commit; local main synced; task branch cleaned. Recorded during 140CTA-01 ledger reconciliation."
       }
-    ]
+    ],
+    "merge_commit_sha": "3ffb6e7a449044f22c78a1dd44fc1fc4aa7e53fd"
   },
   "RIASEC-CONTENT-140CTA-01": {
     "id": "RIASEC-CONTENT-140CTA-01",
@@ -70126,19 +70133,44 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "authorized_pending_start",
-    "commit_sha": null,
+    "status": "local_validation_passed",
+    "commit_sha": "a1d68df7ccb34dbe6d6bfb1e5d0dfab7f9542fa7",
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "phpunit_140q_slot_and_selector_tests": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "11 tests, 319 assertions"
+      },
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "172 tests, 103059 assertions"
+      },
+      "pint": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php",
+        "status": "passed",
+        "summary": "2 files passed"
+      },
+      "manifest_state_parse_and_diff_check": {
+        "command": "ruby YAML parse; python JSON parse; git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
+        "backend/tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -70146,6 +70178,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T18:05:46Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Reframed 60Q/140Q CTA as contextual daily-work detail only; local RIASEC unit subset and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Reframed the 60Q to 140Q CTA as contextual daily-work detail only.
- Scoped the 60Q-only unavailable and CTA slots to `riasec_60` and added explicit non-override flags.
- Added 140Q slot tests proving the CTA does not imply an accuracy upgrade, 60Q repair, raw-delta comparison, job fit, or qualification judgment.
- Reconciled OCC-02 post-merge ledger facts and recorded 140CTA-01 local validation in the PR train state.

## Why
The 140Q entry point must not read as a more accurate version, a correction path, or a replacement for the 60Q result. It should only invite the user to inspect more specific task, environment, and role-responsibility context.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecReportModuleSelectorTest.php --no-ansi --display-warnings` — 11 tests, 319 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings` — 172 tests, 103059 assertions
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php tests/Unit/Services/Riasec/Riasec140qLayerSlotRegistryTest.php` — pass
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No 140Q three-card asset rewrite; that is RIASEC-CONTENT-140CTX-01.
- No 140Q projection/structural comparison rule changes; those are later scoped PRs.
- No CMS write, production import, manual server mutation, staging wait, or deploy.
