### PR TITLE
SECURITY-169-API-03: harden PDF token and locked MBTI report access

### DIFF
--- a/backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php
+++ b/backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php
@@ -102,6 +102,14 @@ final class GotenbergChromiumPdfClient
             throw new InvalidArgumentException($label.' must use http on a private network.');
         }
 
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            throw new InvalidArgumentException($label.' must not include URL credentials.');
+        }
+
+        if (isset($parts['fragment'])) {
+            throw new InvalidArgumentException($label.' must not include a URL fragment.');
+        }
+
         if ($host === '' || ! $this->isPrivateHost($host)) {
             throw new InvalidArgumentException($label.' must resolve to a private/internal host.');
         }
@@ -131,7 +139,7 @@ final class GotenbergChromiumPdfClient
         }
 
         if ((bool) config('gotenberg.allow_single_label_hosts', true) && ! str_contains($host, '.')) {
-            return true;
+            return in_array($host, (array) config('gotenberg.allowed_single_label_hosts', []), true);
         }
 
         foreach ((array) config('gotenberg.allowed_private_suffixes', []) as $suffix) {

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -281,20 +281,24 @@ final class ReportPdfDocumentService
             $manifestHash,
             $variant
         ));
-        $cached = $this->artifactStore->getFirst($candidates);
-        if (is_string($cached) && $cached !== '') {
-            if (! $this->legacyDrainEnabled() && ! $this->artifactStore->exists($path)) {
-                $this->artifactStore->put($path, $cached);
-            }
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        $bypassCache = $scaleCode === 'MBTI' && $locked;
+        if (! $bypassCache) {
+            $cached = $this->artifactStore->getFirst($candidates);
+            if (is_string($cached) && $cached !== '') {
+                if (! $this->legacyDrainEnabled() && ! $this->artifactStore->exists($path)) {
+                    $this->artifactStore->put($path, $cached);
+                }
 
-            return [
-                'binary' => $cached,
-                'storage_path' => $path,
-                'variant' => $variant,
-                'locked' => $locked,
-                'manifest_hash' => $manifestHash,
-                'cached' => true,
-            ];
+                return [
+                    'binary' => $cached,
+                    'storage_path' => $path,
+                    'variant' => $variant,
+                    'locked' => $locked,
+                    'manifest_hash' => $manifestHash,
+                    'cached' => true,
+                ];
+            }
         }
 
         $report = is_array($gate['report'] ?? null) ? $gate['report'] : [];
@@ -317,8 +321,8 @@ final class ReportPdfDocumentService
             ?? data_get($result?->result_json, 'normed_json.quality.level', '')
         )));
 
-        $pdfBinary = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI'
-            ? $this->buildMbtiDocument($attempt, $result)
+        $pdfBinary = $scaleCode === 'MBTI'
+            ? $this->buildMbtiDocument($attempt, $result, $locked, $variant)
             : $this->buildDocument(
                 (string) $attempt->id,
                 (string) ($attempt->scale_code ?? ''),
@@ -580,8 +584,25 @@ final class ReportPdfDocumentService
         return sprintf('fermatmind-enneagram-%s-%s.pdf', $slug, $date);
     }
 
-    private function buildMbtiDocument(Attempt $attempt, ?Result $result): string
+    private function buildMbtiDocument(Attempt $attempt, ?Result $result, bool $locked, string $variant): string
     {
+        if ($locked) {
+            $gotenbergPdf = $this->buildMbtiGotenbergDocument($attempt);
+            if (is_string($gotenbergPdf)) {
+                return $gotenbergPdf;
+            }
+
+            return $this->buildDocument(
+                (string) $attempt->id,
+                'MBTI',
+                true,
+                $this->normalizeVariant($variant),
+                '',
+                '',
+                []
+            );
+        }
+
         $gotenbergPdf = $this->buildMbtiGotenbergDocument($attempt);
         if (is_string($gotenbergPdf)) {
             return $gotenbergPdf;

--- a/backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php
+++ b/backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Report\Pdf;
 
 use App\Models\Attempt;
+use RuntimeException;
 
 final class ResultPagePdfTokenService
 {
@@ -53,7 +54,16 @@ final class ResultPagePdfTokenService
         }
 
         [$encodedPayload, $signature] = explode('.', $token, 2);
-        if ($encodedPayload === '' || $signature === '' || ! hash_equals($this->sign($encodedPayload), $signature)) {
+        if ($encodedPayload === '' || $signature === '') {
+            return null;
+        }
+
+        try {
+            $expectedSignature = $this->sign($encodedPayload);
+        } catch (RuntimeException) {
+            return null;
+        }
+        if (! hash_equals($expectedSignature, $signature)) {
             return null;
         }
 
@@ -141,7 +151,19 @@ final class ResultPagePdfTokenService
             return $secret;
         }
 
-        return 'fap-result-page-pdf-local-key';
+        $appKey = trim((string) config('app.key', ''));
+        if (str_starts_with($appKey, 'base64:')) {
+            $decoded = base64_decode(substr($appKey, 7), true);
+            if (is_string($decoded) && strlen($decoded) >= 32) {
+                return $decoded;
+            }
+        }
+
+        if ($appKey !== '') {
+            return $appKey;
+        }
+
+        throw new RuntimeException('MBTI result-page PDF token secret is not configured.');
     }
 
     private function base64UrlEncode(string $value): string

--- a/backend/config/gotenberg.php
+++ b/backend/config/gotenberg.php
@@ -16,6 +16,10 @@ return [
     'timeout_seconds' => (int) env('GOTENBERG_TIMEOUT_SECONDS', 60),
     'connect_timeout_seconds' => (int) env('GOTENBERG_CONNECT_TIMEOUT_SECONDS', 5),
     'allow_single_label_hosts' => (bool) env('GOTENBERG_ALLOW_SINGLE_LABEL_HOSTS', true),
+    'allowed_single_label_hosts' => array_values(array_filter(array_map(
+        static fn ($host) => strtolower(trim((string) $host)),
+        explode(',', (string) env('GOTENBERG_ALLOWED_SINGLE_LABEL_HOSTS', 'gotenberg,frontend,localhost'))
+    ))),
     'allowed_private_suffixes' => array_values(array_filter(array_map(
         static fn ($suffix) => strtolower(trim((string) $suffix)),
         explode(',', (string) env('GOTENBERG_ALLOWED_PRIVATE_SUFFIXES', '.internal,.local,.lan,.svc,.cluster.local'))

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -71014,6 +71014,10 @@
       "deployment": {
         "status": "not_run",
         "evidence": "No staging wait, manual server deploy, production import, production deploy, CMS write, search submission, sitemap, llms, canonical, noindex, or JSON-LD action was triggered."
+      },
+      "github_pr": {
+        "status": "opened",
+        "evidence": "Opened PR #2629 from codex/security-169-api-03-harden-pdf-token-and-locked-mbti-report-access to main."
       }
     },
     "scope_validation": {
@@ -71039,8 +71043,8 @@
       "status": "pass",
       "evidence": "Changed files are confined to API-03 allowed PDF token, Gotenberg URL, locked MBTI PDF access, config, and train state paths."
     },
-    "pr_url": null,
-    "commit_sha": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2629",
+    "commit_sha": "672afae347e6a71c1a7eddc712fc11933c1ece54",
     "production_write_execution": false,
     "database_mutation": false,
     "cms_mutation": false,
@@ -71063,6 +71067,11 @@
         "at": "2026-07-03T02:17:31+08:00",
         "status": "local_checks_passed",
         "note": "Implemented PDF token secret hardening, locked MBTI PDF cache bypass/fallback, and stricter private Gotenberg URL validation; local focused tests, route list, SQLite migrate, full ci_verify_mbti, and scope validation passed."
+      },
+      {
+        "at": "2026-07-03T02:20:00+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2629 and pushed SECURITY-169-API-03 implementation commit 672afae347e6a71c1a7eddc712fc11933c1ece54."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70947,12 +70947,97 @@
     "depends_on": [
       "SECURITY-169-API-02"
     ],
-    "status": "planned",
+    "status": "local_checks_passed",
     "checks": {
       "authorization": {
         "status": "pass",
         "evidence": "Authorized by the 2026-07-03 SECURITY-169 attached /goal."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "SECURITY-169-API-02 implementation PR #2620 was squash-merged as 915a50976c16ea4d1a73db038774610fd1e0dcab and ledger closeout PR #2623 was merged as 28a74b6d2bfac459bd20ebdc8d5e408bd896e233."
+      },
+      "base_sync": {
+        "status": "pass",
+        "evidence": "API-03 branch was rebased onto latest origin/main cf971a59671519fbde549288bb8eb8a1e3cd4d2d before final validation."
+      },
+      "php_lint": {
+        "status": "pass",
+        "commands": [
+          "cd backend && php -l app/Services/Report/Pdf/ResultPagePdfTokenService.php",
+          "cd backend && php -l app/Services/Report/Pdf/GotenbergChromiumPdfClient.php",
+          "cd backend && php -l app/Services/Report/Pdf/ReportPdfDocumentService.php",
+          "cd backend && php -l config/gotenberg.php"
+        ],
+        "evidence": "All modified PHP/config files reported no syntax errors."
+      },
+      "focused_pdf_contract_tests": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Report/PdfGotenbergEngineSpikeTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/AttemptReportAccessReadTest.php --filter='mbti|result_page_pdf|projection' --no-ansi"
+        ],
+        "evidence": "Focused PDF/access contract tests passed locally; remaining warnings were existing fixture file_get_contents warnings."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && ./vendor/bin/pint --test app/Services/Report/Pdf/ResultPagePdfTokenService.php app/Services/Report/Pdf/GotenbergChromiumPdfClient.php app/Services/Report/Pdf/ReportPdfDocumentService.php config/gotenberg.php",
+        "evidence": "Pint found no formatting changes required for API-03 modified files."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "Route list completed successfully after API-03 changes."
+      },
+      "sqlite_migrate": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-03.sqlite php artisan migrate --force --no-ansi",
+        "evidence": "SQLite migrations completed successfully; API-03 adds no migration."
+      },
+      "ci_verify_mbti": {
+        "status": "pass",
+        "command": "bash backend/scripts/ci_verify_mbti.sh",
+        "evidence": "Full MBTI CI chain passed from repo root on 2026-07-02T18:16:26Z; BigFive compiled JSON side effects were restored because they are outside API-03 scope."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors after restoring generated BigFive compiled artifacts."
+      },
+      "json_state": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "evidence": "PR train state JSON parsed successfully after API-03 state update."
+      },
+      "deployment": {
+        "status": "not_run",
+        "evidence": "No staging wait, manual server deploy, production import, production deploy, CMS write, search submission, sitemap, llms, canonical, noindex, or JSON-LD action was triggered."
       }
+    },
+    "scope_validation": {
+      "allowed_files": [
+        "backend/app/Http/Controllers/API/V0_3/AttemptReadController.php",
+        "backend/app/Services/Report/Pdf/ReportPdfDocumentService.php",
+        "backend/routes/api.php",
+        "backend/config/gotenberg.php",
+        "backend/app/Services/Report/Pdf/Mbti/MbtiPdfPayloadBuilder.php",
+        "backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php",
+        "backend/app/Services/Commerce/MbtiAccessHubBuilder.php",
+        "backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php",
+        "docs/codex/pr-train-state.json"
+      ],
+      "changed_files": [
+        "backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php",
+        "backend/app/Services/Report/Pdf/ReportPdfDocumentService.php",
+        "backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php",
+        "backend/config/gotenberg.php",
+        "docs/codex/pr-train-state.json"
+      ],
+      "outside_scope_files": [],
+      "status": "pass",
+      "evidence": "Changed files are confined to API-03 allowed PDF token, Gotenberg URL, locked MBTI PDF access, config, and train state paths."
     },
     "pr_url": null,
     "commit_sha": null,
@@ -70973,6 +71058,11 @@
         "at": "2026-07-03T00:00:00+08:00",
         "status": "planned",
         "note": "Registered authorized SECURITY-169-API-03; execution waits for declared dependency merge."
+      },
+      {
+        "at": "2026-07-03T02:17:31+08:00",
+        "status": "local_checks_passed",
+        "note": "Implemented PDF token secret hardening, locked MBTI PDF cache bypass/fallback, and stricter private Gotenberg URL validation; local focused tests, route list, SQLite migrate, full ci_verify_mbti, and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Remove the hard-coded MBTI result-page PDF token fallback secret; use configured secret or Laravel app key and fail closed when unavailable.
- Prevent locked MBTI `report.pdf` from serving legacy cached full-content artifacts; keep Gotenberg locked-token generation when available and fall back to a safe locked metadata PDF.
- Tighten Gotenberg private URL validation by rejecting credentials/fragments and allowing single-label hosts only from an explicit allowlist.
- Mark SECURITY-169-API-03 local checks and scope validation in `docs/codex/pr-train-state.json`.

## Scope validation
Changed files are limited to SECURITY-169-API-03 allowed paths:
- `backend/app/Services/Report/Pdf/GotenbergChromiumPdfClient.php`
- `backend/app/Services/Report/Pdf/ReportPdfDocumentService.php`
- `backend/app/Services/Report/Pdf/ResultPagePdfTokenService.php`
- `backend/config/gotenberg.php`
- `docs/codex/pr-train-state.json`

## Tests
- `cd backend && php -l app/Services/Report/Pdf/ResultPagePdfTokenService.php`
- `cd backend && php -l app/Services/Report/Pdf/GotenbergChromiumPdfClient.php`
- `cd backend && php -l app/Services/Report/Pdf/ReportPdfDocumentService.php`
- `cd backend && php -l config/gotenberg.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Report/PdfGotenbergEngineSpikeTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/AttemptReportAccessReadTest.php --filter='mbti|result_page_pdf|projection' --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Services/Report/Pdf/ResultPagePdfTokenService.php app/Services/Report/Pdf/GotenbergChromiumPdfClient.php app/Services/Report/Pdf/ReportPdfDocumentService.php config/gotenberg.php`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-03.sqlite php artisan migrate --force --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- SECURITY-169-API-03 path scope check passed.

## Not run / not included
- No staging deploy wait.
- No manual server deploy.
- No production deploy.
- No production import.
- No CMS write, search submission, sitemap, llms, canonical, noindex, or JSON-LD action.
