### PR TITLE
feat(seo): gate personality comparison sitemap authority

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -7,6 +7,7 @@ use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
 use App\Models\ContentPage;
+use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariant;
 use App\Models\TopicProfile;
 use App\Services\Career\CareerDirectoryAuthorityService;
@@ -14,6 +15,7 @@ use App\Services\Career\Dataset\CareerDatasetPublicationMetadataService;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerGuideSeoService;
 use App\Services\Cms\CareerJobSeoService;
+use App\Services\Cms\Mbti64CrossTypeComparisonPublicReadModel;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\PersonalityProfileService;
 use App\Services\Cms\TopicProfileSeoService;
@@ -47,6 +49,7 @@ class SitemapGenerator
         private readonly CareerJobSeoService $careerJobSeoService,
         private readonly PersonalityProfileService $personalityProfileService,
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
+        private readonly Mbti64CrossTypeComparisonPublicReadModel $crossTypeComparisonReadModel,
         private readonly TopicProfileSeoService $topicProfileSeoService,
         private readonly ScaleRegistry $scaleRegistry,
         private readonly CareerDatasetPublicationMetadataService $datasetPublicationMetadataService,
@@ -95,6 +98,7 @@ class SitemapGenerator
             $this->getCareerJobUrls(),
             $this->getCareerGuideUrls(),
             $this->getPersonalityUrls(),
+            $this->getPersonalityComparisonUrls(),
             $this->getTopicUrls(),
             $this->getContentPageUrls(),
             $this->getStaticIndexUrls()
@@ -302,6 +306,105 @@ class SitemapGenerator
                 'slug' => 'personality-list:'.$segment,
                 'updated_at' => $lastmod->toDateTimeString(),
             ];
+        }
+
+        return $urls;
+    }
+
+    private function getPersonalityComparisonUrls(): array
+    {
+        return array_merge(
+            $this->getPersonalityAtComparisonUrls(),
+            $this->getPersonalityCrossTypeComparisonUrls()
+        );
+    }
+
+    private function getPersonalityAtComparisonUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $rows = $this->personalityProfileService->getSitemapPublicProfiles();
+        $urls = [];
+
+        foreach ($rows as $row) {
+            $locale = trim((string) $row->locale);
+            $segment = $this->personalityProfileSeoService->mapBackendLocaleToFrontendSegment($locale);
+            $baseTypeCode = strtoupper(trim((string) $row->canonical_type_code ?: (string) $row->type_code));
+            if ($segment === '' || ! in_array($baseTypeCode, PersonalityProfile::BASE_TYPE_CODES, true)) {
+                continue;
+            }
+
+            $variants = [];
+            foreach ($row->variants as $variant) {
+                if (! $variant instanceof PersonalityProfileVariant || ! (bool) $variant->is_published) {
+                    continue;
+                }
+
+                $variantCode = strtoupper(trim((string) $variant->variant_code));
+                if (! in_array($variantCode, ['A', 'T'], true)) {
+                    continue;
+                }
+
+                $variants[$variantCode] = $variant;
+            }
+
+            if (! isset($variants['A'], $variants['T'])) {
+                continue;
+            }
+
+            $slug = strtolower($baseTypeCode).'-a-vs-'.strtolower($baseTypeCode).'-t';
+            $lastmod = $this->latestCarbon([
+                $variants['A']->updated_at,
+                $variants['A']->published_at,
+                $variants['T']->updated_at,
+                $variants['T']->published_at,
+                $row->updated_at,
+                $row->published_at,
+            ]) ?? now();
+
+            $urls[] = [
+                'loc' => $baseUrl.'/'.$segment.'/personality/'.$slug,
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'personality-comparison:at:'.$segment.':'.$slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return $urls;
+    }
+
+    private function getPersonalityCrossTypeComparisonUrls(): array
+    {
+        $urls = [];
+        $updatedAt = now();
+
+        foreach (PersonalityProfile::SUPPORTED_LOCALES as $locale) {
+            $segment = $this->personalityProfileSeoService->mapBackendLocaleToFrontendSegment((string) $locale);
+            if ($segment === '') {
+                continue;
+            }
+
+            foreach ($this->crossTypeComparisonReadModel->list((string) $locale) as $item) {
+                if (($item['is_public'] ?? false) !== true || ($item['is_indexable'] ?? false) !== true) {
+                    continue;
+                }
+
+                $canonicalUrl = trim((string) ($item['canonical_url'] ?? $item['public_url'] ?? ''));
+                $slug = trim((string) ($item['slug'] ?? ''));
+                if ($canonicalUrl === '' || $slug === '') {
+                    continue;
+                }
+
+                $urls[] = [
+                    'loc' => $canonicalUrl,
+                    'lastmod' => $updatedAt->toAtomString(),
+                    'slug' => 'personality-comparison:cross-type:'.$segment.':'.$slug,
+                    'updated_at' => $updatedAt->toDateTimeString(),
+                ];
+            }
         }
 
         return $urls;
@@ -872,6 +975,23 @@ class SitemapGenerator
         } catch (\Throwable $e) {
             return null;
         }
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     */
+    private function latestCarbon(array $values): ?Carbon
+    {
+        $latest = null;
+
+        foreach ($values as $value) {
+            $candidate = $value instanceof Carbon ? $value : $this->parseUpdatedAt($value);
+            if ($candidate instanceof Carbon && ($latest === null || $candidate->gt($latest))) {
+                $latest = $candidate;
+            }
+        }
+
+        return $latest;
     }
 
     private function isIndexablePublic(mixed $viewPolicyJson): bool

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -11,6 +11,7 @@ use App\Models\PersonalityProfileSeoMeta;
 use App\Models\PersonalityProfileVariant;
 use App\Models\PersonalityProfileVariantSection;
 use App\Models\PersonalityProfileVariantSeoMeta;
+use App\Services\SEO\SitemapGenerator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -753,6 +754,65 @@ final class PersonalityPublicApiTest extends TestCase
         self::assertStringNotContainsString('/zh/orders', (string) $response->getContent());
         self::assertStringNotContainsString('token=', (string) $response->getContent());
         self::assertStringNotContainsString('order_no=', (string) $response->getContent());
+    }
+
+    public function test_personality_comparison_sitemap_source_uses_indexability_gate(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $intj = $this->createProfile([
+            'type_code' => 'INTJ',
+            'canonical_type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($intj, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+        ]);
+        $this->createVariant($intj, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+        ]);
+
+        $intp = $this->createProfile([
+            'type_code' => 'INTP',
+            'canonical_type_code' => 'INTP',
+            'slug' => 'intp',
+            'locale' => 'en',
+            'title' => 'INTP Personality Type',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($intp, [
+            'canonical_type_code' => 'INTP',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTP-A',
+        ]);
+        $this->createVariant($intp, [
+            'canonical_type_code' => 'INTP',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTP-T',
+        ]);
+
+        $locs = collect(app(SitemapGenerator::class)->generateUrls())
+            ->pluck('loc')
+            ->all();
+
+        self::assertContains('https://fermatmind.com/en/personality/intj-a-vs-intj-t', $locs);
+        self::assertNotContains('https://fermatmind.com/en/personality/intp-a-vs-intp-t', $locs);
+        self::assertNotContains('https://fermatmind.com/zh/personality/intj-vs-intp', $locs);
     }
 
     public function test_personality_comparison_endpoint_returns_cross_type_detail_from_backend_authority(): void


### PR DESCRIPTION
## What changed
- Added personality comparison URL enumeration to the backend sitemap authority.
- Added A/T comparison sitemap entries only when the base personality profile is public/indexable and both A/T variants are published.
- Added cross-type comparison sitemap plumbing behind the public/indexability gate; current cross-type assets remain excluded while `is_indexable=false`.
- Added a focused feature test covering indexable A/T inclusion, non-indexable A/T exclusion, and current cross-type exclusion.

## Why
SEO-01 needs backend authority before frontend sitemap/llms/JSON-LD integration. The frontend public sitemap source already trusts backend `/api/v0.5/seo/sitemap-source`, so comparison discoverability must be gated here first.

## Validation
- `php artisan test --filter=PersonalityPublicApiTest --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `./vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/V0_5/PersonalityPublicApiTest.php`
- `git diff --check`

## Intentionally deferred
- fap-web llms/llms-full/JSON-LD integration for comparison pages.
- Any CMS write/import/publish action.
- Search submission, indexing requests, sitemap runtime release, or production deploy.

## Repository rule impact
This keeps personality comparison discoverability backend-authoritative. The frontend must consume backend/public API or backend sitemap authority and must not introduce local editorial fallback content for comparison SEO enumeration.
