### PR TITLE
RIASEC-CONTENT-140CTX-02 harden RIASEC 140Q structural selection

### DIFF
--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -71,6 +71,7 @@ final class RiasecPublicProjectionService
                 'compare_compatibility_group' => (string) ($comparePolicy['compare_compatibility_group'] ?? ''),
                 'cross_form_comparable' => false,
                 'raw_score_delta_allowed' => false,
+                'cross_form_interpretation' => 'emphasis_difference_only',
             ],
             'measurement_contract_v1' => $measurementContract,
             'compare_policy_v1' => $comparePolicy,
@@ -127,7 +128,9 @@ final class RiasecPublicProjectionService
                 'compare_compatibility_group' => (string) ($comparePolicy['compare_compatibility_group'] ?? ''),
                 'cross_form_comparable' => false,
                 'raw_score_delta_allowed' => false,
+                'cross_form_interpretation' => 'emphasis_difference_only',
             ],
+            'structural_difference' => $this->structuralDifferencePolicy($formCode, $qualityRule['quality_state'] ?? 'normal', $payload, $comparePolicy),
             'measurement_evidence' => [
                 'measurement_contract_version' => (string) ($measurementContract['schema_version'] ?? RiasecMeasurementContract::SCHEMA_VERSION),
                 'scoring_spec_version' => $this->firstString([
@@ -229,7 +232,9 @@ final class RiasecPublicProjectionService
             );
         }
 
-        foreach ($this->selected140qDimensionLayerSlots($topCode, $formCode, $qualityState) as $slot) {
+        $structuralDifferencePolicy = (array) ($projection['structural_difference'] ?? []);
+
+        foreach ($this->selected140qDimensionLayerSlots($topCode, $formCode, $qualityState, $structuralDifferencePolicy) as $slot) {
             $this->appendRenderableSlot(
                 $slots,
                 $slot,
@@ -239,7 +244,7 @@ final class RiasecPublicProjectionService
             );
         }
 
-        foreach ($this->selected140qSlots($formCode, $qualityState) as $slotName) {
+        foreach ($this->selected140qSlots($formCode, $qualityState, $structuralDifferencePolicy) as $slotName) {
             $moduleKey = str_starts_with($slotName, '140q_') ? '140q_cta' : '140q_context_cards';
             $this->appendRenderableSlot(
                 $slots,
@@ -379,7 +384,7 @@ final class RiasecPublicProjectionService
     /**
      * @return list<array<string,mixed>>
      */
-    private function selected140qDimensionLayerSlots(string $topCode, string $formCode, string $qualityState): array
+    private function selected140qDimensionLayerSlots(string $topCode, string $formCode, string $qualityState, array $structuralDifferencePolicy): array
     {
         if ($formCode !== 'riasec_140' || in_array($qualityState, ['low_quality', 'retake_recommended'], true)) {
             return [];
@@ -391,10 +396,14 @@ final class RiasecPublicProjectionService
             return [];
         }
 
+        $layerStates = is_array($structuralDifferencePolicy['layer_states'] ?? null)
+            ? $structuralDifferencePolicy['layer_states']
+            : [];
+
         return [
-            $this->deepCopySlots->resolve140qDimensionLayerSlot($dimensionCode, 'task', 'agreement'),
-            $this->deepCopySlots->resolve140qDimensionLayerSlot($dimensionCode, 'environment', 'agreement'),
-            $this->deepCopySlots->resolve140qDimensionLayerSlot($dimensionCode, 'role', 'agreement'),
+            $this->deepCopySlots->resolve140qDimensionLayerSlot($dimensionCode, 'task', $this->normalize140qSelectionLayerState((string) ($layerStates['task'] ?? 'agreement'))),
+            $this->deepCopySlots->resolve140qDimensionLayerSlot($dimensionCode, 'environment', $this->normalize140qSelectionLayerState((string) ($layerStates['environment'] ?? 'agreement'))),
+            $this->deepCopySlots->resolve140qDimensionLayerSlot($dimensionCode, 'role', $this->normalize140qSelectionLayerState((string) ($layerStates['role'] ?? 'agreement'))),
         ];
     }
 
@@ -415,16 +424,72 @@ final class RiasecPublicProjectionService
     /**
      * @return list<string>
      */
-    private function selected140qSlots(string $formCode, string $qualityState): array
+    private function selected140qSlots(string $formCode, string $qualityState, array $structuralDifferencePolicy): array
     {
         if (in_array($qualityState, ['low_quality', 'retake_recommended'], true)) {
             return [];
         }
         if ($formCode === 'riasec_140') {
-            return ['task_activity_card', 'environment_card', 'role_responsibility_card', 'layer_agreement'];
+            $layerStates = is_array($structuralDifferencePolicy['layer_states'] ?? null)
+                ? $structuralDifferencePolicy['layer_states']
+                : [];
+            $aggregateLayerState = in_array('tension', array_values($layerStates), true) ? 'layer_tension' : 'layer_agreement';
+
+            return ['task_activity_card', 'environment_card', 'role_responsibility_card', $aggregateLayerState];
         }
 
         return ['layer_unavailable', '140q_cta'];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $comparePolicy
+     * @return array<string,mixed>
+     */
+    private function structuralDifferencePolicy(string $formCode, string $qualityState, array $payload, array $comparePolicy): array
+    {
+        $enabled = $formCode === 'riasec_140' && ! in_array($qualityState, ['low_quality', 'retake_recommended'], true);
+        $layerStates = is_array(data_get($payload, 'riasec_140q_layer_states'))
+            ? (array) data_get($payload, 'riasec_140q_layer_states')
+            : (array) data_get($payload, 'enhanced_breakdown.layer_states', []);
+
+        return [
+            'schema_version' => 'riasec.structural_difference_policy.v1',
+            'enabled' => $enabled,
+            'state' => $enabled
+                ? $this->normalizeStructuralDifferenceState((string) data_get($payload, 'structural_difference_state', data_get($comparePolicy, 'structural_difference_state', 'different_emphasis')))
+                : 'cross_form_not_comparable',
+            'basis' => 'task_environment_role_emphasis_only',
+            'selection_rule' => 'explicit_layer_state_or_default_agreement_without_score_delta',
+            'score_comparison_allowed' => false,
+            'raw_score_delta_allowed' => false,
+            'raw_scores_used_for_selection' => false,
+            'different_form_scores_comparable' => false,
+            'layer_states' => [
+                'task' => $this->normalize140qSelectionLayerState((string) ($layerStates['task'] ?? data_get($payload, 'task_layer_state', 'agreement'))),
+                'environment' => $this->normalize140qSelectionLayerState((string) ($layerStates['environment'] ?? data_get($payload, 'environment_layer_state', 'agreement'))),
+                'role' => $this->normalize140qSelectionLayerState((string) ($layerStates['role'] ?? data_get($payload, 'role_layer_state', 'agreement'))),
+            ],
+            'public_copy_boundary' => '60Q 与 140Q 只能读作线索强调不同，不比较 raw score，不输出优劣或覆盖判断。',
+        ];
+    }
+
+    private function normalize140qSelectionLayerState(string $layerState): string
+    {
+        $normalized = strtolower(trim($layerState));
+
+        return in_array($normalized, ['agreement', 'tension', 'unavailable', 'insufficient_quality', 'not_applicable_60q_only'], true)
+            ? $normalized
+            : 'agreement';
+    }
+
+    private function normalizeStructuralDifferenceState(string $state): string
+    {
+        $normalized = strtolower(trim($state));
+
+        return in_array($normalized, RiasecDeepCopySlotRegistry::STRUCTURAL_DIFFERENCE_STATES, true)
+            ? $normalized
+            : 'different_emphasis';
     }
 
     /**

--- a/backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php
@@ -331,6 +331,33 @@ final class RiasecFullContentFixtureMatrixTest extends TestCase
         }
     }
 
+    public function test_140q_projection_selects_layer_emphasis_without_cross_form_score_comparison(): void
+    {
+        $projection = app(RiasecPublicProjectionService::class)->buildV2FromResult($this->resultFor140qLayerTension(), 'zh-CN');
+
+        $this->assertFalse((bool) data_get($projection, 'form.raw_score_delta_allowed'));
+        $this->assertSame('emphasis_difference_only', data_get($projection, 'form.cross_form_interpretation'));
+        $this->assertSame('task_environment_role_emphasis_only', data_get($projection, 'structural_difference.basis'));
+        $this->assertSame('explicit_layer_state_or_default_agreement_without_score_delta', data_get($projection, 'structural_difference.selection_rule'));
+        $this->assertFalse((bool) data_get($projection, 'structural_difference.raw_score_delta_allowed'));
+        $this->assertFalse((bool) data_get($projection, 'structural_difference.raw_scores_used_for_selection'));
+        $this->assertSame('tension', data_get($projection, 'structural_difference.layer_states.environment'));
+        $this->assertArrayNotHasKey('raw_scores_delta', $projection);
+        $this->assertArrayNotHasKey('domains_delta', $projection);
+
+        $environmentSlot = $this->firstSlotForModuleAndState($projection, '140q_context_cards', [
+            'layer' => 'environment',
+            'layer_state' => 'tension',
+        ]);
+        $this->assertStringContainsString('环境层-张力', (string) data_get($environmentSlot, 'content.environment_card'));
+
+        $aggregateSlot = $this->firstSlotForModuleAndState($projection, '140q_context_cards', [
+            'slot_name' => 'layer_tension',
+            'layer_state' => 'tension',
+        ]);
+        $this->assertStringContainsString('张力', (string) data_get($aggregateSlot, 'content.title'));
+    }
+
     /**
      * @return array<string,mixed>
      */
@@ -375,6 +402,30 @@ final class RiasecFullContentFixtureMatrixTest extends TestCase
         $this->fail('Missing RIASEC projection slot for module '.$moduleKey);
     }
 
+    /**
+     * @param  array<string,mixed>  $projection
+     * @param  array<string,string>  $state
+     * @return array<string,mixed>
+     */
+    private function firstSlotForModuleAndState(array $projection, string $moduleKey, array $state): array
+    {
+        foreach ((array) data_get($projection, 'deep_content_slots_v1.slots', []) as $slot) {
+            if (($slot['module_key'] ?? null) !== $moduleKey) {
+                continue;
+            }
+
+            foreach ($state as $key => $value) {
+                if (data_get($slot, 'state.'.$key) !== $value) {
+                    continue 2;
+                }
+            }
+
+            return $slot;
+        }
+
+        $this->fail('Missing RIASEC projection slot for module '.$moduleKey.' and state '.json_encode($state, JSON_THROW_ON_ERROR));
+    }
+
     private function resultForOrderedCode(string $orderedCode): Result
     {
         $scores = array_fill_keys(['R', 'I', 'A', 'S', 'E', 'C'], 0);
@@ -395,6 +446,33 @@ final class RiasecFullContentFixtureMatrixTest extends TestCase
                 'form_code' => 'riasec_60',
                 'scoring_spec_version' => 'riasec_standard_60_v1',
                 'scores_0_100' => $scores,
+            ],
+        ]);
+    }
+
+    private function resultFor140qLayerTension(): Result
+    {
+        $scores = ['R' => 100, 'I' => 75, 'A' => 50, 'S' => 0, 'E' => 0, 'C' => 0];
+
+        return new Result([
+            'scale_code' => 'RIASEC',
+            'type_code' => 'RIA',
+            'scores_pct' => $scores,
+            'result_json' => [
+                'top_code' => 'RIA',
+                'primary_type' => 'R',
+                'secondary_type' => 'I',
+                'tertiary_type' => 'A',
+                'answer_count' => 140,
+                'form_code' => 'riasec_140',
+                'scoring_spec_version' => 'riasec_enhanced_140_v1',
+                'scores_0_100' => $scores,
+                'structural_difference_state' => 'layer_tension',
+                'riasec_140q_layer_states' => [
+                    'task' => 'agreement',
+                    'environment' => 'tension',
+                    'role' => 'agreement',
+                ],
             ],
         ]);
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70411,9 +70411,9 @@
     "depends_on": [
       "RIASEC-CONTENT-140CTX-01"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": "c8ba068c4347ecb5649b78f17777bc19277c9004",
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "2cb334c4fae3473c417060bb51122dbc190ba6d8",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2631",
     "checks": {
       "phpunit_projection_structural_tests": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php --no-ansi --display-warnings",
@@ -70462,6 +70462,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Added explicit structural-difference projection policy and layer-state selection without raw-score delta; local RIASEC unit subset and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:31:16Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2631 after 140CTX-02 local validation, repeated latest-main rebases, and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70329,8 +70329,8 @@
     "depends_on": [
       "RIASEC-CONTENT-140CTA-01"
     ],
-    "status": "pr_opened",
-    "commit_sha": "c3ab256463086dc0ad0088ea7cb5bb3385447aec",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "9a5694163e7c601783dff1361f32e31cdf3373e9",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2627",
     "checks": {
       "phpunit_140q_asset_slot_and_boundary_tests": {
@@ -70359,14 +70359,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T18:20:58Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl",
         "backend/tests/Unit/Services/Riasec/Riasec140qLayerAssetRegistryTest.php",
@@ -70391,8 +70391,15 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2627 after 140CTX-01 local validation, latest-main rebase, and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:25:42Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2627 merged; origin/main contains merge commit; local main synced; task branch cleaned. Recorded during 140CTX-02 ledger reconciliation."
       }
-    ]
+    ],
+    "merge_commit_sha": "20dc6320ab214f07aa6d06eace6f4c4bea072280"
   },
   "RIASEC-CONTENT-140CTX-02": {
     "id": "RIASEC-CONTENT-140CTX-02",
@@ -70404,19 +70411,44 @@
     "depends_on": [
       "RIASEC-CONTENT-140CTX-01"
     ],
-    "status": "authorized_pending_start",
-    "commit_sha": null,
+    "status": "local_validation_passed",
+    "commit_sha": "PENDING_COMMIT_SHA",
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "phpunit_projection_structural_tests": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "14 tests, 997 assertions"
+      },
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "175 tests, 104218 assertions"
+      },
+      "pint_and_php_lint": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecPublicProjectionService.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php && php -l app/Services/Riasec/RiasecPublicProjectionService.php",
+        "status": "passed",
+        "summary": "2 files passed; no syntax errors"
+      },
+      "manifest_state_parse_and_diff_check": {
+        "command": "ruby YAML parse; python JSON parse; git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecPublicProjectionService.php",
+        "backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -70424,6 +70456,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T18:25:42Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Added explicit structural-difference projection policy and layer-state selection without raw-score delta; local RIASEC unit subset and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70412,7 +70412,7 @@
       "RIASEC-CONTENT-140CTX-01"
     ],
     "status": "local_validation_passed",
-    "commit_sha": "PENDING_COMMIT_SHA",
+    "commit_sha": "c8ba068c4347ecb5649b78f17777bc19277c9004",
     "pr_url": null,
     "checks": {
       "phpunit_projection_structural_tests": {


### PR DESCRIPTION
## What changed
- Added an explicit public projection `structural_difference` policy for 140Q context interpretation.
- Made 140Q task/environment/role card selection use explicit layer states, defaulting safely to `agreement`, without reading raw scores or cross-form deltas.
- Switched the aggregate 140Q layer slot to `layer_tension` when a selected layer is explicitly marked tension.
- Added projection tests proving 140Q layer tension changes emphasis copy only and does not expose raw-score delta or cross-form score comparison.
- Reconciled prior 140CTX-01 post-merge ledger facts and recorded 140CTX-02 local validation in the PR train state.

## Why
60Q and 140Q live in different score spaces. The public result page should describe task/environment/role emphasis differences, not score movement, accuracy upgrades, or 60Q replacement.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php --no-ansi --display-warnings` — 14 tests, 997 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings` — 175 tests, 104218 assertions
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecPublicProjectionService.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php` — pass
- `cd backend && php -l app/Services/Riasec/RiasecPublicProjectionService.php` — pass
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No 140Q asset copy rewrite; that was 140CTX-01.
- No share/PDF/history changes.
- No CMS write, production import, manual server mutation, staging wait, or deploy.
