### PR TITLE
PR-EQ-ASSET-SCI-08: repair EQ career_environment decision boundaries

### DIFF
--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T18:17:36.121675Z",
+    "generated_at": "2026-07-02T18:29:17.574221Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -16200,43 +16200,43 @@
                 "interpersonal_density": {
                     "low": {
                         "zh-CN": {
-                            "label": "人际密度：低",
-                            "meaning": "互动频率、会议密度和需要读人的程度",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "人际密度：较低",
+                            "meaning": "工作中互动、会议、协调和读人信号的频率",
+                            "fit_signal": "可观察的环境线索：人际密度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度较低也可能带来额外压力。",
+                            "interview_question": "这个环境的低互动是真正稳定，还是只在出问题时集中爆发？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "会议是否有明确目的和结束条件",
+                                "反馈是否具体到行为和下一步",
+                                "是否允许暂时退出高情绪对话"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "这个环境的低互动是真正稳定，还是只在出问题时集中爆发？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Interpersonal density: low",
-                            "meaning": "the amount of interaction, meeting load, and people-reading required",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+                            "fit_signal": "Environment cue to observe: when interpersonal density is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low interpersonal density can still create pressure.",
+                            "interview_question": "Is the low interaction genuinely stable, or does communication pile up when something goes wrong?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether meetings have a clear purpose and end point",
+                                "Whether feedback names behavior and next steps",
+                                "Whether people can step out of emotionally loaded conversations when needed"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is the low interaction genuinely stable, or does communication pile up when something goes wrong? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "interpersonal_density_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "interpersonal_density_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "interpersonal_density",
                             "level": "low",
                             "overlay_imported": false
@@ -16244,43 +16244,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "人际密度：中",
-                            "meaning": "互动频率、会议密度和需要读人的程度",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "人际密度：中等",
+                            "meaning": "工作中互动、会议、协调和读人信号的频率",
+                            "fit_signal": "可观察的环境线索：人际密度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度中等也可能带来额外压力。",
+                            "interview_question": "团队有没有清楚的会议节奏、反馈方式和可暂停窗口？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "会议是否有明确目的和结束条件",
+                                "反馈是否具体到行为和下一步",
+                                "是否允许暂时退出高情绪对话"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "团队有没有清楚的会议节奏、反馈方式和可暂停窗口？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Interpersonal density: medium",
-                            "meaning": "the amount of interaction, meeting load, and people-reading required",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+                            "fit_signal": "Environment cue to observe: when interpersonal density is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium interpersonal density can still create pressure.",
+                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and pause windows?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether meetings have a clear purpose and end point",
+                                "Whether feedback names behavior and next steps",
+                                "Whether people can step out of emotionally loaded conversations when needed"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and pause windows? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "interpersonal_density_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "interpersonal_density_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "interpersonal_density",
                             "level": "medium",
                             "overlay_imported": false
@@ -16288,43 +16288,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "人际密度：高",
-                            "meaning": "互动频率、会议密度和需要读人的程度",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "人际密度：较高",
+                            "meaning": "工作中互动、会议、协调和读人信号的频率",
+                            "fit_signal": "可观察的环境线索：人际密度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度较高也可能带来额外压力。",
+                            "interview_question": "高互动是否配有清楚边界、交接方式和恢复空间？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "会议是否有明确目的和结束条件",
+                                "反馈是否具体到行为和下一步",
+                                "是否允许暂时退出高情绪对话"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高互动是否配有清楚边界、交接方式和恢复空间？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Interpersonal density: high",
-                            "meaning": "the amount of interaction, meeting load, and people-reading required",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+                            "fit_signal": "Environment cue to observe: when interpersonal density is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high interpersonal density can still create pressure.",
+                            "interview_question": "Does high interaction come with clear boundaries, handoff norms, and recovery space?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether meetings have a clear purpose and end point",
+                                "Whether feedback names behavior and next steps",
+                                "Whether people can step out of emotionally loaded conversations when needed"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does high interaction come with clear boundaries, handoff norms, and recovery space? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "interpersonal_density_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "interpersonal_density_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "interpersonal_density",
                             "level": "high",
                             "overlay_imported": false
@@ -16334,43 +16334,43 @@
                 "emotional_labor": {
                     "low": {
                         "zh-CN": {
-                            "label": "情绪劳动：低",
-                            "meaning": "需要承接、安抚或整理他人情绪的程度",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "情绪劳动：较低",
+                            "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+                            "fit_signal": "可观察的环境线索：情绪劳动较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动较低也可能带来额外压力。",
+                            "interview_question": "情绪劳动低，是因为流程清楚，还是因为情绪问题被延后处理？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "情绪承接是否被正式承认",
+                                "是否有复盘和轮换机制",
+                                "是否把“会安抚人”默认成个人义务"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "情绪劳动低，是因为流程清楚，还是因为情绪问题被延后处理？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Emotional labor: low",
-                            "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+                            "fit_signal": "Environment cue to observe: when emotional labor is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low emotional labor can still create pressure.",
+                            "interview_question": "Is emotional labor low because process is clear, or because emotional issues are postponed?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether emotional labor is formally recognized",
+                                "Whether there is review and rotation",
+                                "Whether soothing others is treated as a personal obligation"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is emotional labor low because process is clear, or because emotional issues are postponed? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "emotional_labor_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "emotional_labor_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "emotional_labor",
                             "level": "low",
                             "overlay_imported": false
@@ -16378,43 +16378,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "情绪劳动：中",
-                            "meaning": "需要承接、安抚或整理他人情绪的程度",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "情绪劳动：中等",
+                            "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+                            "fit_signal": "可观察的环境线索：情绪劳动中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动中等也可能带来额外压力。",
+                            "interview_question": "谁负责承接客户、同事或团队中的情绪压力？是否有轮换和复盘？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "情绪承接是否被正式承认",
+                                "是否有复盘和轮换机制",
+                                "是否把“会安抚人”默认成个人义务"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "谁负责承接客户、同事或团队中的情绪压力？是否有轮换和复盘？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Emotional labor: medium",
-                            "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+                            "fit_signal": "Environment cue to observe: when emotional labor is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium emotional labor can still create pressure.",
+                            "interview_question": "Who carries emotional pressure from clients, colleagues, or the team, and is there rotation or review?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether emotional labor is formally recognized",
+                                "Whether there is review and rotation",
+                                "Whether soothing others is treated as a personal obligation"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Who carries emotional pressure from clients, colleagues, or the team, and is there rotation or review? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "emotional_labor_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "emotional_labor_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "emotional_labor",
                             "level": "medium",
                             "overlay_imported": false
@@ -16422,43 +16422,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "情绪劳动：高",
-                            "meaning": "需要承接、安抚或整理他人情绪的程度",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "情绪劳动：较高",
+                            "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+                            "fit_signal": "可观察的环境线索：情绪劳动较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动较高也可能带来额外压力。",
+                            "interview_question": "高情绪劳动是否有督导、复盘、边界和恢复机制？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "情绪承接是否被正式承认",
+                                "是否有复盘和轮换机制",
+                                "是否把“会安抚人”默认成个人义务"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高情绪劳动是否有督导、复盘、边界和恢复机制？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Emotional labor: high",
-                            "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+                            "fit_signal": "Environment cue to observe: when emotional labor is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high emotional labor can still create pressure.",
+                            "interview_question": "Does high emotional labor come with supervision, review, boundaries, and recovery practices?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether emotional labor is formally recognized",
+                                "Whether there is review and rotation",
+                                "Whether soothing others is treated as a personal obligation"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does high emotional labor come with supervision, review, boundaries, and recovery practices? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "emotional_labor_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "emotional_labor_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "emotional_labor",
                             "level": "high",
                             "overlay_imported": false
@@ -16468,43 +16468,43 @@
                 "conflict_frequency": {
                     "low": {
                         "zh-CN": {
-                            "label": "冲突频率：低",
-                            "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "冲突频率：较低",
+                            "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+                            "fit_signal": "可观察的环境线索：冲突频率较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率较低也可能带来额外压力。",
+                            "interview_question": "低冲突是否来自透明规则，还是来自回避和沉默？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "分歧是否能被记录和复盘",
+                                "权力差是否影响谁能说话",
+                                "是否有安全退出或升级机制"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "低冲突是否来自透明规则，还是来自回避和沉默？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Conflict frequency: low",
-                            "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+                            "fit_signal": "Environment cue to observe: when conflict frequency is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low conflict frequency can still create pressure.",
+                            "interview_question": "Does low conflict come from clear rules, or from avoidance and silence?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether disagreements are documented and reviewed",
+                                "Whether power differences shape who can speak",
+                                "Whether there is a safe exit or escalation path"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does low conflict come from clear rules, or from avoidance and silence? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "conflict_frequency_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "conflict_frequency_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "conflict_frequency",
                             "level": "low",
                             "overlay_imported": false
@@ -16512,43 +16512,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "冲突频率：中",
-                            "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "冲突频率：中等",
+                            "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+                            "fit_signal": "可观察的环境线索：冲突频率中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率中等也可能带来额外压力。",
+                            "interview_question": "冲突出现时，团队用事实、角色和流程处理，还是靠个人关系消化？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "分歧是否能被记录和复盘",
+                                "权力差是否影响谁能说话",
+                                "是否有安全退出或升级机制"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "冲突出现时，团队用事实、角色和流程处理，还是靠个人关系消化？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Conflict frequency: medium",
-                            "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+                            "fit_signal": "Environment cue to observe: when conflict frequency is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium conflict frequency can still create pressure.",
+                            "interview_question": "When conflict appears, does the team use facts, roles, and process, or personal relationships?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether disagreements are documented and reviewed",
+                                "Whether power differences shape who can speak",
+                                "Whether there is a safe exit or escalation path"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "When conflict appears, does the team use facts, roles, and process, or personal relationships? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "conflict_frequency_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "conflict_frequency_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "conflict_frequency",
                             "level": "medium",
                             "overlay_imported": false
@@ -16556,43 +16556,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "冲突频率：高",
-                            "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "冲突频率：较高",
+                            "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+                            "fit_signal": "可观察的环境线索：冲突频率较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率较高也可能带来额外压力。",
+                            "interview_question": "高冲突场景是否有升级路径、记录机制和安全边界？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "分歧是否能被记录和复盘",
+                                "权力差是否影响谁能说话",
+                                "是否有安全退出或升级机制"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高冲突场景是否有升级路径、记录机制和安全边界？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Conflict frequency: high",
-                            "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+                            "fit_signal": "Environment cue to observe: when conflict frequency is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high conflict frequency can still create pressure.",
+                            "interview_question": "Do high-conflict situations have escalation paths, documentation, and safety boundaries?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether disagreements are documented and reviewed",
+                                "Whether power differences shape who can speak",
+                                "Whether there is a safe exit or escalation path"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Do high-conflict situations have escalation paths, documentation, and safety boundaries? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "conflict_frequency_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "conflict_frequency_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "conflict_frequency",
                             "level": "high",
                             "overlay_imported": false
@@ -16602,43 +16602,43 @@
                 "feedback_intensity": {
                     "low": {
                         "zh-CN": {
-                            "label": "反馈强度：低",
-                            "meaning": "被评价、修改、复盘和公开讨论的频率",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "反馈强度：较低",
+                            "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+                            "fit_signal": "可观察的环境线索：反馈强度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度较低也可能带来额外压力。",
+                            "interview_question": "低反馈是否意味着自主空间，还是意味着标准不清？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "反馈是否指向行为而非人格",
+                                "是否有修改资源和时间",
+                                "是否公开比较或羞辱"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "低反馈是否意味着自主空间，还是意味着标准不清？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Feedback intensity: low",
-                            "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+                            "fit_signal": "Environment cue to observe: when feedback intensity is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low feedback intensity can still create pressure.",
+                            "interview_question": "Does low feedback mean autonomy, or unclear standards?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether feedback targets behavior rather than character",
+                                "Whether there is time and resource to revise",
+                                "Whether comparison or humiliation is used"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does low feedback mean autonomy, or unclear standards? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "feedback_intensity_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "feedback_intensity_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "feedback_intensity",
                             "level": "low",
                             "overlay_imported": false
@@ -16646,43 +16646,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "反馈强度：中",
-                            "meaning": "被评价、修改、复盘和公开讨论的频率",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "反馈强度：中等",
+                            "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+                            "fit_signal": "可观察的环境线索：反馈强度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度中等也可能带来额外压力。",
+                            "interview_question": "反馈是否具体、定期，并能区分任务问题和个人评价？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "反馈是否指向行为而非人格",
+                                "是否有修改资源和时间",
+                                "是否公开比较或羞辱"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "反馈是否具体、定期，并能区分任务问题和个人评价？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Feedback intensity: medium",
-                            "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+                            "fit_signal": "Environment cue to observe: when feedback intensity is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium feedback intensity can still create pressure.",
+                            "interview_question": "Is feedback specific, regular, and able to separate task issues from personal judgment?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether feedback targets behavior rather than character",
+                                "Whether there is time and resource to revise",
+                                "Whether comparison or humiliation is used"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is feedback specific, regular, and able to separate task issues from personal judgment? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "feedback_intensity_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "feedback_intensity_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "feedback_intensity",
                             "level": "medium",
                             "overlay_imported": false
@@ -16690,43 +16690,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "反馈强度：高",
-                            "meaning": "被评价、修改、复盘和公开讨论的频率",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "反馈强度：较高",
+                            "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+                            "fit_signal": "可观察的环境线索：反馈强度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度较高也可能带来额外压力。",
+                            "interview_question": "高频反馈是否有清楚标准、节奏和修正空间？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "反馈是否指向行为而非人格",
+                                "是否有修改资源和时间",
+                                "是否公开比较或羞辱"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高频反馈是否有清楚标准、节奏和修正空间？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Feedback intensity: high",
-                            "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+                            "fit_signal": "Environment cue to observe: when feedback intensity is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high feedback intensity can still create pressure.",
+                            "interview_question": "Does frequent feedback come with clear standards, pacing, and room to revise?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether feedback targets behavior rather than character",
+                                "Whether there is time and resource to revise",
+                                "Whether comparison or humiliation is used"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does frequent feedback come with clear standards, pacing, and room to revise? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "feedback_intensity_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "feedback_intensity_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "feedback_intensity",
                             "level": "high",
                             "overlay_imported": false
@@ -16736,43 +16736,43 @@
                 "autonomy_recovery": {
                     "low": {
                         "zh-CN": {
-                            "label": "自主恢复空间：低",
-                            "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "自主恢复空间：较低",
+                            "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+                            "fit_signal": "可观察的环境线索：自主恢复空间较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间较低也可能带来额外压力。",
+                            "interview_question": "恢复空间少时，是否至少有明确交接、暂停和求助规则？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "是否能安排短暂停顿",
+                                "是否有交接和替补机制",
+                                "自主是否变成无人支持"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "恢复空间少时，是否至少有明确交接、暂停和求助规则？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Autonomy and recovery space: low",
-                            "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+                            "fit_signal": "Environment cue to observe: when autonomy and recovery space is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low autonomy and recovery space can still create pressure.",
+                            "interview_question": "When recovery space is low, are there at least clear handoff, pause, and support rules?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether short pauses are possible",
+                                "Whether handoff and backup exist",
+                                "Whether autonomy turns into lack of support"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "When recovery space is low, are there at least clear handoff, pause, and support rules? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "autonomy_recovery_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "autonomy_recovery_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "autonomy_recovery",
                             "level": "low",
                             "overlay_imported": false
@@ -16780,43 +16780,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "自主恢复空间：中",
-                            "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "自主恢复空间：中等",
+                            "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+                            "fit_signal": "可观察的环境线索：自主恢复空间中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间中等也可能带来额外压力。",
+                            "interview_question": "恢复空间是否可预期，还是只取决于当天气氛？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "是否能安排短暂停顿",
+                                "是否有交接和替补机制",
+                                "自主是否变成无人支持"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "恢复空间是否可预期，还是只取决于当天气氛？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Autonomy and recovery space: medium",
-                            "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+                            "fit_signal": "Environment cue to observe: when autonomy and recovery space is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium autonomy and recovery space can still create pressure.",
+                            "interview_question": "Is recovery space predictable, or dependent on the day’s atmosphere?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether short pauses are possible",
+                                "Whether handoff and backup exist",
+                                "Whether autonomy turns into lack of support"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is recovery space predictable, or dependent on the day’s atmosphere? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "autonomy_recovery_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "autonomy_recovery_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "autonomy_recovery",
                             "level": "medium",
                             "overlay_imported": false
@@ -16824,43 +16824,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "自主恢复空间：高",
-                            "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "自主恢复空间：较高",
+                            "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+                            "fit_signal": "可观察的环境线索：自主恢复空间较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间较高也可能带来额外压力。",
+                            "interview_question": "高自主是否伴随清楚目标和反馈，而不是让人孤立承担？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "是否能安排短暂停顿",
+                                "是否有交接和替补机制",
+                                "自主是否变成无人支持"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高自主是否伴随清楚目标和反馈，而不是让人孤立承担？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Autonomy and recovery space: high",
-                            "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+                            "fit_signal": "Environment cue to observe: when autonomy and recovery space is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high autonomy and recovery space can still create pressure.",
+                            "interview_question": "Does high autonomy come with clear goals and feedback, rather than leaving people isolated?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether short pauses are possible",
+                                "Whether handoff and backup exist",
+                                "Whether autonomy turns into lack of support"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does high autonomy come with clear goals and feedback, rather than leaving people isolated? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "autonomy_recovery_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "autonomy_recovery_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "autonomy_recovery",
                             "level": "high",
                             "overlay_imported": false
@@ -16870,43 +16870,43 @@
                 "collaboration_complexity": {
                     "low": {
                         "zh-CN": {
-                            "label": "协作复杂度：低",
-                            "meaning": "需要协调多少角色、目标和隐性关系压力",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "协作复杂度：较低",
+                            "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+                            "fit_signal": "可观察的环境线索：协作复杂度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度较低也可能带来额外压力。",
+                            "interview_question": "协作简单是否有清楚责任，还是只是信息不透明？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "角色和决策权是否明确",
+                                "信息是否同步到相关人",
+                                "协调成本是否被看见"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "协作简单是否有清楚责任，还是只是信息不透明？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Collaboration complexity: low",
-                            "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+                            "fit_signal": "Environment cue to observe: when collaboration complexity is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low collaboration complexity can still create pressure.",
+                            "interview_question": "Is collaboration simple because responsibility is clear, or because information is hidden?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether roles and decision rights are clear",
+                                "Whether information reaches the right people",
+                                "Whether coordination cost is visible"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is collaboration simple because responsibility is clear, or because information is hidden? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "collaboration_complexity_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "collaboration_complexity_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "collaboration_complexity",
                             "level": "low",
                             "overlay_imported": false
@@ -16914,43 +16914,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "协作复杂度：中",
-                            "meaning": "需要协调多少角色、目标和隐性关系压力",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "协作复杂度：中等",
+                            "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+                            "fit_signal": "可观察的环境线索：协作复杂度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度中等也可能带来额外压力。",
+                            "interview_question": "多方协作时，谁拥有决策权、节奏权和最终确认权？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "角色和决策权是否明确",
+                                "信息是否同步到相关人",
+                                "协调成本是否被看见"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "多方协作时，谁拥有决策权、节奏权和最终确认权？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Collaboration complexity: medium",
-                            "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+                            "fit_signal": "Environment cue to observe: when collaboration complexity is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium collaboration complexity can still create pressure.",
+                            "interview_question": "In multi-party work, who owns decisions, pacing, and final confirmation?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether roles and decision rights are clear",
+                                "Whether information reaches the right people",
+                                "Whether coordination cost is visible"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "In multi-party work, who owns decisions, pacing, and final confirmation? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "collaboration_complexity_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "collaboration_complexity_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "collaboration_complexity",
                             "level": "medium",
                             "overlay_imported": false
@@ -16958,43 +16958,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "协作复杂度：高",
-                            "meaning": "需要协调多少角色、目标和隐性关系压力",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "协作复杂度：较高",
+                            "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+                            "fit_signal": "可观察的环境线索：协作复杂度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度较高也可能带来额外压力。",
+                            "interview_question": "高复杂协作是否有角色图、冲突处理机制和信息同步节奏？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "角色和决策权是否明确",
+                                "信息是否同步到相关人",
+                                "协调成本是否被看见"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高复杂协作是否有角色图、冲突处理机制和信息同步节奏？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Collaboration complexity: high",
-                            "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+                            "fit_signal": "Environment cue to observe: when collaboration complexity is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high collaboration complexity can still create pressure.",
+                            "interview_question": "Does complex collaboration have a role map, conflict process, and information rhythm?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether roles and decision rights are clear",
+                                "Whether information reaches the right people",
+                                "Whether coordination cost is visible"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does complex collaboration have a role map, conflict process, and information rhythm? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "collaboration_complexity_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "collaboration_complexity_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "collaboration_complexity",
                             "level": "high",
                             "overlay_imported": false
@@ -17004,8 +17004,8 @@
             },
             "meta": {
                 "v23_source": "career_environment_v2.json",
-                "import_scope": "base_assets_only",
-                "deferred": "formulation_overlays require resolver support and are intentionally left to a later PR."
+                "science_repair": "SCI-08",
+                "content_boundary": "Environment-variable decision support only; no career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction."
             }
         },
         "action_prescriptions": {

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/career_environment.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/career_environment.json
@@ -5,43 +5,43 @@
     "interpersonal_density": {
       "low": {
         "zh-CN": {
-          "label": "人际密度：低",
-          "meaning": "互动频率、会议密度和需要读人的程度",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "人际密度：较低",
+          "meaning": "工作中互动、会议、协调和读人信号的频率",
+          "fit_signal": "可观察的环境线索：人际密度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度较低也可能带来额外压力。",
+          "interview_question": "这个环境的低互动是真正稳定，还是只在出问题时集中爆发？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "会议是否有明确目的和结束条件",
+            "反馈是否具体到行为和下一步",
+            "是否允许暂时退出高情绪对话"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "这个环境的低互动是真正稳定，还是只在出问题时集中爆发？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Interpersonal density: low",
-          "meaning": "the amount of interaction, meeting load, and people-reading required",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+          "fit_signal": "Environment cue to observe: when interpersonal density is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low interpersonal density can still create pressure.",
+          "interview_question": "Is the low interaction genuinely stable, or does communication pile up when something goes wrong?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether meetings have a clear purpose and end point",
+            "Whether feedback names behavior and next steps",
+            "Whether people can step out of emotionally loaded conversations when needed"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is the low interaction genuinely stable, or does communication pile up when something goes wrong? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "interpersonal_density_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "interpersonal_density_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "interpersonal_density",
           "level": "low",
           "overlay_imported": false
@@ -49,43 +49,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "人际密度：中",
-          "meaning": "互动频率、会议密度和需要读人的程度",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "人际密度：中等",
+          "meaning": "工作中互动、会议、协调和读人信号的频率",
+          "fit_signal": "可观察的环境线索：人际密度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度中等也可能带来额外压力。",
+          "interview_question": "团队有没有清楚的会议节奏、反馈方式和可暂停窗口？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "会议是否有明确目的和结束条件",
+            "反馈是否具体到行为和下一步",
+            "是否允许暂时退出高情绪对话"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "团队有没有清楚的会议节奏、反馈方式和可暂停窗口？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Interpersonal density: medium",
-          "meaning": "the amount of interaction, meeting load, and people-reading required",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+          "fit_signal": "Environment cue to observe: when interpersonal density is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium interpersonal density can still create pressure.",
+          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and pause windows?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether meetings have a clear purpose and end point",
+            "Whether feedback names behavior and next steps",
+            "Whether people can step out of emotionally loaded conversations when needed"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and pause windows? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "interpersonal_density_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "interpersonal_density_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "interpersonal_density",
           "level": "medium",
           "overlay_imported": false
@@ -93,43 +93,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "人际密度：高",
-          "meaning": "互动频率、会议密度和需要读人的程度",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "人际密度：较高",
+          "meaning": "工作中互动、会议、协调和读人信号的频率",
+          "fit_signal": "可观察的环境线索：人际密度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度较高也可能带来额外压力。",
+          "interview_question": "高互动是否配有清楚边界、交接方式和恢复空间？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "会议是否有明确目的和结束条件",
+            "反馈是否具体到行为和下一步",
+            "是否允许暂时退出高情绪对话"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高互动是否配有清楚边界、交接方式和恢复空间？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Interpersonal density: high",
-          "meaning": "the amount of interaction, meeting load, and people-reading required",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+          "fit_signal": "Environment cue to observe: when interpersonal density is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high interpersonal density can still create pressure.",
+          "interview_question": "Does high interaction come with clear boundaries, handoff norms, and recovery space?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether meetings have a clear purpose and end point",
+            "Whether feedback names behavior and next steps",
+            "Whether people can step out of emotionally loaded conversations when needed"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does high interaction come with clear boundaries, handoff norms, and recovery space? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "interpersonal_density_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "interpersonal_density_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "interpersonal_density",
           "level": "high",
           "overlay_imported": false
@@ -139,43 +139,43 @@
     "emotional_labor": {
       "low": {
         "zh-CN": {
-          "label": "情绪劳动：低",
-          "meaning": "需要承接、安抚或整理他人情绪的程度",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "情绪劳动：较低",
+          "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+          "fit_signal": "可观察的环境线索：情绪劳动较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动较低也可能带来额外压力。",
+          "interview_question": "情绪劳动低，是因为流程清楚，还是因为情绪问题被延后处理？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "情绪承接是否被正式承认",
+            "是否有复盘和轮换机制",
+            "是否把“会安抚人”默认成个人义务"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "情绪劳动低，是因为流程清楚，还是因为情绪问题被延后处理？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Emotional labor: low",
-          "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+          "fit_signal": "Environment cue to observe: when emotional labor is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low emotional labor can still create pressure.",
+          "interview_question": "Is emotional labor low because process is clear, or because emotional issues are postponed?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether emotional labor is formally recognized",
+            "Whether there is review and rotation",
+            "Whether soothing others is treated as a personal obligation"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is emotional labor low because process is clear, or because emotional issues are postponed? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "emotional_labor_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "emotional_labor_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "emotional_labor",
           "level": "low",
           "overlay_imported": false
@@ -183,43 +183,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "情绪劳动：中",
-          "meaning": "需要承接、安抚或整理他人情绪的程度",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "情绪劳动：中等",
+          "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+          "fit_signal": "可观察的环境线索：情绪劳动中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动中等也可能带来额外压力。",
+          "interview_question": "谁负责承接客户、同事或团队中的情绪压力？是否有轮换和复盘？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "情绪承接是否被正式承认",
+            "是否有复盘和轮换机制",
+            "是否把“会安抚人”默认成个人义务"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "谁负责承接客户、同事或团队中的情绪压力？是否有轮换和复盘？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Emotional labor: medium",
-          "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+          "fit_signal": "Environment cue to observe: when emotional labor is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium emotional labor can still create pressure.",
+          "interview_question": "Who carries emotional pressure from clients, colleagues, or the team, and is there rotation or review?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether emotional labor is formally recognized",
+            "Whether there is review and rotation",
+            "Whether soothing others is treated as a personal obligation"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Who carries emotional pressure from clients, colleagues, or the team, and is there rotation or review? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "emotional_labor_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "emotional_labor_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "emotional_labor",
           "level": "medium",
           "overlay_imported": false
@@ -227,43 +227,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "情绪劳动：高",
-          "meaning": "需要承接、安抚或整理他人情绪的程度",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "情绪劳动：较高",
+          "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+          "fit_signal": "可观察的环境线索：情绪劳动较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动较高也可能带来额外压力。",
+          "interview_question": "高情绪劳动是否有督导、复盘、边界和恢复机制？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "情绪承接是否被正式承认",
+            "是否有复盘和轮换机制",
+            "是否把“会安抚人”默认成个人义务"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高情绪劳动是否有督导、复盘、边界和恢复机制？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Emotional labor: high",
-          "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+          "fit_signal": "Environment cue to observe: when emotional labor is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high emotional labor can still create pressure.",
+          "interview_question": "Does high emotional labor come with supervision, review, boundaries, and recovery practices?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether emotional labor is formally recognized",
+            "Whether there is review and rotation",
+            "Whether soothing others is treated as a personal obligation"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does high emotional labor come with supervision, review, boundaries, and recovery practices? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "emotional_labor_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "emotional_labor_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "emotional_labor",
           "level": "high",
           "overlay_imported": false
@@ -273,43 +273,43 @@
     "conflict_frequency": {
       "low": {
         "zh-CN": {
-          "label": "冲突频率：低",
-          "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "冲突频率：较低",
+          "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+          "fit_signal": "可观察的环境线索：冲突频率较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率较低也可能带来额外压力。",
+          "interview_question": "低冲突是否来自透明规则，还是来自回避和沉默？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "分歧是否能被记录和复盘",
+            "权力差是否影响谁能说话",
+            "是否有安全退出或升级机制"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "低冲突是否来自透明规则，还是来自回避和沉默？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Conflict frequency: low",
-          "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+          "fit_signal": "Environment cue to observe: when conflict frequency is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low conflict frequency can still create pressure.",
+          "interview_question": "Does low conflict come from clear rules, or from avoidance and silence?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether disagreements are documented and reviewed",
+            "Whether power differences shape who can speak",
+            "Whether there is a safe exit or escalation path"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does low conflict come from clear rules, or from avoidance and silence? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "conflict_frequency_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "conflict_frequency_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "conflict_frequency",
           "level": "low",
           "overlay_imported": false
@@ -317,43 +317,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "冲突频率：中",
-          "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "冲突频率：中等",
+          "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+          "fit_signal": "可观察的环境线索：冲突频率中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率中等也可能带来额外压力。",
+          "interview_question": "冲突出现时，团队用事实、角色和流程处理，还是靠个人关系消化？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "分歧是否能被记录和复盘",
+            "权力差是否影响谁能说话",
+            "是否有安全退出或升级机制"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "冲突出现时，团队用事实、角色和流程处理，还是靠个人关系消化？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Conflict frequency: medium",
-          "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+          "fit_signal": "Environment cue to observe: when conflict frequency is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium conflict frequency can still create pressure.",
+          "interview_question": "When conflict appears, does the team use facts, roles, and process, or personal relationships?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether disagreements are documented and reviewed",
+            "Whether power differences shape who can speak",
+            "Whether there is a safe exit or escalation path"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "When conflict appears, does the team use facts, roles, and process, or personal relationships? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "conflict_frequency_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "conflict_frequency_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "conflict_frequency",
           "level": "medium",
           "overlay_imported": false
@@ -361,43 +361,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "冲突频率：高",
-          "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "冲突频率：较高",
+          "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+          "fit_signal": "可观察的环境线索：冲突频率较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率较高也可能带来额外压力。",
+          "interview_question": "高冲突场景是否有升级路径、记录机制和安全边界？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "分歧是否能被记录和复盘",
+            "权力差是否影响谁能说话",
+            "是否有安全退出或升级机制"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高冲突场景是否有升级路径、记录机制和安全边界？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Conflict frequency: high",
-          "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+          "fit_signal": "Environment cue to observe: when conflict frequency is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high conflict frequency can still create pressure.",
+          "interview_question": "Do high-conflict situations have escalation paths, documentation, and safety boundaries?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether disagreements are documented and reviewed",
+            "Whether power differences shape who can speak",
+            "Whether there is a safe exit or escalation path"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Do high-conflict situations have escalation paths, documentation, and safety boundaries? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "conflict_frequency_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "conflict_frequency_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "conflict_frequency",
           "level": "high",
           "overlay_imported": false
@@ -407,43 +407,43 @@
     "feedback_intensity": {
       "low": {
         "zh-CN": {
-          "label": "反馈强度：低",
-          "meaning": "被评价、修改、复盘和公开讨论的频率",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "反馈强度：较低",
+          "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+          "fit_signal": "可观察的环境线索：反馈强度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度较低也可能带来额外压力。",
+          "interview_question": "低反馈是否意味着自主空间，还是意味着标准不清？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "反馈是否指向行为而非人格",
+            "是否有修改资源和时间",
+            "是否公开比较或羞辱"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "低反馈是否意味着自主空间，还是意味着标准不清？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Feedback intensity: low",
-          "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+          "fit_signal": "Environment cue to observe: when feedback intensity is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low feedback intensity can still create pressure.",
+          "interview_question": "Does low feedback mean autonomy, or unclear standards?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether feedback targets behavior rather than character",
+            "Whether there is time and resource to revise",
+            "Whether comparison or humiliation is used"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does low feedback mean autonomy, or unclear standards? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "feedback_intensity_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "feedback_intensity_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "feedback_intensity",
           "level": "low",
           "overlay_imported": false
@@ -451,43 +451,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "反馈强度：中",
-          "meaning": "被评价、修改、复盘和公开讨论的频率",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "反馈强度：中等",
+          "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+          "fit_signal": "可观察的环境线索：反馈强度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度中等也可能带来额外压力。",
+          "interview_question": "反馈是否具体、定期，并能区分任务问题和个人评价？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "反馈是否指向行为而非人格",
+            "是否有修改资源和时间",
+            "是否公开比较或羞辱"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "反馈是否具体、定期，并能区分任务问题和个人评价？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Feedback intensity: medium",
-          "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+          "fit_signal": "Environment cue to observe: when feedback intensity is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium feedback intensity can still create pressure.",
+          "interview_question": "Is feedback specific, regular, and able to separate task issues from personal judgment?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether feedback targets behavior rather than character",
+            "Whether there is time and resource to revise",
+            "Whether comparison or humiliation is used"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is feedback specific, regular, and able to separate task issues from personal judgment? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "feedback_intensity_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "feedback_intensity_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "feedback_intensity",
           "level": "medium",
           "overlay_imported": false
@@ -495,43 +495,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "反馈强度：高",
-          "meaning": "被评价、修改、复盘和公开讨论的频率",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "反馈强度：较高",
+          "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+          "fit_signal": "可观察的环境线索：反馈强度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度较高也可能带来额外压力。",
+          "interview_question": "高频反馈是否有清楚标准、节奏和修正空间？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "反馈是否指向行为而非人格",
+            "是否有修改资源和时间",
+            "是否公开比较或羞辱"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高频反馈是否有清楚标准、节奏和修正空间？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Feedback intensity: high",
-          "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+          "fit_signal": "Environment cue to observe: when feedback intensity is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high feedback intensity can still create pressure.",
+          "interview_question": "Does frequent feedback come with clear standards, pacing, and room to revise?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether feedback targets behavior rather than character",
+            "Whether there is time and resource to revise",
+            "Whether comparison or humiliation is used"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does frequent feedback come with clear standards, pacing, and room to revise? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "feedback_intensity_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "feedback_intensity_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "feedback_intensity",
           "level": "high",
           "overlay_imported": false
@@ -541,43 +541,43 @@
     "autonomy_recovery": {
       "low": {
         "zh-CN": {
-          "label": "自主恢复空间：低",
-          "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "自主恢复空间：较低",
+          "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+          "fit_signal": "可观察的环境线索：自主恢复空间较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间较低也可能带来额外压力。",
+          "interview_question": "恢复空间少时，是否至少有明确交接、暂停和求助规则？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "是否能安排短暂停顿",
+            "是否有交接和替补机制",
+            "自主是否变成无人支持"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "恢复空间少时，是否至少有明确交接、暂停和求助规则？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Autonomy and recovery space: low",
-          "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+          "fit_signal": "Environment cue to observe: when autonomy and recovery space is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low autonomy and recovery space can still create pressure.",
+          "interview_question": "When recovery space is low, are there at least clear handoff, pause, and support rules?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether short pauses are possible",
+            "Whether handoff and backup exist",
+            "Whether autonomy turns into lack of support"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "When recovery space is low, are there at least clear handoff, pause, and support rules? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "autonomy_recovery_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "autonomy_recovery_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "autonomy_recovery",
           "level": "low",
           "overlay_imported": false
@@ -585,43 +585,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "自主恢复空间：中",
-          "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "自主恢复空间：中等",
+          "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+          "fit_signal": "可观察的环境线索：自主恢复空间中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间中等也可能带来额外压力。",
+          "interview_question": "恢复空间是否可预期，还是只取决于当天气氛？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "是否能安排短暂停顿",
+            "是否有交接和替补机制",
+            "自主是否变成无人支持"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "恢复空间是否可预期，还是只取决于当天气氛？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Autonomy and recovery space: medium",
-          "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+          "fit_signal": "Environment cue to observe: when autonomy and recovery space is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium autonomy and recovery space can still create pressure.",
+          "interview_question": "Is recovery space predictable, or dependent on the day’s atmosphere?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether short pauses are possible",
+            "Whether handoff and backup exist",
+            "Whether autonomy turns into lack of support"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is recovery space predictable, or dependent on the day’s atmosphere? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "autonomy_recovery_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "autonomy_recovery_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "autonomy_recovery",
           "level": "medium",
           "overlay_imported": false
@@ -629,43 +629,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "自主恢复空间：高",
-          "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "自主恢复空间：较高",
+          "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+          "fit_signal": "可观察的环境线索：自主恢复空间较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间较高也可能带来额外压力。",
+          "interview_question": "高自主是否伴随清楚目标和反馈，而不是让人孤立承担？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "是否能安排短暂停顿",
+            "是否有交接和替补机制",
+            "自主是否变成无人支持"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高自主是否伴随清楚目标和反馈，而不是让人孤立承担？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Autonomy and recovery space: high",
-          "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+          "fit_signal": "Environment cue to observe: when autonomy and recovery space is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high autonomy and recovery space can still create pressure.",
+          "interview_question": "Does high autonomy come with clear goals and feedback, rather than leaving people isolated?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether short pauses are possible",
+            "Whether handoff and backup exist",
+            "Whether autonomy turns into lack of support"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does high autonomy come with clear goals and feedback, rather than leaving people isolated? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "autonomy_recovery_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "autonomy_recovery_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "autonomy_recovery",
           "level": "high",
           "overlay_imported": false
@@ -675,43 +675,43 @@
     "collaboration_complexity": {
       "low": {
         "zh-CN": {
-          "label": "协作复杂度：低",
-          "meaning": "需要协调多少角色、目标和隐性关系压力",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "协作复杂度：较低",
+          "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+          "fit_signal": "可观察的环境线索：协作复杂度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度较低也可能带来额外压力。",
+          "interview_question": "协作简单是否有清楚责任，还是只是信息不透明？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "角色和决策权是否明确",
+            "信息是否同步到相关人",
+            "协调成本是否被看见"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "协作简单是否有清楚责任，还是只是信息不透明？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Collaboration complexity: low",
-          "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+          "fit_signal": "Environment cue to observe: when collaboration complexity is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low collaboration complexity can still create pressure.",
+          "interview_question": "Is collaboration simple because responsibility is clear, or because information is hidden?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether roles and decision rights are clear",
+            "Whether information reaches the right people",
+            "Whether coordination cost is visible"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is collaboration simple because responsibility is clear, or because information is hidden? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "collaboration_complexity_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "collaboration_complexity_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "collaboration_complexity",
           "level": "low",
           "overlay_imported": false
@@ -719,43 +719,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "协作复杂度：中",
-          "meaning": "需要协调多少角色、目标和隐性关系压力",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "协作复杂度：中等",
+          "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+          "fit_signal": "可观察的环境线索：协作复杂度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度中等也可能带来额外压力。",
+          "interview_question": "多方协作时，谁拥有决策权、节奏权和最终确认权？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "角色和决策权是否明确",
+            "信息是否同步到相关人",
+            "协调成本是否被看见"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "多方协作时，谁拥有决策权、节奏权和最终确认权？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Collaboration complexity: medium",
-          "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+          "fit_signal": "Environment cue to observe: when collaboration complexity is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium collaboration complexity can still create pressure.",
+          "interview_question": "In multi-party work, who owns decisions, pacing, and final confirmation?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether roles and decision rights are clear",
+            "Whether information reaches the right people",
+            "Whether coordination cost is visible"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "In multi-party work, who owns decisions, pacing, and final confirmation? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "collaboration_complexity_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "collaboration_complexity_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "collaboration_complexity",
           "level": "medium",
           "overlay_imported": false
@@ -763,43 +763,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "协作复杂度：高",
-          "meaning": "需要协调多少角色、目标和隐性关系压力",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "协作复杂度：较高",
+          "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+          "fit_signal": "可观察的环境线索：协作复杂度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度较高也可能带来额外压力。",
+          "interview_question": "高复杂协作是否有角色图、冲突处理机制和信息同步节奏？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "角色和决策权是否明确",
+            "信息是否同步到相关人",
+            "协调成本是否被看见"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高复杂协作是否有角色图、冲突处理机制和信息同步节奏？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Collaboration complexity: high",
-          "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+          "fit_signal": "Environment cue to observe: when collaboration complexity is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high collaboration complexity can still create pressure.",
+          "interview_question": "Does complex collaboration have a role map, conflict process, and information rhythm?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether roles and decision rights are clear",
+            "Whether information reaches the right people",
+            "Whether coordination cost is visible"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does complex collaboration have a role map, conflict process, and information rhythm? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "collaboration_complexity_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "collaboration_complexity_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "collaboration_complexity",
           "level": "high",
           "overlay_imported": false
@@ -809,7 +809,7 @@
   },
   "meta": {
     "v23_source": "career_environment_v2.json",
-    "import_scope": "base_assets_only",
-    "deferred": "formulation_overlays require resolver support and are intentionally left to a later PR."
+    "science_repair": "SCI-08",
+    "content_boundary": "Environment-variable decision support only; no career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction."
   }
 }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T18:17:36.121675Z",
+    "generated_at": "2026-07-02T18:29:17.574221Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -16200,43 +16200,43 @@
                 "interpersonal_density": {
                     "low": {
                         "zh-CN": {
-                            "label": "人际密度：低",
-                            "meaning": "互动频率、会议密度和需要读人的程度",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "人际密度：较低",
+                            "meaning": "工作中互动、会议、协调和读人信号的频率",
+                            "fit_signal": "可观察的环境线索：人际密度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度较低也可能带来额外压力。",
+                            "interview_question": "这个环境的低互动是真正稳定，还是只在出问题时集中爆发？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "会议是否有明确目的和结束条件",
+                                "反馈是否具体到行为和下一步",
+                                "是否允许暂时退出高情绪对话"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "这个环境的低互动是真正稳定，还是只在出问题时集中爆发？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Interpersonal density: low",
-                            "meaning": "the amount of interaction, meeting load, and people-reading required",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+                            "fit_signal": "Environment cue to observe: when interpersonal density is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low interpersonal density can still create pressure.",
+                            "interview_question": "Is the low interaction genuinely stable, or does communication pile up when something goes wrong?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether meetings have a clear purpose and end point",
+                                "Whether feedback names behavior and next steps",
+                                "Whether people can step out of emotionally loaded conversations when needed"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is the low interaction genuinely stable, or does communication pile up when something goes wrong? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "interpersonal_density_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "interpersonal_density_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "interpersonal_density",
                             "level": "low",
                             "overlay_imported": false
@@ -16244,43 +16244,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "人际密度：中",
-                            "meaning": "互动频率、会议密度和需要读人的程度",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "人际密度：中等",
+                            "meaning": "工作中互动、会议、协调和读人信号的频率",
+                            "fit_signal": "可观察的环境线索：人际密度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度中等也可能带来额外压力。",
+                            "interview_question": "团队有没有清楚的会议节奏、反馈方式和可暂停窗口？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "会议是否有明确目的和结束条件",
+                                "反馈是否具体到行为和下一步",
+                                "是否允许暂时退出高情绪对话"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "团队有没有清楚的会议节奏、反馈方式和可暂停窗口？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Interpersonal density: medium",
-                            "meaning": "the amount of interaction, meeting load, and people-reading required",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+                            "fit_signal": "Environment cue to observe: when interpersonal density is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium interpersonal density can still create pressure.",
+                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and pause windows?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether meetings have a clear purpose and end point",
+                                "Whether feedback names behavior and next steps",
+                                "Whether people can step out of emotionally loaded conversations when needed"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and pause windows? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "interpersonal_density_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "interpersonal_density_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "interpersonal_density",
                             "level": "medium",
                             "overlay_imported": false
@@ -16288,43 +16288,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "人际密度：高",
-                            "meaning": "互动频率、会议密度和需要读人的程度",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "人际密度：较高",
+                            "meaning": "工作中互动、会议、协调和读人信号的频率",
+                            "fit_signal": "可观察的环境线索：人际密度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度较高也可能带来额外压力。",
+                            "interview_question": "高互动是否配有清楚边界、交接方式和恢复空间？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "会议是否有明确目的和结束条件",
+                                "反馈是否具体到行为和下一步",
+                                "是否允许暂时退出高情绪对话"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高互动是否配有清楚边界、交接方式和恢复空间？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Interpersonal density: high",
-                            "meaning": "the amount of interaction, meeting load, and people-reading required",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+                            "fit_signal": "Environment cue to observe: when interpersonal density is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high interpersonal density can still create pressure.",
+                            "interview_question": "Does high interaction come with clear boundaries, handoff norms, and recovery space?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether meetings have a clear purpose and end point",
+                                "Whether feedback names behavior and next steps",
+                                "Whether people can step out of emotionally loaded conversations when needed"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does high interaction come with clear boundaries, handoff norms, and recovery space? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "interpersonal_density_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "interpersonal_density_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "interpersonal_density",
                             "level": "high",
                             "overlay_imported": false
@@ -16334,43 +16334,43 @@
                 "emotional_labor": {
                     "low": {
                         "zh-CN": {
-                            "label": "情绪劳动：低",
-                            "meaning": "需要承接、安抚或整理他人情绪的程度",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "情绪劳动：较低",
+                            "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+                            "fit_signal": "可观察的环境线索：情绪劳动较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动较低也可能带来额外压力。",
+                            "interview_question": "情绪劳动低，是因为流程清楚，还是因为情绪问题被延后处理？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "情绪承接是否被正式承认",
+                                "是否有复盘和轮换机制",
+                                "是否把“会安抚人”默认成个人义务"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "情绪劳动低，是因为流程清楚，还是因为情绪问题被延后处理？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Emotional labor: low",
-                            "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+                            "fit_signal": "Environment cue to observe: when emotional labor is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low emotional labor can still create pressure.",
+                            "interview_question": "Is emotional labor low because process is clear, or because emotional issues are postponed?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether emotional labor is formally recognized",
+                                "Whether there is review and rotation",
+                                "Whether soothing others is treated as a personal obligation"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is emotional labor low because process is clear, or because emotional issues are postponed? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "emotional_labor_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "emotional_labor_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "emotional_labor",
                             "level": "low",
                             "overlay_imported": false
@@ -16378,43 +16378,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "情绪劳动：中",
-                            "meaning": "需要承接、安抚或整理他人情绪的程度",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "情绪劳动：中等",
+                            "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+                            "fit_signal": "可观察的环境线索：情绪劳动中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动中等也可能带来额外压力。",
+                            "interview_question": "谁负责承接客户、同事或团队中的情绪压力？是否有轮换和复盘？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "情绪承接是否被正式承认",
+                                "是否有复盘和轮换机制",
+                                "是否把“会安抚人”默认成个人义务"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "谁负责承接客户、同事或团队中的情绪压力？是否有轮换和复盘？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Emotional labor: medium",
-                            "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+                            "fit_signal": "Environment cue to observe: when emotional labor is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium emotional labor can still create pressure.",
+                            "interview_question": "Who carries emotional pressure from clients, colleagues, or the team, and is there rotation or review?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether emotional labor is formally recognized",
+                                "Whether there is review and rotation",
+                                "Whether soothing others is treated as a personal obligation"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Who carries emotional pressure from clients, colleagues, or the team, and is there rotation or review? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "emotional_labor_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "emotional_labor_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "emotional_labor",
                             "level": "medium",
                             "overlay_imported": false
@@ -16422,43 +16422,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "情绪劳动：高",
-                            "meaning": "需要承接、安抚或整理他人情绪的程度",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "情绪劳动：较高",
+                            "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+                            "fit_signal": "可观察的环境线索：情绪劳动较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动较高也可能带来额外压力。",
+                            "interview_question": "高情绪劳动是否有督导、复盘、边界和恢复机制？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "情绪承接是否被正式承认",
+                                "是否有复盘和轮换机制",
+                                "是否把“会安抚人”默认成个人义务"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高情绪劳动是否有督导、复盘、边界和恢复机制？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Emotional labor: high",
-                            "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+                            "fit_signal": "Environment cue to observe: when emotional labor is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high emotional labor can still create pressure.",
+                            "interview_question": "Does high emotional labor come with supervision, review, boundaries, and recovery practices?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether emotional labor is formally recognized",
+                                "Whether there is review and rotation",
+                                "Whether soothing others is treated as a personal obligation"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does high emotional labor come with supervision, review, boundaries, and recovery practices? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "emotional_labor_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "emotional_labor_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "emotional_labor",
                             "level": "high",
                             "overlay_imported": false
@@ -16468,43 +16468,43 @@
                 "conflict_frequency": {
                     "low": {
                         "zh-CN": {
-                            "label": "冲突频率：低",
-                            "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "冲突频率：较低",
+                            "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+                            "fit_signal": "可观察的环境线索：冲突频率较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率较低也可能带来额外压力。",
+                            "interview_question": "低冲突是否来自透明规则，还是来自回避和沉默？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "分歧是否能被记录和复盘",
+                                "权力差是否影响谁能说话",
+                                "是否有安全退出或升级机制"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "低冲突是否来自透明规则，还是来自回避和沉默？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Conflict frequency: low",
-                            "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+                            "fit_signal": "Environment cue to observe: when conflict frequency is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low conflict frequency can still create pressure.",
+                            "interview_question": "Does low conflict come from clear rules, or from avoidance and silence?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether disagreements are documented and reviewed",
+                                "Whether power differences shape who can speak",
+                                "Whether there is a safe exit or escalation path"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does low conflict come from clear rules, or from avoidance and silence? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "conflict_frequency_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "conflict_frequency_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "conflict_frequency",
                             "level": "low",
                             "overlay_imported": false
@@ -16512,43 +16512,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "冲突频率：中",
-                            "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "冲突频率：中等",
+                            "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+                            "fit_signal": "可观察的环境线索：冲突频率中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率中等也可能带来额外压力。",
+                            "interview_question": "冲突出现时，团队用事实、角色和流程处理，还是靠个人关系消化？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "分歧是否能被记录和复盘",
+                                "权力差是否影响谁能说话",
+                                "是否有安全退出或升级机制"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "冲突出现时，团队用事实、角色和流程处理，还是靠个人关系消化？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Conflict frequency: medium",
-                            "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+                            "fit_signal": "Environment cue to observe: when conflict frequency is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium conflict frequency can still create pressure.",
+                            "interview_question": "When conflict appears, does the team use facts, roles, and process, or personal relationships?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether disagreements are documented and reviewed",
+                                "Whether power differences shape who can speak",
+                                "Whether there is a safe exit or escalation path"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "When conflict appears, does the team use facts, roles, and process, or personal relationships? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "conflict_frequency_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "conflict_frequency_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "conflict_frequency",
                             "level": "medium",
                             "overlay_imported": false
@@ -16556,43 +16556,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "冲突频率：高",
-                            "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "冲突频率：较高",
+                            "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+                            "fit_signal": "可观察的环境线索：冲突频率较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率较高也可能带来额外压力。",
+                            "interview_question": "高冲突场景是否有升级路径、记录机制和安全边界？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "分歧是否能被记录和复盘",
+                                "权力差是否影响谁能说话",
+                                "是否有安全退出或升级机制"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高冲突场景是否有升级路径、记录机制和安全边界？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Conflict frequency: high",
-                            "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+                            "fit_signal": "Environment cue to observe: when conflict frequency is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high conflict frequency can still create pressure.",
+                            "interview_question": "Do high-conflict situations have escalation paths, documentation, and safety boundaries?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether disagreements are documented and reviewed",
+                                "Whether power differences shape who can speak",
+                                "Whether there is a safe exit or escalation path"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Do high-conflict situations have escalation paths, documentation, and safety boundaries? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "conflict_frequency_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "conflict_frequency_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "conflict_frequency",
                             "level": "high",
                             "overlay_imported": false
@@ -16602,43 +16602,43 @@
                 "feedback_intensity": {
                     "low": {
                         "zh-CN": {
-                            "label": "反馈强度：低",
-                            "meaning": "被评价、修改、复盘和公开讨论的频率",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "反馈强度：较低",
+                            "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+                            "fit_signal": "可观察的环境线索：反馈强度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度较低也可能带来额外压力。",
+                            "interview_question": "低反馈是否意味着自主空间，还是意味着标准不清？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "反馈是否指向行为而非人格",
+                                "是否有修改资源和时间",
+                                "是否公开比较或羞辱"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "低反馈是否意味着自主空间，还是意味着标准不清？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Feedback intensity: low",
-                            "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+                            "fit_signal": "Environment cue to observe: when feedback intensity is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low feedback intensity can still create pressure.",
+                            "interview_question": "Does low feedback mean autonomy, or unclear standards?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether feedback targets behavior rather than character",
+                                "Whether there is time and resource to revise",
+                                "Whether comparison or humiliation is used"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does low feedback mean autonomy, or unclear standards? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "feedback_intensity_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "feedback_intensity_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "feedback_intensity",
                             "level": "low",
                             "overlay_imported": false
@@ -16646,43 +16646,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "反馈强度：中",
-                            "meaning": "被评价、修改、复盘和公开讨论的频率",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "反馈强度：中等",
+                            "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+                            "fit_signal": "可观察的环境线索：反馈强度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度中等也可能带来额外压力。",
+                            "interview_question": "反馈是否具体、定期，并能区分任务问题和个人评价？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "反馈是否指向行为而非人格",
+                                "是否有修改资源和时间",
+                                "是否公开比较或羞辱"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "反馈是否具体、定期，并能区分任务问题和个人评价？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Feedback intensity: medium",
-                            "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+                            "fit_signal": "Environment cue to observe: when feedback intensity is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium feedback intensity can still create pressure.",
+                            "interview_question": "Is feedback specific, regular, and able to separate task issues from personal judgment?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether feedback targets behavior rather than character",
+                                "Whether there is time and resource to revise",
+                                "Whether comparison or humiliation is used"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is feedback specific, regular, and able to separate task issues from personal judgment? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "feedback_intensity_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "feedback_intensity_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "feedback_intensity",
                             "level": "medium",
                             "overlay_imported": false
@@ -16690,43 +16690,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "反馈强度：高",
-                            "meaning": "被评价、修改、复盘和公开讨论的频率",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "反馈强度：较高",
+                            "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+                            "fit_signal": "可观察的环境线索：反馈强度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度较高也可能带来额外压力。",
+                            "interview_question": "高频反馈是否有清楚标准、节奏和修正空间？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "反馈是否指向行为而非人格",
+                                "是否有修改资源和时间",
+                                "是否公开比较或羞辱"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高频反馈是否有清楚标准、节奏和修正空间？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Feedback intensity: high",
-                            "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+                            "fit_signal": "Environment cue to observe: when feedback intensity is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high feedback intensity can still create pressure.",
+                            "interview_question": "Does frequent feedback come with clear standards, pacing, and room to revise?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether feedback targets behavior rather than character",
+                                "Whether there is time and resource to revise",
+                                "Whether comparison or humiliation is used"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does frequent feedback come with clear standards, pacing, and room to revise? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "feedback_intensity_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "feedback_intensity_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "feedback_intensity",
                             "level": "high",
                             "overlay_imported": false
@@ -16736,43 +16736,43 @@
                 "autonomy_recovery": {
                     "low": {
                         "zh-CN": {
-                            "label": "自主恢复空间：低",
-                            "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "自主恢复空间：较低",
+                            "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+                            "fit_signal": "可观察的环境线索：自主恢复空间较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间较低也可能带来额外压力。",
+                            "interview_question": "恢复空间少时，是否至少有明确交接、暂停和求助规则？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "是否能安排短暂停顿",
+                                "是否有交接和替补机制",
+                                "自主是否变成无人支持"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "恢复空间少时，是否至少有明确交接、暂停和求助规则？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Autonomy and recovery space: low",
-                            "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+                            "fit_signal": "Environment cue to observe: when autonomy and recovery space is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low autonomy and recovery space can still create pressure.",
+                            "interview_question": "When recovery space is low, are there at least clear handoff, pause, and support rules?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether short pauses are possible",
+                                "Whether handoff and backup exist",
+                                "Whether autonomy turns into lack of support"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "When recovery space is low, are there at least clear handoff, pause, and support rules? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "autonomy_recovery_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "autonomy_recovery_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "autonomy_recovery",
                             "level": "low",
                             "overlay_imported": false
@@ -16780,43 +16780,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "自主恢复空间：中",
-                            "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "自主恢复空间：中等",
+                            "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+                            "fit_signal": "可观察的环境线索：自主恢复空间中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间中等也可能带来额外压力。",
+                            "interview_question": "恢复空间是否可预期，还是只取决于当天气氛？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "是否能安排短暂停顿",
+                                "是否有交接和替补机制",
+                                "自主是否变成无人支持"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "恢复空间是否可预期，还是只取决于当天气氛？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Autonomy and recovery space: medium",
-                            "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+                            "fit_signal": "Environment cue to observe: when autonomy and recovery space is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium autonomy and recovery space can still create pressure.",
+                            "interview_question": "Is recovery space predictable, or dependent on the day’s atmosphere?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether short pauses are possible",
+                                "Whether handoff and backup exist",
+                                "Whether autonomy turns into lack of support"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is recovery space predictable, or dependent on the day’s atmosphere? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "autonomy_recovery_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "autonomy_recovery_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "autonomy_recovery",
                             "level": "medium",
                             "overlay_imported": false
@@ -16824,43 +16824,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "自主恢复空间：高",
-                            "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "自主恢复空间：较高",
+                            "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+                            "fit_signal": "可观察的环境线索：自主恢复空间较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间较高也可能带来额外压力。",
+                            "interview_question": "高自主是否伴随清楚目标和反馈，而不是让人孤立承担？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "是否能安排短暂停顿",
+                                "是否有交接和替补机制",
+                                "自主是否变成无人支持"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高自主是否伴随清楚目标和反馈，而不是让人孤立承担？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Autonomy and recovery space: high",
-                            "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+                            "fit_signal": "Environment cue to observe: when autonomy and recovery space is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high autonomy and recovery space can still create pressure.",
+                            "interview_question": "Does high autonomy come with clear goals and feedback, rather than leaving people isolated?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether short pauses are possible",
+                                "Whether handoff and backup exist",
+                                "Whether autonomy turns into lack of support"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does high autonomy come with clear goals and feedback, rather than leaving people isolated? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "autonomy_recovery_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "autonomy_recovery_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "autonomy_recovery",
                             "level": "high",
                             "overlay_imported": false
@@ -16870,43 +16870,43 @@
                 "collaboration_complexity": {
                     "low": {
                         "zh-CN": {
-                            "label": "协作复杂度：低",
-                            "meaning": "需要协调多少角色、目标和隐性关系压力",
-                            "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+                            "label": "协作复杂度：较低",
+                            "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+                            "fit_signal": "可观察的环境线索：协作复杂度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度较低也可能带来额外压力。",
+                            "interview_question": "协作简单是否有清楚责任，还是只是信息不透明？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "角色和决策权是否明确",
+                                "信息是否同步到相关人",
+                                "协调成本是否被看见"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "协作简单是否有清楚责任，还是只是信息不透明？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Collaboration complexity: low",
-                            "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-                            "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+                            "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+                            "fit_signal": "Environment cue to observe: when collaboration complexity is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low collaboration complexity can still create pressure.",
+                            "interview_question": "Is collaboration simple because responsibility is clear, or because information is hidden?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether roles and decision rights are clear",
+                                "Whether information reaches the right people",
+                                "Whether coordination cost is visible"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Is collaboration simple because responsibility is clear, or because information is hidden? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "collaboration_complexity_low",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "collaboration_complexity_low",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "collaboration_complexity",
                             "level": "low",
                             "overlay_imported": false
@@ -16914,43 +16914,43 @@
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "协作复杂度：中",
-                            "meaning": "需要协调多少角色、目标和隐性关系压力",
-                            "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+                            "label": "协作复杂度：中等",
+                            "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+                            "fit_signal": "可观察的环境线索：协作复杂度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度中等也可能带来额外压力。",
+                            "interview_question": "多方协作时，谁拥有决策权、节奏权和最终确认权？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "角色和决策权是否明确",
+                                "信息是否同步到相关人",
+                                "协调成本是否被看见"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "多方协作时，谁拥有决策权、节奏权和最终确认权？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Collaboration complexity: medium",
-                            "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-                            "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+                            "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+                            "fit_signal": "Environment cue to observe: when collaboration complexity is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium collaboration complexity can still create pressure.",
+                            "interview_question": "In multi-party work, who owns decisions, pacing, and final confirmation?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether roles and decision rights are clear",
+                                "Whether information reaches the right people",
+                                "Whether coordination cost is visible"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "In multi-party work, who owns decisions, pacing, and final confirmation? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "collaboration_complexity_medium",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "collaboration_complexity_medium",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "collaboration_complexity",
                             "level": "medium",
                             "overlay_imported": false
@@ -16958,43 +16958,43 @@
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "协作复杂度：高",
-                            "meaning": "需要协调多少角色、目标和隐性关系压力",
-                            "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+                            "label": "协作复杂度：较高",
+                            "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+                            "fit_signal": "可观察的环境线索：协作复杂度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+                            "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度较高也可能带来额外压力。",
+                            "interview_question": "高复杂协作是否有角色图、冲突处理机制和信息同步节奏？",
                             "role_observation_checklist": [
-                                "看会议是否有明确目的和结束条件。",
-                                "看反馈是否具体到行为，而不是停留在人身感受。",
-                                "看团队是否允许人暂时退出高情绪对话。"
+                                "角色和决策权是否明确",
+                                "信息是否同步到相关人",
+                                "协调成本是否被看见"
                             ],
-                            "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-                            "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-                            "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-                            "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+                            "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+                            "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+                            "what_to_verify": "高复杂协作是否有角色图、冲突处理机制和信息同步节奏？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+                            "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
                         },
                         "en": {
                             "label": "Collaboration complexity: high",
-                            "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-                            "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+                            "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+                            "fit_signal": "Environment cue to observe: when collaboration complexity is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+                            "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high collaboration complexity can still create pressure.",
+                            "interview_question": "Does complex collaboration have a role map, conflict process, and information rhythm?",
                             "role_observation_checklist": [
-                                "Notice whether meetings have a clear purpose and ending point.",
-                                "Notice whether feedback targets behavior rather than personal character.",
-                                "Notice whether people can step out of emotionally loaded conversations when needed."
+                                "Whether roles and decision rights are clear",
+                                "Whether information reaches the right people",
+                                "Whether coordination cost is visible"
                             ],
-                            "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-                            "recovery_condition": "May require predictable space for pause, review, and handoff.",
-                            "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-                            "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+                            "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+                            "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+                            "what_to_verify": "Does complex collaboration have a role map, conflict process, and information rhythm? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+                            "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
                         },
                         "meta": {
                             "id": "collaboration_complexity_high",
                             "asset_type": "career_environment_base",
                             "v23_source_id": "collaboration_complexity_high",
                             "claim_risk": "medium",
-                            "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                            "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
                             "variable": "collaboration_complexity",
                             "level": "high",
                             "overlay_imported": false
@@ -17004,8 +17004,8 @@
             },
             "meta": {
                 "v23_source": "career_environment_v2.json",
-                "import_scope": "base_assets_only",
-                "deferred": "formulation_overlays require resolver support and are intentionally left to a later PR."
+                "science_repair": "SCI-08",
+                "content_boundary": "Environment-variable decision support only; no career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction."
             }
         },
         "action_prescriptions": {

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/career_environment.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/career_environment.json
@@ -5,43 +5,43 @@
     "interpersonal_density": {
       "low": {
         "zh-CN": {
-          "label": "人际密度：低",
-          "meaning": "互动频率、会议密度和需要读人的程度",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "人际密度：较低",
+          "meaning": "工作中互动、会议、协调和读人信号的频率",
+          "fit_signal": "可观察的环境线索：人际密度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度较低也可能带来额外压力。",
+          "interview_question": "这个环境的低互动是真正稳定，还是只在出问题时集中爆发？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "会议是否有明确目的和结束条件",
+            "反馈是否具体到行为和下一步",
+            "是否允许暂时退出高情绪对话"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "这个环境的低互动是真正稳定，还是只在出问题时集中爆发？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Interpersonal density: low",
-          "meaning": "the amount of interaction, meeting load, and people-reading required",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+          "fit_signal": "Environment cue to observe: when interpersonal density is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low interpersonal density can still create pressure.",
+          "interview_question": "Is the low interaction genuinely stable, or does communication pile up when something goes wrong?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether meetings have a clear purpose and end point",
+            "Whether feedback names behavior and next steps",
+            "Whether people can step out of emotionally loaded conversations when needed"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is the low interaction genuinely stable, or does communication pile up when something goes wrong? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "interpersonal_density_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "interpersonal_density_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "interpersonal_density",
           "level": "low",
           "overlay_imported": false
@@ -49,43 +49,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "人际密度：中",
-          "meaning": "互动频率、会议密度和需要读人的程度",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "人际密度：中等",
+          "meaning": "工作中互动、会议、协调和读人信号的频率",
+          "fit_signal": "可观察的环境线索：人际密度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度中等也可能带来额外压力。",
+          "interview_question": "团队有没有清楚的会议节奏、反馈方式和可暂停窗口？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "会议是否有明确目的和结束条件",
+            "反馈是否具体到行为和下一步",
+            "是否允许暂时退出高情绪对话"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "团队有没有清楚的会议节奏、反馈方式和可暂停窗口？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Interpersonal density: medium",
-          "meaning": "the amount of interaction, meeting load, and people-reading required",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+          "fit_signal": "Environment cue to observe: when interpersonal density is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium interpersonal density can still create pressure.",
+          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and pause windows?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether meetings have a clear purpose and end point",
+            "Whether feedback names behavior and next steps",
+            "Whether people can step out of emotionally loaded conversations when needed"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and pause windows? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "interpersonal_density_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "interpersonal_density_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "interpersonal_density",
           "level": "medium",
           "overlay_imported": false
@@ -93,43 +93,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "人际密度：高",
-          "meaning": "互动频率、会议密度和需要读人的程度",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "人际密度：较高",
+          "meaning": "工作中互动、会议、协调和读人信号的频率",
+          "fit_signal": "可观察的环境线索：人际密度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，人际密度较高也可能带来额外压力。",
+          "interview_question": "高互动是否配有清楚边界、交接方式和恢复空间？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "会议是否有明确目的和结束条件",
+            "反馈是否具体到行为和下一步",
+            "是否允许暂时退出高情绪对话"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高互动是否配有清楚边界、交接方式和恢复空间？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Interpersonal density: high",
-          "meaning": "the amount of interaction, meeting load, and people-reading required",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "how often the work requires interaction, meetings, coordination, and reading social cues",
+          "fit_signal": "Environment cue to observe: when interpersonal density is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high interpersonal density can still create pressure.",
+          "interview_question": "Does high interaction come with clear boundaries, handoff norms, and recovery space?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether meetings have a clear purpose and end point",
+            "Whether feedback names behavior and next steps",
+            "Whether people can step out of emotionally loaded conversations when needed"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does high interaction come with clear boundaries, handoff norms, and recovery space? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "interpersonal_density_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "interpersonal_density_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "interpersonal_density",
           "level": "high",
           "overlay_imported": false
@@ -139,43 +139,43 @@
     "emotional_labor": {
       "low": {
         "zh-CN": {
-          "label": "情绪劳动：低",
-          "meaning": "需要承接、安抚或整理他人情绪的程度",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "情绪劳动：较低",
+          "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+          "fit_signal": "可观察的环境线索：情绪劳动较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动较低也可能带来额外压力。",
+          "interview_question": "情绪劳动低，是因为流程清楚，还是因为情绪问题被延后处理？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "情绪承接是否被正式承认",
+            "是否有复盘和轮换机制",
+            "是否把“会安抚人”默认成个人义务"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "情绪劳动低，是因为流程清楚，还是因为情绪问题被延后处理？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Emotional labor: low",
-          "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+          "fit_signal": "Environment cue to observe: when emotional labor is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low emotional labor can still create pressure.",
+          "interview_question": "Is emotional labor low because process is clear, or because emotional issues are postponed?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether emotional labor is formally recognized",
+            "Whether there is review and rotation",
+            "Whether soothing others is treated as a personal obligation"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is emotional labor low because process is clear, or because emotional issues are postponed? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "emotional_labor_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "emotional_labor_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "emotional_labor",
           "level": "low",
           "overlay_imported": false
@@ -183,43 +183,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "情绪劳动：中",
-          "meaning": "需要承接、安抚或整理他人情绪的程度",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "情绪劳动：中等",
+          "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+          "fit_signal": "可观察的环境线索：情绪劳动中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动中等也可能带来额外压力。",
+          "interview_question": "谁负责承接客户、同事或团队中的情绪压力？是否有轮换和复盘？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "情绪承接是否被正式承认",
+            "是否有复盘和轮换机制",
+            "是否把“会安抚人”默认成个人义务"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "谁负责承接客户、同事或团队中的情绪压力？是否有轮换和复盘？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Emotional labor: medium",
-          "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+          "fit_signal": "Environment cue to observe: when emotional labor is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium emotional labor can still create pressure.",
+          "interview_question": "Who carries emotional pressure from clients, colleagues, or the team, and is there rotation or review?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether emotional labor is formally recognized",
+            "Whether there is review and rotation",
+            "Whether soothing others is treated as a personal obligation"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Who carries emotional pressure from clients, colleagues, or the team, and is there rotation or review? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "emotional_labor_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "emotional_labor_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "emotional_labor",
           "level": "medium",
           "overlay_imported": false
@@ -227,43 +227,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "情绪劳动：高",
-          "meaning": "需要承接、安抚或整理他人情绪的程度",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "情绪劳动：较高",
+          "meaning": "工作是否经常要求承接、安抚、协调或管理他人情绪",
+          "fit_signal": "可观察的环境线索：情绪劳动较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，情绪劳动较高也可能带来额外压力。",
+          "interview_question": "高情绪劳动是否有督导、复盘、边界和恢复机制？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "情绪承接是否被正式承认",
+            "是否有复盘和轮换机制",
+            "是否把“会安抚人”默认成个人义务"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高情绪劳动是否有督导、复盘、边界和恢复机制？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Emotional labor: high",
-          "meaning": "how often the role asks you to receive, soothe, or organize other people’s emotion",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "how often the work asks people to absorb, soothe, coordinate, or manage others’ emotions",
+          "fit_signal": "Environment cue to observe: when emotional labor is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high emotional labor can still create pressure.",
+          "interview_question": "Does high emotional labor come with supervision, review, boundaries, and recovery practices?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether emotional labor is formally recognized",
+            "Whether there is review and rotation",
+            "Whether soothing others is treated as a personal obligation"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does high emotional labor come with supervision, review, boundaries, and recovery practices? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "emotional_labor_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "emotional_labor_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "emotional_labor",
           "level": "high",
           "overlay_imported": false
@@ -273,43 +273,43 @@
     "conflict_frequency": {
       "low": {
         "zh-CN": {
-          "label": "冲突频率：低",
-          "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "冲突频率：较低",
+          "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+          "fit_signal": "可观察的环境线索：冲突频率较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率较低也可能带来额外压力。",
+          "interview_question": "低冲突是否来自透明规则，还是来自回避和沉默？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "分歧是否能被记录和复盘",
+            "权力差是否影响谁能说话",
+            "是否有安全退出或升级机制"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "低冲突是否来自透明规则，还是来自回避和沉默？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Conflict frequency: low",
-          "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+          "fit_signal": "Environment cue to observe: when conflict frequency is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low conflict frequency can still create pressure.",
+          "interview_question": "Does low conflict come from clear rules, or from avoidance and silence?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether disagreements are documented and reviewed",
+            "Whether power differences shape who can speak",
+            "Whether there is a safe exit or escalation path"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does low conflict come from clear rules, or from avoidance and silence? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "conflict_frequency_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "conflict_frequency_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "conflict_frequency",
           "level": "low",
           "overlay_imported": false
@@ -317,43 +317,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "冲突频率：中",
-          "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "冲突频率：中等",
+          "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+          "fit_signal": "可观察的环境线索：冲突频率中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率中等也可能带来额外压力。",
+          "interview_question": "冲突出现时，团队用事实、角色和流程处理，还是靠个人关系消化？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "分歧是否能被记录和复盘",
+            "权力差是否影响谁能说话",
+            "是否有安全退出或升级机制"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "冲突出现时，团队用事实、角色和流程处理，还是靠个人关系消化？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Conflict frequency: medium",
-          "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+          "fit_signal": "Environment cue to observe: when conflict frequency is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium conflict frequency can still create pressure.",
+          "interview_question": "When conflict appears, does the team use facts, roles, and process, or personal relationships?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether disagreements are documented and reviewed",
+            "Whether power differences shape who can speak",
+            "Whether there is a safe exit or escalation path"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "When conflict appears, does the team use facts, roles, and process, or personal relationships? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "conflict_frequency_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "conflict_frequency_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "conflict_frequency",
           "level": "medium",
           "overlay_imported": false
@@ -361,43 +361,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "冲突频率：高",
-          "meaning": "分歧、投诉、谈判或资源博弈出现的频率",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "冲突频率：较高",
+          "meaning": "工作中分歧、投诉、谈判、博弈或高压对话出现的频率",
+          "fit_signal": "可观察的环境线索：冲突频率较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，冲突频率较高也可能带来额外压力。",
+          "interview_question": "高冲突场景是否有升级路径、记录机制和安全边界？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "分歧是否能被记录和复盘",
+            "权力差是否影响谁能说话",
+            "是否有安全退出或升级机制"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高冲突场景是否有升级路径、记录机制和安全边界？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Conflict frequency: high",
-          "meaning": "how often disagreements, complaints, negotiations, or resource tensions appear",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "how often disagreement, complaints, negotiation, trade-offs, or high-pressure conversations appear",
+          "fit_signal": "Environment cue to observe: when conflict frequency is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high conflict frequency can still create pressure.",
+          "interview_question": "Do high-conflict situations have escalation paths, documentation, and safety boundaries?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether disagreements are documented and reviewed",
+            "Whether power differences shape who can speak",
+            "Whether there is a safe exit or escalation path"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Do high-conflict situations have escalation paths, documentation, and safety boundaries? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "conflict_frequency_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "conflict_frequency_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "conflict_frequency",
           "level": "high",
           "overlay_imported": false
@@ -407,43 +407,43 @@
     "feedback_intensity": {
       "low": {
         "zh-CN": {
-          "label": "反馈强度：低",
-          "meaning": "被评价、修改、复盘和公开讨论的频率",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "反馈强度：较低",
+          "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+          "fit_signal": "可观察的环境线索：反馈强度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度较低也可能带来额外压力。",
+          "interview_question": "低反馈是否意味着自主空间，还是意味着标准不清？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "反馈是否指向行为而非人格",
+            "是否有修改资源和时间",
+            "是否公开比较或羞辱"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "低反馈是否意味着自主空间，还是意味着标准不清？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Feedback intensity: low",
-          "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+          "fit_signal": "Environment cue to observe: when feedback intensity is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low feedback intensity can still create pressure.",
+          "interview_question": "Does low feedback mean autonomy, or unclear standards?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether feedback targets behavior rather than character",
+            "Whether there is time and resource to revise",
+            "Whether comparison or humiliation is used"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does low feedback mean autonomy, or unclear standards? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "feedback_intensity_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "feedback_intensity_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "feedback_intensity",
           "level": "low",
           "overlay_imported": false
@@ -451,43 +451,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "反馈强度：中",
-          "meaning": "被评价、修改、复盘和公开讨论的频率",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "反馈强度：中等",
+          "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+          "fit_signal": "可观察的环境线索：反馈强度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度中等也可能带来额外压力。",
+          "interview_question": "反馈是否具体、定期，并能区分任务问题和个人评价？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "反馈是否指向行为而非人格",
+            "是否有修改资源和时间",
+            "是否公开比较或羞辱"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "反馈是否具体、定期，并能区分任务问题和个人评价？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Feedback intensity: medium",
-          "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+          "fit_signal": "Environment cue to observe: when feedback intensity is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium feedback intensity can still create pressure.",
+          "interview_question": "Is feedback specific, regular, and able to separate task issues from personal judgment?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether feedback targets behavior rather than character",
+            "Whether there is time and resource to revise",
+            "Whether comparison or humiliation is used"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is feedback specific, regular, and able to separate task issues from personal judgment? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "feedback_intensity_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "feedback_intensity_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "feedback_intensity",
           "level": "medium",
           "overlay_imported": false
@@ -495,43 +495,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "反馈强度：高",
-          "meaning": "被评价、修改、复盘和公开讨论的频率",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "反馈强度：较高",
+          "meaning": "被评价、修改、复盘、公开比较或快速迭代的频率",
+          "fit_signal": "可观察的环境线索：反馈强度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，反馈强度较高也可能带来额外压力。",
+          "interview_question": "高频反馈是否有清楚标准、节奏和修正空间？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "反馈是否指向行为而非人格",
+            "是否有修改资源和时间",
+            "是否公开比较或羞辱"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高频反馈是否有清楚标准、节奏和修正空间？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Feedback intensity: high",
-          "meaning": "how often your work is reviewed, revised, discussed, or evaluated",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "how often the work involves evaluation, revision, review, public comparison, or fast iteration",
+          "fit_signal": "Environment cue to observe: when feedback intensity is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high feedback intensity can still create pressure.",
+          "interview_question": "Does frequent feedback come with clear standards, pacing, and room to revise?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether feedback targets behavior rather than character",
+            "Whether there is time and resource to revise",
+            "Whether comparison or humiliation is used"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does frequent feedback come with clear standards, pacing, and room to revise? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "feedback_intensity_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "feedback_intensity_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "feedback_intensity",
           "level": "high",
           "overlay_imported": false
@@ -541,43 +541,43 @@
     "autonomy_recovery": {
       "low": {
         "zh-CN": {
-          "label": "自主恢复空间：低",
-          "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "自主恢复空间：较低",
+          "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+          "fit_signal": "可观察的环境线索：自主恢复空间较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间较低也可能带来额外压力。",
+          "interview_question": "恢复空间少时，是否至少有明确交接、暂停和求助规则？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "是否能安排短暂停顿",
+            "是否有交接和替补机制",
+            "自主是否变成无人支持"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "恢复空间少时，是否至少有明确交接、暂停和求助规则？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Autonomy and recovery space: low",
-          "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+          "fit_signal": "Environment cue to observe: when autonomy and recovery space is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low autonomy and recovery space can still create pressure.",
+          "interview_question": "When recovery space is low, are there at least clear handoff, pause, and support rules?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether short pauses are possible",
+            "Whether handoff and backup exist",
+            "Whether autonomy turns into lack of support"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "When recovery space is low, are there at least clear handoff, pause, and support rules? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "autonomy_recovery_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "autonomy_recovery_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "autonomy_recovery",
           "level": "low",
           "overlay_imported": false
@@ -585,43 +585,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "自主恢复空间：中",
-          "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "自主恢复空间：中等",
+          "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+          "fit_signal": "可观察的环境线索：自主恢复空间中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间中等也可能带来额外压力。",
+          "interview_question": "恢复空间是否可预期，还是只取决于当天气氛？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "是否能安排短暂停顿",
+            "是否有交接和替补机制",
+            "自主是否变成无人支持"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "恢复空间是否可预期，还是只取决于当天气氛？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Autonomy and recovery space: medium",
-          "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+          "fit_signal": "Environment cue to observe: when autonomy and recovery space is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium autonomy and recovery space can still create pressure.",
+          "interview_question": "Is recovery space predictable, or dependent on the day’s atmosphere?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether short pauses are possible",
+            "Whether handoff and backup exist",
+            "Whether autonomy turns into lack of support"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is recovery space predictable, or dependent on the day’s atmosphere? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "autonomy_recovery_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "autonomy_recovery_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "autonomy_recovery",
           "level": "medium",
           "overlay_imported": false
@@ -629,43 +629,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "自主恢复空间：高",
-          "meaning": "你能否安排独处、复盘和情绪恢复的空间",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "自主恢复空间：较高",
+          "meaning": "工作是否允许暂停、独处、切换节奏和从情绪负荷中恢复",
+          "fit_signal": "可观察的环境线索：自主恢复空间较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，自主恢复空间较高也可能带来额外压力。",
+          "interview_question": "高自主是否伴随清楚目标和反馈，而不是让人孤立承担？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "是否能安排短暂停顿",
+            "是否有交接和替补机制",
+            "自主是否变成无人支持"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高自主是否伴随清楚目标和反馈，而不是让人孤立承担？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Autonomy and recovery space: high",
-          "meaning": "whether you can create space for solitude, reflection, and emotional reset",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "whether the work allows pausing, solitude, pace changes, and recovery from emotional load",
+          "fit_signal": "Environment cue to observe: when autonomy and recovery space is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high autonomy and recovery space can still create pressure.",
+          "interview_question": "Does high autonomy come with clear goals and feedback, rather than leaving people isolated?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether short pauses are possible",
+            "Whether handoff and backup exist",
+            "Whether autonomy turns into lack of support"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does high autonomy come with clear goals and feedback, rather than leaving people isolated? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "autonomy_recovery_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "autonomy_recovery_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "autonomy_recovery",
           "level": "high",
           "overlay_imported": false
@@ -675,43 +675,43 @@
     "collaboration_complexity": {
       "low": {
         "zh-CN": {
-          "label": "协作复杂度：低",
-          "meaning": "需要协调多少角色、目标和隐性关系压力",
-          "fit_signal": "可优先观察是否需要先把任务做深、减少连续情绪切换的阶段。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是关系信号不足时，你可能难以及时校准他人预期。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "这个环境是否真的安静，还是只是把沟通延后到危机时？",
+          "label": "协作复杂度：较低",
+          "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+          "fit_signal": "可观察的环境线索：协作复杂度较低时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度较低也可能带来额外压力。",
+          "interview_question": "协作简单是否有清楚责任，还是只是信息不透明？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "角色和决策权是否明确",
+            "信息是否同步到相关人",
+            "协调成本是否被看见"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "这个环境是否真的安静，还是只是把沟通延后到危机时？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "协作简单是否有清楚责任，还是只是信息不透明？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Collaboration complexity: low",
-          "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-          "fit_signal": "May be easier to evaluate when the work requires depth, fewer social switches, and more continuity. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that fewer relational cues can make expectation-setting slower. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem?",
+          "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+          "fit_signal": "Environment cue to observe: when collaboration complexity is low, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, low collaboration complexity can still create pressure.",
+          "interview_question": "Is collaboration simple because responsibility is clear, or because information is hidden?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether roles and decision rights are clear",
+            "Whether information reaches the right people",
+            "Whether coordination cost is visible"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Is the environment genuinely quiet, or does it only postpone communication until there is a problem? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Is collaboration simple because responsibility is clear, or because information is hidden? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "collaboration_complexity_low",
           "asset_type": "career_environment_base",
           "v23_source_id": "collaboration_complexity_low",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "collaboration_complexity",
           "level": "low",
           "overlay_imported": false
@@ -719,43 +719,43 @@
       },
       "medium": {
         "zh-CN": {
-          "label": "协作复杂度：中",
-          "meaning": "需要协调多少角色、目标和隐性关系压力",
-          "fit_signal": "可优先观察是否能在互动和独立之间切换，并用复盘保持稳定。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是模糊边界让互动慢慢侵入恢复时间。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？",
+          "label": "协作复杂度：中等",
+          "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+          "fit_signal": "可观察的环境线索：协作复杂度中等时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度中等也可能带来额外压力。",
+          "interview_question": "多方协作时，谁拥有决策权、节奏权和最终确认权？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "角色和决策权是否明确",
+            "信息是否同步到相关人",
+            "协调成本是否被看见"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "团队是否有清楚的会议节奏、反馈方式和恢复窗口？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "多方协作时，谁拥有决策权、节奏权和最终确认权？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Collaboration complexity: medium",
-          "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-          "fit_signal": "May be easier to evaluate when you can move between interaction and solo work with enough review time. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is that unclear boundaries can slowly eat into recovery time. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Does the team have clear meeting rhythm, feedback norms, and recovery windows?",
+          "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+          "fit_signal": "Environment cue to observe: when collaboration complexity is medium, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, medium collaboration complexity can still create pressure.",
+          "interview_question": "In multi-party work, who owns decisions, pacing, and final confirmation?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether roles and decision rights are clear",
+            "Whether information reaches the right people",
+            "Whether coordination cost is visible"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Does the team have clear meeting rhythm, feedback norms, and recovery windows? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "In multi-party work, who owns decisions, pacing, and final confirmation? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "collaboration_complexity_medium",
           "asset_type": "career_environment_base",
           "v23_source_id": "collaboration_complexity_medium",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "collaboration_complexity",
           "level": "medium",
           "overlay_imported": false
@@ -763,43 +763,43 @@
       },
       "high": {
         "zh-CN": {
-          "label": "协作复杂度：高",
-          "meaning": "需要协调多少角色、目标和隐性关系压力",
-          "fit_signal": "可优先观察是否能把情绪信息转成沟通和决策的人，但需要明确边界。 这不是职业适配结论。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "strain_signal": "可能的风险是持续承接他人情绪，导致判断和恢复被消耗。 真实消耗取决于岗位设计、组织文化、权力结构和支持系统。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "interview_question": "长期看，这个环境是否允许暂停、交接和情绪复位？",
+          "label": "协作复杂度：较高",
+          "meaning": "是否需要在多方目标、角色、利益和沟通风格之间协调",
+          "fit_signal": "可观察的环境线索：协作复杂度较高时，重点不是判断岗位好坏，而是看它怎样影响沟通负荷、边界和恢复。",
+          "strain_signal": "可能增加消耗的条件：如果规则、权力差、支持系统和恢复空间不清楚，协作复杂度较高也可能带来额外压力。",
+          "interview_question": "高复杂协作是否有角色图、冲突处理机制和信息同步节奏？",
           "role_observation_checklist": [
-            "看会议是否有明确目的和结束条件。",
-            "看反馈是否具体到行为，而不是停留在人身感受。",
-            "看团队是否允许人暂时退出高情绪对话。"
+            "角色和决策权是否明确",
+            "信息是否同步到相关人",
+            "协调成本是否被看见"
           ],
-          "team_risk": "如果这个变量被长期忽视，团队会把情绪成本转嫁给最愿意承担的人。",
-          "recovery_condition": "可能需要可预期的暂停、复盘和交接空间。",
-          "what_to_verify": "长期看，这个环境是否允许暂停、交接和情绪复位？ 必须先验证真实岗位环境，再做判断。 请结合具体岗位、组织文化、管理方式和权力结构验证。",
-          "do_not_overread": "这描述的是职业环境变量，不是职业推荐、岗位适配结论、招聘信号或绩效预测。 请把它作为职业环境变量阅读，不是职业推荐、招聘信号或岗位表现预测。 具体情境、文化背景、岗位期待、权力差、安全性和关系历史都会影响这个模式如何出现。"
+          "team_risk": "若这个变量长期不被看见，团队容易把情绪协调、信息补位或冲突缓冲交给最愿意承担的人。",
+          "recovery_condition": "优先验证是否有可预期的暂停、交接、复盘和求助空间。",
+          "what_to_verify": "高复杂协作是否有角色图、冲突处理机制和信息同步节奏？ 同时观察具体角色、组织文化、管理方式、权力结构、团队资源和你的当前生活阶段。",
+          "do_not_overread": "这是职业环境变量，不是职业建议、岗位匹配判断、录用依据或绩效预测。它只能帮助你提出验证问题；同一变量在不同组织、管理者、文化和权力结构下可能完全不同。"
         },
         "en": {
           "label": "Collaboration complexity: high",
-          "meaning": "how many roles, goals, and hidden relational pressures must be coordinated",
-          "fit_signal": "May be easier to evaluate when emotional information can be discussed with explicit boundaries and recovery practices. This is not an occupation fit statement. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "strain_signal": "A possible strain is sustained emotional load, which can drain judgment and recovery. Actual strain depends on role design, organization, culture, power, and support. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "interview_question": "Over time, does the environment allow pause, handoff, and emotional reset?",
+          "meaning": "whether the work requires coordination across multiple goals, roles, interests, and communication styles",
+          "fit_signal": "Environment cue to observe: when collaboration complexity is high, the point is not to judge a role as good or bad. The point is to see how it may affect communication load, boundaries, and recovery.",
+          "strain_signal": "Possible strain condition: if rules, power differences, support, and recovery space are unclear, high collaboration complexity can still create pressure.",
+          "interview_question": "Does complex collaboration have a role map, conflict process, and information rhythm?",
           "role_observation_checklist": [
-            "Notice whether meetings have a clear purpose and ending point.",
-            "Notice whether feedback targets behavior rather than personal character.",
-            "Notice whether people can step out of emotionally loaded conversations when needed."
+            "Whether roles and decision rights are clear",
+            "Whether information reaches the right people",
+            "Whether coordination cost is visible"
           ],
-          "team_risk": "If this variable is ignored, teams often shift emotional cost onto the person most willing to carry it.",
-          "recovery_condition": "May require predictable space for pause, review, and handoff.",
-          "what_to_verify": "Over time, does the environment allow pause, handoff, and emotional reset? Verify the real role context before drawing conclusions. Check the actual role, organization, management style, culture, and power structure before drawing conclusions.",
-          "do_not_overread": "This describes an environment variable, not a role recommendation. Use this as an environment lens, not an occupation recommendation, hiring signal, or prediction of role performance. Context, culture, role expectations, power differences, safety, and relationship history can change how this pattern shows up. This describes an environment variable, not an occupation recommendation, hiring signal, or prediction of role performance."
+          "team_risk": "When this variable stays invisible, teams often shift emotional coordination, information cleanup, or conflict buffering onto the person most willing to carry it.",
+          "recovery_condition": "Verify whether there is predictable room for pause, handoff, review, and support.",
+          "what_to_verify": "Does complex collaboration have a role map, conflict process, and information rhythm? Also observe the actual role, organization culture, management style, power structure, team resources, and your current life context.",
+          "do_not_overread": "This is a work-environment variable, not career advice, role-fit evidence, selection evidence, or a performance prediction. It can help you ask better verification questions; the same variable can work very differently across organizations, managers, cultures, and power structures."
         },
         "meta": {
           "id": "collaboration_complexity_high",
           "asset_type": "career_environment_base",
           "v23_source_id": "collaboration_complexity_high",
           "claim_risk": "medium",
-          "risk_notes": "Career environment variable only; no occupation recommendation or hiring inference. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+          "risk_notes": "Work-environment variable only; not career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction.",
           "variable": "collaboration_complexity",
           "level": "high",
           "overlay_imported": false
@@ -809,7 +809,7 @@
   },
   "meta": {
     "v23_source": "career_environment_v2.json",
-    "import_scope": "base_assets_only",
-    "deferred": "formulation_overlays require resolver support and are intentionally left to a later PR."
+    "science_repair": "SCI-08",
+    "content_boundary": "Environment-variable decision support only; no career advice, selection evidence, role-fit proof, diagnosis, ability evidence, or performance prediction."
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69119,8 +69119,8 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-06"
     ],
-    "status": "pr_open",
-    "commit_sha": "1a99b62bed7e4eea58f4bf3ab4c2a76b3d76fcf9",
+    "status": "merged",
+    "commit_sha": "93ab2227954d846bae4973b3e5b0551e28bb39eb",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2628",
     "checks": [
       {
@@ -69165,14 +69165,14 @@
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T18:25:36Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -69189,8 +69189,14 @@
         "at": "2026-07-02T18:19:11.803617Z",
         "status": "pr_open",
         "summary": "Opened PR #2628 for SCI-07 with head commit 1a99b62bed7e4eea58f4bf3ab4c2a76b3d76fcf9."
+      },
+      {
+        "at": "2026-07-02T18:29:43.669049Z",
+        "status": "merged",
+        "summary": "Reconciled after GitHub confirmed PR #2628 merged with merge commit 99f54e2573dccc6ab37207bd8d14c05a73afc407; remote and local task branches were cleaned."
       }
-    ]
+    ],
+    "merge_commit_sha": "99f54e2573dccc6ab37207bd8d14c05a73afc407"
   },
   "PR-EQ-ASSET-SCI-08": {
     "id": "PR-EQ-ASSET-SCI-08",
@@ -69201,17 +69207,58 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-05"
     ],
-    "status": "user_authorized",
-    "commit_sha": null,
-    "pr_url": null,
-    "checks": [],
+    "status": "pr_open",
+    "commit_sha": "1b9c06425c3e64a39957f9cd08ae2d5dcd31e45b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2633",
+    "checks": [
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed after career_environment decision-boundary updates."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; scoped report_assets compiled output retained and alias mirror synchronized."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 432 assertions; PHPUnit reported existing environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed_with_warnings",
+        "summary": "12 tests passed, 683 assertions; PHPUnit reported existing environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 208 assertions; PHPUnit reported existing environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed_with_warnings",
+        "summary": "4 tests passed, 130 assertions; PHPUnit reported existing environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 16 assertions; PHPUnit reported existing environment file_get_contents warning only."
+      },
+      {
+        "command": "python/json scans + cmp raw mirror",
+        "status": "passed",
+        "summary": "No job-fit, occupation recommendation, hiring, screening, paywall, or SKU wording found; raw career_environment mirror matched byte-for-byte."
+      }
+    ],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -69220,6 +69267,16 @@
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      },
+      {
+        "at": "2026-07-02T18:29:43.669049Z",
+        "status": "local_checks_passed",
+        "summary": "Career environment assets repaired as environment-variable decision support without job-fit, selection, or performance claims; local checks passed."
+      },
+      {
+        "at": "2026-07-02T18:30:59.802033Z",
+        "status": "pr_open",
+        "summary": "Opened PR #2633 for SCI-08 with head commit 1b9c06425c3e64a39957f9cd08ae2d5dcd31e45b."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Repaired EQ `career_environment` assets for both `EQ_60` and `EQ_EMOTIONAL_INTELLIGENCE`.
- Reframed all 6 environment variables x 3 levels as work-environment verification questions, not job-fit or occupation recommendations.
- Added clearer role, organization, culture, management style, power-structure, support-system, and recovery-space boundaries.
- Removed job-fit, occupation recommendation, hiring/screening, paywall, and SKU wording from user-visible career environment assets.
- Refreshed scoped compiled `report_assets.compiled.json` mirrors.
- Reconciled `PR-EQ-ASSET-SCI-07` ledger state and recorded local validation for this PR.

## Why
Career environment assets are useful only if they stay as environment-variable decision support. This PR prevents EQ self-report results from being read as occupation advice, role-fit proof, selection evidence, or performance prediction.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1` — passed
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1` — passed
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest` — passed with existing environment warning
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest` — passed with existing environment warnings
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest` — passed with existing environment warning
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest` — passed with existing environment warnings
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest` — passed with existing environment warning
- JSON/YAML parse — passed
- Raw and compiled EQ_60 / EQ_EMOTIONAL_INTELLIGENCE mirror cmp — passed
- Job-fit / occupation recommendation / hiring / screening / paywall wording scan — passed
- `git diff --check` / `git diff --cached --check` — passed

## Deferred
- No composer selection changes.
- No scoring, question, norm, SJT, commerce, frontend, CMS, or deployment changes.

## Repository rule impact
Backend content pack remains the authority layer for EQ report content. No frontend or CMS authority change.
