### PR TITLE
RIASEC-CONTENT-SHARE-01 repair RIASEC public share card copy

### DIFF
--- a/backend/app/Services/Riasec/RiasecLifecycleCopyService.php
+++ b/backend/app/Services/Riasec/RiasecLifecycleCopyService.php
@@ -209,6 +209,11 @@ final class RiasecLifecycleCopyService
                 'public_safe' => (bool) ($row['public_safe'] ?? false),
                 'raw_scores_allowed' => false,
                 'raw_feedback_allowed' => false,
+                'public_summary_mode' => (string) ($row['public_summary_mode'] ?? 'surface_specific_boundary'),
+                'holland_code_exposure_allowed' => (bool) ($row['holland_code_exposure_allowed'] ?? false),
+                'private_context_allowed' => (bool) ($row['private_context_allowed'] ?? false),
+                'identity_label_allowed' => (bool) ($row['identity_label_allowed'] ?? false),
+                'share_card_default_visible' => (bool) ($row['share_card_default_visible'] ?? false),
             ];
         }
 

--- a/backend/content_assets/riasec/share_pdf_history_v1.en.json
+++ b/backend/content_assets/riasec/share_pdf_history_v1.en.json
@@ -7,17 +7,27 @@
   "surfaces": [
     {
       "surface": "share_safe_card",
-      "copy": "My RIASEC result points to work activities that may be worth exploring first. The share version shows only a safe summary and does not expose raw feedback or private context.",
+      "copy": "This is a public summary of a RIASEC interest snapshot. It only names broad activity clues that stood out in this response and is meant to start a conversation; it does not show scores, raw feedback, detailed Holland-code ordering, or private context.",
       "public_safe": true,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "public_summary_mode": "minimal_anonymous_interest_snapshot",
+      "holland_code_exposure_allowed": false,
+      "private_context_allowed": false,
+      "identity_label_allowed": false,
+      "share_card_default_visible": true
     },
     {
       "surface": "share_detail_boundary",
-      "copy": "The share page is not a full report and does not state a career conclusion. It summarizes the interest pattern and the method boundaries for this result.",
+      "copy": "The share page is not a full report and is not career advice. It keeps only a minimal interest-clue summary and method boundary, and must not be used to judge ability, job fit, or stable identity.",
       "public_safe": true,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "public_summary_mode": "minimal_anonymous_interest_snapshot",
+      "holland_code_exposure_allowed": false,
+      "private_context_allowed": false,
+      "identity_label_allowed": false,
+      "share_card_default_visible": true
     },
     {
       "surface": "pdf_personal",
@@ -49,10 +59,15 @@
     },
     {
       "surface": "low_quality_share",
-      "copy": "A cautious-reading result allows only a safe share summary by default and does not show a strong activity chain or occupation-context examples.",
+      "copy": "A cautious-reading result allows only a minimal public summary: it keeps the cautious-reading boundary and does not show strong interpretation content, occupation examples, scores, or private feedback.",
       "public_safe": true,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "public_summary_mode": "minimal_anonymous_interest_snapshot",
+      "holland_code_exposure_allowed": false,
+      "private_context_allowed": false,
+      "identity_label_allowed": false,
+      "share_card_default_visible": true
     }
   ],
   "required_boundaries": [

--- a/backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json
+++ b/backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json
@@ -7,17 +7,27 @@
   "surfaces": [
     {
       "surface": "share_safe_card",
-      "copy": "我的 RIASEC 结果显示：我更容易被若干工作活动线索吸引。分享版只展示安全摘要，不展示原始反馈或隐私上下文。",
+      "copy": "这是一张 RIASEC 兴趣快照的公开摘要：只说明本次作答中较靠前的活动线索，适合用来开启讨论；不展示分数、原始反馈、三字码细节或个人情境。",
       "public_safe": true,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "public_summary_mode": "minimal_anonymous_interest_snapshot",
+      "holland_code_exposure_allowed": false,
+      "private_context_allowed": false,
+      "identity_label_allowed": false,
+      "share_card_default_visible": true
     },
     {
       "surface": "share_detail_boundary",
-      "copy": "分享页不是完整报告，也不展示职业结论。它只说明本次结果的兴趣结构和方法边界。",
+      "copy": "分享页不是完整报告，也不是职业建议。它只保留最小化的兴趣线索摘要和方法边界，不能用于判断能力、岗位适配或长期身份。",
       "public_safe": true,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "public_summary_mode": "minimal_anonymous_interest_snapshot",
+      "holland_code_exposure_allowed": false,
+      "private_context_allowed": false,
+      "identity_label_allowed": false,
+      "share_card_default_visible": true
     },
     {
       "surface": "pdf_personal",
@@ -49,10 +59,15 @@
     },
     {
       "surface": "low_quality_share",
-      "copy": "谨慎阅读结果只允许安全分享摘要，默认不展示强活动线索组合或职业场景例子。",
+      "copy": "谨慎阅读结果只允许最小公开摘要：保留“需要谨慎阅读”的边界，不展示强解释内容、职业例子、分数或私人反馈。",
       "public_safe": true,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "public_summary_mode": "minimal_anonymous_interest_snapshot",
+      "holland_code_exposure_allowed": false,
+      "private_context_allowed": false,
+      "identity_label_allowed": false,
+      "share_card_default_visible": true
     }
   ],
   "required_boundaries": [

--- a/backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
@@ -194,6 +194,31 @@ final class RiasecLifecycleCopyPreflightTest extends TestCase
         $this->assertSame([], $hits);
     }
 
+    public function test_public_share_surfaces_are_minimal_anonymous_summaries(): void
+    {
+        $contract = app(\App\Services\Riasec\RiasecLifecycleCopyService::class)->lifecycleCopyContract(true);
+        $publicSurfaces = array_values(array_filter(
+            (array) data_get($contract, 'surfaces', []),
+            static fn (array $surface): bool => (bool) ($surface['public_safe'] ?? false)
+        ));
+
+        $this->assertSame(['share_safe_card', 'share_detail_boundary', 'low_quality_share'], array_column($publicSurfaces, 'surface'));
+
+        foreach ($publicSurfaces as $surface) {
+            $copy = (string) ($surface['copy'] ?? '');
+
+            $this->assertSame('minimal_anonymous_interest_snapshot', $surface['public_summary_mode']);
+            $this->assertFalse($surface['raw_scores_allowed']);
+            $this->assertFalse($surface['raw_feedback_allowed']);
+            $this->assertFalse($surface['holland_code_exposure_allowed']);
+            $this->assertFalse($surface['private_context_allowed']);
+            $this->assertFalse($surface['identity_label_allowed']);
+            $this->assertStringNotContainsString('我的 RIASEC 结果', $copy);
+            $this->assertDoesNotMatchRegularExpression('/\\b[RIASEC]{3}\\b/', $copy);
+            $this->assertDoesNotMatchRegularExpression('/\\b(?:100|75|50|25|0)(?:\\.0+)?\\b/', $copy);
+        }
+    }
+
     public function test_current_runtime_contracts_remain_snapshot_bound_and_public_safe(): void
     {
         $contract = app(RiasecTechnicalNoteService::class)->contract();

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70468,8 +70468,8 @@
     "depends_on": [
       "RIASEC-CONTENT-140CTX-01"
     ],
-    "status": "pr_opened",
-    "commit_sha": "2cb334c4fae3473c417060bb51122dbc190ba6d8",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "3218160238ba49ec1b6b205c385a4305b2dc6938",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2631",
     "checks": {
       "phpunit_projection_structural_tests": {
@@ -70493,14 +70493,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T18:37:26Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/app/Services/Riasec/RiasecPublicProjectionService.php",
         "backend/tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php",
@@ -70525,8 +70525,15 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2631 after 140CTX-02 local validation, repeated latest-main rebases, and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:41:34Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2631 merged; origin/main contains merge commit; local main synced; task branch cleaned. Recorded during SHARE-01 ledger reconciliation."
       }
-    ]
+    ],
+    "merge_commit_sha": "d1e1fe1e48467b5e257b2d94dfdddc2e9d86682e"
   },
   "RIASEC-CONTENT-SHARE-01": {
     "id": "RIASEC-CONTENT-SHARE-01",
@@ -70538,19 +70545,45 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "authorized_pending_start",
-    "commit_sha": null,
+    "status": "local_validation_passed",
+    "commit_sha": "PENDING_COMMIT_SHA",
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "phpunit_lifecycle_share_tests": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "11 tests, 1106 assertions"
+      },
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "176 tests, 104246 assertions"
+      },
+      "pint_and_json_parse": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php && python JSON parse share_pdf_history zh/en",
+        "status": "passed"
+      },
+      "manifest_state_parse_and_diff_check": {
+        "command": "ruby YAML parse; python JSON parse; git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecLifecycleCopyService.php",
+        "backend/content_assets/riasec/share_pdf_history_v1.en.json",
+        "backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json",
+        "backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -70558,6 +70591,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T18:41:34Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Repaired public share-card copy as minimal anonymous summary and added public-surface guard fields; local RIASEC unit subset and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70546,7 +70546,7 @@
       "RIASEC-CONTENT-SCIENCE-00"
     ],
     "status": "local_validation_passed",
-    "commit_sha": "PENDING_COMMIT_SHA",
+    "commit_sha": "24f517a928667f599d41b913c7e09ea215776340",
     "pr_url": null,
     "checks": {
       "phpunit_lifecycle_share_tests": {
@@ -70560,7 +70560,7 @@
         "summary": "176 tests, 104246 assertions"
       },
       "pint_and_json_parse": {
-        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php && python JSON parse share_pdf_history zh/en",
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php && php JSON parse share_pdf_history zh/en",
         "status": "passed"
       },
       "manifest_state_parse_and_diff_check": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70545,9 +70545,9 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": "24f517a928667f599d41b913c7e09ea215776340",
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "791df9c2dcd1e88a0fef777f277624a5b9fecfa0",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2634",
     "checks": {
       "phpunit_lifecycle_share_tests": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php --no-ansi --display-warnings",
@@ -70597,6 +70597,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Repaired public share-card copy as minimal anonymous summary and added public-surface guard fields; local RIASEC unit subset and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:46:36Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2634 after SHARE-01 local validation and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Reframed RIASEC public share-card copy as minimal anonymous interest snapshots in zh-CN and en.
- Added normalized public-share guard fields for summary mode, Holland-code exposure, private context, identity labels, and default visibility.
- Added lifecycle preflight coverage that blocks scores, private context, identity labeling, and specific Holland-code leakage on public share surfaces.
- Reconciled the previous 140CTX-02 ledger closeout and recorded SHARE-01 local validation state.

## Why
Public share cards must not expose scores, private feedback context, specific Holland-code details, or identity-like labels. They should be a compact public snapshot only, with deeper context remaining inside the private result/report surfaces.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php --no-ansi --display-warnings`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php`
- `php -r 'foreach (["backend/content_assets/riasec/share_pdf_history_v1.en.json", "backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json"] as $f) { json_decode(file_get_contents($f), true); if (json_last_error() !== JSON_ERROR_NONE) { fwrite(STDERR, "$f: ".json_last_error_msg()."\n"); exit(1); } echo "$f OK\n"; }'`
- `php -r 'json_decode(file_get_contents("docs/codex/pr-train-state.json"), true); if (json_last_error() !== JSON_ERROR_NONE) { fwrite(STDERR, json_last_error_msg()."\n"); exit(1); } echo "state JSON OK\n";'`
- `git diff --check`

## Intentionally deferred
- PDF density and parity changes remain for RIASEC-CONTENT-PDF-01.
- History-page summary wording remains for RIASEC-CONTENT-HISTORY-01.
- No CMS write, production import, manual deploy, production deploy, or staging deploy wait.

## Repository rule impact
RIASEC share content remains backend-authoritative under content assets and service projection guards. No fap-web public editorial content was added or modified.