### PR TITLE
RIASEC-CONTENT-PDF-01 repair RIASEC PDF density and boundaries

### DIFF
--- a/backend/app/Services/Riasec/RiasecLifecycleCopyService.php
+++ b/backend/app/Services/Riasec/RiasecLifecycleCopyService.php
@@ -214,6 +214,11 @@ final class RiasecLifecycleCopyService
                 'private_context_allowed' => (bool) ($row['private_context_allowed'] ?? false),
                 'identity_label_allowed' => (bool) ($row['identity_label_allowed'] ?? false),
                 'share_card_default_visible' => (bool) ($row['share_card_default_visible'] ?? false),
+                'pdf_surface_mode' => (string) ($row['pdf_surface_mode'] ?? 'not_pdf_surface'),
+                'pdf_density_mode' => (string) ($row['pdf_density_mode'] ?? 'not_pdf_surface'),
+                'boundary_repetition_allowed' => (bool) ($row['boundary_repetition_allowed'] ?? false),
+                'snapshot_bound_required' => (bool) ($row['snapshot_bound_required'] ?? false),
+                'pdf_default_visible' => (bool) ($row['pdf_default_visible'] ?? false),
             ];
         }
 

--- a/backend/content_assets/riasec/share_pdf_history_v1.en.json
+++ b/backend/content_assets/riasec/share_pdf_history_v1.en.json
@@ -31,17 +31,27 @@
     },
     {
       "surface": "pdf_personal",
-      "copy": "A personal PDF can preserve the full result, generation time, and method boundaries. Once a PDF is forwarded, the platform cannot remotely recall it.",
+      "copy": "A personal PDF is only a saved copy of this result: it keeps the assessment snapshot, generation time, and necessary method boundary once, without adding new career judgments. Once forwarded, the platform cannot remotely recall it.",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "pdf_surface_mode": "compact_snapshot_pdf",
+      "pdf_density_mode": "compact_boundary_once",
+      "boundary_repetition_allowed": false,
+      "snapshot_bound_required": true,
+      "pdf_default_visible": true
     },
     {
       "surface": "pdf_counselor_discussion",
-      "copy": "A counselor discussion version may show more exploration summary with user permission. It must not be used for screening, admission, promotion, elimination, or qualification decisions.",
+      "copy": "A counselor discussion PDF is for shared reading with user permission: it keeps a small exploration summary and the necessary limits, then turns them into next observation questions. It must not be used for screening, admission, promotion, elimination, or qualification decisions.",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "pdf_surface_mode": "compact_snapshot_pdf",
+      "pdf_density_mode": "compact_boundary_once",
+      "boundary_repetition_allowed": false,
+      "snapshot_bound_required": true,
+      "pdf_default_visible": true
     },
     {
       "surface": "history_same_form",

--- a/backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json
+++ b/backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json
@@ -31,17 +31,27 @@
     },
     {
       "surface": "pdf_personal",
-      "copy": "个人留存版可保留完整结果、生成时间和方法边界。请注意 PDF 一旦转发，平台无法远程撤回。",
+      "copy": "个人 PDF 只作为本次结果的留存版：保留测评快照、生成时间和必要方法边界；边界只出现一次，不重复展开，不加入新的职业判断。转发后平台无法远程撤回。",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "pdf_surface_mode": "compact_snapshot_pdf",
+      "pdf_density_mode": "compact_boundary_once",
+      "boundary_repetition_allowed": false,
+      "snapshot_bound_required": true,
+      "pdf_default_visible": true
     },
     {
       "surface": "pdf_counselor_discussion",
-      "copy": "咨询讨论版可以在用户授权下展示更多探索摘要，但不得用于筛选、录取、晋升、淘汰或资格判断。",
+      "copy": "咨询讨论版只用于用户授权下的共同阅读：保留少量探索摘要和必要限制，帮助提出下一步观察问题；不得用于筛选、录取、晋升、淘汰或资格判断。",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "pdf_surface_mode": "compact_snapshot_pdf",
+      "pdf_density_mode": "compact_boundary_once",
+      "boundary_repetition_allowed": false,
+      "snapshot_bound_required": true,
+      "pdf_default_visible": true
     },
     {
       "surface": "history_same_form",

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -195,6 +195,14 @@ final class RiasecAssessmentFlowTest extends TestCase
         $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.snapshot_bound', true);
         $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.internal_snapshot_id_public_exposure_allowed', false);
         $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.faq_markdown_reference_available', true);
+        $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.surfaces.2.surface', 'pdf_personal');
+        $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.surfaces.2.pdf_surface_mode', 'compact_snapshot_pdf');
+        $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.surfaces.2.pdf_density_mode', 'compact_boundary_once');
+        $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.surfaces.2.boundary_repetition_allowed', false);
+        $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.surfaces.2.snapshot_bound_required', true);
+        $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.surfaces.2.pdf_default_visible', true);
+        $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.surfaces.3.surface', 'pdf_counselor_discussion');
+        $report->assertJsonPath('riasec_public_projection_v2.lifecycle_copy_v1.surfaces.3.pdf_density_mode', 'compact_boundary_once');
 
         $reportAccess = $this->withHeaders([
             'X-Anon-Id' => $anonId,

--- a/backend/tests/Fixtures/Riasec/share_pdf_history_v1.zh-CN.json
+++ b/backend/tests/Fixtures/Riasec/share_pdf_history_v1.zh-CN.json
@@ -21,17 +21,27 @@
     },
     {
       "surface": "pdf_personal",
-      "copy": "个人留存版可保留完整结果、生成时间和方法边界。请注意 PDF 一旦转发，平台无法远程撤回。",
+      "copy": "个人 PDF 只作为本次结果的留存版：保留测评快照、生成时间和必要方法边界；边界只出现一次，不重复展开，不加入新的职业判断。转发后平台无法远程撤回。",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "pdf_surface_mode": "compact_snapshot_pdf",
+      "pdf_density_mode": "compact_boundary_once",
+      "boundary_repetition_allowed": false,
+      "snapshot_bound_required": true,
+      "pdf_default_visible": true
     },
     {
       "surface": "pdf_counselor_discussion",
-      "copy": "咨询讨论版可以在用户授权下展示更多探索摘要，但不得用于筛选、录取、晋升、淘汰或资格判断。",
+      "copy": "咨询讨论版只用于用户授权下的共同阅读：保留少量探索摘要和必要限制，帮助提出下一步观察问题；不得用于筛选、录取、晋升、淘汰或资格判断。",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "pdf_surface_mode": "compact_snapshot_pdf",
+      "pdf_density_mode": "compact_boundary_once",
+      "boundary_repetition_allowed": false,
+      "snapshot_bound_required": true,
+      "pdf_default_visible": true
     },
     {
       "surface": "history_same_form",

--- a/backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
@@ -108,6 +108,16 @@ final class RiasecLifecycleCopyPreflightTest extends TestCase
         foreach ($share['surfaces'] as $surface) {
             $this->assertFalse($surface['raw_scores_allowed']);
             $this->assertFalse($surface['raw_feedback_allowed']);
+
+            if (str_starts_with((string) $surface['surface'], 'pdf_')) {
+                $this->assertFalse($surface['public_safe']);
+                $this->assertSame('compact_snapshot_pdf', $surface['pdf_surface_mode']);
+                $this->assertSame('compact_boundary_once', $surface['pdf_density_mode']);
+                $this->assertFalse($surface['boundary_repetition_allowed']);
+                $this->assertTrue($surface['snapshot_bound_required']);
+                $this->assertTrue($surface['pdf_default_visible']);
+                $this->assertLessThanOrEqual(110, mb_strlen((string) $surface['copy']));
+            }
         }
         $this->assertSame('omit_module', $share['fallback_behavior']);
         $this->assertFalse($share['frontend_fallback_allowed']);
@@ -216,6 +226,37 @@ final class RiasecLifecycleCopyPreflightTest extends TestCase
             $this->assertStringNotContainsString('我的 RIASEC 结果', $copy);
             $this->assertDoesNotMatchRegularExpression('/\\b[RIASEC]{3}\\b/', $copy);
             $this->assertDoesNotMatchRegularExpression('/\\b(?:100|75|50|25|0)(?:\\.0+)?\\b/', $copy);
+        }
+    }
+
+    public function test_pdf_surfaces_use_compact_snapshot_boundary_policy(): void
+    {
+        $service = app(\App\Services\Riasec\RiasecLifecycleCopyService::class);
+
+        foreach (['zh-CN', 'en'] as $locale) {
+            $contract = $service->lifecycleCopyContract(true, $locale);
+            $pdfSurfaces = array_values(array_filter(
+                (array) data_get($contract, 'surfaces', []),
+                static fn (array $surface): bool => str_starts_with((string) ($surface['surface'] ?? ''), 'pdf_')
+            ));
+
+            $this->assertSame(['pdf_personal', 'pdf_counselor_discussion'], array_column($pdfSurfaces, 'surface'));
+
+            foreach ($pdfSurfaces as $surface) {
+                $copy = (string) ($surface['copy'] ?? '');
+
+                $this->assertFalse($surface['public_safe']);
+                $this->assertFalse($surface['raw_scores_allowed']);
+                $this->assertFalse($surface['raw_feedback_allowed']);
+                $this->assertSame('compact_snapshot_pdf', $surface['pdf_surface_mode']);
+                $this->assertSame('compact_boundary_once', $surface['pdf_density_mode']);
+                $this->assertFalse($surface['boundary_repetition_allowed']);
+                $this->assertTrue($surface['snapshot_bound_required']);
+                $this->assertTrue($surface['pdf_default_visible']);
+                $this->assertStringNotContainsString('raw score', strtolower($copy));
+                $this->assertDoesNotMatchRegularExpression('/\\b[RIASEC]{3}\\b/', $copy);
+                $this->assertDoesNotMatchRegularExpression('/\\b(?:100|75|50|25|0)(?:\\.0+)?\\b/', $copy);
+            }
         }
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70623,9 +70623,9 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": "055329859cad0ff74d67b0899dd9f0623dc85fe6",
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "cb78c8d32d4564d4f147292e665962466ce592dd",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2635",
     "checks": {
       "phpunit_lifecycle_pdf_report_tests": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi --display-warnings",
@@ -70677,6 +70677,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Compacted PDF lifecycle copy to one boundary pass, added snapshot-bound PDF policy fields, and validated lifecycle/report parity."
+      },
+      {
+        "at": "2026-07-02T18:58:18Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2635 after PDF-01 local validation and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70545,8 +70545,8 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "pr_opened",
-    "commit_sha": "791df9c2dcd1e88a0fef777f277624a5b9fecfa0",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "af132cf868a710ee3f84c7009cb7485f1d9c4cc5",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2634",
     "checks": {
       "phpunit_lifecycle_share_tests": {
@@ -70569,14 +70569,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T18:52:35Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/app/Services/Riasec/RiasecLifecycleCopyService.php",
         "backend/content_assets/riasec/share_pdf_history_v1.en.json",
@@ -70603,8 +70603,15 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2634 after SHARE-01 local validation and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T18:53:12Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2634 merged; origin/main contains merge commit; local main synced; task branch cleaned. Recorded during PDF-01 ledger reconciliation."
       }
-    ]
+    ],
+    "merge_commit_sha": "095730762b006fe09495e35fb1fa3d62db62b7de"
   },
   "RIASEC-CONTENT-PDF-01": {
     "id": "RIASEC-CONTENT-PDF-01",
@@ -70616,19 +70623,47 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "authorized_pending_start",
-    "commit_sha": null,
+    "status": "local_validation_passed",
+    "commit_sha": "055329859cad0ff74d67b0899dd9f0623dc85fe6",
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "phpunit_lifecycle_pdf_report_tests": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "12 tests, 1201 assertions"
+      },
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "177 tests, 104308 assertions"
+      },
+      "pint_and_json_parse": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php && php JSON parse share_pdf_history zh/en and zh fixture",
+        "status": "passed"
+      },
+      "diff_check": {
+        "command": "git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecLifecycleCopyService.php",
+        "backend/content_assets/riasec/share_pdf_history_v1.en.json",
+        "backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json",
+        "backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+        "backend/tests/Fixtures/Riasec/share_pdf_history_v1.zh-CN.json",
+        "backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -70636,6 +70671,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T18:56:32Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Compacted PDF lifecycle copy to one boundary pass, added snapshot-bound PDF policy fields, and validated lifecycle/report parity."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Rewrote the RIASEC PDF lifecycle surfaces in zh-CN and en as compact snapshot-bound PDF copy.
- Added explicit PDF policy fields for compact snapshot mode, one-pass boundary density, no repeated boundary expansion, snapshot-bound requirement, and default PDF visibility.
- Exposed the PDF policy fields through `RiasecLifecycleCopyService`.
- Added lifecycle preflight coverage and RIASEC report/PDF flow assertions for PDF policy parity.
- Reconciled SHARE-01 post-merge state in the train ledger.

## Why
PDF copy was carrying repeatable boundary language without a machine-readable density policy. The PDF surface now keeps the necessary scientific boundary once, avoids adding new career judgments, and remains snapshot-bound.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi --display-warnings`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `php -r 'foreach (["backend/content_assets/riasec/share_pdf_history_v1.en.json", "backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json", "backend/tests/Fixtures/Riasec/share_pdf_history_v1.zh-CN.json"] as $f) { json_decode(file_get_contents($f), true); if (json_last_error() !== JSON_ERROR_NONE) { fwrite(STDERR, "$f: ".json_last_error_msg()."\n"); exit(1); } echo "$f OK\n"; }'`
- `php -r 'json_decode(file_get_contents("docs/codex/pr-train-state.json"), true); if (json_last_error() !== JSON_ERROR_NONE) { fwrite(STDERR, json_last_error_msg()."\n"); exit(1); } echo "state JSON OK\n";'`
- `git diff --check`

## Intentionally deferred
- History-page wording remains for RIASEC-CONTENT-HISTORY-01.
- Feedback overlay and next-node copy remain for their dedicated PRs.
- No CMS write, production import, manual deploy, production deploy, or staging deploy wait.

## Repository rule impact
RIASEC PDF lifecycle content remains backend-authoritative under content assets and service projection guards. No fap-web public editorial content was added or modified.