### PR TITLE
RIASEC-CONTENT-HISTORY-01 repair RIASEC history summary boundaries

### DIFF
--- a/backend/app/Services/Riasec/RiasecLifecycleCopyService.php
+++ b/backend/app/Services/Riasec/RiasecLifecycleCopyService.php
@@ -219,6 +219,12 @@ final class RiasecLifecycleCopyService
                 'boundary_repetition_allowed' => (bool) ($row['boundary_repetition_allowed'] ?? false),
                 'snapshot_bound_required' => (bool) ($row['snapshot_bound_required'] ?? false),
                 'pdf_default_visible' => (bool) ($row['pdf_default_visible'] ?? false),
+                'history_surface_mode' => (string) ($row['history_surface_mode'] ?? 'not_history_surface'),
+                'history_summary_mode' => (string) ($row['history_summary_mode'] ?? 'not_history_surface'),
+                'stable_identity_claim_allowed' => (bool) ($row['stable_identity_claim_allowed'] ?? false),
+                'longitudinal_trait_claim_allowed' => (bool) ($row['longitudinal_trait_claim_allowed'] ?? false),
+                'history_raw_delta_allowed' => (bool) ($row['history_raw_delta_allowed'] ?? false),
+                'history_default_visible' => (bool) ($row['history_default_visible'] ?? false),
             ];
         }
 

--- a/backend/content_assets/riasec/share_pdf_history_v1.en.json
+++ b/backend/content_assets/riasec/share_pdf_history_v1.en.json
@@ -55,17 +55,29 @@
     },
     {
       "surface": "history_same_form",
-      "copy": "History for the same form should emphasize Top 3 overlap, near ties, and reading strength. It should not draw cross-form raw score movement.",
+      "copy": "History records same-form result snapshots: Top 3 overlap, near ties, and reading strength for that response. It is an exploration log, not evidence of stable personality or ability change.",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "history_surface_mode": "snapshot_exploration_record",
+      "history_summary_mode": "same_form_snapshot_overlap",
+      "stable_identity_claim_allowed": false,
+      "longitudinal_trait_claim_allowed": false,
+      "history_raw_delta_allowed": false,
+      "history_default_visible": true
     },
     {
       "surface": "history_cross_form",
-      "copy": "60Q and 140Q use different score spaces. History can explain which interest clues were emphasized in each result, but it must not chart raw score gains or drops across forms.",
+      "copy": "60Q and 140Q use different score spaces. History may note which clues each snapshot emphasized, but it must not compare raw-score gains or drops or say the interest profile improved or declined.",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "history_surface_mode": "snapshot_exploration_record",
+      "history_summary_mode": "cross_form_emphasis_difference",
+      "stable_identity_claim_allowed": false,
+      "longitudinal_trait_claim_allowed": false,
+      "history_raw_delta_allowed": false,
+      "history_default_visible": true
     },
     {
       "surface": "low_quality_share",

--- a/backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json
+++ b/backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json
@@ -55,17 +55,29 @@
     },
     {
       "surface": "history_same_form",
-      "copy": "历史记录优先展示同表单的 Top3 重叠、near-tie 和阅读力度，不画跨表原始分变化。",
+      "copy": "历史页只记录同表单结果快照：展示 Top3 重叠、near-tie 和当次阅读力度，用来回看探索轨迹；不把多次结果写成稳定人格或能力变化。",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "history_surface_mode": "snapshot_exploration_record",
+      "history_summary_mode": "same_form_snapshot_overlap",
+      "stable_identity_claim_allowed": false,
+      "longitudinal_trait_claim_allowed": false,
+      "history_raw_delta_allowed": false,
+      "history_default_visible": true
     },
     {
       "surface": "history_cross_form",
-      "copy": "60Q 与 140Q 是不同分数空间。历史页只能解释两次结果强调的线索不同，不能画 raw score 涨跌。",
+      "copy": "60Q 与 140Q 属于不同分数空间。历史页只说明两次快照强调的线索不同，不比较 raw score 涨跌，也不判断兴趣是否变好或变差。",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "history_surface_mode": "snapshot_exploration_record",
+      "history_summary_mode": "cross_form_emphasis_difference",
+      "stable_identity_claim_allowed": false,
+      "longitudinal_trait_claim_allowed": false,
+      "history_raw_delta_allowed": false,
+      "history_default_visible": true
     },
     {
       "surface": "low_quality_share",

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -249,6 +249,13 @@ final class RiasecAssessmentFlowTest extends TestCase
         $history->assertJsonPath('items.0.compare_policy_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
         $history->assertJsonPath('items.0.compare_policy_v1.raw_score_delta_allowed', false);
         $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.measured_payload_mutation_allowed', false);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.4.surface', 'history_same_form');
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.4.history_surface_mode', 'snapshot_exploration_record');
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.4.history_summary_mode', 'same_form_snapshot_overlap');
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.4.stable_identity_claim_allowed', false);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.4.history_raw_delta_allowed', false);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.5.surface', 'history_cross_form');
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.5.history_summary_mode', 'cross_form_emphasis_difference');
         $history->assertJsonPath('history_compare.current_compare_policy_v1.score_space_version', 'riasec_60_likert5_activity_sum_space.v1');
     }
 
@@ -353,6 +360,8 @@ final class RiasecAssessmentFlowTest extends TestCase
         $history->assertJsonPath('items.0.riasec_public_projection_v2.exploration_feedback_overlay_v0_1.measured_result_guard.scores_mutation_allowed', false);
         $history->assertJsonPath('items.0.riasec_public_projection_v2.exploration_feedback_overlay_v0_1.claim_boundary.feedback_is_career_match', false);
         $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.internal_snapshot_id_public_exposure_allowed', false);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.4.longitudinal_trait_claim_allowed', false);
+        $history->assertJsonPath('items.0.riasec_public_projection_v2.lifecycle_copy_v1.surfaces.5.history_raw_delta_allowed', false);
         $history->assertJsonPath('history_compare.current_top_code', 'RIA');
 
         $pdf = $this->withHeaders([

--- a/backend/tests/Fixtures/Riasec/share_pdf_history_v1.zh-CN.json
+++ b/backend/tests/Fixtures/Riasec/share_pdf_history_v1.zh-CN.json
@@ -45,17 +45,29 @@
     },
     {
       "surface": "history_same_form",
-      "copy": "历史记录优先展示同表单的 Top3 重叠、near-tie 和阅读力度，不画跨表原始分变化。",
+      "copy": "历史页只记录同表单结果快照：展示 Top3 重叠、near-tie 和当次阅读力度，用来回看探索轨迹；不把多次结果写成稳定人格或能力变化。",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "history_surface_mode": "snapshot_exploration_record",
+      "history_summary_mode": "same_form_snapshot_overlap",
+      "stable_identity_claim_allowed": false,
+      "longitudinal_trait_claim_allowed": false,
+      "history_raw_delta_allowed": false,
+      "history_default_visible": true
     },
     {
       "surface": "history_cross_form",
-      "copy": "60Q 与 140Q 是不同分数空间。历史页只能解释两次结果强调的线索不同，不能画 raw score 涨跌。",
+      "copy": "60Q 与 140Q 属于不同分数空间。历史页只说明两次快照强调的线索不同，不比较 raw score 涨跌，也不判断兴趣是否变好或变差。",
       "public_safe": false,
       "raw_scores_allowed": false,
-      "raw_feedback_allowed": false
+      "raw_feedback_allowed": false,
+      "history_surface_mode": "snapshot_exploration_record",
+      "history_summary_mode": "cross_form_emphasis_difference",
+      "stable_identity_claim_allowed": false,
+      "longitudinal_trait_claim_allowed": false,
+      "history_raw_delta_allowed": false,
+      "history_default_visible": true
     },
     {
       "surface": "low_quality_share",

--- a/backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php
@@ -118,6 +118,16 @@ final class RiasecLifecycleCopyPreflightTest extends TestCase
                 $this->assertTrue($surface['pdf_default_visible']);
                 $this->assertLessThanOrEqual(110, mb_strlen((string) $surface['copy']));
             }
+
+            if (str_starts_with((string) $surface['surface'], 'history_')) {
+                $this->assertFalse($surface['public_safe']);
+                $this->assertSame('snapshot_exploration_record', $surface['history_surface_mode']);
+                $this->assertFalse($surface['stable_identity_claim_allowed']);
+                $this->assertFalse($surface['longitudinal_trait_claim_allowed']);
+                $this->assertFalse($surface['history_raw_delta_allowed']);
+                $this->assertTrue($surface['history_default_visible']);
+                $this->assertLessThanOrEqual(105, mb_strlen((string) $surface['copy']));
+            }
         }
         $this->assertSame('omit_module', $share['fallback_behavior']);
         $this->assertFalse($share['frontend_fallback_allowed']);
@@ -254,6 +264,40 @@ final class RiasecLifecycleCopyPreflightTest extends TestCase
                 $this->assertTrue($surface['snapshot_bound_required']);
                 $this->assertTrue($surface['pdf_default_visible']);
                 $this->assertStringNotContainsString('raw score', strtolower($copy));
+                $this->assertDoesNotMatchRegularExpression('/\\b[RIASEC]{3}\\b/', $copy);
+                $this->assertDoesNotMatchRegularExpression('/\\b(?:100|75|50|25|0)(?:\\.0+)?\\b/', $copy);
+            }
+        }
+    }
+
+    public function test_history_surfaces_are_snapshot_and_exploration_records(): void
+    {
+        $service = app(\App\Services\Riasec\RiasecLifecycleCopyService::class);
+
+        foreach (['zh-CN', 'en'] as $locale) {
+            $contract = $service->lifecycleCopyContract(true, $locale);
+            $historySurfaces = array_values(array_filter(
+                (array) data_get($contract, 'surfaces', []),
+                static fn (array $surface): bool => str_starts_with((string) ($surface['surface'] ?? ''), 'history_')
+            ));
+
+            $this->assertSame(['history_same_form', 'history_cross_form'], array_column($historySurfaces, 'surface'));
+            $this->assertSame(
+                ['same_form_snapshot_overlap', 'cross_form_emphasis_difference'],
+                array_column($historySurfaces, 'history_summary_mode')
+            );
+
+            foreach ($historySurfaces as $surface) {
+                $copy = (string) ($surface['copy'] ?? '');
+
+                $this->assertFalse($surface['public_safe']);
+                $this->assertFalse($surface['raw_scores_allowed']);
+                $this->assertFalse($surface['raw_feedback_allowed']);
+                $this->assertSame('snapshot_exploration_record', $surface['history_surface_mode']);
+                $this->assertFalse($surface['stable_identity_claim_allowed']);
+                $this->assertFalse($surface['longitudinal_trait_claim_allowed']);
+                $this->assertFalse($surface['history_raw_delta_allowed']);
+                $this->assertTrue($surface['history_default_visible']);
                 $this->assertDoesNotMatchRegularExpression('/\\b[RIASEC]{3}\\b/', $copy);
                 $this->assertDoesNotMatchRegularExpression('/\\b(?:100|75|50|25|0)(?:\\.0+)?\\b/', $copy);
             }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70623,8 +70623,8 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "pr_opened",
-    "commit_sha": "cb78c8d32d4564d4f147292e665962466ce592dd",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "5f037f33c34e958fee154eaaaaa093041b4009d8",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2635",
     "checks": {
       "phpunit_lifecycle_pdf_report_tests": {
@@ -70636,6 +70636,86 @@
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
         "status": "passed",
         "summary": "177 tests, 104308 assertions"
+      },
+      "pint_and_json_parse": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php && php JSON parse share_pdf_history zh/en and zh fixture",
+        "status": "passed"
+      },
+      "diff_check": {
+        "command": "git diff --check",
+        "status": "passed"
+      }
+    },
+    "failure_reason": null,
+    "merged_at": "2026-07-02T19:04:10Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecLifecycleCopyService.php",
+        "backend/content_assets/riasec/share_pdf_history_v1.en.json",
+        "backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json",
+        "backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php",
+        "backend/tests/Fixtures/Riasec/share_pdf_history_v1.zh-CN.json",
+        "backend/tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
+    },
+    "transitions": [
+      {
+        "at": "2026-07-02T16:08:07.295Z",
+        "from": null,
+        "to": "authorized_pending_start",
+        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T18:56:32Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "Compacted PDF lifecycle copy to one boundary pass, added snapshot-bound PDF policy fields, and validated lifecycle/report parity."
+      },
+      {
+        "at": "2026-07-02T18:58:18Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2635 after PDF-01 local validation and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T19:04:33Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2635 merged; origin/main contains merge commit; local main synced; task branch cleaned. Recorded during HISTORY-01 ledger reconciliation."
+      }
+    ],
+    "merge_commit_sha": "2bf370be17dc88a48e35c65fcfe429a16c7e4b5e"
+  },
+  "RIASEC-CONTENT-HISTORY-01": {
+    "id": "RIASEC-CONTENT-HISTORY-01",
+    "repo": "fap-api",
+    "branch": "codex/riasec-content-history-01",
+    "title": "RIASEC-CONTENT-HISTORY-01 repair RIASEC history summary boundaries",
+    "train_scope": "riasec_result_content_science_repair",
+    "base": "main",
+    "depends_on": [
+      "RIASEC-CONTENT-SCIENCE-00"
+    ],
+    "status": "local_validation_passed",
+    "commit_sha": "177e733455d62b8030b6b03c4f71e14aff6961a8",
+    "pr_url": null,
+    "checks": {
+      "phpunit_lifecycle_history_report_tests": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "13 tests, 1270 assertions"
+      },
+      "phpunit_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "178 tests, 104368 assertions"
       },
       "pint_and_json_parse": {
         "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php && php JSON parse share_pdf_history zh/en and zh fixture",
@@ -70673,49 +70753,10 @@
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
       },
       {
-        "at": "2026-07-02T18:56:32Z",
+        "at": "2026-07-02T19:07:21Z",
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
-        "note": "Compacted PDF lifecycle copy to one boundary pass, added snapshot-bound PDF policy fields, and validated lifecycle/report parity."
-      },
-      {
-        "at": "2026-07-02T18:58:18Z",
-        "from": "local_validation_passed",
-        "to": "pr_opened",
-        "note": "Opened PR #2635 after PDF-01 local validation and scope validation passed."
-      }
-    ]
-  },
-  "RIASEC-CONTENT-HISTORY-01": {
-    "id": "RIASEC-CONTENT-HISTORY-01",
-    "repo": "fap-api",
-    "branch": "codex/riasec-content-history-01",
-    "title": "RIASEC-CONTENT-HISTORY-01 repair RIASEC history summary boundaries",
-    "train_scope": "riasec_result_content_science_repair",
-    "base": "main",
-    "depends_on": [
-      "RIASEC-CONTENT-SCIENCE-00"
-    ],
-    "status": "authorized_pending_start",
-    "commit_sha": null,
-    "pr_url": null,
-    "checks": {},
-    "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
-    "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
-    },
-    "transitions": [
-      {
-        "at": "2026-07-02T16:08:07.295Z",
-        "from": null,
-        "to": "authorized_pending_start",
-        "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+        "note": "Reframed history surfaces as snapshot/exploration records, blocked stable identity and raw-delta claims, and validated lifecycle/history responses."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -70703,9 +70703,9 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": "177e733455d62b8030b6b03c4f71e14aff6961a8",
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "6b95df4625e6d754765b912c5bda36663715c56e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2637",
     "checks": {
       "phpunit_lifecycle_history_report_tests": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi --display-warnings",
@@ -70757,6 +70757,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "Reframed history surfaces as snapshot/exploration records, blocked stable identity and raw-delta claims, and validated lifecycle/history responses."
+      },
+      {
+        "at": "2026-07-02T19:08:18Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2637 after HISTORY-01 local validation and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Reframed RIASEC history lifecycle copy in zh-CN and en as snapshot and exploration records.
- Added history policy fields that block stable identity claims, longitudinal trait claims, and raw-score delta interpretation.
- Exposed the history policy fields through `RiasecLifecycleCopyService`.
- Added lifecycle preflight coverage and `/me/attempts` flow assertions for history response parity.
- Reconciled PDF-01 post-merge state in the train ledger.

## Why
History pages should help users revisit attempt snapshots and exploration traces. They must not imply stable personality, ability movement, or cross-form raw-score gains/losses.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php --no-ansi --display-warnings`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings`
- `cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecLifecycleCopyService.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Feature/V0_3/RiasecAssessmentFlowTest.php`
- `php -r 'foreach (["backend/content_assets/riasec/share_pdf_history_v1.en.json", "backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json", "backend/tests/Fixtures/Riasec/share_pdf_history_v1.zh-CN.json"] as $f) { json_decode(file_get_contents($f), true); if (json_last_error() !== JSON_ERROR_NONE) { fwrite(STDERR, "$f: ".json_last_error_msg()."\n"); exit(1); } echo "$f OK\n"; }'`
- `php -r 'json_decode(file_get_contents("docs/codex/pr-train-state.json"), true); if (json_last_error() !== JSON_ERROR_NONE) { fwrite(STDERR, json_last_error_msg()."\n"); exit(1); } echo "state JSON OK\n";'`
- `git diff --check`

## Intentionally deferred
- Feedback overlay copy remains for RIASEC-CONTENT-FEEDBACK-01.
- Next exploration nodes remain for RIASEC-CONTENT-FEEDBACK-02.
- No CMS write, production import, manual deploy, production deploy, or staging deploy wait.

## Repository rule impact
RIASEC history lifecycle content remains backend-authoritative under content assets and service projection guards. No fap-web public editorial content was added or modified.