### PR TITLE
chore(codex): correct SECURITY-169-API-04 ledger status

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -2445,7 +2445,7 @@
         "summary": "Full vendor/bin/pint --test reported class_attributes_separation in backend/tests/Feature/V0_3/IqReportContractTest.php. User authorized including the Pint-only formatting fix in the current PR; full Pint now passes."
       }
     ],
-    "status": "merged",
+    "status": "pr_open",
     "title": "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01 allow global org0 funnel scope entry",
     "transitions": [
       {
@@ -20885,7 +20885,7 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2467",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "status": "merged",
+    "status": "pr_open",
     "title": "MBTI-PDF-PRODUCT-05: expand PDF coverage to result-page sections",
     "train_scope": "mbti_pdf_product",
     "transitions": [
@@ -71557,7 +71557,7 @@
     "depends_on": [
       "SECURITY-169-API-03"
     ],
-    "status": "pr_open",
+    "status": "merged",
     "checks": {
       "authorization": {
         "status": "pass",


### PR DESCRIPTION
## Summary
- set SECURITY-169-API-04 top-level ledger status to merged
- revert two unrelated status flips introduced by the prior ledger closeout

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- git diff --check

Ledger-only correction. No runtime, deploy, CMS, search, sitemap, llms, canonical, noindex, JSON-LD, manual server, staging, or production action was triggered.