### PR TITLE
RIASEC-CONTENT-QUALITY-01 repair RIASEC quality boundary copy

### DIFF
--- a/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+++ b/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
@@ -1027,6 +1027,21 @@ final class RiasecDeepCopySlotRegistry
             if (! in_array((string) ($slot['quality_state'] ?? ''), self::QUALITY_COPY_STATES, true)) {
                 $errors[] = 'unsupported_quality_copy_state';
             }
+            foreach (['user_blame_allowed', 'upsell_140q_allowed', 'strong_interpretation_allowed', 'result_mutation_allowed'] as $flag) {
+                if (($slot[$flag] ?? true) !== false) {
+                    $errors[] = 'quality_copy_'.$flag.'_must_be_false';
+                }
+            }
+            if (! in_array((string) ($slot['recommended_action_type'] ?? ''), [
+                'cautious_reading_or_retake_only',
+                'cautious_reading_or_low_risk_observation',
+                'minimal_boundary_cautious_reading',
+                'retake_when_ready',
+                'hide_strong_interpretation',
+                'safe_private_record_only',
+            ], true)) {
+                $errors[] = 'unsupported_quality_copy_recommended_action_type';
+            }
         }
 
         if (($slot['slot_group'] ?? null) === 'structural_difference_copy') {
@@ -1204,6 +1219,11 @@ final class RiasecDeepCopySlotRegistry
             'content_version',
             'evidence_level',
             'content_status',
+            'user_blame_allowed',
+            'upsell_140q_allowed',
+            'strong_interpretation_allowed',
+            'result_mutation_allowed',
+            'recommended_action_type',
         ];
     }
 
@@ -1943,11 +1963,22 @@ final class RiasecDeepCopySlotRegistry
             if ($slotName === null) {
                 continue;
             }
+            $recommendedActionType = (string) ($row['recommended_action_type'] ?? match ($slotName) {
+                'retake_guidance' => 'retake_when_ready',
+                'hidden_modules_explanation' => 'hide_strong_interpretation',
+                'share_pdf_boundary' => 'safe_private_record_only',
+                default => 'cautious_reading_or_retake_only',
+            });
             $copyBySlot[$slotName] = [
                 'title' => (string) ($this->lowQualitySlotTitle($slotName)),
                 'summary' => (string) ($row['text'] ?? ''),
                 'content_version' => (string) ($asset['asset_id'] ?? 'low_quality_cautious_reading_v1.zh-CN'),
                 'user_visible_boundary' => '质量状态只限制本次结果的阅读强度，不评价用户，也不改变分数或 Holland Code。',
+                'user_blame_allowed' => false,
+                'upsell_140q_allowed' => false,
+                'strong_interpretation_allowed' => false,
+                'result_mutation_allowed' => false,
+                'recommended_action_type' => $recommendedActionType,
             ];
         }
 
@@ -1964,6 +1995,11 @@ final class RiasecDeepCopySlotRegistry
                 'quality_state' => 'caution',
                 'content_version' => (string) ($asset['asset_id'] ?? 'low_quality_cautious_reading_v1.zh-CN'),
                 'user_visible_boundary' => '谨慎阅读只说明本次线索需要观察，不是结果无效，也不是能力判断。',
+                'user_blame_allowed' => false,
+                'upsell_140q_allowed' => false,
+                'strong_interpretation_allowed' => false,
+                'result_mutation_allowed' => false,
+                'recommended_action_type' => 'cautious_reading_or_low_risk_observation',
             ];
         }
         if (($states['minimal_60q'] ?? '') !== '') {
@@ -1973,6 +2009,11 @@ final class RiasecDeepCopySlotRegistry
                 'quality_state' => 'minimal_quality_boundary_60q',
                 'content_version' => (string) ($asset['asset_id'] ?? 'low_quality_cautious_reading_v1.zh-CN'),
                 'user_visible_boundary' => '60Q 的质量边界只限制阅读方式，不比较 60Q 和 140Q 的正确性。',
+                'user_blame_allowed' => false,
+                'upsell_140q_allowed' => false,
+                'strong_interpretation_allowed' => false,
+                'result_mutation_allowed' => false,
+                'recommended_action_type' => 'minimal_boundary_cautious_reading',
             ];
         }
 
@@ -2287,6 +2328,11 @@ final class RiasecDeepCopySlotRegistry
             'fallback_behavior' => 'omit_module',
             'content_status' => 'authored',
             'frontend_fallback_allowed' => false,
+            'user_blame_allowed' => false,
+            'upsell_140q_allowed' => false,
+            'strong_interpretation_allowed' => false,
+            'result_mutation_allowed' => false,
+            'recommended_action_type' => 'cautious_reading_or_retake_only',
         ], $content);
     }
 

--- a/backend/app/Services/Riasec/RiasecQualityRuleContract.php
+++ b/backend/app/Services/Riasec/RiasecQualityRuleContract.php
@@ -55,6 +55,9 @@ final class RiasecQualityRuleContract
                 'show_activity_chain' => $qualityState !== 'low_quality',
                 'show_occupation_examples' => $qualityState === 'normal',
                 'allow_140q_cta' => $qualityState !== 'low_quality',
+                'user_blame_allowed' => false,
+                'upsell_140q_allowed' => $qualityState !== 'low_quality',
+                'strong_interpretation_allowed' => $qualityState === 'normal',
                 'cta_strength' => match ($qualityState) {
                     'normal' => 'standard',
                     'caution' => 'soft_or_hidden',
@@ -63,6 +66,15 @@ final class RiasecQualityRuleContract
             ],
             'score_mutation_allowed' => false,
             'measured_holland_code_mutation_allowed' => false,
+            'result_mutation_allowed' => false,
+            'user_blame_allowed' => false,
+            'upsell_140q_allowed' => false,
+            'strong_interpretation_allowed' => $qualityState === 'normal',
+            'recommended_action_type' => match ($qualityState) {
+                'low_quality' => 'cautious_reading_or_retake_only',
+                'caution' => 'cautious_reading_or_low_risk_observation',
+                default => 'standard_interest_exploration',
+            },
             'field_authority' => [
                 'quality_state' => 'backend_owned',
                 'response_quality' => 'backend_owned',

--- a/backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json
+++ b/backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json
@@ -5,7 +5,7 @@
   "scale_code": "RIASEC",
   "review_status": "content_review_v7_3_final_preflight_candidate",
   "target_review_status_after_owner_signoff": "owner_signoff_required_before_runtime_import_after_owner_signoff",
-  "global_message": "这次结果请谨慎阅读。它可以作为六维兴趣草图，帮助你先观察哪些活动让你愿意靠近、哪些活动明显负担；暂时不适合展开强组合解释、职业场景例子或深度承接。",
+  "global_message": "这次结果请谨慎阅读。它只适合作为本次作答条件下的六维兴趣草图，帮助你先观察哪些活动让你愿意靠近、哪些活动明显负担；暂时不适合展开强组合解释、职业场景例子或深度承接。",
   "states": [
     {
       "quality_state": "normal",
@@ -16,7 +16,10 @@
         "activity_explorer",
         "140q_cta"
       ],
-      "copy": "本次结果可以作为职业兴趣探索入口。"
+      "copy": "本次结果可以作为职业兴趣探索入口，但仍然只说明兴趣线索，不代表能力、身份或职业结论。",
+      "reading_strength": "normal_reading",
+      "strong_interpretation_allowed": true,
+      "recommended_action_type": "standard_interest_exploration"
     },
     {
       "quality_state": "caution",
@@ -26,7 +29,10 @@
         "pair_blend_collapsed",
         "activity_explorer_limited"
       ],
-      "copy": "本次结果可读，但建议把强结论降级为“待观察线索”。"
+      "copy": "本次结果可读，但建议把强结论降级为“待观察线索”；先用小实验确认活动吸引力，不急着做职业判断。",
+      "reading_strength": "cautious_reading",
+      "strong_interpretation_allowed": false,
+      "recommended_action_type": "cautious_reading_or_low_risk_observation"
     },
     {
       "quality_state": "low_quality",
@@ -34,7 +40,10 @@
         "dimension_map_only",
         "retake_guidance"
       ],
-      "copy": "先暂缓强调三字母 Code，只看六维初步线索，并建议稍后重测。"
+      "copy": "先暂缓强调三字母 Code，只看六维初步线索；如果当时赶时间、分心或题目想象困难，建议稍后在状态稳定时重测。",
+      "reading_strength": "retake_recommended",
+      "strong_interpretation_allowed": false,
+      "recommended_action_type": "cautious_reading_or_retake_only"
     },
     {
       "quality_state": "minimal_60q",
@@ -42,7 +51,10 @@
         "dimension_map",
         "method_boundary"
       ],
-      "copy": "60Q 当前只在明确缺题或完成度不足时强降级；其他情况只做谨慎提示。"
+      "copy": "60Q 当前只在明确缺题或完成度不足时强降级；其他较弱信号只做谨慎提示，不把 60Q 写成低质量人格判断。",
+      "reading_strength": "cautious_reading",
+      "strong_interpretation_allowed": false,
+      "recommended_action_type": "minimal_boundary_cautious_reading"
     },
     {
       "quality_state": "retake_recommended",
@@ -50,29 +62,45 @@
         "retake_card",
         "safe_boundary"
       ],
-      "copy": "重测建议是为了获得更稳定的兴趣线索，不是为了追求某个“好看结果”。"
+      "copy": "重测建议是为了获得更稳定的兴趣线索，不是为了追求某个“好看结果”，也不是要求进入更长版本。",
+      "reading_strength": "retake_recommended",
+      "strong_interpretation_allowed": false,
+      "recommended_action_type": "retake_when_ready"
     }
   ],
   "copy_slots": [
     {
       "slot": "top_notice",
-      "text": "本次结果需要谨慎阅读。你可以先保留它作为初步兴趣线索。"
+      "text": "本次结果需要谨慎阅读。你可以先保留它作为初步兴趣线索，不用把三字母 Code 当成固定身份或职业判断。",
+      "strong_interpretation_allowed": false,
+      "recommended_action_type": "cautious_reading_or_retake_only"
     },
     {
       "slot": "retake_guidance",
-      "text": "如果你当时注意力分散、赶时间或对题目想象不清，可以稍后在状态稳定时重测。"
+      "text": "如果你当时注意力分散、赶时间或对题目想象不清，可以稍后在状态稳定时重测；这只是改善作答条件，不是责备你，也不是要求购买更长版本。",
+      "strong_interpretation_allowed": false,
+      "recommended_action_type": "retake_when_ready"
     },
     {
       "slot": "module_downgrade",
-      "text": "页面会减少强解释和职业场景展示，避免把不稳定结果读成方向判断。"
+      "text": "页面会减少强解释、职业场景展示和深度组合承接，避免把本次不稳定线索读成方向判断。",
+      "strong_interpretation_allowed": false,
+      "recommended_action_type": "hide_strong_interpretation"
     },
     {
       "slot": "share_pdf_note",
-      "text": "谨慎阅读结果在分享和 PDF 中应默认展示边界提示，不展示强活动线索组合。"
+      "text": "谨慎阅读结果在分享和 PDF 中应默认展示边界提示，不展示强活动线索组合、职业例子或公开 Holland Code 摘要。",
+      "strong_interpretation_allowed": false,
+      "recommended_action_type": "safe_private_record_only"
     }
   ],
   "upsell_140q_allowed": false,
   "user_blame_allowed": false,
+  "strong_interpretation_allowed": false,
+  "result_mutation_allowed": false,
+  "score_mutation_allowed": false,
+  "measured_holland_code_mutation_allowed": false,
+  "recommended_action_type": "cautious_reading_or_retake_only",
   "required_boundaries": [
     "interest_evidence_only",
     "not_personality_identity",

--- a/backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php
@@ -32,10 +32,19 @@ final class RiasecLowQualityCopySlotRegistryTest extends TestCase
             $this->assertSame('quality_copy', $slot['slot_group']);
             $this->assertSame('authored', $slot['content_status']);
             $this->assertFalse($slot['frontend_fallback_allowed']);
+            $this->assertFalse($slot['user_blame_allowed']);
+            $this->assertFalse($slot['upsell_140q_allowed']);
+            $this->assertFalse($slot['strong_interpretation_allowed']);
+            $this->assertFalse($slot['result_mutation_allowed']);
+            $this->assertNotSame('standard_interest_exploration', $slot['recommended_action_type']);
 
             foreach ($registry->qualityCopyRequiredFields() as $field) {
                 $this->assertArrayHasKey($field, $slot);
-                $this->assertNotEmpty($slot[$field]);
+                if (str_ends_with($field, '_allowed')) {
+                    $this->assertIsBool($slot[$field]);
+                } else {
+                    $this->assertNotEmpty($slot[$field]);
+                }
             }
 
             $this->assertSame([], $registry->validateSlot($slot), $slotName.' should be contract-clean.');
@@ -173,10 +182,39 @@ final class RiasecLowQualityCopySlotRegistryTest extends TestCase
         $registry = new RiasecDeepCopySlotRegistry;
         $slot = $registry->lowQualitySlots()['top_notice'];
         $slot['summary'] = '你答得不好，不认真。请购买 140Q 得到更准结果。';
+        $slot['user_blame_allowed'] = true;
+        $slot['upsell_140q_allowed'] = true;
+        $slot['strong_interpretation_allowed'] = true;
+        $slot['result_mutation_allowed'] = true;
 
         $errors = $registry->validateSlot($slot);
 
         $this->assertContains('forbidden_claim_phrase_non_ascii', $errors);
+        $this->assertContains('quality_copy_user_blame_allowed_must_be_false', $errors);
+        $this->assertContains('quality_copy_upsell_140q_allowed_must_be_false', $errors);
+        $this->assertContains('quality_copy_strong_interpretation_allowed_must_be_false', $errors);
+        $this->assertContains('quality_copy_result_mutation_allowed_must_be_false', $errors);
+    }
+
+    public function test_low_quality_asset_global_policy_is_non_blaming_and_non_mutating(): void
+    {
+        $asset = json_decode((string) file_get_contents(__DIR__.'/../../../../content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json'), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertFalse($asset['user_blame_allowed']);
+        $this->assertFalse($asset['upsell_140q_allowed']);
+        $this->assertFalse($asset['strong_interpretation_allowed']);
+        $this->assertFalse($asset['result_mutation_allowed']);
+        $this->assertFalse($asset['score_mutation_allowed']);
+        $this->assertFalse($asset['measured_holland_code_mutation_allowed']);
+        $this->assertSame('cautious_reading_or_retake_only', $asset['recommended_action_type']);
+
+        foreach ($asset['states'] as $state) {
+            if (($state['quality_state'] ?? '') === 'normal') {
+                continue;
+            }
+            $this->assertFalse($state['strong_interpretation_allowed']);
+            $this->assertNotSame('standard_interest_exploration', $state['recommended_action_type']);
+        }
     }
 
     /**

--- a/backend/tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php
@@ -22,6 +22,9 @@ final class RiasecQualityRuleContractTest extends TestCase
         $this->assertSame('normal_reading', $state['reading_strength']);
         $this->assertSame('show_standard_result_page', $state['result_page_behavior']);
         $this->assertTrue($state['module_policy']['allow_140q_cta']);
+        $this->assertFalse($state['user_blame_allowed']);
+        $this->assertFalse($state['result_mutation_allowed']);
+        $this->assertTrue($state['strong_interpretation_allowed']);
         $this->assertStringContainsString('minimal', $state['quality_boundary_note']);
         $this->assertFalse($state['score_mutation_allowed']);
         $this->assertFalse($state['measured_holland_code_mutation_allowed']);
@@ -41,6 +44,9 @@ final class RiasecQualityRuleContractTest extends TestCase
         $this->assertSame('show_cautious_result_page', $state['result_page_behavior']);
         $this->assertTrue($state['module_policy']['allow_140q_cta']);
         $this->assertSame('soft_or_hidden', $state['module_policy']['cta_strength']);
+        $this->assertFalse($state['module_policy']['user_blame_allowed']);
+        $this->assertFalse($state['module_policy']['strong_interpretation_allowed']);
+        $this->assertSame('cautious_reading_or_low_risk_observation', $state['recommended_action_type']);
         $this->assertNoForbiddenClaims($state);
     }
 
@@ -56,6 +62,13 @@ final class RiasecQualityRuleContractTest extends TestCase
         $this->assertSame('show_retake_recommended_page', $state['result_page_behavior']);
         $this->assertFalse($state['module_policy']['allow_140q_cta']);
         $this->assertSame('hidden', $state['module_policy']['cta_strength']);
+        $this->assertFalse($state['module_policy']['user_blame_allowed']);
+        $this->assertFalse($state['module_policy']['upsell_140q_allowed']);
+        $this->assertFalse($state['module_policy']['strong_interpretation_allowed']);
+        $this->assertFalse($state['user_blame_allowed']);
+        $this->assertFalse($state['upsell_140q_allowed']);
+        $this->assertFalse($state['strong_interpretation_allowed']);
+        $this->assertSame('cautious_reading_or_retake_only', $state['recommended_action_type']);
         $this->assertStringContainsString('incomplete', $state['quality_boundary_note']);
         $this->assertNoForbiddenClaims($state);
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -71174,9 +71174,9 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "58672bb19544d8a557e06bb0283407a7e28d2d46",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2645",
     "checks": {
       "targeted_quality_tests": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php --no-ansi --display-warnings",
@@ -71231,6 +71231,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "QUALITY-01 repaired low-quality/cautious reading boundaries; targeted tests, full RIASEC unit subset, Pint, JSON parse, and diff check passed before commit."
+      },
+      {
+        "at": "2026-07-02T20:31:39Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2645 for QUALITY-01 after local validation and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21090,7 +21090,7 @@
     "base": "main",
     "branch": "codex/ops-ci-codescan-api-01",
     "checks": {
-      "github": {},
+      "github": [],
       "local": {
         "git_diff_check": "passed",
         "json_validation": "passed",
@@ -21542,7 +21542,7 @@
     "base": "main",
     "branch": "codex/ops-release-workflow-01",
     "checks": {
-      "github": {},
+      "github": [],
       "local": {
         "git_diff_check": "passed",
         "json_parse": "passed",
@@ -32794,7 +32794,7 @@
   },
   "SEO-CMS-CANARY-PREVIEW-01": {
     "branch": "codex/seo-cms-canary-preview-01",
-    "checks": {},
+    "checks": [],
     "commit_sha": "11e82c0c7000bc90f2ec550b83d80a9b941465dc",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
@@ -33191,7 +33191,7 @@
   },
   "SEO-CONTENT-P1-09": {
     "branch": "codex/seo-content-p1-09",
-    "checks": {},
+    "checks": [],
     "commit_sha": "6547f4e08aebd665da98916dd5787a4a23adfed9",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
@@ -40074,7 +40074,7 @@
     "CLINICAL-LAUNCH-02": {
       "base": "main",
       "branch": "codex/clinical-launch-02",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-01"
@@ -40101,7 +40101,7 @@
     "CLINICAL-LAUNCH-03": {
       "base": "main",
       "branch": "codex/clinical-launch-03",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-02"
@@ -40128,7 +40128,7 @@
     "CLINICAL-LAUNCH-04": {
       "base": "main",
       "branch": "codex/clinical-launch-04",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-03"
@@ -40155,7 +40155,7 @@
     "CLINICAL-LAUNCH-05": {
       "base": "main",
       "branch": "codex/clinical-launch-05",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-04"
@@ -40182,7 +40182,7 @@
     "CLINICAL-LAUNCH-06": {
       "base": "main",
       "branch": "codex/clinical-launch-06",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-05"
@@ -40209,7 +40209,7 @@
     "CLINICAL-LAUNCH-07": {
       "base": "main",
       "branch": "codex/clinical-launch-07",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-06"
@@ -40236,7 +40236,7 @@
     "CLINICAL-LAUNCH-08": {
       "base": "main",
       "branch": "codex/clinical-launch-08",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-07"
@@ -40263,7 +40263,7 @@
     "CLINICAL-LAUNCH-09": {
       "base": "main",
       "branch": "codex/clinical-launch-09",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-08"
@@ -40290,7 +40290,7 @@
     "CLINICAL-LAUNCH-10": {
       "base": "main",
       "branch": "codex/clinical-launch-10",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-09"
@@ -40317,7 +40317,7 @@
     "CLINICAL-LAUNCH-11": {
       "base": "main",
       "branch": "codex/clinical-launch-11",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-10"
@@ -40344,7 +40344,7 @@
     "CLINICAL-LAUNCH-12": {
       "base": "main",
       "branch": "codex/clinical-launch-12",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-11"
@@ -40371,7 +40371,7 @@
     "CLINICAL-LAUNCH-13": {
       "base": "main",
       "branch": "codex/clinical-launch-13",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-12"
@@ -40398,7 +40398,7 @@
     "CLINICAL-LAUNCH-14": {
       "base": "main",
       "branch": "codex/clinical-launch-14",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-13"
@@ -40425,7 +40425,7 @@
     "CLINICAL-LAUNCH-15": {
       "base": "main",
       "branch": "codex/clinical-launch-15",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-14"
@@ -40452,7 +40452,7 @@
     "CLINICAL-LAUNCH-16": {
       "base": "main",
       "branch": "codex/clinical-launch-16",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-15"
@@ -40479,7 +40479,7 @@
     "CLINICAL-LAUNCH-17": {
       "base": "main",
       "branch": "codex/clinical-launch-17",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-16"
@@ -40506,7 +40506,7 @@
     "CLINICAL-LAUNCH-18": {
       "base": "main",
       "branch": "codex/clinical-launch-18",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-17"
@@ -40533,7 +40533,7 @@
     "CLINICAL-LAUNCH-19": {
       "base": "main",
       "branch": "codex/clinical-launch-19",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-18"
@@ -40560,7 +40560,7 @@
     "CLINICAL-LAUNCH-20": {
       "base": "main",
       "branch": "codex/clinical-launch-20",
-      "checks": {},
+      "checks": [],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-19"
@@ -44977,7 +44977,7 @@
     "IQ-CMS-MEDIA-02": {
       "base": "main",
       "branch": "codex/iq-cms-media-02-rendering-guard",
-      "checks": {},
+      "checks": [],
       "depends_on": [
         "IQ-CMS-MEDIA-01"
       ],
@@ -45568,7 +45568,7 @@
     "IQ-PAID-REPORT-01": {
       "base": "main",
       "branch": "codex/iq-paid-report-01-entitlement-contract",
-      "checks": {},
+      "checks": [],
       "commit_sha": "60eabe326f7e24e71a1bef555493dc9a1d6e6f13",
       "depends_on": [
         "IQ-NORM-03"
@@ -45606,7 +45606,7 @@
     "IQ-PAID-REPORT-02": {
       "base": "main",
       "branch": "codex/iq-paid-report-02-render-entitlement-states",
-      "checks": {},
+      "checks": [],
       "depends_on": [
         "IQ-PAID-REPORT-01"
       ],
@@ -45636,7 +45636,7 @@
     "IQ-RELEASE-01": {
       "base": "main",
       "branch": "codex/iq-release-01-launch-readiness-ledger",
-      "checks": {},
+      "checks": [],
       "depends_on": [
         "IQ-OBS-01"
       ],
@@ -45758,7 +45758,7 @@
     "IQ-SEO-RAMP-02": {
       "base": "main",
       "branch": "codex/iq-seo-ramp-02-indexation-gate",
-      "checks": {},
+      "checks": [],
       "depends_on": [
         "IQ-SEO-RAMP-01"
       ],
@@ -54393,7 +54393,7 @@
         "docs/codex/pr-train-state.json"
       ],
       "branch": "codex/riasec-personalization-06-frontend-fail-closed",
-      "checks": {},
+      "checks": [],
       "commit_sha": "bb01c378674b28857b98ddbdf3d657144ef3b83e",
       "depends_on": [
         "RIASEC-PERSONALIZATION-03",
@@ -54417,7 +54417,7 @@
         "docs/codex/pr-train-state.json"
       ],
       "branch": "codex/riasec-personalization-07-fixture-matrix",
-      "checks": {},
+      "checks": [],
       "commit_sha": "7740b1b09ce6dddb693ac5dbcf8a1d027b0db08b",
       "depends_on": [
         "RIASEC-PERSONALIZATION-01",
@@ -54441,7 +54441,7 @@
     "SEARCH-CHANNEL-LIVE-MBTI-01": {
       "branch": "codex/search-channel-live-mbti-01-preflight",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "focused_live_preflight_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveMbti01Preflight --no-ansi (1 test, 25 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -54499,7 +54499,7 @@
     "SEARCH-CHANNEL-LIVE-MBTI-02": {
       "branch": "codex/search-channel-live-mbti-02",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "focused_live_submission_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveMbti02 --no-ansi (1 test, 14 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -54569,7 +54569,7 @@
     "SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW": {
       "branch": "codex/search-channel-live-mbti-02-24h-review",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "focused_twenty_four_hour_review_test": "passed_with_warnings: php artisan test --filter=SeoIntelSearchChannelLiveMbti02TwentyFourHourReview --no-ansi exited 0 with 1 warning and 14 assertions",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -57921,7 +57921,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B": {
       "branch": "codex/seo-growth-mbti-action-01b-enqueue",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "focused_enqueue_report_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bSearchChannelEnqueue --no-ansi (5 tests, 31 assertions)",
           "git_diff_check": "passed: git diff --check",
@@ -57977,7 +57977,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-01": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-01",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "command_help": "passed: php artisan seo-intel:search-channel-queue --help exposes --canonical-url and --enqueue",
           "focused_single_url_command_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommand --no-ansi (9 tests, 64 assertions)",
@@ -58030,7 +58030,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "focused_url_truth_alignment_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignment --no-ansi (1 test, 34 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -58155,7 +58155,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-preflight",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "focused_prod_preflight_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdPreflight --no-ansi (5 tests, 29 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -58465,7 +58465,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-www-cleanup-plan",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "focused_www_cleanup_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlan --no-ansi (4 tests, 30 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -58716,7 +58716,7 @@
     "SEO-GROWTH-MBTI-ACTION-01B-R2": {
       "branch": "codex/seo-growth-mbti-action-01b-r2-enqueue",
       "checks": {
-        "github": {},
+        "github": [],
         "local": {
           "focused_enqueue_report_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueue --no-ansi (1 test, 17 assertions)",
           "git_diff_check": "passed: git diff --check",
@@ -60539,7 +60539,7 @@
     },
     "iq-commerce-unlock-199-500": {
       "branch": "codex/iq-commerce-unlock-199-500",
-      "checks": {},
+      "checks": [],
       "depends_on": [
         "iq-report-builder-three-dimension-result-schema"
       ],
@@ -71096,8 +71096,8 @@
       "RIASEC-CONTENT-140CTA-01",
       "RIASEC-CONTENT-140CTX-02"
     ],
-    "status": "pr_opened",
-    "commit_sha": "20d37478bfb78b3f70abd232b3e0b29ed82cf881",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "181f6ea612071f275b7a3e778aa8bbd5c0d29b01",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2644",
     "checks": {
       "phpunit_140q_layer_tests": {
@@ -71121,14 +71121,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T20:22:26Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": false,
-      "post_merge_revalidated": false,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
         "backend/content_assets/riasec/140q_task_environment_role_v1.zh-CN.jsonl",
@@ -71155,6 +71155,12 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2644 after 140LAYER-01 local validation and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T20:29:24Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2644 merge commit verified on origin/main; local main synced in occupied main worktree; task branch cleanup verified before RIASEC-CONTENT-QUALITY-01."
       }
     ]
   },
@@ -71168,19 +71174,50 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "authorized_pending_start",
+    "status": "local_validation_passed",
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "targeted_quality_tests": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "17 tests, 681 assertions"
+      },
+      "full_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "179 tests, 112966 assertions"
+      },
+      "pint": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecQualityRuleContract.php tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php",
+        "status": "passed"
+      },
+      "json_parse": {
+        "command": "jq empty backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json",
+        "status": "passed"
+      },
+      "diff_check": {
+        "command": "git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json",
+        "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
+        "backend/app/Services/Riasec/RiasecQualityRuleContract.php",
+        "backend/tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php",
+        "backend/tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -71188,6 +71225,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T20:29:24Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "QUALITY-01 repaired low-quality/cautious reading boundaries; targeted tests, full RIASEC unit subset, Pint, JSON parse, and diff check passed before commit."
       }
     ]
   },
@@ -71204,7 +71247,7 @@
     "status": "authorized_pending_start",
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -71237,7 +71280,7 @@
     "status": "authorized_pending_start",
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -71270,7 +71313,7 @@
     "status": "authorized_pending_start",
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -71318,7 +71361,7 @@
     "status": "authorized_pending_start",
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73380,7 +73423,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73412,7 +73455,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73444,7 +73487,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73476,7 +73519,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73508,7 +73551,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73540,7 +73583,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73572,7 +73615,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73604,7 +73647,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73636,7 +73679,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73668,7 +73711,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73700,7 +73743,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73732,7 +73775,7 @@
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": [],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,


### PR DESCRIPTION
## What changed
- Tightened the low-quality/cautious reading content asset so weak response quality is framed as cautious reading or retake guidance, not user blame.
- Added machine-verifiable quality copy boundaries for no 140Q upsell, no strong interpretation, and no result/code mutation.
- Extended registry and quality-rule tests to enforce the quality-copy boundary contract without affecting pair, top3, or 140Q layer contracts.

## Why
Low-quality and cautious RIASEC states must avoid blaming the user, selling a longer form as a fix, or presenting unstable signals as strong Holland-code conclusions.

## Validation
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php --no-ansi --display-warnings\n- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings\n- cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecQualityRuleContract.php tests/Unit/Services/Riasec/RiasecLowQualityCopySlotRegistryTest.php tests/Unit/Services/Riasec/RiasecQualityRuleContractTest.php\n- jq empty backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json\n- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"\n- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null\n- git diff --check\n\n## Intentionally deferred\n- No CMS writes, production import, database migration, deploy, SEO runtime, sitemap/llms/canonical/noindex/JSON-LD, or frontend fallback work.\n- Adjacent STRUCT, ASPIRATION, DISAGREE, and FINALQA content scopes remain deferred to their own PRs.