### PR TITLE
RIASEC-CONTENT-STRUCT-01 repair RIASEC structural difference copy

### DIFF
--- a/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
+++ b/backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php
@@ -1053,6 +1053,19 @@ final class RiasecDeepCopySlotRegistry
             if (! in_array((string) ($slot['structural_difference_state'] ?? ''), self::STRUCTURAL_DIFFERENCE_STATES, true)) {
                 $errors[] = 'unsupported_structural_difference_state';
             }
+            if (($slot['emphasis_difference_only'] ?? false) !== true) {
+                $errors[] = 'structural_difference_emphasis_difference_only_must_be_true';
+            }
+            foreach ([
+                'correctness_ranking_allowed',
+                'raw_score_comparison_allowed',
+                'result_override_allowed',
+                'code_conversion_allowed',
+            ] as $flag) {
+                if (($slot[$flag] ?? true) !== false) {
+                    $errors[] = 'structural_difference_'.$flag.'_must_be_false';
+                }
+            }
         }
 
         if (($slot['slot_key'] ?? null) === 'aspirations_calibration_copy') {
@@ -1242,6 +1255,12 @@ final class RiasecDeepCopySlotRegistry
             'content_version',
             'evidence_level',
             'content_status',
+            'emphasis_difference_only',
+            'correctness_ranking_allowed',
+            'raw_score_comparison_allowed',
+            'result_override_allowed',
+            'code_conversion_allowed',
+            'selection_basis',
         ];
     }
 
@@ -2401,6 +2420,12 @@ final class RiasecDeepCopySlotRegistry
             ],
             'required_boundaries' => $this->requiredBoundaries(),
             'user_visible_boundary' => '跨表单摘要只说明兴趣线索强调不同；不比较分数，不改写结果，也不形成职业结论。',
+            'emphasis_difference_only' => true,
+            'correctness_ranking_allowed' => false,
+            'raw_score_comparison_allowed' => false,
+            'result_override_allowed' => false,
+            'code_conversion_allowed' => false,
+            'selection_basis' => 'task_environment_role_emphasis_only',
             'evidence_level' => 'expert_reviewed',
             'source_status' => 'reviewed_content_copy',
             'review_status' => 'approved_for_staging',

--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -465,6 +465,11 @@ final class RiasecPublicProjectionService
             'raw_score_delta_allowed' => false,
             'raw_scores_used_for_selection' => false,
             'different_form_scores_comparable' => false,
+            'emphasis_difference_only' => true,
+            'correctness_ranking_allowed' => false,
+            'raw_score_comparison_allowed' => false,
+            'result_override_allowed' => false,
+            'code_conversion_allowed' => false,
             'layer_states' => [
                 'task' => $this->normalize140qSelectionLayerState((string) ($layerStates['task'] ?? data_get($payload, 'task_layer_state', 'agreement'))),
                 'environment' => $this->normalize140qSelectionLayerState((string) ($layerStates['environment'] ?? data_get($payload, 'environment_layer_state', 'agreement'))),
@@ -612,6 +617,7 @@ final class RiasecPublicProjectionService
             'question',
             'what_user_sees',
             'button_label',
+            'selection_basis',
         ];
         $content = [];
         foreach ($contentKeys as $key) {
@@ -663,6 +669,11 @@ final class RiasecPublicProjectionService
                 'user_visible_boundary' => (string) ($slot['user_visible_boundary'] ?? ''),
                 'required_boundaries' => array_values((array) ($slot['required_boundaries'] ?? [])),
                 'forbidden_claims' => array_values((array) ($slot['forbidden_claims'] ?? [])),
+                'emphasis_difference_only' => (bool) ($slot['emphasis_difference_only'] ?? false),
+                'correctness_ranking_allowed' => (bool) ($slot['correctness_ranking_allowed'] ?? false),
+                'raw_score_comparison_allowed' => (bool) ($slot['raw_score_comparison_allowed'] ?? false),
+                'result_override_allowed' => (bool) ($slot['result_override_allowed'] ?? false),
+                'code_conversion_allowed' => (bool) ($slot['code_conversion_allowed'] ?? false),
             ],
         ];
     }

--- a/backend/tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php
@@ -6,10 +6,17 @@ namespace Tests\Unit\Services\Riasec;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Riasec\RiasecActivityExplorerService;
 use App\Services\Riasec\RiasecCompareGuardService;
 use App\Services\Riasec\RiasecDeepCopySlotRegistry;
+use App\Services\Riasec\RiasecExplorationFeedbackOverlayService;
+use App\Services\Riasec\RiasecInterpretationRuleContract;
+use App\Services\Riasec\RiasecLifecycleCopyService;
 use App\Services\Riasec\RiasecMeasurementContract;
-use PHPUnit\Framework\TestCase;
+use App\Services\Riasec\RiasecPublicProjectionService;
+use App\Services\Riasec\RiasecQualityRuleContract;
+use App\Services\Riasec\RiasecReportModuleSelector;
+use Tests\TestCase;
 
 final class RiasecStructuralDifferenceSlotRegistryTest extends TestCase
 {
@@ -32,10 +39,20 @@ final class RiasecStructuralDifferenceSlotRegistryTest extends TestCase
             $this->assertSame('structural_difference_copy', $slot['slot_group']);
             $this->assertSame('authored', $slot['content_status']);
             $this->assertFalse($slot['frontend_fallback_allowed']);
+            $this->assertTrue($slot['emphasis_difference_only']);
+            $this->assertFalse($slot['correctness_ranking_allowed']);
+            $this->assertFalse($slot['raw_score_comparison_allowed']);
+            $this->assertFalse($slot['result_override_allowed']);
+            $this->assertFalse($slot['code_conversion_allowed']);
+            $this->assertSame('task_environment_role_emphasis_only', $slot['selection_basis']);
 
             foreach ($registry->structuralDifferenceRequiredFields() as $field) {
                 $this->assertArrayHasKey($field, $slot);
-                $this->assertNotEmpty($slot[$field]);
+                if (str_ends_with($field, '_allowed')) {
+                    $this->assertIsBool($slot[$field]);
+                } else {
+                    $this->assertNotEmpty($slot[$field]);
+                }
             }
 
             $this->assertSame([], $registry->validateSlot($slot), $slotName.' should be contract-clean.');
@@ -70,11 +87,21 @@ final class RiasecStructuralDifferenceSlotRegistryTest extends TestCase
         $registry = new RiasecDeepCopySlotRegistry;
         $slot = $registry->structuralDifferenceSlots()['summary'];
         $slot['summary'] = '60Q 错了，140Q 更准并推翻 60Q；你从 IAS 变成 SEC，分数上升，raw score delta 可比较。';
+        $slot['emphasis_difference_only'] = false;
+        $slot['correctness_ranking_allowed'] = true;
+        $slot['raw_score_comparison_allowed'] = true;
+        $slot['result_override_allowed'] = true;
+        $slot['code_conversion_allowed'] = true;
 
         $errors = $registry->validateSlot($slot);
 
         $this->assertContains('forbidden_claim_phrase_non_ascii', $errors);
         $this->assertContains('forbidden_claim_phrase_raw_score_delta', $errors);
+        $this->assertContains('structural_difference_emphasis_difference_only_must_be_true', $errors);
+        $this->assertContains('structural_difference_correctness_ranking_allowed_must_be_false', $errors);
+        $this->assertContains('structural_difference_raw_score_comparison_allowed_must_be_false', $errors);
+        $this->assertContains('structural_difference_result_override_allowed_must_be_false', $errors);
+        $this->assertContains('structural_difference_code_conversion_allowed_must_be_false', $errors);
     }
 
     public function test_compare_guard_still_blocks_cross_form_raw_score_comparison(): void
@@ -91,6 +118,43 @@ final class RiasecStructuralDifferenceSlotRegistryTest extends TestCase
         $this->assertSame('cross_form_score_space_mismatch', $guard['reason']);
         $this->assertArrayNotHasKey('raw_scores_delta', $guard);
         $this->assertArrayNotHasKey('domains_delta', $guard);
+    }
+
+    public function test_public_projection_exposes_structural_difference_as_emphasis_only(): void
+    {
+        $result = new Result;
+        $result->scale_code = 'RIASEC';
+        $result->type_code = 'IAS';
+        $result->scores_pct = ['I' => 92, 'A' => 78, 'S' => 64, 'R' => 30, 'E' => 22, 'C' => 18];
+        $result->result_json = [
+            'top_code' => 'IAS',
+            'form_code' => 'riasec_140',
+            'answer_count' => 140,
+            'structural_difference_state' => 'different_emphasis',
+            'riasec_140q_layer_states' => [
+                'task' => 'agreement',
+                'environment' => 'tension',
+                'role' => 'agreement',
+            ],
+        ];
+
+        $projection = $this->projectionService()->buildV2FromResult($result);
+        $policy = $projection['structural_difference'];
+
+        $this->assertTrue($policy['emphasis_difference_only']);
+        $this->assertFalse($policy['correctness_ranking_allowed']);
+        $this->assertFalse($policy['raw_score_comparison_allowed']);
+        $this->assertFalse($policy['result_override_allowed']);
+        $this->assertFalse($policy['code_conversion_allowed']);
+        $this->assertSame('task_environment_role_emphasis_only', $policy['basis']);
+
+        $summarySlot = (new RiasecDeepCopySlotRegistry)->structuralDifferenceSlots()['summary'];
+        $this->assertTrue($summarySlot['emphasis_difference_only']);
+        $this->assertFalse($summarySlot['correctness_ranking_allowed']);
+        $this->assertFalse($summarySlot['raw_score_comparison_allowed']);
+        $this->assertFalse($summarySlot['result_override_allowed']);
+        $this->assertFalse($summarySlot['code_conversion_allowed']);
+        $this->assertSame('task_environment_role_emphasis_only', $summarySlot['selection_basis']);
     }
 
     private function attempt(string $id, string $formCode, int $questionCount): Attempt
@@ -120,5 +184,19 @@ final class RiasecStructuralDifferenceSlotRegistryTest extends TestCase
         ];
 
         return $result;
+    }
+
+    private function projectionService(): RiasecPublicProjectionService
+    {
+        return new RiasecPublicProjectionService(
+            new RiasecMeasurementContract,
+            new RiasecActivityExplorerService,
+            new RiasecExplorationFeedbackOverlayService,
+            new RiasecLifecycleCopyService,
+            new RiasecInterpretationRuleContract,
+            new RiasecQualityRuleContract,
+            new RiasecReportModuleSelector,
+            new RiasecDeepCopySlotRegistry,
+        );
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -71174,8 +71174,8 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "pr_opened",
-    "commit_sha": "58672bb19544d8a557e06bb0283407a7e28d2d46",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "92d3fa7d4853fbb57c9903ffaab0617faad050b6",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2645",
     "checks": {
       "targeted_quality_tests": {
@@ -71202,14 +71202,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-02T20:37:19Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json",
         "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
@@ -71237,6 +71237,12 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2645 for QUALITY-01 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-07-02T20:44:16Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2645 merged with squash commit 92d3fa7d4853fbb57c9903ffaab0617faad050b6; origin/main contains merge commit; local main synced; local and remote task branches cleaned."
       }
     ]
   },
@@ -71250,19 +71256,52 @@
     "depends_on": [
       "RIASEC-CONTENT-140LAYER-01"
     ],
-    "status": "authorized_pending_start",
+    "status": "local_validation_passed",
     "commit_sha": null,
     "pr_url": null,
-    "checks": [],
+    "checks": {
+      "targeted_structural_tests": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "10 tests, 344 assertions"
+      },
+      "full_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "180 tests, 113109 assertions"
+      },
+      "pint": {
+        "command": "cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecPublicProjectionService.php tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php",
+        "status": "passed"
+      },
+      "yaml_manifest": {
+        "command": "ruby -e require-yaml-load-pr-train-yaml",
+        "status": "passed"
+      },
+      "json_state": {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed"
+      },
+      "diff_check": {
+        "command": "git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
+        "backend/app/Services/Riasec/RiasecPublicProjectionService.php",
+        "backend/tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -71270,6 +71309,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-02T20:44:16Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "STRUCT-01 repaired structural difference contract and projection policy as emphasis-only; local checks and scope validation passed before commit."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -71256,9 +71256,9 @@
     "depends_on": [
       "RIASEC-CONTENT-140LAYER-01"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "992bf6f650f2d285b1113db64344d949a243985a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2646",
     "checks": {
       "targeted_structural_tests": {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php --no-ansi --display-warnings",
@@ -71315,6 +71315,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "STRUCT-01 repaired structural difference contract and projection policy as emphasis-only; local checks and scope validation passed before commit."
+      },
+      {
+        "at": "2026-07-02T20:45:59Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2646 for STRUCT-01 after local validation and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added machine-verifiable structural-difference boundaries: emphasis-only, no correctness ranking, no raw-score comparison, no result override, and no code conversion.
- Exposed the same emphasis-only boundary fields through the RIASEC public projection structural policy.
- Extended structural tests to enforce the contract without changing selector/module visibility scope.

## Why
60Q/140Q structural differences must be read only as differences in task/environment/role emphasis, never as one form being more correct or as raw-score/code conversion evidence.

## Validation
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php tests/Unit/Services/Riasec/RiasecCompareGuardContractTest.php --no-ansi --display-warnings
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings
- cd backend && vendor/bin/pint --test app/Services/Riasec/RiasecDeepCopySlotRegistry.php app/Services/Riasec/RiasecPublicProjectionService.php tests/Unit/Services/Riasec/RiasecStructuralDifferenceSlotRegistryTest.php
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"\n- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null\n- git diff --check\n\n## Intentionally deferred\n- No selector/module visibility changes; structural_difference module visibility is outside this PR scope.\n- No CMS writes, production import, database migration, deploy, SEO runtime, sitemap/llms/canonical/noindex/JSON-LD, or frontend fallback work.\n- ASPIRATION, DISAGREE, and FINALQA scopes remain deferred to their own PRs.