### PR TITLE
PR-EQ-ASSET-SCI-12: harden EQ quality runtime gating

### DIFF
--- a/backend/app/Services/Report/Eq60ReportComposer.php
+++ b/backend/app/Services/Report/Eq60ReportComposer.php
@@ -11,6 +11,14 @@ use App\Services\Eq\EqCrossAssessmentContextGuard;
 
 final class Eq60ReportComposer
 {
+    private const LOW_CONFIDENCE_FLAGS = [
+        'SPEEDING',
+        'VERY_SHORT_DURATION',
+        'LOW_ATTENTION',
+        'LONGSTRING',
+        'INCONSISTENCY',
+    ];
+
     public function __construct(
         private readonly Eq60PackLoader $packLoader,
         private readonly EqCrossAssessmentContextGuard $crossAssessmentContextGuard,
@@ -352,14 +360,33 @@ final class Eq60ReportComposer
             static fn ($flag): string => strtoupper(trim((string) $flag)),
             (array) ($quality['flags'] ?? [])
         )));
-        $quality['confidence_label'] = match ($level) {
+        $runtimeLowConfidence = $this->isLowConfidenceQuality($quality);
+        $quality['confidence_label'] = $runtimeLowConfidence ? 'low' : match ($level) {
             'A' => 'high',
             'B' => 'medium',
             default => 'low',
         };
-        $quality['explanation_asset_id'] = 'eq.quality.level.'.$level;
+        $quality['explanation_asset_id'] = 'eq.quality.level.'.($runtimeLowConfidence && ! in_array($level, ['C', 'D'], true) ? 'D' : $level);
 
         return $quality;
+    }
+
+    /**
+     * @param  array<string,mixed>  $quality
+     */
+    private function isLowConfidenceQuality(array $quality): bool
+    {
+        $level = strtoupper(trim((string) ($quality['level'] ?? '')));
+        if (in_array($level, ['C', 'D'], true)) {
+            return true;
+        }
+
+        $flags = array_values(array_map(
+            static fn ($flag): string => strtoupper(trim((string) $flag)),
+            (array) ($quality['flags'] ?? [])
+        ));
+
+        return array_values(array_intersect($flags, self::LOW_CONFIDENCE_FLAGS)) !== [];
     }
 
     /**
@@ -373,7 +400,7 @@ final class Eq60ReportComposer
         $strongest = $this->rankDimension($dimensionScores, true);
         $developmentLever = $this->rankDimension($dimensionScores, false);
         $qualityLevel = strtoupper(trim((string) ($quality['level'] ?? '')));
-        $formulationId = $this->selectCoreFormulation($dimensionScores, $qualityLevel);
+        $formulationId = $this->selectCoreFormulation($dimensionScores, $qualityLevel, $this->isLowConfidenceQuality($quality));
         $route = $this->selectPersonalizationRoute($routeMatrix, $formulationId, $dimensionScores, $quality);
         $selectedAssetIds = $this->selectedAssetIds($route, $formulationId, $dimensionScores, $developmentLever);
         if ((array) ($selectedAssetIds['scene_variant_ids'] ?? []) === []) {
@@ -460,15 +487,20 @@ final class Eq60ReportComposer
             static fn ($level): string => strtoupper(trim((string) $level)),
             (array) ($match['quality_levels'] ?? [])
         ));
-        if ($qualityLevels !== [] && ! in_array($qualityLevel, $qualityLevels, true)) {
+        $runtimeLowConfidence = $this->isLowConfidenceQuality($quality);
+        if (
+            $qualityLevels !== []
+            && ! in_array($qualityLevel, $qualityLevels, true)
+            && ! ($runtimeLowConfidence && array_values(array_intersect($qualityLevels, ['C', 'D'])) !== [])
+        ) {
             return false;
         }
 
         $confidence = strtolower(trim((string) ($match['confidence'] ?? '')));
-        if ($confidence === 'low' && ! in_array($qualityLevel, ['C', 'D'], true)) {
+        if ($confidence === 'low' && ! $runtimeLowConfidence) {
             return false;
         }
-        if ($confidence === 'normal' && in_array($qualityLevel, ['C', 'D'], true)) {
+        if ($confidence === 'normal' && $runtimeLowConfidence) {
             return false;
         }
 
@@ -590,6 +622,14 @@ final class Eq60ReportComposer
         $selectedScenes = $selected['scene_ids'] ?? $selected['scenes'] ?? null;
         $selectedCareer = $selected['career_environment_ids'] ?? $selected['career_environment'] ?? null;
         $selectedAction = trim((string) ($selected['action_prescription_id'] ?? $this->stripAssetPrefix((string) ($selected['action_prescription'] ?? ''), 'eq.action.')));
+
+        if ($formulationId === 'low_confidence_result') {
+            $selectedCore = 'low_confidence_result';
+            $selectedMechanisms = [];
+            $selectedScenes = ['pressure_recovery', 'feedback'];
+            $selectedCareer = ['autonomy_recovery_high'];
+            $selectedAction = 'retest_reflection';
+        }
 
         if (! in_array($selectedCore, $this->coreFormulationIds(), true)) {
             $selectedCore = $formulationId;
@@ -812,9 +852,9 @@ final class Eq60ReportComposer
     /**
      * @param  array<string,array<string,mixed>>  $dimensionScores
      */
-    private function selectCoreFormulation(array $dimensionScores, string $qualityLevel): string
+    private function selectCoreFormulation(array $dimensionScores, string $qualityLevel, bool $runtimeLowConfidence = false): string
     {
-        if (in_array($qualityLevel, ['C', 'D'], true)) {
+        if ($runtimeLowConfidence || in_array($qualityLevel, ['C', 'D'], true)) {
             return 'low_confidence_result';
         }
 

--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T18:29:17.574221Z",
+    "generated_at": "2026-07-03T02:44:58.241909Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-02T18:29:17.574221Z",
+    "generated_at": "2026-07-03T02:44:58.241909Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",

--- a/backend/tests/Feature/Report/Eq60V5ReportContractTest.php
+++ b/backend/tests/Feature/Report/Eq60V5ReportContractTest.php
@@ -180,6 +180,41 @@ final class Eq60V5ReportContractTest extends TestCase
         $this->assertSame('eq.quality.level.C', (string) data_get($fixture, 'report.assets.quality_confidence.id'));
     }
 
+    public function test_quality_runtime_speeding_flag_forces_low_confidence_even_when_level_is_not_cd(): void
+    {
+        $this->prepareEqContent();
+
+        $score = $this->strongDimensionScoreWithQuality('B', ['speeding']);
+        $fixture = $this->canonicalFixtureFromScore('EQ60_SPEEDING_RUNTIME_GUARD_SYNTHETIC', 'en', $score);
+
+        $this->assertSame('B', (string) data_get($fixture, 'report.quality.level'));
+        $this->assertSame('low', (string) data_get($fixture, 'report.quality.confidence_label'));
+        $this->assertSame('eq.quality.level.D', (string) data_get($fixture, 'report.quality.explanation_asset_id'));
+        $this->assertSame('low_confidence_result', (string) data_get($fixture, 'report.interpretation.core_formulation_id'));
+        $this->assertSame('retest_reflection', (string) data_get($fixture, 'report.interpretation.action_prescription_id'));
+        $this->assertSame([], (array) data_get($fixture, 'report.interpretation.primary_mechanism_ids'));
+        $this->assertSame('quality_low_overrides_dimension_pattern', (string) data_get($fixture, 'report.interpretation.signal_signature.match_pattern'));
+        $this->assertSame('retest_reflection', (string) data_get($fixture, 'report.assets.action_prescription.id'));
+        $this->assertNotContains('empathy_boundary', (array) data_get($fixture, 'report.interpretation.selected_asset_ids'));
+    }
+
+    public function test_quality_runtime_level_d_without_flags_forces_low_confidence_and_no_strong_assets(): void
+    {
+        $this->prepareEqContent();
+
+        $score = $this->strongDimensionScoreWithQuality('D', []);
+        $fixture = $this->canonicalFixtureFromScore('EQ60_D_LEVEL_RUNTIME_GUARD_SYNTHETIC', 'zh-CN', $score);
+
+        $this->assertSame('D', (string) data_get($fixture, 'report.quality.level'));
+        $this->assertSame('low', (string) data_get($fixture, 'report.quality.confidence_label'));
+        $this->assertSame('eq.quality.level.D', (string) data_get($fixture, 'report.quality.explanation_asset_id'));
+        $this->assertSame('low_confidence_result', (string) data_get($fixture, 'report.interpretation.core_formulation_id'));
+        $this->assertSame('retest_reflection', (string) data_get($fixture, 'report.interpretation.action_prescription_id'));
+        $this->assertSame([], (array) data_get($fixture, 'report.interpretation.primary_mechanism_ids'));
+        $this->assertNotSame('balanced_integrated', (string) data_get($fixture, 'report.assets.core_formulation.id'));
+        $this->assertNotSame('empathy_boundary', (string) data_get($fixture, 'report.assets.action_prescription.id'));
+    }
+
     public function test_aware_but_unregulated_route_matrix_selects_deterministic_asset_ids(): void
     {
         $this->prepareEqContent();
@@ -667,6 +702,28 @@ final class Eq60V5ReportContractTest extends TestCase
                 'ER' => ['raw_sum' => 38, 'std_score' => 82, 'percentile' => 16, 'level' => 'baseline'],
                 'EM' => ['raw_sum' => 45, 'std_score' => 98, 'percentile' => 50, 'level' => 'competent'],
                 'RM' => ['raw_sum' => 41, 'std_score' => 94, 'percentile' => 42, 'level' => 'competent'],
+            ],
+            'report' => [],
+            'report_tags' => [],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $flags
+     * @return array<string,mixed>
+     */
+    private function strongDimensionScoreWithQuality(string $level, array $flags): array
+    {
+        return [
+            'quality' => ['level' => $level, 'flags' => $flags],
+            'norms' => ['status' => 'PROVISIONAL'],
+            'version_snapshot' => ['engine_version' => 'v1.0_normed_validity'],
+            'scores' => [
+                'global' => ['raw_sum' => 210, 'std_score' => 118, 'percentile' => 86, 'level' => 'exceptional'],
+                'SA' => ['raw_sum' => 61, 'std_score' => 116, 'percentile' => 79, 'level' => 'exceptional'],
+                'ER' => ['raw_sum' => 58, 'std_score' => 111, 'percentile' => 73, 'level' => 'proficient'],
+                'EM' => ['raw_sum' => 62, 'std_score' => 119, 'percentile' => 84, 'level' => 'exceptional'],
+                'RM' => ['raw_sum' => 57, 'std_score' => 110, 'percentile' => 71, 'level' => 'proficient'],
             ],
             'report' => [],
             'report_tags' => [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69383,9 +69383,9 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-03"
     ],
-    "status": "local_checks_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "2b0b5c4b0e96c5f7a5c5c31c5a11a3c9b898b7e0",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2649",
     "checks": [
       {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
@@ -69428,7 +69428,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
+      "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
@@ -69443,6 +69443,11 @@
         "at": "2026-07-03T02:45:42.120095Z",
         "status": "local_checks_passed",
         "summary": "SCI-12 runtime guard implemented; local manifest validation passed with existing PHPUnit environment warnings only."
+      },
+      {
+        "at": "2026-07-03T02:47:53.311389Z",
+        "status": "pr_open",
+        "summary": "Opened PR #2649 for SCI-12 after local validation and scope checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69383,8 +69383,8 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-03"
     ],
-    "status": "pr_open",
-    "commit_sha": "2b0b5c4b0e96c5f7a5c5c31c5a11a3c9b898b7e0",
+    "status": "ready_to_merge",
+    "commit_sha": "6988c1d314dd5df02210288ea60b42985de61b98",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2649",
     "checks": [
       {
@@ -69430,7 +69430,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -69448,6 +69448,11 @@
         "at": "2026-07-03T02:47:53.311389Z",
         "status": "pr_open",
         "summary": "Opened PR #2649 for SCI-12 after local validation and scope checks."
+      },
+      {
+        "at": "2026-07-03T02:53:19.538124Z",
+        "status": "ready_to_merge",
+        "summary": "GitHub checks passed for PR #2649; ready to squash merge under manifest policy."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69383,17 +69383,53 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-03"
     ],
-    "status": "user_authorized",
+    "status": "local_checks_passed",
     "commit_sha": null,
     "pr_url": null,
-    "checks": [],
+    "checks": [
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; scoped report assets compiled output retained and mirrored."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 432 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed_with_warnings",
+        "summary": "14 tests passed, 706 assertions; PHPUnit reported environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 208 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed_with_warnings",
+        "summary": "4 tests passed, 130 assertions; PHPUnit reported environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 16 assertions; PHPUnit reported environment file_get_contents warning only."
+      }
+    ],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
       "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -69402,6 +69438,11 @@
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      },
+      {
+        "at": "2026-07-03T02:45:42.120095Z",
+        "status": "local_checks_passed",
+        "summary": "SCI-12 runtime guard implemented; local manifest validation passed with existing PHPUnit environment warnings only."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Hardened `Eq60ReportComposer` quality runtime gating so low-confidence quality level `C/D` and severe quality flags such as `SPEEDING` force `low_confidence_result`.
- Low-confidence runtime now clears strong mechanism outputs and forces `retest_reflection` instead of strong action/career routes.
- Added regression coverage for `D` quality and `SPEEDING` flag cases with strong underlying scores.
- Refreshed scoped EQ report-assets compiled output and alias compiled mirror.

## Why
`SCI-12` needs runtime behavior to match the science-boundary copy: low-confidence sessions should not emit strong formulation, career, mechanism, or action outputs.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

All PHPUnit runs passed with existing environment `file_get_contents` warnings only.

## Deferred
- `SCI-13` will clean the user-facing `quality_confidence.json` copy.
- `SCI-09` will reduce action-prescription intervention claims after `SCI-13` merges.

## Repository rule impact
Backend report/content-pack remains the authority layer. No frontend content authority, SJT enablement, commerce, CMS, production import, or deploy changes.
