### PR TITLE
RIASEC-CONTENT-FINALQA-01 revalidate all RIASEC content sections

### DIFF
--- a/backend/docs/riasec/riasec-content-finalqa-2026-07-03.md
+++ b/backend/docs/riasec/riasec-content-finalqa-2026-07-03.md
@@ -1,0 +1,48 @@
+# RIASEC Content Final QA 2026-07-03
+
+## Scope
+
+This report closes the `riasec_result_content_science_repair` train for backend-authored RIASEC result content assets.
+
+Covered surfaces:
+
+- Hero/top3 activity-chain copy
+- Six-dimension map and confidence copy
+- Pair module selector and pair deep copy
+- Activity explorer assets and service selection
+- Occupation example boundaries and public projection
+- 60Q/140Q CTA, context cards, layer copy, and structural differences
+- Share, PDF, and history lifecycle copy
+- Feedback overlay, next exploration nodes, aspirations, and disagree path
+- Quality-state cautious reading copy
+
+## Validation Results
+
+All checks below passed locally on the `RIASEC-CONTENT-FINALQA-01` branch from `origin/main` commit `e1b4efaeb4e233d3a0509bd62b45eeeff87bdc1c`.
+
+| Check | Result |
+|---|---|
+| `php` parse of all `backend/content_assets/riasec/**/*.json` | Passed: 72 JSON files |
+| `php` parse of all `backend/content_assets/riasec/**/*.jsonl` | Passed: 17 JSONL files |
+| `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings` | Passed: 184 tests, 114276 assertions |
+| RIASEC feature/API plus share/PDF/history contract subset | Passed: 25 tests, 2530 assertions |
+| RIASEC science boundary, full fixture matrix, lifecycle, all-surface, selector QA subset | Passed: 24 tests, 1805 assertions |
+
+## Boundary Conclusions
+
+- RIASEC result copy remains interest-evidence copy, not personality identity, ability inference, job fit, occupation ranking, hiring suitability, or success prediction.
+- 60Q and 140Q differences remain form-structure/context-emphasis differences; no raw-score comparison or accuracy upgrade claim is introduced.
+- Feedback, aspirations, and disagree paths remain overlay-only exploration inputs; they do not mutate measured Holland Code, scores, report snapshots, share payloads, PDF output, or history records.
+- Share, PDF, and history surfaces remain public-safe and snapshot-bound.
+- Missing or unsupported RIASEC content remains fail-closed; no frontend fallback copy is introduced.
+
+## Deferred / Not Performed
+
+- No CMS write.
+- No production import.
+- No database migration.
+- No SEO runtime, sitemap, `llms.txt`, canonical, noindex, or JSON-LD change.
+- No staging deploy wait.
+- No manual server deploy.
+- No production deploy.
+

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65789,7 +65789,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T02:48:11Z",
+  "updated_at": "2026-07-03T02:49:03Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",
@@ -71538,9 +71538,9 @@
       "RIASEC-CONTENT-DIMDEEP-01",
       "RIASEC-CONTENT-PAIRDEEP-01"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "812ec65a14800f5e1936133b9a9057d8246c30f9",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2650",
     "checks": {
       "riasec_content_asset_parse": {
         "command": "php parse all backend/content_assets/riasec JSON and JSONL files",
@@ -71601,6 +71601,12 @@
         "from": "authorized_pending_start",
         "to": "local_validation_passed",
         "note": "FINALQA-01 completed full RIASEC content parse, lint, unit, feature, share/PDF/history, and all-surface QA locally; no deploy or production mutation performed."
+      },
+      {
+        "at": "2026-07-03T02:49:03Z",
+        "from": "local_validation_passed",
+        "to": "pr_opened",
+        "note": "Opened PR #2650 for FINALQA-01 after final local validation and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -65789,7 +65789,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T02:38:56Z",
+  "updated_at": "2026-07-03T02:48:11Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",
@@ -71429,8 +71429,8 @@
     "depends_on": [
       "RIASEC-CONTENT-SCIENCE-00"
     ],
-    "status": "pr_opened",
-    "commit_sha": "b6488aebb778ebfea84d187d9e298dc8aa15725b",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "e1b4efaeb4e233d3a0509bd62b45eeeff87bdc1c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2648",
     "checks": {
       "targeted_disagree_and_matrix_tests": {
@@ -71471,14 +71471,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-03T02:44:41Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "changed_files": [
         "backend/app/Services/Riasec/RiasecDeepCopySlotRegistry.php",
         "backend/content_assets/riasec/disagree_path_v1.zh-CN.jsonl",
@@ -71504,6 +71504,12 @@
         "from": "local_validation_passed",
         "to": "pr_opened",
         "note": "Opened PR #2648 for DISAGREE-01 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-07-03T02:47:55Z",
+        "from": "pr_opened",
+        "to": "merged_post_merge_revalidated",
+        "note": "PR #2648 merged; origin/main contains merge commit; local main synced; local and remote task branches cleaned."
       }
     ]
   },
@@ -71532,19 +71538,56 @@
       "RIASEC-CONTENT-DIMDEEP-01",
       "RIASEC-CONTENT-PAIRDEEP-01"
     ],
-    "status": "authorized_pending_start",
+    "status": "local_validation_passed",
     "commit_sha": null,
     "pr_url": null,
-    "checks": [],
+    "checks": {
+      "riasec_content_asset_parse": {
+        "command": "php parse all backend/content_assets/riasec JSON and JSONL files",
+        "status": "passed",
+        "summary": "72 JSON files, 17 JSONL files"
+      },
+      "full_riasec_unit_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "184 tests, 114276 assertions"
+      },
+      "riasec_feature_share_pdf_history_contract_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Feature/V0_3/RiasecTechnicalNoteContractTest.php tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "25 tests, 2530 assertions"
+      },
+      "riasec_content_finalqa_subset": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php tests/Unit/Services/Riasec/RiasecResultContentScienceAuditTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Unit/Services/Riasec/RiasecResultPageAllSurfacePilotQaTest.php tests/Unit/Services/Riasec/RiasecResultPageSelectorCoverageBatchTest.php --no-ansi --display-warnings",
+        "status": "passed",
+        "summary": "24 tests, 1805 assertions"
+      },
+      "yaml_manifest": {
+        "command": "ruby -e require-yaml-load-pr-train-yaml",
+        "status": "passed"
+      },
+      "json_state": {
+        "command": "jq empty docs/codex/pr-train-state.json",
+        "status": "passed"
+      },
+      "diff_check": {
+        "command": "git diff --check",
+        "status": "passed"
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": null,
+      "changed_files": [
+        "backend/docs/riasec/riasec-content-finalqa-2026-07-03.md",
+        "docs/codex/pr-train-state.json"
+      ]
     },
     "transitions": [
       {
@@ -71552,6 +71595,12 @@
         "from": null,
         "to": "authorized_pending_start",
         "note": "User authorized full RIASEC content science repair train; registered pending execution entry."
+      },
+      {
+        "at": "2026-07-03T02:47:55Z",
+        "from": "authorized_pending_start",
+        "to": "local_validation_passed",
+        "note": "FINALQA-01 completed full RIASEC content parse, lint, unit, feature, share/PDF/history, and all-surface QA locally; no deploy or production mutation performed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added the final RIASEC content QA evidence report for the completed content science repair train.
- Reconciled DISAGREE-01 post-merge cleanup in the PR train ledger.
- Recorded FINALQA-01 local validation evidence in the ledger.

## Why
This closes the backend RIASEC content science repair train with full content parse, science-boundary lint, unit contracts, feature/API contracts, and share/PDF/history surface validation evidence.

## Validation
- `php` parse of all `backend/content_assets/riasec/**/*.json` and `**/*.jsonl`: 72 JSON files, 17 JSONL files
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec --no-ansi --display-warnings`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Feature/V0_3/RiasecTechnicalNoteContractTest.php tests/Feature/V0_3/RiasecQuestionLocaleTranslationTest.php tests/Feature/V0_3/AttemptPublicReportPdfParityTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php --no-ansi --display-warnings`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/Riasec/RiasecContentScienceBoundaryLintTest.php tests/Unit/Services/Riasec/RiasecResultContentScienceAuditTest.php tests/Unit/Services/Riasec/RiasecFullContentFixtureMatrixTest.php tests/Unit/Services/Riasec/RiasecLifecycleCopyPreflightTest.php tests/Unit/Services/Riasec/RiasecResultPageAllSurfacePilotQaTest.php tests/Unit/Services/Riasec/RiasecResultPageSelectorCoverageBatchTest.php --no-ansi --display-warnings`
- `ruby -e require-yaml-load-pr-train-yaml`
- `jq empty docs/codex/pr-train-state.json`
- `git diff --check`

## Intentionally deferred
- No CMS write, production import, DB migration, SEO runtime, sitemap/llms/canonical/noindex/JSON-LD change, manual deploy, staging deploy wait, or production deploy.
- No fap-web public editorial content changes.
