### PR TITLE
ENNEA-RP-05: fix(enneagram): repair confidence band content

### DIFF
--- a/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
+++ b/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
@@ -1190,12 +1190,12 @@ final class EnneagramPublicProjectionService
     private function confidenceLabel(string $confidenceLevel, string $language): string
     {
         return match ($confidenceLevel) {
-            'high_confidence' => $language === 'zh' ? '高置信结果' : 'High-confidence result',
-            'medium_confidence' => $language === 'zh' ? '中等置信结果' : 'Medium-confidence result',
-            'close_call' => $language === 'zh' ? '近距离辨析结果' : 'Close-call result',
-            'diffuse' => $language === 'zh' ? '分散型结果' : 'Diffuse result',
-            'low_quality' => $language === 'zh' ? '低质量边界结果' : 'Low-quality boundary result',
-            default => $language === 'zh' ? '结果待解释' : 'Result requires interpretation',
+            'high_confidence' => $language === 'zh' ? '较稳定的解释线索' : 'Relatively stable interpretation signal',
+            'medium_confidence' => $language === 'zh' ? '中等稳定的解释线索' : 'Moderately stable interpretation signal',
+            'close_call' => $language === 'zh' ? '需要近距离辨析' : 'Close-call interpretation range',
+            'diffuse' => $language === 'zh' ? '分散型解释范围' : 'Diffuse interpretation range',
+            'low_quality' => $language === 'zh' ? '作答质量边界' : 'Response-quality boundary',
+            default => $language === 'zh' ? '需要结合情境解释' : 'Requires contextual interpretation',
         };
     }
 

--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -744,10 +744,22 @@ final class EnneagramReportComposer
             'visible',
             'all',
             [
+                'title' => '解释稳定性',
+                'subtitle' => '这张卡说明本次结果适合用多确定的语气阅读。',
                 'confidence_level' => data_get($projectionV2, 'classification.confidence_level'),
                 'confidence_label' => data_get($projectionV2, 'classification.confidence_label'),
                 'interpretation_scope' => data_get($projectionV2, 'classification.interpretation_scope'),
                 'interpretation_reason' => data_get($projectionV2, 'classification.interpretation_reason'),
+                'reader_guidance' => '这里的稳定性来自本次答题轮廓的清晰度、第一与第二候选类型的距离、作答质量信号和解释范围规则。它不是测试准确率、临床效度、人格定论或未来行为预测。',
+                'boundary_note' => '高稳定只表示当前答题中主型线索更集中；中等稳定表示可以先阅读主型，但需要用实际情境核对；close_call、diffuse 与 low_quality 表示页面会降低确定语气，并引导辨析、观察或重测。',
+                'not_for' => ['accuracy_claim', 'external_validity_claim', 'diagnosis', 'personality_verdict', 'prediction'],
+                'level_guide' => [
+                    'high_confidence' => '主型线索相对集中，可以把结果作为较稳定的解释假设阅读，但仍需结合真实情境验证。',
+                    'medium_confidence' => '主型线索可读，但相邻候选或情境差异仍可能影响解释，应把结果当作需要核对的工作假设。',
+                    'close_call' => '两个或多个类型线索接近，重点应放在差异辨析，而不是急着固定一个号码。',
+                    'diffuse' => '多种类型线索分散，结果更适合作为观察清单，不适合强行给出单一身份结论。',
+                    'low_quality' => '作答质量信号不足时，页面只保留边界解释和重测建议，不应解读为人格判断。',
+                ],
                 'quality_level' => data_get($projectionV2, 'classification.quality_level'),
                 'low_quality_status' => data_get($projectionV2, 'classification.low_quality_status'),
                 'policy_versions' => [

--- a/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
+++ b/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
@@ -128,6 +128,34 @@ final class EnneagramReportComposerV2Test extends TestCase
         $this->assertSame('这不是常模分数、诊断标签、能力评价或固定人格定论。', $first['score_boundary_note'] ?? null);
     }
 
+    public function test_confidence_band_card_frames_confidence_as_interpretation_stability_not_accuracy(): void
+    {
+        $payload = $this->composeReportV2($this->syntheticProjectionInput('enneagram_likert_105', [
+            'T3' => 89.0,
+            'T8' => 62.0,
+            'T1' => 55.0,
+            'T6' => 37.0,
+            'T2' => 28.0,
+            'T7' => 24.0,
+            'T4' => 21.0,
+            'T5' => 16.0,
+            'T9' => 13.0,
+        ]));
+
+        $module = $this->module($payload, 'confidence_band_card');
+        $content = (array) data_get($module, 'content');
+        $encoded = json_encode($content, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        $this->assertSame('解释稳定性', $content['title'] ?? null);
+        $this->assertSame('较稳定的解释线索', $content['confidence_label'] ?? null);
+        $this->assertStringContainsString('本次答题轮廓的清晰度', (string) ($content['reader_guidance'] ?? ''));
+        $this->assertStringContainsString('它不是测试准确率、临床效度、人格定论或未来行为预测', (string) ($content['reader_guidance'] ?? ''));
+        $this->assertStringContainsString('较稳定的解释假设', (string) data_get($content, 'level_guide.high_confidence'));
+        $this->assertSame(['accuracy_claim', 'external_validity_claim', 'diagnosis', 'personality_verdict', 'prediction'], $content['not_for'] ?? null);
+        $this->assertStringNotContainsString('高置信结果', $encoded);
+        $this->assertStringNotContainsString('中等置信结果', $encoded);
+    }
+
     public function test_unavailable_v2_report_uses_public_error_code_without_registry_exception_details(): void
     {
         $composer = app(EnneagramReportComposer::class);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -558,9 +558,9 @@
     "depends_on": [
       "ENNEA-RP-04"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "4415fc15da7151b3c9b0789a1d5f9d3556ce9244",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2653",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -634,6 +634,11 @@
         "at": "2026-07-03T05:01:00Z",
         "status": "local_validation_passed",
         "notes": "Implemented confidence band content as interpretation stability, not accuracy; required local validation passed."
+      },
+      {
+        "at": "2026-07-03T05:04:00Z",
+        "status": "pr_opened",
+        "notes": "Opened PR #2653 for confidence band content repair; awaiting GitHub required checks."
       }
     ]
   },
@@ -65930,7 +65935,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T05:01:00Z",
+  "updated_at": "2026-07-03T05:04:00Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -558,8 +558,8 @@
     "depends_on": [
       "ENNEA-RP-04"
     ],
-    "status": "pr_opened",
-    "commit_sha": "4415fc15da7151b3c9b0789a1d5f9d3556ce9244",
+    "status": "ready_to_merge",
+    "commit_sha": "6cfcccf59d0925968c8a76c76295d2ed071153b1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2653",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -603,6 +603,11 @@
         "status": "pass",
         "command": "git diff --check",
         "evidence": "No whitespace errors."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2653 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All reported checks for PR #2653 passed on head 6cfcccf59d0925968c8a76c76295d2ed071153b1, including hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, and Semgrep checks."
       }
     },
     "scope_validation": {
@@ -639,6 +644,11 @@
         "at": "2026-07-03T05:04:00Z",
         "status": "pr_opened",
         "notes": "Opened PR #2653 for confidence band content repair; awaiting GitHub required checks."
+      },
+      {
+        "at": "2026-07-03T05:12:00Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub required checks passed; recording ready-to-merge before squash merge per train policy."
       }
     ]
   },
@@ -65935,7 +65945,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T05:04:00Z",
+  "updated_at": "2026-07-03T05:12:00Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -422,12 +422,12 @@
     "depends_on": [
       "ENNEA-RP-03"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "d5e4e23df3ff2c04c1cfc221b037cdd767d68a1a",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "5c236350b29bea5cd7f8ac7a810685be6a41fdbe",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2622",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-03T03:06:41Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "failure_reason": null,
     "checks": {
       "authorization": {
@@ -491,6 +491,10 @@
         "status": "pass",
         "command": "gh pr checks 2622 --repo fermatmind/fap-api --watch --interval 15",
         "evidence": "All reported checks for PR #2622 passed before the latest ledger-only rebase, including hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, and Semgrep checks. Rebase touched train ledger only; final head will be rechecked before merge."
+      },
+      "post_merge_cleanup": {
+        "status": "pass",
+        "evidence": "PR #2622 is MERGED; merge commit 5c236350b29bea5cd7f8ac7a810685be6a41fdbe is contained in origin/main; local main fast-forwarded to origin/main; local branch codex/ennea-rp-04-all9-profile deleted; remote branch absent."
       }
     },
     "scope_validation": {
@@ -536,6 +540,11 @@
         "at": "2026-07-03T04:19:00Z",
         "status": "ready_to_merge",
         "notes": "Replayed ready-to-merge state while rebasing over latest main; final head will be rechecked before merge."
+      },
+      {
+        "at": "2026-07-03T03:12:00Z",
+        "status": "merged_post_merge_revalidated",
+        "notes": "Post-merge cleanup completed; no staging deploy wait or production deploy performed."
       }
     ]
   },
@@ -549,8 +558,8 @@
     "depends_on": [
       "ENNEA-RP-04"
     ],
-    "status": "pending_dependency",
-    "commit_sha": "38d70625d1140350f843cf705f72b585813fb8a7",
+    "status": "local_validation_passed",
+    "commit_sha": null,
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -560,6 +569,40 @@
       "authorization": {
         "status": "pass",
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-04 merged as PR #2622 and merge commit 5c236350b29bea5cd7f8ac7a810685be6a41fdbe is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All ENNEAGRAM v2 registry JSON files parsed successfully."
+      },
+      "type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed: 2 warnings, 14509 assertions."
+      },
+      "registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Passed: 3 warnings, 26 assertions."
+      },
+      "composer_v2_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Passed: 13 warnings, 116 assertions."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed: 260 warnings, 2 passed, 83394 assertions, duration 130.30s."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
       }
     },
     "scope_validation": {
@@ -571,13 +614,26 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "changed_files": [
+        "backend/app/Services/Enneagram/EnneagramPublicProjectionService.php",
+        "backend/app/Services/Report/EnneagramReportComposer.php",
+        "backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php",
+        "docs/codex/pr-train-state.json"
+      ],
+      "outside_scope_files": [],
+      "status": "pass",
+      "evidence": "Changed files are confined to confidence-band projection labels, confidence_band_card composer content, related Enneagram composer test, and train ledger reconciliation."
     },
     "events": [
       {
         "at": "2026-07-02T16:10:24Z",
         "status": "pending_dependency",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge."
+      },
+      {
+        "at": "2026-07-03T05:01:00Z",
+        "status": "local_validation_passed",
+        "notes": "Implemented confidence band content as interpretation stability, not accuracy; required local validation passed."
       }
     ]
   },
@@ -65874,7 +65930,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T04:19:00Z",
+  "updated_at": "2026-07-03T05:01:00Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",


### PR DESCRIPTION
## What changed\n- Reframed Enneagram confidence labels as interpretation stability signals rather than accuracy labels.\n- Added confidence_band_card reader guidance, boundary copy, level guide, and explicit non-use cases.\n- Added composer coverage proving the card avoids old high/medium confidence result wording and frames confidence as interpretation stability.\n- Reconciled ENNEA-RP-04 post-merge cleanup state in the train ledger.\n\n## Why\nThe confidence band should describe how cautiously the result page should be read based on the current answer profile, not imply accuracy, diagnosis, external validity, prediction, or a fixed personality verdict.\n\n## Validation\n- cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json\n- cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest\n- cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest\n- cd backend && php artisan test --filter=EnneagramReportComposerV2Test\n- cd backend && php artisan test --filter=Enneagram\n- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"\n- git diff --check\n- git diff --cached --check\n\n## Intentionally deferred\n- No staging deploy wait.\n- No server deployment verification.\n- No registry release activation.\n- No production deploy or CMS write.