### PR TITLE
PR-EQ-ASSET-SCI-09: reduce EQ action_prescription intervention claims

### DIFF
--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-03T03:04:45.949377Z",
+    "generated_at": "2026-07-03T03:24:01.377499Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -17015,9 +17015,9 @@
                 "emotion_labeling": {
                     "zh-CN": {
                         "title": "情绪命名练习",
-                        "why_this_matters": "把模糊的不舒服拆成一个具体情绪词，而不是马上解释或压下去。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先不急着判断对错。我现在更像是感到……”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我先不急着判断对错。我现在更像是感到…… 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把模糊的不舒服拆成一个具体情绪词，而不是马上解释或压下去。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先不急着判断对错。我现在更像是感到……”这句话。",
+                        "script": "我先不急着判断对错。我现在更像是感到……",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17050,14 +17050,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「情绪命名练习」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Name the Emotion",
-                        "why_this_matters": "Turn a vague discomfort into a specific emotion word before explaining it away or pushing it down. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I do not need to decide whether this is right or wrong yet. What I notice first is...” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I do not need to decide whether this is right or wrong yet. What I notice first is... This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn a vague discomfort into a specific emotion word before explaining it away or pushing it down.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I do not need to decide whether this is right or wrong yet. What I notice first is...”",
+                        "script": "I do not need to decide whether this is right or wrong yet. What I notice first is...",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17090,15 +17090,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Name the Emotion” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "emotion_labeling",
                         "asset_type": "action_prescription",
                         "v23_source_id": "emotion_labeling",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "developing_foundation",
@@ -17109,9 +17109,9 @@
                 "pause_recovery": {
                     "zh-CN": {
                         "title": "暂停与恢复",
-                        "why_this_matters": "在被触发后先创造几秒钟空间，让回应不完全由第一反应决定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想停一下再回答，这样我能说得更清楚。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我想停一下再回答，这样我能说得更清楚。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在被触发后先创造几秒钟空间，让回应不完全由第一反应决定。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想停一下再回答，这样我能说得更清楚。”这句话。",
+                        "script": "我想停一下再回答，这样我能说得更清楚。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17144,14 +17144,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「暂停与恢复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Pause and Recover",
-                        "why_this_matters": "Create a few seconds of space after being triggered, so your response is not decided by the first impulse. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I want to pause before I answer, so I can respond more clearly.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I want to pause before I answer, so I can respond more clearly. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Create a few seconds of space after being triggered, so your response is not decided by the first impulse.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I want to pause before I answer, so I can respond more clearly.”",
+                        "script": "I want to pause before I answer, so I can respond more clearly.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17184,15 +17184,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Pause and Recover” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "pause_recovery",
                         "asset_type": "action_prescription",
                         "v23_source_id": "pause_recovery",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "aware_but_unregulated",
@@ -17203,9 +17203,9 @@
                 "feedback_decompression": {
                     "zh-CN": {
                         "title": "反馈减压",
-                        "why_this_matters": "把反馈里的事实、情绪和下一步拆开，避免把别人的语气全部当成自我否定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把反馈里的事实、情绪和下一步拆开，避免把别人的语气全部当成自我否定。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？”这句话。",
+                        "script": "我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17238,14 +17238,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「反馈减压」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Decompress Feedback",
-                        "why_this_matters": "Separate facts, tone, and next steps so the other person’s emotion does not become your self-judgment. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "Let me check: are you asking me to adjust the outcome, the process, or the way I communicated? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Separate facts, tone, and next steps so the other person’s emotion does not become your self-judgment.",
+                        "do_today": "Today, use one low-risk version of this sentence: “Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?”",
+                        "script": "Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17278,15 +17278,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Decompress Feedback” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "feedback_decompression",
                         "asset_type": "action_prescription",
                         "v23_source_id": "feedback_decompression",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "feedback_absorber",
@@ -17297,9 +17297,9 @@
                 "empathy_boundary": {
                     "zh-CN": {
                         "title": "共情后的边界",
-                        "why_this_matters": "理解别人之后，明确你能支持什么、不能替对方承担什么。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "理解别人之后，明确你能支持什么、不能替对方承担什么。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。”这句话。",
+                        "script": "我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17332,14 +17332,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「共情后的边界」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Empathy with a Boundary",
-                        "why_this_matters": "After understanding someone, clarify what you can support and what you cannot carry for them. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "After understanding someone, clarify what you can support and what you cannot carry for them.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.”",
+                        "script": "I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17372,15 +17372,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Empathy with a Boundary” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "empathy_boundary",
                         "asset_type": "action_prescription",
                         "v23_source_id": "empathy_boundary",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "high_empathy_low_recovery",
@@ -17392,9 +17392,9 @@
                 "repair_after_conflict": {
                     "zh-CN": {
                         "title": "冲突后的修复",
-                        "why_this_matters": "把“我不是故意的”升级成“我看见了影响，并愿意修复”。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把“我不是故意的”升级成“我看见了影响，并愿意修复”。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。”这句话。",
+                        "script": "刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17427,14 +17427,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「冲突后的修复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Repair After Impact",
-                        "why_this_matters": "Move from “I did not mean it” to “I see the impact and I want to repair it.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Move from “I did not mean it” to “I see the impact and I want to repair it.”",
+                        "do_today": "Today, use one low-risk version of this sentence: “What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.”",
+                        "script": "What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17467,15 +17467,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Repair After Impact” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "repair_after_conflict",
                         "asset_type": "action_prescription",
                         "v23_source_id": "repair_after_conflict",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "self_clear_repair_weak",
@@ -17486,9 +17486,9 @@
                 "express_without_escalation": {
                     "zh-CN": {
                         "title": "不升级的表达",
-                        "why_this_matters": "把真实表达从攻击、证明或压制里分离出来。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想说清楚我的感受，但不是为了压过你。我的重点是……”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我想说清楚我的感受，但不是为了压过你。我的重点是…… 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把真实表达从攻击、证明或压制里分离出来。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想说清楚我的感受，但不是为了压过你。我的重点是……”这句话。",
+                        "script": "我想说清楚我的感受，但不是为了压过你。我的重点是……",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17521,14 +17521,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「不升级的表达」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Express Without Escalating",
-                        "why_this_matters": "Separate honest expression from attacking, proving, or overpowering. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I want to be clear about my experience, not to overpower yours. The point I want to make is...” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I want to be clear about my experience, not to overpower yours. The point I want to make is... This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Separate honest expression from attacking, proving, or overpowering.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I want to be clear about my experience, not to overpower yours. The point I want to make is...”",
+                        "script": "I want to be clear about my experience, not to overpower yours. The point I want to make is...",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17561,15 +17561,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Express Without Escalating” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "express_without_escalation",
                         "asset_type": "action_prescription",
                         "v23_source_id": "express_without_escalation",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "direct_without_softening",
@@ -17580,9 +17580,9 @@
                 "support_without_rescuing": {
                     "zh-CN": {
                         "title": "支持但不拯救",
-                        "why_this_matters": "把帮助别人从“我替你解决”改成“我陪你找下一步”。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮你一起理清选择，但决定和后果还是需要由你来拿。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我可以帮你一起理清选择，但决定和后果还是需要由你来拿。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把帮助别人从“我替你解决”改成“我陪你找下一步”。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮你一起理清选择，但决定和后果还是需要由你来拿。”这句话。",
+                        "script": "我可以帮你一起理清选择，但决定和后果还是需要由你来拿。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17615,14 +17615,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「支持但不拯救」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Support Without Rescuing",
-                        "why_this_matters": "Shift from “I will fix this for you” to “I can help you find your next step.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I can help you think through the options, but the decision and the consequences need to stay with you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I can help you think through the options, but the decision and the consequences need to stay with you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Shift from “I will fix this for you” to “I can help you find your next step.”",
+                        "do_today": "Today, use one low-risk version of this sentence: “I can help you think through the options, but the decision and the consequences need to stay with you.”",
+                        "script": "I can help you think through the options, but the decision and the consequences need to stay with you.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17655,15 +17655,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Support Without Rescuing” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "support_without_rescuing",
                         "asset_type": "action_prescription",
                         "v23_source_id": "support_without_rescuing",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "over_responsible_helper",
@@ -17674,9 +17674,9 @@
                 "cold_to_warm_response": {
                     "zh-CN": {
                         "title": "先回应情绪",
-                        "why_this_matters": "在提出方案前，先让对方知道你听见了情绪。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“听起来这件事让你很失望。我们可以一起看下一步怎么处理。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "听起来这件事让你很失望。我们可以一起看下一步怎么处理。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在提出方案前，先让对方知道你听见了情绪。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“听起来这件事让你很失望。我们可以一起看下一步怎么处理。”这句话。",
+                        "script": "听起来这件事让你很失望。我们可以一起看下一步怎么处理。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17709,14 +17709,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「先回应情绪」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Add Warmth Before Solving",
-                        "why_this_matters": "Before offering a solution, let the other person know you registered the feeling. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “It sounds like this was really disappointing. We can look at the next step together.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "It sounds like this was really disappointing. We can look at the next step together. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before offering a solution, let the other person know you registered the feeling.",
+                        "do_today": "Today, use one low-risk version of this sentence: “It sounds like this was really disappointing. We can look at the next step together.”",
+                        "script": "It sounds like this was really disappointing. We can look at the next step together.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17749,15 +17749,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Add Warmth Before Solving” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "cold_to_warm_response",
                         "asset_type": "action_prescription",
                         "v23_source_id": "cold_to_warm_response",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "calm_but_distant",
@@ -17768,9 +17768,9 @@
                 "relationship_energy_management": {
                     "zh-CN": {
                         "title": "关系能量管理",
-                        "why_this_matters": "在高互动或高情绪场景后，给自己一个可执行的恢复流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要十分钟整理一下自己，再继续这个话题。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我需要十分钟整理一下自己，再继续这个话题。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在高互动或高情绪场景后，给自己一个可执行的恢复流程。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要十分钟整理一下自己，再继续这个话题。”这句话。",
+                        "script": "我需要十分钟整理一下自己，再继续这个话题。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17803,14 +17803,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「关系能量管理」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Relationship Energy Management",
-                        "why_this_matters": "After high-contact or emotionally loaded situations, give yourself a concrete recovery routine. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I need ten minutes to reset before we continue this conversation.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I need ten minutes to reset before we continue this conversation. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "After high-contact or emotionally loaded situations, give yourself a concrete recovery routine.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I need ten minutes to reset before we continue this conversation.”",
+                        "script": "I need ten minutes to reset before we continue this conversation.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17843,15 +17843,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Relationship Energy Management” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "relationship_energy_management",
                         "asset_type": "action_prescription",
                         "v23_source_id": "relationship_energy_management",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "sensitive_absorber",
@@ -17862,9 +17862,9 @@
                 "conflict_deescalation": {
                     "zh-CN": {
                         "title": "冲突降温",
-                        "why_this_matters": "把对话从谁对谁错拉回具体分歧和下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们先暂停一下。现在真正分歧的是哪一点？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我们先暂停一下。现在真正分歧的是哪一点？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把对话从谁对谁错拉回具体分歧和下一步。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们先暂停一下。现在真正分歧的是哪一点？”这句话。",
+                        "script": "我们先暂停一下。现在真正分歧的是哪一点？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17897,14 +17897,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「冲突降温」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "De-escalate the Conflict",
-                        "why_this_matters": "Move the conversation from winning and losing back to the specific disagreement and next step. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “Let’s pause. What is the exact point we are disagreeing about?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "Let’s pause. What is the exact point we are disagreeing about? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Move the conversation from winning and losing back to the specific disagreement and next step.",
+                        "do_today": "Today, use one low-risk version of this sentence: “Let’s pause. What is the exact point we are disagreeing about?”",
+                        "script": "Let’s pause. What is the exact point we are disagreeing about?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17937,15 +17937,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “De-escalate the Conflict” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "conflict_deescalation",
                         "asset_type": "action_prescription",
                         "v23_source_id": "conflict_deescalation",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "steady_collaborator",
@@ -17957,9 +17957,9 @@
                 "self_connection": {
                     "zh-CN": {
                         "title": "回到自己",
-                        "why_this_matters": "在照顾关系前，先确认自己真实的感受和需要。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想先确认一下自己的感受，再回应你。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我想先确认一下自己的感受，再回应你。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在照顾关系前，先确认自己真实的感受和需要。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想先确认一下自己的感受，再回应你。”这句话。",
+                        "script": "我想先确认一下自己的感受，再回应你。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17992,14 +17992,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「回到自己」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Return to Yourself",
-                        "why_this_matters": "Before managing the relationship, check what you are actually feeling and needing. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I want to check in with myself before I respond.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I want to check in with myself before I respond. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before managing the relationship, check what you are actually feeling and needing.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I want to check in with myself before I respond.”",
+                        "script": "I want to check in with myself before I respond.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18032,15 +18032,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Return to Yourself” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "self_connection",
                         "asset_type": "action_prescription",
                         "v23_source_id": "self_connection",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "relationship_first_self_later",
@@ -18051,9 +18051,9 @@
                 "retest_reflection": {
                     "zh-CN": {
                         "title": "复测前的自我回顾",
-                        "why_this_matters": "低置信结果主要支持复测准备，不支持行为改变结论。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "记录本次作答环境，并在更稳定、不被打断时复测。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我会轻读本次结果，在条件更稳定时复测。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "低置信结果主要支持复测准备，不支持行为改变结论。",
+                        "do_today": "记录本次作答环境，并在更稳定、不被打断时复测。",
+                        "script": "我会轻读本次结果，在条件更稳定时复测。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18062,14 +18062,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「复测前的自我回顾」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Reflect Before Retesting",
-                        "why_this_matters": "This low-confidence session mainly supports retest preparation, not behavior-change conclusions. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Record the response context and retake in a steadier, uninterrupted setting. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I will hold this session lightly and retake it when conditions are steadier. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "This low-confidence session mainly supports retest preparation, not behavior-change conclusions.",
+                        "do_today": "Record the response context and retake in a steadier, uninterrupted setting.",
+                        "script": "I will hold this session lightly and retake it when conditions are steadier.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18078,15 +18078,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Reflect Before Retesting” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "retest_reflection",
                         "asset_type": "action_prescription",
                         "v23_source_id": "retest_reflection",
                         "claim_risk": "high",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "QUALITY",
                         "best_for": [
                             "low_confidence_result"
@@ -18096,9 +18096,9 @@
                 "ask_before_solving": {
                     "zh-CN": {
                         "title": "先问再解决",
-                        "why_this_matters": "在提供建议前确认对方想要理解、建议还是只是被听见。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“你现在更想让我听你说，还是一起想办法？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "你现在更想让我听你说，还是一起想办法？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在提供建议前确认对方想要理解、建议还是只是被听见。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“你现在更想让我听你说，还是一起想办法？”这句话。",
+                        "script": "你现在更想让我听你说，还是一起想办法？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18131,14 +18131,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「先问再解决」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Ask Before Solving",
-                        "why_this_matters": "Before offering advice, ask whether the person wants understanding, ideas, or simply to be heard. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “Do you want me to just listen right now, or would it help to think through options together?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "Do you want me to just listen right now, or would it help to think through options together? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before offering advice, ask whether the person wants understanding, ideas, or simply to be heard.",
+                        "do_today": "Today, use one low-risk version of this sentence: “Do you want me to just listen right now, or would it help to think through options together?”",
+                        "script": "Do you want me to just listen right now, or would it help to think through options together?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18171,15 +18171,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Ask Before Solving” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "ask_before_solving",
                         "asset_type": "action_prescription",
                         "v23_source_id": "ask_before_solving",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "strategic_listener",
@@ -18190,9 +18190,9 @@
                 "delayed_processing_note": {
                     "zh-CN": {
                         "title": "延迟处理笔记",
-                        "why_this_matters": "给事后才出现的情绪一个出口，避免它变成沉默或突然爆发。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我刚才还没完全处理好，现在我想补充我的真实感受。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我刚才还没完全处理好，现在我想补充我的真实感受。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "给事后才出现的情绪一个出口，避免它变成沉默或突然爆发。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我刚才还没完全处理好，现在我想补充我的真实感受。”这句话。",
+                        "script": "我刚才还没完全处理好，现在我想补充我的真实感受。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18225,14 +18225,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「延迟处理笔记」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Delayed Processing Note",
-                        "why_this_matters": "Give late-arriving feelings a place to land before they become silence or a sudden reaction. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I did not fully process it earlier. I want to add what I actually felt.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I did not fully process it earlier. I want to add what I actually felt. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Give late-arriving feelings a place to land before they become silence or a sudden reaction.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I did not fully process it earlier. I want to add what I actually felt.”",
+                        "script": "I did not fully process it earlier. I want to add what I actually felt.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18265,15 +18265,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Delayed Processing Note” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "delayed_processing_note",
                         "asset_type": "action_prescription",
                         "v23_source_id": "delayed_processing_note",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "delayed_processor",
@@ -18284,9 +18284,9 @@
                 "body_reset": {
                     "zh-CN": {
                         "title": "身体重置",
-                        "why_this_matters": "用身体信号而不是反复思考来结束压力循环。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在身体很紧，我先把节奏慢下来。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我现在身体很紧，我先把节奏慢下来。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "用身体信号而不是反复思考来结束压力循环。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在身体很紧，我先把节奏慢下来。”这句话。",
+                        "script": "我现在身体很紧，我先把节奏慢下来。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18319,14 +18319,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「身体重置」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Body Reset",
-                        "why_this_matters": "Use a body cue, not more thinking, to close the stress loop. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “My body feels tense. I am going to slow the pace down first.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "My body feels tense. I am going to slow the pace down first. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Use a body cue, not more thinking, to close the stress loop.",
+                        "do_today": "Today, use one low-risk version of this sentence: “My body feels tense. I am going to slow the pace down first.”",
+                        "script": "My body feels tense. I am going to slow the pace down first.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18359,15 +18359,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Body Reset” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "body_reset",
                         "asset_type": "action_prescription",
                         "v23_source_id": "body_reset",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "pressure_contained",
@@ -18378,9 +18378,9 @@
                 "empathy_to_action": {
                     "zh-CN": {
                         "title": "从理解到行动",
-                        "why_this_matters": "把“我懂你”转成一个小而清楚的下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听懂了。我们先选一个今天能做的小步骤。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我听懂了。我们先选一个今天能做的小步骤。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把“我懂你”转成一个小而清楚的下一步。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听懂了。我们先选一个今天能做的小步骤。”这句话。",
+                        "script": "我听懂了。我们先选一个今天能做的小步骤。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18413,14 +18413,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「从理解到行动」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "From Empathy to Action",
-                        "why_this_matters": "Turn “I understand” into one small, clear next step. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I understand. Let’s choose one small step we can take today.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I understand. Let’s choose one small step we can take today. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn “I understand” into one small, clear next step.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I understand. Let’s choose one small step we can take today.”",
+                        "script": "I understand. Let’s choose one small step we can take today.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18453,15 +18453,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “From Empathy to Action” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "empathy_to_action",
                         "asset_type": "action_prescription",
                         "v23_source_id": "empathy_to_action",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "empathy_to_action_gap",
@@ -18472,9 +18472,9 @@
                 "warm_signal": {
                     "zh-CN": {
                         "title": "释放温度信号",
-                        "why_this_matters": "在保持距离的同时给对方一个可读的善意信号。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要一点空间，但不是要推开你。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我需要一点空间，但不是要推开你。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在保持距离的同时给对方一个可读的善意信号。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要一点空间，但不是要推开你。”这句话。",
+                        "script": "我需要一点空间，但不是要推开你。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18507,14 +18507,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「释放温度信号」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Send a Warm Signal",
-                        "why_this_matters": "Keep your boundary while giving the other person a readable signal of goodwill. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I need some space, but I am not trying to push you away.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I need some space, but I am not trying to push you away. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Keep your boundary while giving the other person a readable signal of goodwill.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I need some space, but I am not trying to push you away.”",
+                        "script": "I need some space, but I am not trying to push you away.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18547,15 +18547,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Send a Warm Signal” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "warm_signal",
                         "asset_type": "action_prescription",
                         "v23_source_id": "warm_signal",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "self_protective_distance",
@@ -18566,9 +18566,9 @@
                 "values_pause": {
                     "zh-CN": {
                         "title": "价值触发暂停",
-                        "why_this_matters": "当原则被触碰时，先暂停，避免把价值感变成攻击。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "当原则被触碰时，先暂停，避免把价值感变成攻击。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。”这句话。",
+                        "script": "这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18601,14 +18601,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「价值触发暂停」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Values Trigger Pause",
-                        "why_this_matters": "When a value is touched, pause before turning conviction into attack. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “This touches a value for me. I want to name the point clearly rather than react immediately.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "This touches a value for me. I want to name the point clearly rather than react immediately. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "When a value is touched, pause before turning conviction into attack.",
+                        "do_today": "Today, use one low-risk version of this sentence: “This touches a value for me. I want to name the point clearly rather than react immediately.”",
+                        "script": "This touches a value for me. I want to name the point clearly rather than react immediately.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18641,15 +18641,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Values Trigger Pause” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "values_pause",
                         "asset_type": "action_prescription",
                         "v23_source_id": "values_pause",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "values_sensitive",
@@ -18660,9 +18660,9 @@
                 "shared_stability": {
                     "zh-CN": {
                         "title": "共享稳定责任",
-                        "why_this_matters": "让稳定不只靠你一个人承担。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮我们整理下一步，但我们需要一起承担这个节奏。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我可以帮我们整理下一步，但我们需要一起承担这个节奏。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "让稳定不只靠你一个人承担。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮我们整理下一步，但我们需要一起承担这个节奏。”这句话。",
+                        "script": "我可以帮我们整理下一步，但我们需要一起承担这个节奏。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18695,14 +18695,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「共享稳定责任」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Share the Stability Load",
-                        "why_this_matters": "Make steadiness a shared process, not your private job. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I can help organize the next step, but we need to share responsibility for the pace.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I can help organize the next step, but we need to share responsibility for the pace. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Make steadiness a shared process, not your private job.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I can help organize the next step, but we need to share responsibility for the pace.”",
+                        "script": "I can help organize the next step, but we need to share responsibility for the pace.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18735,15 +18735,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Share the Stability Load” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "shared_stability",
                         "asset_type": "action_prescription",
                         "v23_source_id": "shared_stability",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "team_stabilizer",
@@ -18754,9 +18754,9 @@
                 "followthrough_bridge": {
                     "zh-CN": {
                         "title": "倾听后的跟进",
-                        "why_this_matters": "把一次好的倾听转成一个可追踪的承诺。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听见了。我们约定一个具体时间回来确认进展。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我听见了。我们约定一个具体时间回来确认进展。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把一次好的倾听转成一个可追踪的承诺。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听见了。我们约定一个具体时间回来确认进展。”这句话。",
+                        "script": "我听见了。我们约定一个具体时间回来确认进展。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18789,14 +18789,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「倾听后的跟进」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Follow Through After Listening",
-                        "why_this_matters": "Turn good listening into a trackable commitment. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I hear you. Let’s set a specific time to check progress.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I hear you. Let’s set a specific time to check progress. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn good listening into a trackable commitment.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I hear you. Let’s set a specific time to check progress.”",
+                        "script": "I hear you. Let’s set a specific time to check progress.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18829,15 +18829,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Follow Through After Listening” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "followthrough_bridge",
                         "asset_type": "action_prescription",
                         "v23_source_id": "followthrough_bridge",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "listening_without_followthrough",
@@ -18848,9 +18848,9 @@
                 "small_conflict_step": {
                     "zh-CN": {
                         "title": "小步进入冲突",
-                        "why_this_matters": "先处理一个小分歧，训练自己不再把所有张力都推迟。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不想把这个压下去。我们先谈其中一个具体点。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我不想把这个压下去。我们先谈其中一个具体点。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "先处理一个小分歧，训练自己不再把所有张力都推迟。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不想把这个压下去。我们先谈其中一个具体点。”这句话。",
+                        "script": "我不想把这个压下去。我们先谈其中一个具体点。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18883,14 +18883,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「小步进入冲突」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Take a Small Conflict Step",
-                        "why_this_matters": "Address one small disagreement first so tension does not always get postponed. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I do not want to bury this. Let’s start with one specific point.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I do not want to bury this. Let’s start with one specific point. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Address one small disagreement first so tension does not always get postponed.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I do not want to bury this. Let’s start with one specific point.”",
+                        "script": "I do not want to bury this. Let’s start with one specific point.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18923,15 +18923,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Take a Small Conflict Step” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "small_conflict_step",
                         "asset_type": "action_prescription",
                         "v23_source_id": "small_conflict_step",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "conflict_avoider",
@@ -18942,9 +18942,9 @@
                 "boundary_before_advice": {
                     "zh-CN": {
                         "title": "建议前先设边界",
-                        "why_this_matters": "在给建议之前先说明你能投入的范围。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在给建议之前先说明你能投入的范围。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。”这句话。",
+                        "script": "我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18977,14 +18977,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「建议前先设边界」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Set the Boundary Before Advice",
-                        "why_this_matters": "Before giving advice, state the amount of time, energy, or responsibility you can offer. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I can think this through with you for twenty minutes, and then the decision needs to be yours.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I can think this through with you for twenty minutes, and then the decision needs to be yours. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before giving advice, state the amount of time, energy, or responsibility you can offer.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I can think this through with you for twenty minutes, and then the decision needs to be yours.”",
+                        "script": "I can think this through with you for twenty minutes, and then the decision needs to be yours.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19017,15 +19017,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Set the Boundary Before Advice” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "boundary_before_advice",
                         "asset_type": "action_prescription",
                         "v23_source_id": "boundary_before_advice",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "over_responsible_helper",
@@ -19036,9 +19036,9 @@
                 "repair_without_self_blame": {
                     "zh-CN": {
                         "title": "修复但不自责",
-                        "why_this_matters": "承认影响，不把整个自我都判成失败。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "承认影响，不把整个自我都判成失败。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。”这句话。",
+                        "script": "我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19071,14 +19071,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「修复但不自责」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Repair Without Self-Blame",
-                        "why_this_matters": "Acknowledge the impact without turning your whole self into the problem. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I see that what I said affected you. I will adjust it, and I want to understand the specific part to change. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Acknowledge the impact without turning your whole self into the problem.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.”",
+                        "script": "I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19111,15 +19111,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Repair Without Self-Blame” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "repair_without_self_blame",
                         "asset_type": "action_prescription",
                         "v23_source_id": "repair_without_self_blame",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "feedback_absorber",
@@ -19130,9 +19130,9 @@
                 "name_the_request": {
                     "zh-CN": {
                         "title": "说出请求",
-                        "why_this_matters": "把委屈或沉默转成一个清楚请求。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我真正需要的是……你能不能……？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我真正需要的是……你能不能……？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把委屈或沉默转成一个清楚请求。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我真正需要的是……你能不能……？”这句话。",
+                        "script": "我真正需要的是……你能不能……？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19165,14 +19165,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「说出请求」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Name the Request",
-                        "why_this_matters": "Turn resentment or silence into a clear request. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “What I actually need is... Would you be willing to...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "What I actually need is... Would you be willing to...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn resentment or silence into a clear request.",
+                        "do_today": "Today, use one low-risk version of this sentence: “What I actually need is... Would you be willing to...?”",
+                        "script": "What I actually need is... Would you be willing to...?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19205,15 +19205,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Name the Request” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "name_the_request",
                         "asset_type": "action_prescription",
                         "v23_source_id": "name_the_request",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "relationship_first_self_later",
@@ -19224,9 +19224,9 @@
                 "slow_the_reply": {
                     "zh-CN": {
                         "title": "放慢回复",
-                        "why_this_matters": "当你想马上回应时，先把回应拆成草稿和发送。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先写下来，但不立刻发。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我先写下来，但不立刻发。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "当你想马上回应时，先把回应拆成草稿和发送。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先写下来，但不立刻发。”这句话。",
+                        "script": "我先写下来，但不立刻发。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19259,14 +19259,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「放慢回复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Slow the Reply",
-                        "why_this_matters": "When you want to answer immediately, separate drafting from sending. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I will write it first, but I will not send it immediately.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I will write it first, but I will not send it immediately. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "When you want to answer immediately, separate drafting from sending.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I will write it first, but I will not send it immediately.”",
+                        "script": "I will write it first, but I will not send it immediately.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19299,15 +19299,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Slow the Reply” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "slow_the_reply",
                         "asset_type": "action_prescription",
                         "v23_source_id": "slow_the_reply",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "fast_reactor",
@@ -19318,9 +19318,9 @@
                 "make_empathy_visible": {
                     "zh-CN": {
                         "title": "让共情被看见",
-                        "why_this_matters": "把心里的理解说出来，让对方不是只能猜。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听到你其实是在担心……对吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我听到你其实是在担心……对吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把心里的理解说出来，让对方不是只能猜。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听到你其实是在担心……对吗？”这句话。",
+                        "script": "我听到你其实是在担心……对吗？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19353,14 +19353,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「让共情被看见」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Make Empathy Visible",
-                        "why_this_matters": "Say the understanding out loud so the other person does not have to guess it. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “What I hear is that you are worried about... Is that right?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "What I hear is that you are worried about... Is that right? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Say the understanding out loud so the other person does not have to guess it.",
+                        "do_today": "Today, use one low-risk version of this sentence: “What I hear is that you are worried about... Is that right?”",
+                        "script": "What I hear is that you are worried about... Is that right?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19393,15 +19393,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Make Empathy Visible” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "make_empathy_visible",
                         "asset_type": "action_prescription",
                         "v23_source_id": "make_empathy_visible",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "quiet_empathy",
@@ -19412,9 +19412,9 @@
                 "repair_the_tone": {
                     "zh-CN": {
                         "title": "修复语气",
-                        "why_this_matters": "内容不一定错，但语气需要被修复。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想保留我的观点，但刚才语气太硬了。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我想保留我的观点，但刚才语气太硬了。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "内容不一定错，但语气需要被修复。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想保留我的观点，但刚才语气太硬了。”这句话。",
+                        "script": "我想保留我的观点，但刚才语气太硬了。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19447,14 +19447,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「修复语气」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Repair the Tone",
-                        "why_this_matters": "The content may be valid, but the tone may need repair. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I stand by the point, but my tone was too hard.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I stand by the point, but my tone was too hard. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "The content may be valid, but the tone may need repair.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I stand by the point, but my tone was too hard.”",
+                        "script": "I stand by the point, but my tone was too hard.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19487,15 +19487,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Repair the Tone” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "repair_the_tone",
                         "asset_type": "action_prescription",
                         "v23_source_id": "repair_the_tone",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "direct_without_softening",
@@ -19506,9 +19506,9 @@
                 "protect_recovery_time": {
                     "zh-CN": {
                         "title": "保护恢复时间",
-                        "why_this_matters": "把恢复时间当成结果质量的一部分，而不是偷懒。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要恢复一下，之后会给你更清楚的回应。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我需要恢复一下，之后会给你更清楚的回应。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把恢复时间当成结果质量的一部分，而不是偷懒。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要恢复一下，之后会给你更清楚的回应。”这句话。",
+                        "script": "我需要恢复一下，之后会给你更清楚的回应。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19541,14 +19541,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「保护恢复时间」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Protect Recovery Time",
-                        "why_this_matters": "Treat recovery time as part of the quality of your response, not as avoidance. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I need to recover first so I can give you a clearer response later.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I need to recover first so I can give you a clearer response later. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Treat recovery time as part of the quality of your response, not as avoidance.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I need to recover first so I can give you a clearer response later.”",
+                        "script": "I need to recover first so I can give you a clearer response later.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19581,15 +19581,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Protect Recovery Time” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "protect_recovery_time",
                         "asset_type": "action_prescription",
                         "v23_source_id": "protect_recovery_time",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "sensitive_absorber",
@@ -19600,9 +19600,9 @@
                 "clarify_before_concluding": {
                     "zh-CN": {
                         "title": "先澄清再下结论",
-                        "why_this_matters": "在判断对方意图前，先用一个问题确认。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不确定我理解对了。你是指……吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我不确定我理解对了。你是指……吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在判断对方意图前，先用一个问题确认。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不确定我理解对了。你是指……吗？”这句话。",
+                        "script": "我不确定我理解对了。你是指……吗？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19635,14 +19635,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「先澄清再下结论」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Clarify Before Concluding",
-                        "why_this_matters": "Before deciding what someone meant, check with one question. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I want to make sure I understood. Do you mean...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I want to make sure I understood. Do you mean...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before deciding what someone meant, check with one question.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I want to make sure I understood. Do you mean...?”",
+                        "script": "I want to make sure I understood. Do you mean...?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19675,15 +19675,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Clarify Before Concluding” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "clarify_before_concluding",
                         "asset_type": "action_prescription",
                         "v23_source_id": "clarify_before_concluding",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "strategic_listener",
@@ -19694,9 +19694,9 @@
                 "turn_stability_into_process": {
                     "zh-CN": {
                         "title": "把稳定变流程",
-                        "why_this_matters": "不要只靠你当下状态好，把稳定步骤写成流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们可以用三个步骤来处理：事实、感受、下一步。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我们可以用三个步骤来处理：事实、感受、下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "不要只靠你当下状态好，把稳定步骤写成流程。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们可以用三个步骤来处理：事实、感受、下一步。”这句话。",
+                        "script": "我们可以用三个步骤来处理：事实、感受、下一步。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19729,14 +19729,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「把稳定变流程」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Turn Stability Into a Process",
-                        "why_this_matters": "Do not rely only on being in a good state; turn steadiness into a process. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “We can handle this in three steps: facts, feelings, next action.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "We can handle this in three steps: facts, feelings, next action. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Do not rely only on being in a good state; turn steadiness into a process.",
+                        "do_today": "Today, use one low-risk version of this sentence: “We can handle this in three steps: facts, feelings, next action.”",
+                        "script": "We can handle this in three steps: facts, feelings, next action.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19769,15 +19769,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Turn Stability Into a Process” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "turn_stability_into_process",
                         "asset_type": "action_prescription",
                         "v23_source_id": "turn_stability_into_process",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "balanced_integrated",
@@ -19788,9 +19788,9 @@
                 "integrated_maintenance": {
                     "zh-CN": {
                         "title": "整合优势维护",
-                        "why_this_matters": "把已经可用的觉察、调节、共情和关系行动固定成可重复流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们按三步来：事实、感受、下一步。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我们按三步来：事实、感受、下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把已经可用的觉察、调节、共情和关系行动固定成可重复流程。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们按三步来：事实、感受、下一步。”这句话。",
+                        "script": "我们按三步来：事实、感受、下一步。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19823,14 +19823,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「整合优势维护」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Maintain Integrated Strength",
-                        "why_this_matters": "Turn existing awareness, regulation, empathy, and relationship action into a repeatable routine. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “Let’s use three steps: facts, feelings, next action.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "Let’s use three steps: facts, feelings, next action. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn existing awareness, regulation, empathy, and relationship action into a repeatable routine.",
+                        "do_today": "Today, use one low-risk version of this sentence: “Let’s use three steps: facts, feelings, next action.”",
+                        "script": "Let’s use three steps: facts, feelings, next action.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19863,15 +19863,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Maintain Integrated Strength” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "integrated_maintenance",
                         "asset_type": "action_prescription",
                         "v23_source_id": "integrated_maintenance",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "balanced_integrated",
@@ -19882,9 +19882,9 @@
                 "express_need_clearly": {
                     "zh-CN": {
                         "title": "清楚表达需要",
-                        "why_this_matters": "把内在稳定转成别人能听懂的需求，而不是只在心里处理。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在需要的是……你可以……吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我现在需要的是……你可以……吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把内在稳定转成别人能听懂的需求，而不是只在心里处理。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在需要的是……你可以……吗？”这句话。",
+                        "script": "我现在需要的是……你可以……吗？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19917,14 +19917,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「清楚表达需要」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "State the Need Clearly",
-                        "why_this_matters": "Turn internal steadiness into a request another person can actually understand. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “What I need right now is... Would you be willing to...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "What I need right now is... Would you be willing to...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn internal steadiness into a request another person can actually understand.",
+                        "do_today": "Today, use one low-risk version of this sentence: “What I need right now is... Would you be willing to...?”",
+                        "script": "What I need right now is... Would you be willing to...?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19957,15 +19957,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “State the Need Clearly” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "express_need_clearly",
                         "asset_type": "action_prescription",
                         "v23_source_id": "express_need_clearly",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "regulated_but_private",

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/action_prescriptions.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/action_prescriptions.json
@@ -5,9 +5,9 @@
     "emotion_labeling": {
       "zh-CN": {
         "title": "情绪命名练习",
-        "why_this_matters": "把模糊的不舒服拆成一个具体情绪词，而不是马上解释或压下去。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先不急着判断对错。我现在更像是感到……”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我先不急着判断对错。我现在更像是感到…… 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把模糊的不舒服拆成一个具体情绪词，而不是马上解释或压下去。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先不急着判断对错。我现在更像是感到……”这句话。",
+        "script": "我先不急着判断对错。我现在更像是感到……",
         "seven_day_plan": [
           {
             "day": 1,
@@ -40,14 +40,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「情绪命名练习」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Name the Emotion",
-        "why_this_matters": "Turn a vague discomfort into a specific emotion word before explaining it away or pushing it down. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I do not need to decide whether this is right or wrong yet. What I notice first is...” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I do not need to decide whether this is right or wrong yet. What I notice first is... This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn a vague discomfort into a specific emotion word before explaining it away or pushing it down.",
+        "do_today": "Today, use one low-risk version of this sentence: “I do not need to decide whether this is right or wrong yet. What I notice first is...”",
+        "script": "I do not need to decide whether this is right or wrong yet. What I notice first is...",
         "seven_day_plan": [
           {
             "day": 1,
@@ -80,15 +80,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Name the Emotion” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "emotion_labeling",
         "asset_type": "action_prescription",
         "v23_source_id": "emotion_labeling",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "developing_foundation",
@@ -99,9 +99,9 @@
     "pause_recovery": {
       "zh-CN": {
         "title": "暂停与恢复",
-        "why_this_matters": "在被触发后先创造几秒钟空间，让回应不完全由第一反应决定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想停一下再回答，这样我能说得更清楚。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我想停一下再回答，这样我能说得更清楚。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在被触发后先创造几秒钟空间，让回应不完全由第一反应决定。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想停一下再回答，这样我能说得更清楚。”这句话。",
+        "script": "我想停一下再回答，这样我能说得更清楚。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -134,14 +134,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「暂停与恢复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Pause and Recover",
-        "why_this_matters": "Create a few seconds of space after being triggered, so your response is not decided by the first impulse. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I want to pause before I answer, so I can respond more clearly.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I want to pause before I answer, so I can respond more clearly. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Create a few seconds of space after being triggered, so your response is not decided by the first impulse.",
+        "do_today": "Today, use one low-risk version of this sentence: “I want to pause before I answer, so I can respond more clearly.”",
+        "script": "I want to pause before I answer, so I can respond more clearly.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -174,15 +174,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Pause and Recover” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "pause_recovery",
         "asset_type": "action_prescription",
         "v23_source_id": "pause_recovery",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "aware_but_unregulated",
@@ -193,9 +193,9 @@
     "feedback_decompression": {
       "zh-CN": {
         "title": "反馈减压",
-        "why_this_matters": "把反馈里的事实、情绪和下一步拆开，避免把别人的语气全部当成自我否定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把反馈里的事实、情绪和下一步拆开，避免把别人的语气全部当成自我否定。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？”这句话。",
+        "script": "我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -228,14 +228,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「反馈减压」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Decompress Feedback",
-        "why_this_matters": "Separate facts, tone, and next steps so the other person’s emotion does not become your self-judgment. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "Let me check: are you asking me to adjust the outcome, the process, or the way I communicated? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Separate facts, tone, and next steps so the other person’s emotion does not become your self-judgment.",
+        "do_today": "Today, use one low-risk version of this sentence: “Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?”",
+        "script": "Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -268,15 +268,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Decompress Feedback” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "feedback_decompression",
         "asset_type": "action_prescription",
         "v23_source_id": "feedback_decompression",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "feedback_absorber",
@@ -287,9 +287,9 @@
     "empathy_boundary": {
       "zh-CN": {
         "title": "共情后的边界",
-        "why_this_matters": "理解别人之后，明确你能支持什么、不能替对方承担什么。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "理解别人之后，明确你能支持什么、不能替对方承担什么。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。”这句话。",
+        "script": "我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -322,14 +322,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「共情后的边界」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Empathy with a Boundary",
-        "why_this_matters": "After understanding someone, clarify what you can support and what you cannot carry for them. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "After understanding someone, clarify what you can support and what you cannot carry for them.",
+        "do_today": "Today, use one low-risk version of this sentence: “I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.”",
+        "script": "I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -362,15 +362,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Empathy with a Boundary” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "empathy_boundary",
         "asset_type": "action_prescription",
         "v23_source_id": "empathy_boundary",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "high_empathy_low_recovery",
@@ -382,9 +382,9 @@
     "repair_after_conflict": {
       "zh-CN": {
         "title": "冲突后的修复",
-        "why_this_matters": "把“我不是故意的”升级成“我看见了影响，并愿意修复”。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把“我不是故意的”升级成“我看见了影响，并愿意修复”。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。”这句话。",
+        "script": "刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -417,14 +417,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「冲突后的修复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Repair After Impact",
-        "why_this_matters": "Move from “I did not mean it” to “I see the impact and I want to repair it.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Move from “I did not mean it” to “I see the impact and I want to repair it.”",
+        "do_today": "Today, use one low-risk version of this sentence: “What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.”",
+        "script": "What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -457,15 +457,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Repair After Impact” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "repair_after_conflict",
         "asset_type": "action_prescription",
         "v23_source_id": "repair_after_conflict",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "self_clear_repair_weak",
@@ -476,9 +476,9 @@
     "express_without_escalation": {
       "zh-CN": {
         "title": "不升级的表达",
-        "why_this_matters": "把真实表达从攻击、证明或压制里分离出来。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想说清楚我的感受，但不是为了压过你。我的重点是……”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我想说清楚我的感受，但不是为了压过你。我的重点是…… 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把真实表达从攻击、证明或压制里分离出来。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想说清楚我的感受，但不是为了压过你。我的重点是……”这句话。",
+        "script": "我想说清楚我的感受，但不是为了压过你。我的重点是……",
         "seven_day_plan": [
           {
             "day": 1,
@@ -511,14 +511,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「不升级的表达」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Express Without Escalating",
-        "why_this_matters": "Separate honest expression from attacking, proving, or overpowering. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I want to be clear about my experience, not to overpower yours. The point I want to make is...” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I want to be clear about my experience, not to overpower yours. The point I want to make is... This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Separate honest expression from attacking, proving, or overpowering.",
+        "do_today": "Today, use one low-risk version of this sentence: “I want to be clear about my experience, not to overpower yours. The point I want to make is...”",
+        "script": "I want to be clear about my experience, not to overpower yours. The point I want to make is...",
         "seven_day_plan": [
           {
             "day": 1,
@@ -551,15 +551,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Express Without Escalating” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "express_without_escalation",
         "asset_type": "action_prescription",
         "v23_source_id": "express_without_escalation",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "direct_without_softening",
@@ -570,9 +570,9 @@
     "support_without_rescuing": {
       "zh-CN": {
         "title": "支持但不拯救",
-        "why_this_matters": "把帮助别人从“我替你解决”改成“我陪你找下一步”。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮你一起理清选择，但决定和后果还是需要由你来拿。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我可以帮你一起理清选择，但决定和后果还是需要由你来拿。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把帮助别人从“我替你解决”改成“我陪你找下一步”。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮你一起理清选择，但决定和后果还是需要由你来拿。”这句话。",
+        "script": "我可以帮你一起理清选择，但决定和后果还是需要由你来拿。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -605,14 +605,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「支持但不拯救」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Support Without Rescuing",
-        "why_this_matters": "Shift from “I will fix this for you” to “I can help you find your next step.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I can help you think through the options, but the decision and the consequences need to stay with you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I can help you think through the options, but the decision and the consequences need to stay with you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Shift from “I will fix this for you” to “I can help you find your next step.”",
+        "do_today": "Today, use one low-risk version of this sentence: “I can help you think through the options, but the decision and the consequences need to stay with you.”",
+        "script": "I can help you think through the options, but the decision and the consequences need to stay with you.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -645,15 +645,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Support Without Rescuing” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "support_without_rescuing",
         "asset_type": "action_prescription",
         "v23_source_id": "support_without_rescuing",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "over_responsible_helper",
@@ -664,9 +664,9 @@
     "cold_to_warm_response": {
       "zh-CN": {
         "title": "先回应情绪",
-        "why_this_matters": "在提出方案前，先让对方知道你听见了情绪。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“听起来这件事让你很失望。我们可以一起看下一步怎么处理。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "听起来这件事让你很失望。我们可以一起看下一步怎么处理。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在提出方案前，先让对方知道你听见了情绪。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“听起来这件事让你很失望。我们可以一起看下一步怎么处理。”这句话。",
+        "script": "听起来这件事让你很失望。我们可以一起看下一步怎么处理。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -699,14 +699,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「先回应情绪」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Add Warmth Before Solving",
-        "why_this_matters": "Before offering a solution, let the other person know you registered the feeling. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “It sounds like this was really disappointing. We can look at the next step together.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "It sounds like this was really disappointing. We can look at the next step together. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before offering a solution, let the other person know you registered the feeling.",
+        "do_today": "Today, use one low-risk version of this sentence: “It sounds like this was really disappointing. We can look at the next step together.”",
+        "script": "It sounds like this was really disappointing. We can look at the next step together.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -739,15 +739,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Add Warmth Before Solving” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "cold_to_warm_response",
         "asset_type": "action_prescription",
         "v23_source_id": "cold_to_warm_response",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "calm_but_distant",
@@ -758,9 +758,9 @@
     "relationship_energy_management": {
       "zh-CN": {
         "title": "关系能量管理",
-        "why_this_matters": "在高互动或高情绪场景后，给自己一个可执行的恢复流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要十分钟整理一下自己，再继续这个话题。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我需要十分钟整理一下自己，再继续这个话题。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在高互动或高情绪场景后，给自己一个可执行的恢复流程。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要十分钟整理一下自己，再继续这个话题。”这句话。",
+        "script": "我需要十分钟整理一下自己，再继续这个话题。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -793,14 +793,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「关系能量管理」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Relationship Energy Management",
-        "why_this_matters": "After high-contact or emotionally loaded situations, give yourself a concrete recovery routine. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I need ten minutes to reset before we continue this conversation.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I need ten minutes to reset before we continue this conversation. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "After high-contact or emotionally loaded situations, give yourself a concrete recovery routine.",
+        "do_today": "Today, use one low-risk version of this sentence: “I need ten minutes to reset before we continue this conversation.”",
+        "script": "I need ten minutes to reset before we continue this conversation.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -833,15 +833,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Relationship Energy Management” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "relationship_energy_management",
         "asset_type": "action_prescription",
         "v23_source_id": "relationship_energy_management",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "sensitive_absorber",
@@ -852,9 +852,9 @@
     "conflict_deescalation": {
       "zh-CN": {
         "title": "冲突降温",
-        "why_this_matters": "把对话从谁对谁错拉回具体分歧和下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们先暂停一下。现在真正分歧的是哪一点？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我们先暂停一下。现在真正分歧的是哪一点？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把对话从谁对谁错拉回具体分歧和下一步。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们先暂停一下。现在真正分歧的是哪一点？”这句话。",
+        "script": "我们先暂停一下。现在真正分歧的是哪一点？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -887,14 +887,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「冲突降温」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "De-escalate the Conflict",
-        "why_this_matters": "Move the conversation from winning and losing back to the specific disagreement and next step. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “Let’s pause. What is the exact point we are disagreeing about?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "Let’s pause. What is the exact point we are disagreeing about? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Move the conversation from winning and losing back to the specific disagreement and next step.",
+        "do_today": "Today, use one low-risk version of this sentence: “Let’s pause. What is the exact point we are disagreeing about?”",
+        "script": "Let’s pause. What is the exact point we are disagreeing about?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -927,15 +927,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “De-escalate the Conflict” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "conflict_deescalation",
         "asset_type": "action_prescription",
         "v23_source_id": "conflict_deescalation",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "steady_collaborator",
@@ -947,9 +947,9 @@
     "self_connection": {
       "zh-CN": {
         "title": "回到自己",
-        "why_this_matters": "在照顾关系前，先确认自己真实的感受和需要。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想先确认一下自己的感受，再回应你。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我想先确认一下自己的感受，再回应你。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在照顾关系前，先确认自己真实的感受和需要。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想先确认一下自己的感受，再回应你。”这句话。",
+        "script": "我想先确认一下自己的感受，再回应你。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -982,14 +982,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「回到自己」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Return to Yourself",
-        "why_this_matters": "Before managing the relationship, check what you are actually feeling and needing. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I want to check in with myself before I respond.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I want to check in with myself before I respond. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before managing the relationship, check what you are actually feeling and needing.",
+        "do_today": "Today, use one low-risk version of this sentence: “I want to check in with myself before I respond.”",
+        "script": "I want to check in with myself before I respond.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1022,15 +1022,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Return to Yourself” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "self_connection",
         "asset_type": "action_prescription",
         "v23_source_id": "self_connection",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "relationship_first_self_later",
@@ -1041,9 +1041,9 @@
     "retest_reflection": {
       "zh-CN": {
         "title": "复测前的自我回顾",
-        "why_this_matters": "低置信结果主要支持复测准备，不支持行为改变结论。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "记录本次作答环境，并在更稳定、不被打断时复测。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我会轻读本次结果，在条件更稳定时复测。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "低置信结果主要支持复测准备，不支持行为改变结论。",
+        "do_today": "记录本次作答环境，并在更稳定、不被打断时复测。",
+        "script": "我会轻读本次结果，在条件更稳定时复测。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1052,14 +1052,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「复测前的自我回顾」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Reflect Before Retesting",
-        "why_this_matters": "This low-confidence session mainly supports retest preparation, not behavior-change conclusions. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Record the response context and retake in a steadier, uninterrupted setting. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I will hold this session lightly and retake it when conditions are steadier. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "This low-confidence session mainly supports retest preparation, not behavior-change conclusions.",
+        "do_today": "Record the response context and retake in a steadier, uninterrupted setting.",
+        "script": "I will hold this session lightly and retake it when conditions are steadier.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1068,15 +1068,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Reflect Before Retesting” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "retest_reflection",
         "asset_type": "action_prescription",
         "v23_source_id": "retest_reflection",
         "claim_risk": "high",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "QUALITY",
         "best_for": [
           "low_confidence_result"
@@ -1086,9 +1086,9 @@
     "ask_before_solving": {
       "zh-CN": {
         "title": "先问再解决",
-        "why_this_matters": "在提供建议前确认对方想要理解、建议还是只是被听见。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“你现在更想让我听你说，还是一起想办法？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "你现在更想让我听你说，还是一起想办法？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在提供建议前确认对方想要理解、建议还是只是被听见。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“你现在更想让我听你说，还是一起想办法？”这句话。",
+        "script": "你现在更想让我听你说，还是一起想办法？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1121,14 +1121,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「先问再解决」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Ask Before Solving",
-        "why_this_matters": "Before offering advice, ask whether the person wants understanding, ideas, or simply to be heard. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “Do you want me to just listen right now, or would it help to think through options together?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "Do you want me to just listen right now, or would it help to think through options together? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before offering advice, ask whether the person wants understanding, ideas, or simply to be heard.",
+        "do_today": "Today, use one low-risk version of this sentence: “Do you want me to just listen right now, or would it help to think through options together?”",
+        "script": "Do you want me to just listen right now, or would it help to think through options together?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1161,15 +1161,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Ask Before Solving” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "ask_before_solving",
         "asset_type": "action_prescription",
         "v23_source_id": "ask_before_solving",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "strategic_listener",
@@ -1180,9 +1180,9 @@
     "delayed_processing_note": {
       "zh-CN": {
         "title": "延迟处理笔记",
-        "why_this_matters": "给事后才出现的情绪一个出口，避免它变成沉默或突然爆发。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我刚才还没完全处理好，现在我想补充我的真实感受。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我刚才还没完全处理好，现在我想补充我的真实感受。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "给事后才出现的情绪一个出口，避免它变成沉默或突然爆发。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我刚才还没完全处理好，现在我想补充我的真实感受。”这句话。",
+        "script": "我刚才还没完全处理好，现在我想补充我的真实感受。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1215,14 +1215,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「延迟处理笔记」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Delayed Processing Note",
-        "why_this_matters": "Give late-arriving feelings a place to land before they become silence or a sudden reaction. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I did not fully process it earlier. I want to add what I actually felt.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I did not fully process it earlier. I want to add what I actually felt. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Give late-arriving feelings a place to land before they become silence or a sudden reaction.",
+        "do_today": "Today, use one low-risk version of this sentence: “I did not fully process it earlier. I want to add what I actually felt.”",
+        "script": "I did not fully process it earlier. I want to add what I actually felt.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1255,15 +1255,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Delayed Processing Note” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "delayed_processing_note",
         "asset_type": "action_prescription",
         "v23_source_id": "delayed_processing_note",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "delayed_processor",
@@ -1274,9 +1274,9 @@
     "body_reset": {
       "zh-CN": {
         "title": "身体重置",
-        "why_this_matters": "用身体信号而不是反复思考来结束压力循环。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在身体很紧，我先把节奏慢下来。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我现在身体很紧，我先把节奏慢下来。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "用身体信号而不是反复思考来结束压力循环。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在身体很紧，我先把节奏慢下来。”这句话。",
+        "script": "我现在身体很紧，我先把节奏慢下来。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1309,14 +1309,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「身体重置」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Body Reset",
-        "why_this_matters": "Use a body cue, not more thinking, to close the stress loop. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “My body feels tense. I am going to slow the pace down first.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "My body feels tense. I am going to slow the pace down first. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Use a body cue, not more thinking, to close the stress loop.",
+        "do_today": "Today, use one low-risk version of this sentence: “My body feels tense. I am going to slow the pace down first.”",
+        "script": "My body feels tense. I am going to slow the pace down first.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1349,15 +1349,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Body Reset” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "body_reset",
         "asset_type": "action_prescription",
         "v23_source_id": "body_reset",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "pressure_contained",
@@ -1368,9 +1368,9 @@
     "empathy_to_action": {
       "zh-CN": {
         "title": "从理解到行动",
-        "why_this_matters": "把“我懂你”转成一个小而清楚的下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听懂了。我们先选一个今天能做的小步骤。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我听懂了。我们先选一个今天能做的小步骤。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把“我懂你”转成一个小而清楚的下一步。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听懂了。我们先选一个今天能做的小步骤。”这句话。",
+        "script": "我听懂了。我们先选一个今天能做的小步骤。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1403,14 +1403,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「从理解到行动」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "From Empathy to Action",
-        "why_this_matters": "Turn “I understand” into one small, clear next step. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I understand. Let’s choose one small step we can take today.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I understand. Let’s choose one small step we can take today. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn “I understand” into one small, clear next step.",
+        "do_today": "Today, use one low-risk version of this sentence: “I understand. Let’s choose one small step we can take today.”",
+        "script": "I understand. Let’s choose one small step we can take today.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1443,15 +1443,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “From Empathy to Action” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "empathy_to_action",
         "asset_type": "action_prescription",
         "v23_source_id": "empathy_to_action",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "empathy_to_action_gap",
@@ -1462,9 +1462,9 @@
     "warm_signal": {
       "zh-CN": {
         "title": "释放温度信号",
-        "why_this_matters": "在保持距离的同时给对方一个可读的善意信号。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要一点空间，但不是要推开你。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我需要一点空间，但不是要推开你。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在保持距离的同时给对方一个可读的善意信号。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要一点空间，但不是要推开你。”这句话。",
+        "script": "我需要一点空间，但不是要推开你。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1497,14 +1497,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「释放温度信号」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Send a Warm Signal",
-        "why_this_matters": "Keep your boundary while giving the other person a readable signal of goodwill. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I need some space, but I am not trying to push you away.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I need some space, but I am not trying to push you away. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Keep your boundary while giving the other person a readable signal of goodwill.",
+        "do_today": "Today, use one low-risk version of this sentence: “I need some space, but I am not trying to push you away.”",
+        "script": "I need some space, but I am not trying to push you away.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1537,15 +1537,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Send a Warm Signal” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "warm_signal",
         "asset_type": "action_prescription",
         "v23_source_id": "warm_signal",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "self_protective_distance",
@@ -1556,9 +1556,9 @@
     "values_pause": {
       "zh-CN": {
         "title": "价值触发暂停",
-        "why_this_matters": "当原则被触碰时，先暂停，避免把价值感变成攻击。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "当原则被触碰时，先暂停，避免把价值感变成攻击。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。”这句话。",
+        "script": "这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1591,14 +1591,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「价值触发暂停」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Values Trigger Pause",
-        "why_this_matters": "When a value is touched, pause before turning conviction into attack. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “This touches a value for me. I want to name the point clearly rather than react immediately.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "This touches a value for me. I want to name the point clearly rather than react immediately. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "When a value is touched, pause before turning conviction into attack.",
+        "do_today": "Today, use one low-risk version of this sentence: “This touches a value for me. I want to name the point clearly rather than react immediately.”",
+        "script": "This touches a value for me. I want to name the point clearly rather than react immediately.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1631,15 +1631,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Values Trigger Pause” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "values_pause",
         "asset_type": "action_prescription",
         "v23_source_id": "values_pause",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "values_sensitive",
@@ -1650,9 +1650,9 @@
     "shared_stability": {
       "zh-CN": {
         "title": "共享稳定责任",
-        "why_this_matters": "让稳定不只靠你一个人承担。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮我们整理下一步，但我们需要一起承担这个节奏。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我可以帮我们整理下一步，但我们需要一起承担这个节奏。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "让稳定不只靠你一个人承担。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮我们整理下一步，但我们需要一起承担这个节奏。”这句话。",
+        "script": "我可以帮我们整理下一步，但我们需要一起承担这个节奏。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1685,14 +1685,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「共享稳定责任」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Share the Stability Load",
-        "why_this_matters": "Make steadiness a shared process, not your private job. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I can help organize the next step, but we need to share responsibility for the pace.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I can help organize the next step, but we need to share responsibility for the pace. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Make steadiness a shared process, not your private job.",
+        "do_today": "Today, use one low-risk version of this sentence: “I can help organize the next step, but we need to share responsibility for the pace.”",
+        "script": "I can help organize the next step, but we need to share responsibility for the pace.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1725,15 +1725,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Share the Stability Load” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "shared_stability",
         "asset_type": "action_prescription",
         "v23_source_id": "shared_stability",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "team_stabilizer",
@@ -1744,9 +1744,9 @@
     "followthrough_bridge": {
       "zh-CN": {
         "title": "倾听后的跟进",
-        "why_this_matters": "把一次好的倾听转成一个可追踪的承诺。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听见了。我们约定一个具体时间回来确认进展。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我听见了。我们约定一个具体时间回来确认进展。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把一次好的倾听转成一个可追踪的承诺。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听见了。我们约定一个具体时间回来确认进展。”这句话。",
+        "script": "我听见了。我们约定一个具体时间回来确认进展。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1779,14 +1779,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「倾听后的跟进」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Follow Through After Listening",
-        "why_this_matters": "Turn good listening into a trackable commitment. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I hear you. Let’s set a specific time to check progress.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I hear you. Let’s set a specific time to check progress. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn good listening into a trackable commitment.",
+        "do_today": "Today, use one low-risk version of this sentence: “I hear you. Let’s set a specific time to check progress.”",
+        "script": "I hear you. Let’s set a specific time to check progress.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1819,15 +1819,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Follow Through After Listening” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "followthrough_bridge",
         "asset_type": "action_prescription",
         "v23_source_id": "followthrough_bridge",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "listening_without_followthrough",
@@ -1838,9 +1838,9 @@
     "small_conflict_step": {
       "zh-CN": {
         "title": "小步进入冲突",
-        "why_this_matters": "先处理一个小分歧，训练自己不再把所有张力都推迟。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不想把这个压下去。我们先谈其中一个具体点。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我不想把这个压下去。我们先谈其中一个具体点。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "先处理一个小分歧，训练自己不再把所有张力都推迟。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不想把这个压下去。我们先谈其中一个具体点。”这句话。",
+        "script": "我不想把这个压下去。我们先谈其中一个具体点。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1873,14 +1873,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「小步进入冲突」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Take a Small Conflict Step",
-        "why_this_matters": "Address one small disagreement first so tension does not always get postponed. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I do not want to bury this. Let’s start with one specific point.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I do not want to bury this. Let’s start with one specific point. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Address one small disagreement first so tension does not always get postponed.",
+        "do_today": "Today, use one low-risk version of this sentence: “I do not want to bury this. Let’s start with one specific point.”",
+        "script": "I do not want to bury this. Let’s start with one specific point.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1913,15 +1913,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Take a Small Conflict Step” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "small_conflict_step",
         "asset_type": "action_prescription",
         "v23_source_id": "small_conflict_step",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "conflict_avoider",
@@ -1932,9 +1932,9 @@
     "boundary_before_advice": {
       "zh-CN": {
         "title": "建议前先设边界",
-        "why_this_matters": "在给建议之前先说明你能投入的范围。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在给建议之前先说明你能投入的范围。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。”这句话。",
+        "script": "我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1967,14 +1967,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「建议前先设边界」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Set the Boundary Before Advice",
-        "why_this_matters": "Before giving advice, state the amount of time, energy, or responsibility you can offer. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I can think this through with you for twenty minutes, and then the decision needs to be yours.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I can think this through with you for twenty minutes, and then the decision needs to be yours. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before giving advice, state the amount of time, energy, or responsibility you can offer.",
+        "do_today": "Today, use one low-risk version of this sentence: “I can think this through with you for twenty minutes, and then the decision needs to be yours.”",
+        "script": "I can think this through with you for twenty minutes, and then the decision needs to be yours.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2007,15 +2007,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Set the Boundary Before Advice” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "boundary_before_advice",
         "asset_type": "action_prescription",
         "v23_source_id": "boundary_before_advice",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "over_responsible_helper",
@@ -2026,9 +2026,9 @@
     "repair_without_self_blame": {
       "zh-CN": {
         "title": "修复但不自责",
-        "why_this_matters": "承认影响，不把整个自我都判成失败。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "承认影响，不把整个自我都判成失败。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。”这句话。",
+        "script": "我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2061,14 +2061,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「修复但不自责」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Repair Without Self-Blame",
-        "why_this_matters": "Acknowledge the impact without turning your whole self into the problem. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I see that what I said affected you. I will adjust it, and I want to understand the specific part to change. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Acknowledge the impact without turning your whole self into the problem.",
+        "do_today": "Today, use one low-risk version of this sentence: “I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.”",
+        "script": "I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2101,15 +2101,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Repair Without Self-Blame” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "repair_without_self_blame",
         "asset_type": "action_prescription",
         "v23_source_id": "repair_without_self_blame",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "feedback_absorber",
@@ -2120,9 +2120,9 @@
     "name_the_request": {
       "zh-CN": {
         "title": "说出请求",
-        "why_this_matters": "把委屈或沉默转成一个清楚请求。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我真正需要的是……你能不能……？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我真正需要的是……你能不能……？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把委屈或沉默转成一个清楚请求。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我真正需要的是……你能不能……？”这句话。",
+        "script": "我真正需要的是……你能不能……？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2155,14 +2155,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「说出请求」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Name the Request",
-        "why_this_matters": "Turn resentment or silence into a clear request. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “What I actually need is... Would you be willing to...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "What I actually need is... Would you be willing to...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn resentment or silence into a clear request.",
+        "do_today": "Today, use one low-risk version of this sentence: “What I actually need is... Would you be willing to...?”",
+        "script": "What I actually need is... Would you be willing to...?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2195,15 +2195,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Name the Request” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "name_the_request",
         "asset_type": "action_prescription",
         "v23_source_id": "name_the_request",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "relationship_first_self_later",
@@ -2214,9 +2214,9 @@
     "slow_the_reply": {
       "zh-CN": {
         "title": "放慢回复",
-        "why_this_matters": "当你想马上回应时，先把回应拆成草稿和发送。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先写下来，但不立刻发。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我先写下来，但不立刻发。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "当你想马上回应时，先把回应拆成草稿和发送。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先写下来，但不立刻发。”这句话。",
+        "script": "我先写下来，但不立刻发。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2249,14 +2249,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「放慢回复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Slow the Reply",
-        "why_this_matters": "When you want to answer immediately, separate drafting from sending. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I will write it first, but I will not send it immediately.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I will write it first, but I will not send it immediately. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "When you want to answer immediately, separate drafting from sending.",
+        "do_today": "Today, use one low-risk version of this sentence: “I will write it first, but I will not send it immediately.”",
+        "script": "I will write it first, but I will not send it immediately.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2289,15 +2289,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Slow the Reply” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "slow_the_reply",
         "asset_type": "action_prescription",
         "v23_source_id": "slow_the_reply",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "fast_reactor",
@@ -2308,9 +2308,9 @@
     "make_empathy_visible": {
       "zh-CN": {
         "title": "让共情被看见",
-        "why_this_matters": "把心里的理解说出来，让对方不是只能猜。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听到你其实是在担心……对吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我听到你其实是在担心……对吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把心里的理解说出来，让对方不是只能猜。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听到你其实是在担心……对吗？”这句话。",
+        "script": "我听到你其实是在担心……对吗？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2343,14 +2343,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「让共情被看见」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Make Empathy Visible",
-        "why_this_matters": "Say the understanding out loud so the other person does not have to guess it. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “What I hear is that you are worried about... Is that right?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "What I hear is that you are worried about... Is that right? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Say the understanding out loud so the other person does not have to guess it.",
+        "do_today": "Today, use one low-risk version of this sentence: “What I hear is that you are worried about... Is that right?”",
+        "script": "What I hear is that you are worried about... Is that right?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2383,15 +2383,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Make Empathy Visible” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "make_empathy_visible",
         "asset_type": "action_prescription",
         "v23_source_id": "make_empathy_visible",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "quiet_empathy",
@@ -2402,9 +2402,9 @@
     "repair_the_tone": {
       "zh-CN": {
         "title": "修复语气",
-        "why_this_matters": "内容不一定错，但语气需要被修复。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想保留我的观点，但刚才语气太硬了。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我想保留我的观点，但刚才语气太硬了。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "内容不一定错，但语气需要被修复。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想保留我的观点，但刚才语气太硬了。”这句话。",
+        "script": "我想保留我的观点，但刚才语气太硬了。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2437,14 +2437,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「修复语气」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Repair the Tone",
-        "why_this_matters": "The content may be valid, but the tone may need repair. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I stand by the point, but my tone was too hard.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I stand by the point, but my tone was too hard. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "The content may be valid, but the tone may need repair.",
+        "do_today": "Today, use one low-risk version of this sentence: “I stand by the point, but my tone was too hard.”",
+        "script": "I stand by the point, but my tone was too hard.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2477,15 +2477,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Repair the Tone” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "repair_the_tone",
         "asset_type": "action_prescription",
         "v23_source_id": "repair_the_tone",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "direct_without_softening",
@@ -2496,9 +2496,9 @@
     "protect_recovery_time": {
       "zh-CN": {
         "title": "保护恢复时间",
-        "why_this_matters": "把恢复时间当成结果质量的一部分，而不是偷懒。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要恢复一下，之后会给你更清楚的回应。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我需要恢复一下，之后会给你更清楚的回应。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把恢复时间当成结果质量的一部分，而不是偷懒。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要恢复一下，之后会给你更清楚的回应。”这句话。",
+        "script": "我需要恢复一下，之后会给你更清楚的回应。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2531,14 +2531,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「保护恢复时间」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Protect Recovery Time",
-        "why_this_matters": "Treat recovery time as part of the quality of your response, not as avoidance. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I need to recover first so I can give you a clearer response later.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I need to recover first so I can give you a clearer response later. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Treat recovery time as part of the quality of your response, not as avoidance.",
+        "do_today": "Today, use one low-risk version of this sentence: “I need to recover first so I can give you a clearer response later.”",
+        "script": "I need to recover first so I can give you a clearer response later.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2571,15 +2571,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Protect Recovery Time” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "protect_recovery_time",
         "asset_type": "action_prescription",
         "v23_source_id": "protect_recovery_time",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "sensitive_absorber",
@@ -2590,9 +2590,9 @@
     "clarify_before_concluding": {
       "zh-CN": {
         "title": "先澄清再下结论",
-        "why_this_matters": "在判断对方意图前，先用一个问题确认。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不确定我理解对了。你是指……吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我不确定我理解对了。你是指……吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在判断对方意图前，先用一个问题确认。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不确定我理解对了。你是指……吗？”这句话。",
+        "script": "我不确定我理解对了。你是指……吗？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2625,14 +2625,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「先澄清再下结论」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Clarify Before Concluding",
-        "why_this_matters": "Before deciding what someone meant, check with one question. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I want to make sure I understood. Do you mean...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I want to make sure I understood. Do you mean...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before deciding what someone meant, check with one question.",
+        "do_today": "Today, use one low-risk version of this sentence: “I want to make sure I understood. Do you mean...?”",
+        "script": "I want to make sure I understood. Do you mean...?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2665,15 +2665,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Clarify Before Concluding” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "clarify_before_concluding",
         "asset_type": "action_prescription",
         "v23_source_id": "clarify_before_concluding",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "strategic_listener",
@@ -2684,9 +2684,9 @@
     "turn_stability_into_process": {
       "zh-CN": {
         "title": "把稳定变流程",
-        "why_this_matters": "不要只靠你当下状态好，把稳定步骤写成流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们可以用三个步骤来处理：事实、感受、下一步。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我们可以用三个步骤来处理：事实、感受、下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "不要只靠你当下状态好，把稳定步骤写成流程。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们可以用三个步骤来处理：事实、感受、下一步。”这句话。",
+        "script": "我们可以用三个步骤来处理：事实、感受、下一步。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2719,14 +2719,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「把稳定变流程」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Turn Stability Into a Process",
-        "why_this_matters": "Do not rely only on being in a good state; turn steadiness into a process. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “We can handle this in three steps: facts, feelings, next action.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "We can handle this in three steps: facts, feelings, next action. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Do not rely only on being in a good state; turn steadiness into a process.",
+        "do_today": "Today, use one low-risk version of this sentence: “We can handle this in three steps: facts, feelings, next action.”",
+        "script": "We can handle this in three steps: facts, feelings, next action.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2759,15 +2759,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Turn Stability Into a Process” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "turn_stability_into_process",
         "asset_type": "action_prescription",
         "v23_source_id": "turn_stability_into_process",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "balanced_integrated",
@@ -2778,9 +2778,9 @@
     "integrated_maintenance": {
       "zh-CN": {
         "title": "整合优势维护",
-        "why_this_matters": "把已经可用的觉察、调节、共情和关系行动固定成可重复流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们按三步来：事实、感受、下一步。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我们按三步来：事实、感受、下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把已经可用的觉察、调节、共情和关系行动固定成可重复流程。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们按三步来：事实、感受、下一步。”这句话。",
+        "script": "我们按三步来：事实、感受、下一步。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2813,14 +2813,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「整合优势维护」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Maintain Integrated Strength",
-        "why_this_matters": "Turn existing awareness, regulation, empathy, and relationship action into a repeatable routine. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “Let’s use three steps: facts, feelings, next action.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "Let’s use three steps: facts, feelings, next action. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn existing awareness, regulation, empathy, and relationship action into a repeatable routine.",
+        "do_today": "Today, use one low-risk version of this sentence: “Let’s use three steps: facts, feelings, next action.”",
+        "script": "Let’s use three steps: facts, feelings, next action.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2853,15 +2853,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Maintain Integrated Strength” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "integrated_maintenance",
         "asset_type": "action_prescription",
         "v23_source_id": "integrated_maintenance",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "balanced_integrated",
@@ -2872,9 +2872,9 @@
     "express_need_clearly": {
       "zh-CN": {
         "title": "清楚表达需要",
-        "why_this_matters": "把内在稳定转成别人能听懂的需求，而不是只在心里处理。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在需要的是……你可以……吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我现在需要的是……你可以……吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把内在稳定转成别人能听懂的需求，而不是只在心里处理。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在需要的是……你可以……吗？”这句话。",
+        "script": "我现在需要的是……你可以……吗？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2907,14 +2907,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「清楚表达需要」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "State the Need Clearly",
-        "why_this_matters": "Turn internal steadiness into a request another person can actually understand. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “What I need right now is... Would you be willing to...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "What I need right now is... Would you be willing to...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn internal steadiness into a request another person can actually understand.",
+        "do_today": "Today, use one low-risk version of this sentence: “What I need right now is... Would you be willing to...?”",
+        "script": "What I need right now is... Would you be willing to...?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2947,15 +2947,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “State the Need Clearly” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "express_need_clearly",
         "asset_type": "action_prescription",
         "v23_source_id": "express_need_clearly",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "regulated_but_private",

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-03T03:04:45.949377Z",
+    "generated_at": "2026-07-03T03:24:01.377499Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -17015,9 +17015,9 @@
                 "emotion_labeling": {
                     "zh-CN": {
                         "title": "情绪命名练习",
-                        "why_this_matters": "把模糊的不舒服拆成一个具体情绪词，而不是马上解释或压下去。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先不急着判断对错。我现在更像是感到……”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我先不急着判断对错。我现在更像是感到…… 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把模糊的不舒服拆成一个具体情绪词，而不是马上解释或压下去。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先不急着判断对错。我现在更像是感到……”这句话。",
+                        "script": "我先不急着判断对错。我现在更像是感到……",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17050,14 +17050,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「情绪命名练习」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Name the Emotion",
-                        "why_this_matters": "Turn a vague discomfort into a specific emotion word before explaining it away or pushing it down. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I do not need to decide whether this is right or wrong yet. What I notice first is...” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I do not need to decide whether this is right or wrong yet. What I notice first is... This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn a vague discomfort into a specific emotion word before explaining it away or pushing it down.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I do not need to decide whether this is right or wrong yet. What I notice first is...”",
+                        "script": "I do not need to decide whether this is right or wrong yet. What I notice first is...",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17090,15 +17090,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Name the Emotion” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "emotion_labeling",
                         "asset_type": "action_prescription",
                         "v23_source_id": "emotion_labeling",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "developing_foundation",
@@ -17109,9 +17109,9 @@
                 "pause_recovery": {
                     "zh-CN": {
                         "title": "暂停与恢复",
-                        "why_this_matters": "在被触发后先创造几秒钟空间，让回应不完全由第一反应决定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想停一下再回答，这样我能说得更清楚。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我想停一下再回答，这样我能说得更清楚。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在被触发后先创造几秒钟空间，让回应不完全由第一反应决定。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想停一下再回答，这样我能说得更清楚。”这句话。",
+                        "script": "我想停一下再回答，这样我能说得更清楚。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17144,14 +17144,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「暂停与恢复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Pause and Recover",
-                        "why_this_matters": "Create a few seconds of space after being triggered, so your response is not decided by the first impulse. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I want to pause before I answer, so I can respond more clearly.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I want to pause before I answer, so I can respond more clearly. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Create a few seconds of space after being triggered, so your response is not decided by the first impulse.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I want to pause before I answer, so I can respond more clearly.”",
+                        "script": "I want to pause before I answer, so I can respond more clearly.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17184,15 +17184,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Pause and Recover” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "pause_recovery",
                         "asset_type": "action_prescription",
                         "v23_source_id": "pause_recovery",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "aware_but_unregulated",
@@ -17203,9 +17203,9 @@
                 "feedback_decompression": {
                     "zh-CN": {
                         "title": "反馈减压",
-                        "why_this_matters": "把反馈里的事实、情绪和下一步拆开，避免把别人的语气全部当成自我否定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把反馈里的事实、情绪和下一步拆开，避免把别人的语气全部当成自我否定。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？”这句话。",
+                        "script": "我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17238,14 +17238,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「反馈减压」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Decompress Feedback",
-                        "why_this_matters": "Separate facts, tone, and next steps so the other person’s emotion does not become your self-judgment. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "Let me check: are you asking me to adjust the outcome, the process, or the way I communicated? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Separate facts, tone, and next steps so the other person’s emotion does not become your self-judgment.",
+                        "do_today": "Today, use one low-risk version of this sentence: “Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?”",
+                        "script": "Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17278,15 +17278,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Decompress Feedback” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "feedback_decompression",
                         "asset_type": "action_prescription",
                         "v23_source_id": "feedback_decompression",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "feedback_absorber",
@@ -17297,9 +17297,9 @@
                 "empathy_boundary": {
                     "zh-CN": {
                         "title": "共情后的边界",
-                        "why_this_matters": "理解别人之后，明确你能支持什么、不能替对方承担什么。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "理解别人之后，明确你能支持什么、不能替对方承担什么。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。”这句话。",
+                        "script": "我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17332,14 +17332,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「共情后的边界」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Empathy with a Boundary",
-                        "why_this_matters": "After understanding someone, clarify what you can support and what you cannot carry for them. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "After understanding someone, clarify what you can support and what you cannot carry for them.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.”",
+                        "script": "I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17372,15 +17372,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Empathy with a Boundary” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "empathy_boundary",
                         "asset_type": "action_prescription",
                         "v23_source_id": "empathy_boundary",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "high_empathy_low_recovery",
@@ -17392,9 +17392,9 @@
                 "repair_after_conflict": {
                     "zh-CN": {
                         "title": "冲突后的修复",
-                        "why_this_matters": "把“我不是故意的”升级成“我看见了影响，并愿意修复”。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把“我不是故意的”升级成“我看见了影响，并愿意修复”。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。”这句话。",
+                        "script": "刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17427,14 +17427,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「冲突后的修复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Repair After Impact",
-                        "why_this_matters": "Move from “I did not mean it” to “I see the impact and I want to repair it.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Move from “I did not mean it” to “I see the impact and I want to repair it.”",
+                        "do_today": "Today, use one low-risk version of this sentence: “What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.”",
+                        "script": "What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17467,15 +17467,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Repair After Impact” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "repair_after_conflict",
                         "asset_type": "action_prescription",
                         "v23_source_id": "repair_after_conflict",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "self_clear_repair_weak",
@@ -17486,9 +17486,9 @@
                 "express_without_escalation": {
                     "zh-CN": {
                         "title": "不升级的表达",
-                        "why_this_matters": "把真实表达从攻击、证明或压制里分离出来。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想说清楚我的感受，但不是为了压过你。我的重点是……”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我想说清楚我的感受，但不是为了压过你。我的重点是…… 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把真实表达从攻击、证明或压制里分离出来。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想说清楚我的感受，但不是为了压过你。我的重点是……”这句话。",
+                        "script": "我想说清楚我的感受，但不是为了压过你。我的重点是……",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17521,14 +17521,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「不升级的表达」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Express Without Escalating",
-                        "why_this_matters": "Separate honest expression from attacking, proving, or overpowering. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I want to be clear about my experience, not to overpower yours. The point I want to make is...” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I want to be clear about my experience, not to overpower yours. The point I want to make is... This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Separate honest expression from attacking, proving, or overpowering.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I want to be clear about my experience, not to overpower yours. The point I want to make is...”",
+                        "script": "I want to be clear about my experience, not to overpower yours. The point I want to make is...",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17561,15 +17561,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Express Without Escalating” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "express_without_escalation",
                         "asset_type": "action_prescription",
                         "v23_source_id": "express_without_escalation",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "direct_without_softening",
@@ -17580,9 +17580,9 @@
                 "support_without_rescuing": {
                     "zh-CN": {
                         "title": "支持但不拯救",
-                        "why_this_matters": "把帮助别人从“我替你解决”改成“我陪你找下一步”。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮你一起理清选择，但决定和后果还是需要由你来拿。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我可以帮你一起理清选择，但决定和后果还是需要由你来拿。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把帮助别人从“我替你解决”改成“我陪你找下一步”。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮你一起理清选择，但决定和后果还是需要由你来拿。”这句话。",
+                        "script": "我可以帮你一起理清选择，但决定和后果还是需要由你来拿。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17615,14 +17615,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「支持但不拯救」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Support Without Rescuing",
-                        "why_this_matters": "Shift from “I will fix this for you” to “I can help you find your next step.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I can help you think through the options, but the decision and the consequences need to stay with you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I can help you think through the options, but the decision and the consequences need to stay with you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Shift from “I will fix this for you” to “I can help you find your next step.”",
+                        "do_today": "Today, use one low-risk version of this sentence: “I can help you think through the options, but the decision and the consequences need to stay with you.”",
+                        "script": "I can help you think through the options, but the decision and the consequences need to stay with you.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17655,15 +17655,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Support Without Rescuing” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "support_without_rescuing",
                         "asset_type": "action_prescription",
                         "v23_source_id": "support_without_rescuing",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "over_responsible_helper",
@@ -17674,9 +17674,9 @@
                 "cold_to_warm_response": {
                     "zh-CN": {
                         "title": "先回应情绪",
-                        "why_this_matters": "在提出方案前，先让对方知道你听见了情绪。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“听起来这件事让你很失望。我们可以一起看下一步怎么处理。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "听起来这件事让你很失望。我们可以一起看下一步怎么处理。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在提出方案前，先让对方知道你听见了情绪。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“听起来这件事让你很失望。我们可以一起看下一步怎么处理。”这句话。",
+                        "script": "听起来这件事让你很失望。我们可以一起看下一步怎么处理。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17709,14 +17709,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「先回应情绪」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Add Warmth Before Solving",
-                        "why_this_matters": "Before offering a solution, let the other person know you registered the feeling. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “It sounds like this was really disappointing. We can look at the next step together.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "It sounds like this was really disappointing. We can look at the next step together. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before offering a solution, let the other person know you registered the feeling.",
+                        "do_today": "Today, use one low-risk version of this sentence: “It sounds like this was really disappointing. We can look at the next step together.”",
+                        "script": "It sounds like this was really disappointing. We can look at the next step together.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17749,15 +17749,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Add Warmth Before Solving” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "cold_to_warm_response",
                         "asset_type": "action_prescription",
                         "v23_source_id": "cold_to_warm_response",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "calm_but_distant",
@@ -17768,9 +17768,9 @@
                 "relationship_energy_management": {
                     "zh-CN": {
                         "title": "关系能量管理",
-                        "why_this_matters": "在高互动或高情绪场景后，给自己一个可执行的恢复流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要十分钟整理一下自己，再继续这个话题。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我需要十分钟整理一下自己，再继续这个话题。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在高互动或高情绪场景后，给自己一个可执行的恢复流程。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要十分钟整理一下自己，再继续这个话题。”这句话。",
+                        "script": "我需要十分钟整理一下自己，再继续这个话题。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17803,14 +17803,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「关系能量管理」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Relationship Energy Management",
-                        "why_this_matters": "After high-contact or emotionally loaded situations, give yourself a concrete recovery routine. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I need ten minutes to reset before we continue this conversation.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I need ten minutes to reset before we continue this conversation. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "After high-contact or emotionally loaded situations, give yourself a concrete recovery routine.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I need ten minutes to reset before we continue this conversation.”",
+                        "script": "I need ten minutes to reset before we continue this conversation.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17843,15 +17843,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Relationship Energy Management” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "relationship_energy_management",
                         "asset_type": "action_prescription",
                         "v23_source_id": "relationship_energy_management",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "sensitive_absorber",
@@ -17862,9 +17862,9 @@
                 "conflict_deescalation": {
                     "zh-CN": {
                         "title": "冲突降温",
-                        "why_this_matters": "把对话从谁对谁错拉回具体分歧和下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们先暂停一下。现在真正分歧的是哪一点？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我们先暂停一下。现在真正分歧的是哪一点？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把对话从谁对谁错拉回具体分歧和下一步。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们先暂停一下。现在真正分歧的是哪一点？”这句话。",
+                        "script": "我们先暂停一下。现在真正分歧的是哪一点？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17897,14 +17897,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「冲突降温」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "De-escalate the Conflict",
-                        "why_this_matters": "Move the conversation from winning and losing back to the specific disagreement and next step. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “Let’s pause. What is the exact point we are disagreeing about?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "Let’s pause. What is the exact point we are disagreeing about? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Move the conversation from winning and losing back to the specific disagreement and next step.",
+                        "do_today": "Today, use one low-risk version of this sentence: “Let’s pause. What is the exact point we are disagreeing about?”",
+                        "script": "Let’s pause. What is the exact point we are disagreeing about?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17937,15 +17937,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “De-escalate the Conflict” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "conflict_deescalation",
                         "asset_type": "action_prescription",
                         "v23_source_id": "conflict_deescalation",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "steady_collaborator",
@@ -17957,9 +17957,9 @@
                 "self_connection": {
                     "zh-CN": {
                         "title": "回到自己",
-                        "why_this_matters": "在照顾关系前，先确认自己真实的感受和需要。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想先确认一下自己的感受，再回应你。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我想先确认一下自己的感受，再回应你。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在照顾关系前，先确认自己真实的感受和需要。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想先确认一下自己的感受，再回应你。”这句话。",
+                        "script": "我想先确认一下自己的感受，再回应你。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -17992,14 +17992,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「回到自己」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Return to Yourself",
-                        "why_this_matters": "Before managing the relationship, check what you are actually feeling and needing. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I want to check in with myself before I respond.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I want to check in with myself before I respond. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before managing the relationship, check what you are actually feeling and needing.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I want to check in with myself before I respond.”",
+                        "script": "I want to check in with myself before I respond.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18032,15 +18032,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Return to Yourself” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "self_connection",
                         "asset_type": "action_prescription",
                         "v23_source_id": "self_connection",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "relationship_first_self_later",
@@ -18051,9 +18051,9 @@
                 "retest_reflection": {
                     "zh-CN": {
                         "title": "复测前的自我回顾",
-                        "why_this_matters": "低置信结果主要支持复测准备，不支持行为改变结论。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "记录本次作答环境，并在更稳定、不被打断时复测。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我会轻读本次结果，在条件更稳定时复测。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "低置信结果主要支持复测准备，不支持行为改变结论。",
+                        "do_today": "记录本次作答环境，并在更稳定、不被打断时复测。",
+                        "script": "我会轻读本次结果，在条件更稳定时复测。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18062,14 +18062,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「复测前的自我回顾」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Reflect Before Retesting",
-                        "why_this_matters": "This low-confidence session mainly supports retest preparation, not behavior-change conclusions. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Record the response context and retake in a steadier, uninterrupted setting. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I will hold this session lightly and retake it when conditions are steadier. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "This low-confidence session mainly supports retest preparation, not behavior-change conclusions.",
+                        "do_today": "Record the response context and retake in a steadier, uninterrupted setting.",
+                        "script": "I will hold this session lightly and retake it when conditions are steadier.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18078,15 +18078,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Reflect Before Retesting” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "retest_reflection",
                         "asset_type": "action_prescription",
                         "v23_source_id": "retest_reflection",
                         "claim_risk": "high",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "QUALITY",
                         "best_for": [
                             "low_confidence_result"
@@ -18096,9 +18096,9 @@
                 "ask_before_solving": {
                     "zh-CN": {
                         "title": "先问再解决",
-                        "why_this_matters": "在提供建议前确认对方想要理解、建议还是只是被听见。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“你现在更想让我听你说，还是一起想办法？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "你现在更想让我听你说，还是一起想办法？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在提供建议前确认对方想要理解、建议还是只是被听见。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“你现在更想让我听你说，还是一起想办法？”这句话。",
+                        "script": "你现在更想让我听你说，还是一起想办法？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18131,14 +18131,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「先问再解决」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Ask Before Solving",
-                        "why_this_matters": "Before offering advice, ask whether the person wants understanding, ideas, or simply to be heard. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “Do you want me to just listen right now, or would it help to think through options together?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "Do you want me to just listen right now, or would it help to think through options together? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before offering advice, ask whether the person wants understanding, ideas, or simply to be heard.",
+                        "do_today": "Today, use one low-risk version of this sentence: “Do you want me to just listen right now, or would it help to think through options together?”",
+                        "script": "Do you want me to just listen right now, or would it help to think through options together?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18171,15 +18171,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Ask Before Solving” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "ask_before_solving",
                         "asset_type": "action_prescription",
                         "v23_source_id": "ask_before_solving",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "strategic_listener",
@@ -18190,9 +18190,9 @@
                 "delayed_processing_note": {
                     "zh-CN": {
                         "title": "延迟处理笔记",
-                        "why_this_matters": "给事后才出现的情绪一个出口，避免它变成沉默或突然爆发。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我刚才还没完全处理好，现在我想补充我的真实感受。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我刚才还没完全处理好，现在我想补充我的真实感受。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "给事后才出现的情绪一个出口，避免它变成沉默或突然爆发。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我刚才还没完全处理好，现在我想补充我的真实感受。”这句话。",
+                        "script": "我刚才还没完全处理好，现在我想补充我的真实感受。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18225,14 +18225,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「延迟处理笔记」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Delayed Processing Note",
-                        "why_this_matters": "Give late-arriving feelings a place to land before they become silence or a sudden reaction. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I did not fully process it earlier. I want to add what I actually felt.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I did not fully process it earlier. I want to add what I actually felt. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Give late-arriving feelings a place to land before they become silence or a sudden reaction.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I did not fully process it earlier. I want to add what I actually felt.”",
+                        "script": "I did not fully process it earlier. I want to add what I actually felt.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18265,15 +18265,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Delayed Processing Note” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "delayed_processing_note",
                         "asset_type": "action_prescription",
                         "v23_source_id": "delayed_processing_note",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "delayed_processor",
@@ -18284,9 +18284,9 @@
                 "body_reset": {
                     "zh-CN": {
                         "title": "身体重置",
-                        "why_this_matters": "用身体信号而不是反复思考来结束压力循环。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在身体很紧，我先把节奏慢下来。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我现在身体很紧，我先把节奏慢下来。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "用身体信号而不是反复思考来结束压力循环。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在身体很紧，我先把节奏慢下来。”这句话。",
+                        "script": "我现在身体很紧，我先把节奏慢下来。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18319,14 +18319,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「身体重置」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Body Reset",
-                        "why_this_matters": "Use a body cue, not more thinking, to close the stress loop. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “My body feels tense. I am going to slow the pace down first.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "My body feels tense. I am going to slow the pace down first. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Use a body cue, not more thinking, to close the stress loop.",
+                        "do_today": "Today, use one low-risk version of this sentence: “My body feels tense. I am going to slow the pace down first.”",
+                        "script": "My body feels tense. I am going to slow the pace down first.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18359,15 +18359,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Body Reset” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "body_reset",
                         "asset_type": "action_prescription",
                         "v23_source_id": "body_reset",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "pressure_contained",
@@ -18378,9 +18378,9 @@
                 "empathy_to_action": {
                     "zh-CN": {
                         "title": "从理解到行动",
-                        "why_this_matters": "把“我懂你”转成一个小而清楚的下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听懂了。我们先选一个今天能做的小步骤。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我听懂了。我们先选一个今天能做的小步骤。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把“我懂你”转成一个小而清楚的下一步。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听懂了。我们先选一个今天能做的小步骤。”这句话。",
+                        "script": "我听懂了。我们先选一个今天能做的小步骤。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18413,14 +18413,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「从理解到行动」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "From Empathy to Action",
-                        "why_this_matters": "Turn “I understand” into one small, clear next step. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I understand. Let’s choose one small step we can take today.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I understand. Let’s choose one small step we can take today. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn “I understand” into one small, clear next step.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I understand. Let’s choose one small step we can take today.”",
+                        "script": "I understand. Let’s choose one small step we can take today.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18453,15 +18453,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “From Empathy to Action” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "empathy_to_action",
                         "asset_type": "action_prescription",
                         "v23_source_id": "empathy_to_action",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "empathy_to_action_gap",
@@ -18472,9 +18472,9 @@
                 "warm_signal": {
                     "zh-CN": {
                         "title": "释放温度信号",
-                        "why_this_matters": "在保持距离的同时给对方一个可读的善意信号。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要一点空间，但不是要推开你。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我需要一点空间，但不是要推开你。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在保持距离的同时给对方一个可读的善意信号。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要一点空间，但不是要推开你。”这句话。",
+                        "script": "我需要一点空间，但不是要推开你。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18507,14 +18507,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「释放温度信号」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Send a Warm Signal",
-                        "why_this_matters": "Keep your boundary while giving the other person a readable signal of goodwill. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I need some space, but I am not trying to push you away.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I need some space, but I am not trying to push you away. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Keep your boundary while giving the other person a readable signal of goodwill.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I need some space, but I am not trying to push you away.”",
+                        "script": "I need some space, but I am not trying to push you away.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18547,15 +18547,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Send a Warm Signal” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "warm_signal",
                         "asset_type": "action_prescription",
                         "v23_source_id": "warm_signal",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "self_protective_distance",
@@ -18566,9 +18566,9 @@
                 "values_pause": {
                     "zh-CN": {
                         "title": "价值触发暂停",
-                        "why_this_matters": "当原则被触碰时，先暂停，避免把价值感变成攻击。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "当原则被触碰时，先暂停，避免把价值感变成攻击。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。”这句话。",
+                        "script": "这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18601,14 +18601,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「价值触发暂停」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Values Trigger Pause",
-                        "why_this_matters": "When a value is touched, pause before turning conviction into attack. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “This touches a value for me. I want to name the point clearly rather than react immediately.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "This touches a value for me. I want to name the point clearly rather than react immediately. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "When a value is touched, pause before turning conviction into attack.",
+                        "do_today": "Today, use one low-risk version of this sentence: “This touches a value for me. I want to name the point clearly rather than react immediately.”",
+                        "script": "This touches a value for me. I want to name the point clearly rather than react immediately.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18641,15 +18641,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Values Trigger Pause” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "values_pause",
                         "asset_type": "action_prescription",
                         "v23_source_id": "values_pause",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "values_sensitive",
@@ -18660,9 +18660,9 @@
                 "shared_stability": {
                     "zh-CN": {
                         "title": "共享稳定责任",
-                        "why_this_matters": "让稳定不只靠你一个人承担。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮我们整理下一步，但我们需要一起承担这个节奏。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我可以帮我们整理下一步，但我们需要一起承担这个节奏。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "让稳定不只靠你一个人承担。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮我们整理下一步，但我们需要一起承担这个节奏。”这句话。",
+                        "script": "我可以帮我们整理下一步，但我们需要一起承担这个节奏。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18695,14 +18695,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「共享稳定责任」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Share the Stability Load",
-                        "why_this_matters": "Make steadiness a shared process, not your private job. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I can help organize the next step, but we need to share responsibility for the pace.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I can help organize the next step, but we need to share responsibility for the pace. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Make steadiness a shared process, not your private job.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I can help organize the next step, but we need to share responsibility for the pace.”",
+                        "script": "I can help organize the next step, but we need to share responsibility for the pace.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18735,15 +18735,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Share the Stability Load” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "shared_stability",
                         "asset_type": "action_prescription",
                         "v23_source_id": "shared_stability",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "team_stabilizer",
@@ -18754,9 +18754,9 @@
                 "followthrough_bridge": {
                     "zh-CN": {
                         "title": "倾听后的跟进",
-                        "why_this_matters": "把一次好的倾听转成一个可追踪的承诺。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听见了。我们约定一个具体时间回来确认进展。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我听见了。我们约定一个具体时间回来确认进展。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把一次好的倾听转成一个可追踪的承诺。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听见了。我们约定一个具体时间回来确认进展。”这句话。",
+                        "script": "我听见了。我们约定一个具体时间回来确认进展。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18789,14 +18789,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「倾听后的跟进」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Follow Through After Listening",
-                        "why_this_matters": "Turn good listening into a trackable commitment. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I hear you. Let’s set a specific time to check progress.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I hear you. Let’s set a specific time to check progress. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn good listening into a trackable commitment.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I hear you. Let’s set a specific time to check progress.”",
+                        "script": "I hear you. Let’s set a specific time to check progress.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18829,15 +18829,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Follow Through After Listening” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "followthrough_bridge",
                         "asset_type": "action_prescription",
                         "v23_source_id": "followthrough_bridge",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "listening_without_followthrough",
@@ -18848,9 +18848,9 @@
                 "small_conflict_step": {
                     "zh-CN": {
                         "title": "小步进入冲突",
-                        "why_this_matters": "先处理一个小分歧，训练自己不再把所有张力都推迟。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不想把这个压下去。我们先谈其中一个具体点。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我不想把这个压下去。我们先谈其中一个具体点。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "先处理一个小分歧，训练自己不再把所有张力都推迟。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不想把这个压下去。我们先谈其中一个具体点。”这句话。",
+                        "script": "我不想把这个压下去。我们先谈其中一个具体点。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18883,14 +18883,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「小步进入冲突」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Take a Small Conflict Step",
-                        "why_this_matters": "Address one small disagreement first so tension does not always get postponed. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I do not want to bury this. Let’s start with one specific point.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I do not want to bury this. Let’s start with one specific point. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Address one small disagreement first so tension does not always get postponed.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I do not want to bury this. Let’s start with one specific point.”",
+                        "script": "I do not want to bury this. Let’s start with one specific point.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18923,15 +18923,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Take a Small Conflict Step” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "small_conflict_step",
                         "asset_type": "action_prescription",
                         "v23_source_id": "small_conflict_step",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "conflict_avoider",
@@ -18942,9 +18942,9 @@
                 "boundary_before_advice": {
                     "zh-CN": {
                         "title": "建议前先设边界",
-                        "why_this_matters": "在给建议之前先说明你能投入的范围。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在给建议之前先说明你能投入的范围。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。”这句话。",
+                        "script": "我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -18977,14 +18977,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「建议前先设边界」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Set the Boundary Before Advice",
-                        "why_this_matters": "Before giving advice, state the amount of time, energy, or responsibility you can offer. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I can think this through with you for twenty minutes, and then the decision needs to be yours.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I can think this through with you for twenty minutes, and then the decision needs to be yours. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before giving advice, state the amount of time, energy, or responsibility you can offer.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I can think this through with you for twenty minutes, and then the decision needs to be yours.”",
+                        "script": "I can think this through with you for twenty minutes, and then the decision needs to be yours.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19017,15 +19017,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Set the Boundary Before Advice” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "boundary_before_advice",
                         "asset_type": "action_prescription",
                         "v23_source_id": "boundary_before_advice",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "over_responsible_helper",
@@ -19036,9 +19036,9 @@
                 "repair_without_self_blame": {
                     "zh-CN": {
                         "title": "修复但不自责",
-                        "why_this_matters": "承认影响，不把整个自我都判成失败。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "承认影响，不把整个自我都判成失败。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。”这句话。",
+                        "script": "我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19071,14 +19071,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「修复但不自责」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Repair Without Self-Blame",
-                        "why_this_matters": "Acknowledge the impact without turning your whole self into the problem. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I see that what I said affected you. I will adjust it, and I want to understand the specific part to change. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Acknowledge the impact without turning your whole self into the problem.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.”",
+                        "script": "I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19111,15 +19111,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Repair Without Self-Blame” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "repair_without_self_blame",
                         "asset_type": "action_prescription",
                         "v23_source_id": "repair_without_self_blame",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "feedback_absorber",
@@ -19130,9 +19130,9 @@
                 "name_the_request": {
                     "zh-CN": {
                         "title": "说出请求",
-                        "why_this_matters": "把委屈或沉默转成一个清楚请求。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我真正需要的是……你能不能……？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我真正需要的是……你能不能……？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把委屈或沉默转成一个清楚请求。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我真正需要的是……你能不能……？”这句话。",
+                        "script": "我真正需要的是……你能不能……？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19165,14 +19165,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「说出请求」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Name the Request",
-                        "why_this_matters": "Turn resentment or silence into a clear request. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “What I actually need is... Would you be willing to...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "What I actually need is... Would you be willing to...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn resentment or silence into a clear request.",
+                        "do_today": "Today, use one low-risk version of this sentence: “What I actually need is... Would you be willing to...?”",
+                        "script": "What I actually need is... Would you be willing to...?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19205,15 +19205,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Name the Request” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "name_the_request",
                         "asset_type": "action_prescription",
                         "v23_source_id": "name_the_request",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "relationship_first_self_later",
@@ -19224,9 +19224,9 @@
                 "slow_the_reply": {
                     "zh-CN": {
                         "title": "放慢回复",
-                        "why_this_matters": "当你想马上回应时，先把回应拆成草稿和发送。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先写下来，但不立刻发。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我先写下来，但不立刻发。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "当你想马上回应时，先把回应拆成草稿和发送。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先写下来，但不立刻发。”这句话。",
+                        "script": "我先写下来，但不立刻发。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19259,14 +19259,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「放慢回复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Slow the Reply",
-                        "why_this_matters": "When you want to answer immediately, separate drafting from sending. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I will write it first, but I will not send it immediately.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I will write it first, but I will not send it immediately. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "When you want to answer immediately, separate drafting from sending.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I will write it first, but I will not send it immediately.”",
+                        "script": "I will write it first, but I will not send it immediately.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19299,15 +19299,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Slow the Reply” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "slow_the_reply",
                         "asset_type": "action_prescription",
                         "v23_source_id": "slow_the_reply",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "fast_reactor",
@@ -19318,9 +19318,9 @@
                 "make_empathy_visible": {
                     "zh-CN": {
                         "title": "让共情被看见",
-                        "why_this_matters": "把心里的理解说出来，让对方不是只能猜。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听到你其实是在担心……对吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我听到你其实是在担心……对吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把心里的理解说出来，让对方不是只能猜。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听到你其实是在担心……对吗？”这句话。",
+                        "script": "我听到你其实是在担心……对吗？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19353,14 +19353,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「让共情被看见」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Make Empathy Visible",
-                        "why_this_matters": "Say the understanding out loud so the other person does not have to guess it. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “What I hear is that you are worried about... Is that right?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "What I hear is that you are worried about... Is that right? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Say the understanding out loud so the other person does not have to guess it.",
+                        "do_today": "Today, use one low-risk version of this sentence: “What I hear is that you are worried about... Is that right?”",
+                        "script": "What I hear is that you are worried about... Is that right?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19393,15 +19393,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Make Empathy Visible” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "make_empathy_visible",
                         "asset_type": "action_prescription",
                         "v23_source_id": "make_empathy_visible",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "EM",
                         "best_for": [
                             "quiet_empathy",
@@ -19412,9 +19412,9 @@
                 "repair_the_tone": {
                     "zh-CN": {
                         "title": "修复语气",
-                        "why_this_matters": "内容不一定错，但语气需要被修复。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想保留我的观点，但刚才语气太硬了。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我想保留我的观点，但刚才语气太硬了。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "内容不一定错，但语气需要被修复。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想保留我的观点，但刚才语气太硬了。”这句话。",
+                        "script": "我想保留我的观点，但刚才语气太硬了。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19447,14 +19447,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「修复语气」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Repair the Tone",
-                        "why_this_matters": "The content may be valid, but the tone may need repair. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I stand by the point, but my tone was too hard.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I stand by the point, but my tone was too hard. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "The content may be valid, but the tone may need repair.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I stand by the point, but my tone was too hard.”",
+                        "script": "I stand by the point, but my tone was too hard.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19487,15 +19487,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Repair the Tone” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "repair_the_tone",
                         "asset_type": "action_prescription",
                         "v23_source_id": "repair_the_tone",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "direct_without_softening",
@@ -19506,9 +19506,9 @@
                 "protect_recovery_time": {
                     "zh-CN": {
                         "title": "保护恢复时间",
-                        "why_this_matters": "把恢复时间当成结果质量的一部分，而不是偷懒。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要恢复一下，之后会给你更清楚的回应。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我需要恢复一下，之后会给你更清楚的回应。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把恢复时间当成结果质量的一部分，而不是偷懒。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要恢复一下，之后会给你更清楚的回应。”这句话。",
+                        "script": "我需要恢复一下，之后会给你更清楚的回应。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19541,14 +19541,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「保护恢复时间」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Protect Recovery Time",
-                        "why_this_matters": "Treat recovery time as part of the quality of your response, not as avoidance. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I need to recover first so I can give you a clearer response later.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I need to recover first so I can give you a clearer response later. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Treat recovery time as part of the quality of your response, not as avoidance.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I need to recover first so I can give you a clearer response later.”",
+                        "script": "I need to recover first so I can give you a clearer response later.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19581,15 +19581,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Protect Recovery Time” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "protect_recovery_time",
                         "asset_type": "action_prescription",
                         "v23_source_id": "protect_recovery_time",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "ER",
                         "best_for": [
                             "sensitive_absorber",
@@ -19600,9 +19600,9 @@
                 "clarify_before_concluding": {
                     "zh-CN": {
                         "title": "先澄清再下结论",
-                        "why_this_matters": "在判断对方意图前，先用一个问题确认。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不确定我理解对了。你是指……吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我不确定我理解对了。你是指……吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "在判断对方意图前，先用一个问题确认。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不确定我理解对了。你是指……吗？”这句话。",
+                        "script": "我不确定我理解对了。你是指……吗？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19635,14 +19635,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「先澄清再下结论」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Clarify Before Concluding",
-                        "why_this_matters": "Before deciding what someone meant, check with one question. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “I want to make sure I understood. Do you mean...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "I want to make sure I understood. Do you mean...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Before deciding what someone meant, check with one question.",
+                        "do_today": "Today, use one low-risk version of this sentence: “I want to make sure I understood. Do you mean...?”",
+                        "script": "I want to make sure I understood. Do you mean...?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19675,15 +19675,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Clarify Before Concluding” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "clarify_before_concluding",
                         "asset_type": "action_prescription",
                         "v23_source_id": "clarify_before_concluding",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "strategic_listener",
@@ -19694,9 +19694,9 @@
                 "turn_stability_into_process": {
                     "zh-CN": {
                         "title": "把稳定变流程",
-                        "why_this_matters": "不要只靠你当下状态好，把稳定步骤写成流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们可以用三个步骤来处理：事实、感受、下一步。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我们可以用三个步骤来处理：事实、感受、下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "不要只靠你当下状态好，把稳定步骤写成流程。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们可以用三个步骤来处理：事实、感受、下一步。”这句话。",
+                        "script": "我们可以用三个步骤来处理：事实、感受、下一步。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19729,14 +19729,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「把稳定变流程」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Turn Stability Into a Process",
-                        "why_this_matters": "Do not rely only on being in a good state; turn steadiness into a process. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “We can handle this in three steps: facts, feelings, next action.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "We can handle this in three steps: facts, feelings, next action. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Do not rely only on being in a good state; turn steadiness into a process.",
+                        "do_today": "Today, use one low-risk version of this sentence: “We can handle this in three steps: facts, feelings, next action.”",
+                        "script": "We can handle this in three steps: facts, feelings, next action.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19769,15 +19769,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Turn Stability Into a Process” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "turn_stability_into_process",
                         "asset_type": "action_prescription",
                         "v23_source_id": "turn_stability_into_process",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "balanced_integrated",
@@ -19788,9 +19788,9 @@
                 "integrated_maintenance": {
                     "zh-CN": {
                         "title": "整合优势维护",
-                        "why_this_matters": "把已经可用的觉察、调节、共情和关系行动固定成可重复流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们按三步来：事实、感受、下一步。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我们按三步来：事实、感受、下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把已经可用的觉察、调节、共情和关系行动固定成可重复流程。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们按三步来：事实、感受、下一步。”这句话。",
+                        "script": "我们按三步来：事实、感受、下一步。",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19823,14 +19823,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「整合优势维护」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "Maintain Integrated Strength",
-                        "why_this_matters": "Turn existing awareness, regulation, empathy, and relationship action into a repeatable routine. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “Let’s use three steps: facts, feelings, next action.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "Let’s use three steps: facts, feelings, next action. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn existing awareness, regulation, empathy, and relationship action into a repeatable routine.",
+                        "do_today": "Today, use one low-risk version of this sentence: “Let’s use three steps: facts, feelings, next action.”",
+                        "script": "Let’s use three steps: facts, feelings, next action.",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19863,15 +19863,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “Maintain Integrated Strength” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "integrated_maintenance",
                         "asset_type": "action_prescription",
                         "v23_source_id": "integrated_maintenance",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "RM",
                         "best_for": [
                             "balanced_integrated",
@@ -19882,9 +19882,9 @@
                 "express_need_clearly": {
                     "zh-CN": {
                         "title": "清楚表达需要",
-                        "why_this_matters": "把内在稳定转成别人能听懂的需求，而不是只在心里处理。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在需要的是……你可以……吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "script": "我现在需要的是……你可以……吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+                        "why_this_matters": "把内在稳定转成别人能听懂的需求，而不是只在心里处理。",
+                        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在需要的是……你可以……吗？”这句话。",
+                        "script": "我现在需要的是……你可以……吗？",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19917,14 +19917,14 @@
                         ],
                         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
                         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-                        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-                        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+                        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+                        "do_not_overread": "请把「清楚表达需要」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
                     },
                     "en": {
                         "title": "State the Need Clearly",
-                        "why_this_matters": "Turn internal steadiness into a request another person can actually understand. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_today": "Today, use one low-risk version of this sentence: “What I need right now is... Would you be willing to...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "script": "What I need right now is... Would you be willing to...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+                        "why_this_matters": "Turn internal steadiness into a request another person can actually understand.",
+                        "do_today": "Today, use one low-risk version of this sentence: “What I need right now is... Would you be willing to...?”",
+                        "script": "What I need right now is... Would you be willing to...?",
                         "seven_day_plan": [
                             {
                                 "day": 1,
@@ -19957,15 +19957,15 @@
                         ],
                         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
                         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-                        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-                        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+                        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+                        "do_not_overread": "Treat “State the Need Clearly” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
                     },
                     "meta": {
                         "id": "express_need_clearly",
                         "asset_type": "action_prescription",
                         "v23_source_id": "express_need_clearly",
                         "claim_risk": "medium",
-                        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+                        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
                         "development_lever": "SA",
                         "best_for": [
                             "regulated_but_private",

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/action_prescriptions.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/action_prescriptions.json
@@ -5,9 +5,9 @@
     "emotion_labeling": {
       "zh-CN": {
         "title": "情绪命名练习",
-        "why_this_matters": "把模糊的不舒服拆成一个具体情绪词，而不是马上解释或压下去。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先不急着判断对错。我现在更像是感到……”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我先不急着判断对错。我现在更像是感到…… 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把模糊的不舒服拆成一个具体情绪词，而不是马上解释或压下去。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先不急着判断对错。我现在更像是感到……”这句话。",
+        "script": "我先不急着判断对错。我现在更像是感到……",
         "seven_day_plan": [
           {
             "day": 1,
@@ -40,14 +40,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「情绪命名练习」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Name the Emotion",
-        "why_this_matters": "Turn a vague discomfort into a specific emotion word before explaining it away or pushing it down. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I do not need to decide whether this is right or wrong yet. What I notice first is...” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I do not need to decide whether this is right or wrong yet. What I notice first is... This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn a vague discomfort into a specific emotion word before explaining it away or pushing it down.",
+        "do_today": "Today, use one low-risk version of this sentence: “I do not need to decide whether this is right or wrong yet. What I notice first is...”",
+        "script": "I do not need to decide whether this is right or wrong yet. What I notice first is...",
         "seven_day_plan": [
           {
             "day": 1,
@@ -80,15 +80,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Name the Emotion” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "emotion_labeling",
         "asset_type": "action_prescription",
         "v23_source_id": "emotion_labeling",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "developing_foundation",
@@ -99,9 +99,9 @@
     "pause_recovery": {
       "zh-CN": {
         "title": "暂停与恢复",
-        "why_this_matters": "在被触发后先创造几秒钟空间，让回应不完全由第一反应决定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想停一下再回答，这样我能说得更清楚。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我想停一下再回答，这样我能说得更清楚。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在被触发后先创造几秒钟空间，让回应不完全由第一反应决定。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想停一下再回答，这样我能说得更清楚。”这句话。",
+        "script": "我想停一下再回答，这样我能说得更清楚。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -134,14 +134,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「暂停与恢复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Pause and Recover",
-        "why_this_matters": "Create a few seconds of space after being triggered, so your response is not decided by the first impulse. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I want to pause before I answer, so I can respond more clearly.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I want to pause before I answer, so I can respond more clearly. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Create a few seconds of space after being triggered, so your response is not decided by the first impulse.",
+        "do_today": "Today, use one low-risk version of this sentence: “I want to pause before I answer, so I can respond more clearly.”",
+        "script": "I want to pause before I answer, so I can respond more clearly.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -174,15 +174,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Pause and Recover” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "pause_recovery",
         "asset_type": "action_prescription",
         "v23_source_id": "pause_recovery",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "aware_but_unregulated",
@@ -193,9 +193,9 @@
     "feedback_decompression": {
       "zh-CN": {
         "title": "反馈减压",
-        "why_this_matters": "把反馈里的事实、情绪和下一步拆开，避免把别人的语气全部当成自我否定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把反馈里的事实、情绪和下一步拆开，避免把别人的语气全部当成自我否定。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？”这句话。",
+        "script": "我先确认一下：你最希望我调整的是结果、过程，还是沟通方式？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -228,14 +228,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「反馈减压」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Decompress Feedback",
-        "why_this_matters": "Separate facts, tone, and next steps so the other person’s emotion does not become your self-judgment. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "Let me check: are you asking me to adjust the outcome, the process, or the way I communicated? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Separate facts, tone, and next steps so the other person’s emotion does not become your self-judgment.",
+        "do_today": "Today, use one low-risk version of this sentence: “Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?”",
+        "script": "Let me check: are you asking me to adjust the outcome, the process, or the way I communicated?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -268,15 +268,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Decompress Feedback” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "feedback_decompression",
         "asset_type": "action_prescription",
         "v23_source_id": "feedback_decompression",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "feedback_absorber",
@@ -287,9 +287,9 @@
     "empathy_boundary": {
       "zh-CN": {
         "title": "共情后的边界",
-        "why_this_matters": "理解别人之后，明确你能支持什么、不能替对方承担什么。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "理解别人之后，明确你能支持什么、不能替对方承担什么。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。”这句话。",
+        "script": "我理解这件事对你很重。我可以陪你理清下一步，但不能替你承接全部压力。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -322,14 +322,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「共情后的边界」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Empathy with a Boundary",
-        "why_this_matters": "After understanding someone, clarify what you can support and what you cannot carry for them. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "After understanding someone, clarify what you can support and what you cannot carry for them.",
+        "do_today": "Today, use one low-risk version of this sentence: “I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.”",
+        "script": "I can see this is heavy for you. I can help you sort the next step, but I cannot carry the whole weight for you.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -362,15 +362,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Empathy with a Boundary” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "empathy_boundary",
         "asset_type": "action_prescription",
         "v23_source_id": "empathy_boundary",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "high_empathy_low_recovery",
@@ -382,9 +382,9 @@
     "repair_after_conflict": {
       "zh-CN": {
         "title": "冲突后的修复",
-        "why_this_matters": "把“我不是故意的”升级成“我看见了影响，并愿意修复”。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把“我不是故意的”升级成“我看见了影响，并愿意修复”。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。”这句话。",
+        "script": "刚才我的表达可能让你觉得被否定了。我想重新说一次，并先听听你听到了什么。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -417,14 +417,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「冲突后的修复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Repair After Impact",
-        "why_this_matters": "Move from “I did not mean it” to “I see the impact and I want to repair it.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Move from “I did not mean it” to “I see the impact and I want to repair it.”",
+        "do_today": "Today, use one low-risk version of this sentence: “What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.”",
+        "script": "What I said may have landed as dismissive. I want to try again, and first I want to hear how it landed for you.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -457,15 +457,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Repair After Impact” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "repair_after_conflict",
         "asset_type": "action_prescription",
         "v23_source_id": "repair_after_conflict",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "self_clear_repair_weak",
@@ -476,9 +476,9 @@
     "express_without_escalation": {
       "zh-CN": {
         "title": "不升级的表达",
-        "why_this_matters": "把真实表达从攻击、证明或压制里分离出来。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想说清楚我的感受，但不是为了压过你。我的重点是……”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我想说清楚我的感受，但不是为了压过你。我的重点是…… 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把真实表达从攻击、证明或压制里分离出来。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想说清楚我的感受，但不是为了压过你。我的重点是……”这句话。",
+        "script": "我想说清楚我的感受，但不是为了压过你。我的重点是……",
         "seven_day_plan": [
           {
             "day": 1,
@@ -511,14 +511,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「不升级的表达」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Express Without Escalating",
-        "why_this_matters": "Separate honest expression from attacking, proving, or overpowering. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I want to be clear about my experience, not to overpower yours. The point I want to make is...” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I want to be clear about my experience, not to overpower yours. The point I want to make is... This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Separate honest expression from attacking, proving, or overpowering.",
+        "do_today": "Today, use one low-risk version of this sentence: “I want to be clear about my experience, not to overpower yours. The point I want to make is...”",
+        "script": "I want to be clear about my experience, not to overpower yours. The point I want to make is...",
         "seven_day_plan": [
           {
             "day": 1,
@@ -551,15 +551,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Express Without Escalating” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "express_without_escalation",
         "asset_type": "action_prescription",
         "v23_source_id": "express_without_escalation",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "direct_without_softening",
@@ -570,9 +570,9 @@
     "support_without_rescuing": {
       "zh-CN": {
         "title": "支持但不拯救",
-        "why_this_matters": "把帮助别人从“我替你解决”改成“我陪你找下一步”。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮你一起理清选择，但决定和后果还是需要由你来拿。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我可以帮你一起理清选择，但决定和后果还是需要由你来拿。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把帮助别人从“我替你解决”改成“我陪你找下一步”。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮你一起理清选择，但决定和后果还是需要由你来拿。”这句话。",
+        "script": "我可以帮你一起理清选择，但决定和后果还是需要由你来拿。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -605,14 +605,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「支持但不拯救」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Support Without Rescuing",
-        "why_this_matters": "Shift from “I will fix this for you” to “I can help you find your next step.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I can help you think through the options, but the decision and the consequences need to stay with you.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I can help you think through the options, but the decision and the consequences need to stay with you. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Shift from “I will fix this for you” to “I can help you find your next step.”",
+        "do_today": "Today, use one low-risk version of this sentence: “I can help you think through the options, but the decision and the consequences need to stay with you.”",
+        "script": "I can help you think through the options, but the decision and the consequences need to stay with you.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -645,15 +645,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Support Without Rescuing” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "support_without_rescuing",
         "asset_type": "action_prescription",
         "v23_source_id": "support_without_rescuing",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "over_responsible_helper",
@@ -664,9 +664,9 @@
     "cold_to_warm_response": {
       "zh-CN": {
         "title": "先回应情绪",
-        "why_this_matters": "在提出方案前，先让对方知道你听见了情绪。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“听起来这件事让你很失望。我们可以一起看下一步怎么处理。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "听起来这件事让你很失望。我们可以一起看下一步怎么处理。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在提出方案前，先让对方知道你听见了情绪。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“听起来这件事让你很失望。我们可以一起看下一步怎么处理。”这句话。",
+        "script": "听起来这件事让你很失望。我们可以一起看下一步怎么处理。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -699,14 +699,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「先回应情绪」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Add Warmth Before Solving",
-        "why_this_matters": "Before offering a solution, let the other person know you registered the feeling. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “It sounds like this was really disappointing. We can look at the next step together.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "It sounds like this was really disappointing. We can look at the next step together. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before offering a solution, let the other person know you registered the feeling.",
+        "do_today": "Today, use one low-risk version of this sentence: “It sounds like this was really disappointing. We can look at the next step together.”",
+        "script": "It sounds like this was really disappointing. We can look at the next step together.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -739,15 +739,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Add Warmth Before Solving” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "cold_to_warm_response",
         "asset_type": "action_prescription",
         "v23_source_id": "cold_to_warm_response",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "calm_but_distant",
@@ -758,9 +758,9 @@
     "relationship_energy_management": {
       "zh-CN": {
         "title": "关系能量管理",
-        "why_this_matters": "在高互动或高情绪场景后，给自己一个可执行的恢复流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要十分钟整理一下自己，再继续这个话题。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我需要十分钟整理一下自己，再继续这个话题。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在高互动或高情绪场景后，给自己一个可执行的恢复流程。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要十分钟整理一下自己，再继续这个话题。”这句话。",
+        "script": "我需要十分钟整理一下自己，再继续这个话题。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -793,14 +793,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「关系能量管理」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Relationship Energy Management",
-        "why_this_matters": "After high-contact or emotionally loaded situations, give yourself a concrete recovery routine. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I need ten minutes to reset before we continue this conversation.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I need ten minutes to reset before we continue this conversation. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "After high-contact or emotionally loaded situations, give yourself a concrete recovery routine.",
+        "do_today": "Today, use one low-risk version of this sentence: “I need ten minutes to reset before we continue this conversation.”",
+        "script": "I need ten minutes to reset before we continue this conversation.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -833,15 +833,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Relationship Energy Management” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "relationship_energy_management",
         "asset_type": "action_prescription",
         "v23_source_id": "relationship_energy_management",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "sensitive_absorber",
@@ -852,9 +852,9 @@
     "conflict_deescalation": {
       "zh-CN": {
         "title": "冲突降温",
-        "why_this_matters": "把对话从谁对谁错拉回具体分歧和下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们先暂停一下。现在真正分歧的是哪一点？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我们先暂停一下。现在真正分歧的是哪一点？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把对话从谁对谁错拉回具体分歧和下一步。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们先暂停一下。现在真正分歧的是哪一点？”这句话。",
+        "script": "我们先暂停一下。现在真正分歧的是哪一点？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -887,14 +887,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「冲突降温」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "De-escalate the Conflict",
-        "why_this_matters": "Move the conversation from winning and losing back to the specific disagreement and next step. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “Let’s pause. What is the exact point we are disagreeing about?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "Let’s pause. What is the exact point we are disagreeing about? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Move the conversation from winning and losing back to the specific disagreement and next step.",
+        "do_today": "Today, use one low-risk version of this sentence: “Let’s pause. What is the exact point we are disagreeing about?”",
+        "script": "Let’s pause. What is the exact point we are disagreeing about?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -927,15 +927,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “De-escalate the Conflict” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "conflict_deescalation",
         "asset_type": "action_prescription",
         "v23_source_id": "conflict_deescalation",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "steady_collaborator",
@@ -947,9 +947,9 @@
     "self_connection": {
       "zh-CN": {
         "title": "回到自己",
-        "why_this_matters": "在照顾关系前，先确认自己真实的感受和需要。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想先确认一下自己的感受，再回应你。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我想先确认一下自己的感受，再回应你。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在照顾关系前，先确认自己真实的感受和需要。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想先确认一下自己的感受，再回应你。”这句话。",
+        "script": "我想先确认一下自己的感受，再回应你。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -982,14 +982,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「回到自己」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Return to Yourself",
-        "why_this_matters": "Before managing the relationship, check what you are actually feeling and needing. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I want to check in with myself before I respond.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I want to check in with myself before I respond. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before managing the relationship, check what you are actually feeling and needing.",
+        "do_today": "Today, use one low-risk version of this sentence: “I want to check in with myself before I respond.”",
+        "script": "I want to check in with myself before I respond.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1022,15 +1022,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Return to Yourself” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "self_connection",
         "asset_type": "action_prescription",
         "v23_source_id": "self_connection",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "relationship_first_self_later",
@@ -1041,9 +1041,9 @@
     "retest_reflection": {
       "zh-CN": {
         "title": "复测前的自我回顾",
-        "why_this_matters": "低置信结果主要支持复测准备，不支持行为改变结论。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "记录本次作答环境，并在更稳定、不被打断时复测。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我会轻读本次结果，在条件更稳定时复测。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "低置信结果主要支持复测准备，不支持行为改变结论。",
+        "do_today": "记录本次作答环境，并在更稳定、不被打断时复测。",
+        "script": "我会轻读本次结果，在条件更稳定时复测。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1052,14 +1052,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「复测前的自我回顾」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Reflect Before Retesting",
-        "why_this_matters": "This low-confidence session mainly supports retest preparation, not behavior-change conclusions. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Record the response context and retake in a steadier, uninterrupted setting. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I will hold this session lightly and retake it when conditions are steadier. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "This low-confidence session mainly supports retest preparation, not behavior-change conclusions.",
+        "do_today": "Record the response context and retake in a steadier, uninterrupted setting.",
+        "script": "I will hold this session lightly and retake it when conditions are steadier.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1068,15 +1068,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Reflect Before Retesting” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "retest_reflection",
         "asset_type": "action_prescription",
         "v23_source_id": "retest_reflection",
         "claim_risk": "high",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "QUALITY",
         "best_for": [
           "low_confidence_result"
@@ -1086,9 +1086,9 @@
     "ask_before_solving": {
       "zh-CN": {
         "title": "先问再解决",
-        "why_this_matters": "在提供建议前确认对方想要理解、建议还是只是被听见。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“你现在更想让我听你说，还是一起想办法？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "你现在更想让我听你说，还是一起想办法？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在提供建议前确认对方想要理解、建议还是只是被听见。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“你现在更想让我听你说，还是一起想办法？”这句话。",
+        "script": "你现在更想让我听你说，还是一起想办法？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1121,14 +1121,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「先问再解决」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Ask Before Solving",
-        "why_this_matters": "Before offering advice, ask whether the person wants understanding, ideas, or simply to be heard. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “Do you want me to just listen right now, or would it help to think through options together?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "Do you want me to just listen right now, or would it help to think through options together? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before offering advice, ask whether the person wants understanding, ideas, or simply to be heard.",
+        "do_today": "Today, use one low-risk version of this sentence: “Do you want me to just listen right now, or would it help to think through options together?”",
+        "script": "Do you want me to just listen right now, or would it help to think through options together?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1161,15 +1161,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Ask Before Solving” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "ask_before_solving",
         "asset_type": "action_prescription",
         "v23_source_id": "ask_before_solving",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "strategic_listener",
@@ -1180,9 +1180,9 @@
     "delayed_processing_note": {
       "zh-CN": {
         "title": "延迟处理笔记",
-        "why_this_matters": "给事后才出现的情绪一个出口，避免它变成沉默或突然爆发。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我刚才还没完全处理好，现在我想补充我的真实感受。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我刚才还没完全处理好，现在我想补充我的真实感受。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "给事后才出现的情绪一个出口，避免它变成沉默或突然爆发。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我刚才还没完全处理好，现在我想补充我的真实感受。”这句话。",
+        "script": "我刚才还没完全处理好，现在我想补充我的真实感受。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1215,14 +1215,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「延迟处理笔记」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Delayed Processing Note",
-        "why_this_matters": "Give late-arriving feelings a place to land before they become silence or a sudden reaction. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I did not fully process it earlier. I want to add what I actually felt.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I did not fully process it earlier. I want to add what I actually felt. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Give late-arriving feelings a place to land before they become silence or a sudden reaction.",
+        "do_today": "Today, use one low-risk version of this sentence: “I did not fully process it earlier. I want to add what I actually felt.”",
+        "script": "I did not fully process it earlier. I want to add what I actually felt.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1255,15 +1255,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Delayed Processing Note” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "delayed_processing_note",
         "asset_type": "action_prescription",
         "v23_source_id": "delayed_processing_note",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "delayed_processor",
@@ -1274,9 +1274,9 @@
     "body_reset": {
       "zh-CN": {
         "title": "身体重置",
-        "why_this_matters": "用身体信号而不是反复思考来结束压力循环。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在身体很紧，我先把节奏慢下来。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我现在身体很紧，我先把节奏慢下来。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "用身体信号而不是反复思考来结束压力循环。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在身体很紧，我先把节奏慢下来。”这句话。",
+        "script": "我现在身体很紧，我先把节奏慢下来。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1309,14 +1309,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「身体重置」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Body Reset",
-        "why_this_matters": "Use a body cue, not more thinking, to close the stress loop. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “My body feels tense. I am going to slow the pace down first.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "My body feels tense. I am going to slow the pace down first. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Use a body cue, not more thinking, to close the stress loop.",
+        "do_today": "Today, use one low-risk version of this sentence: “My body feels tense. I am going to slow the pace down first.”",
+        "script": "My body feels tense. I am going to slow the pace down first.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1349,15 +1349,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Body Reset” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "body_reset",
         "asset_type": "action_prescription",
         "v23_source_id": "body_reset",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "pressure_contained",
@@ -1368,9 +1368,9 @@
     "empathy_to_action": {
       "zh-CN": {
         "title": "从理解到行动",
-        "why_this_matters": "把“我懂你”转成一个小而清楚的下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听懂了。我们先选一个今天能做的小步骤。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我听懂了。我们先选一个今天能做的小步骤。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把“我懂你”转成一个小而清楚的下一步。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听懂了。我们先选一个今天能做的小步骤。”这句话。",
+        "script": "我听懂了。我们先选一个今天能做的小步骤。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1403,14 +1403,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「从理解到行动」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "From Empathy to Action",
-        "why_this_matters": "Turn “I understand” into one small, clear next step. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I understand. Let’s choose one small step we can take today.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I understand. Let’s choose one small step we can take today. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn “I understand” into one small, clear next step.",
+        "do_today": "Today, use one low-risk version of this sentence: “I understand. Let’s choose one small step we can take today.”",
+        "script": "I understand. Let’s choose one small step we can take today.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1443,15 +1443,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “From Empathy to Action” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "empathy_to_action",
         "asset_type": "action_prescription",
         "v23_source_id": "empathy_to_action",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "empathy_to_action_gap",
@@ -1462,9 +1462,9 @@
     "warm_signal": {
       "zh-CN": {
         "title": "释放温度信号",
-        "why_this_matters": "在保持距离的同时给对方一个可读的善意信号。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要一点空间，但不是要推开你。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我需要一点空间，但不是要推开你。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在保持距离的同时给对方一个可读的善意信号。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要一点空间，但不是要推开你。”这句话。",
+        "script": "我需要一点空间，但不是要推开你。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1497,14 +1497,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「释放温度信号」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Send a Warm Signal",
-        "why_this_matters": "Keep your boundary while giving the other person a readable signal of goodwill. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I need some space, but I am not trying to push you away.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I need some space, but I am not trying to push you away. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Keep your boundary while giving the other person a readable signal of goodwill.",
+        "do_today": "Today, use one low-risk version of this sentence: “I need some space, but I am not trying to push you away.”",
+        "script": "I need some space, but I am not trying to push you away.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1537,15 +1537,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Send a Warm Signal” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "warm_signal",
         "asset_type": "action_prescription",
         "v23_source_id": "warm_signal",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "self_protective_distance",
@@ -1556,9 +1556,9 @@
     "values_pause": {
       "zh-CN": {
         "title": "价值触发暂停",
-        "why_this_matters": "当原则被触碰时，先暂停，避免把价值感变成攻击。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "当原则被触碰时，先暂停，避免把价值感变成攻击。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。”这句话。",
+        "script": "这件事碰到我的原则了。我想先把重点说清楚，而不是马上反击。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1591,14 +1591,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「价值触发暂停」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Values Trigger Pause",
-        "why_this_matters": "When a value is touched, pause before turning conviction into attack. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “This touches a value for me. I want to name the point clearly rather than react immediately.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "This touches a value for me. I want to name the point clearly rather than react immediately. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "When a value is touched, pause before turning conviction into attack.",
+        "do_today": "Today, use one low-risk version of this sentence: “This touches a value for me. I want to name the point clearly rather than react immediately.”",
+        "script": "This touches a value for me. I want to name the point clearly rather than react immediately.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1631,15 +1631,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Values Trigger Pause” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "values_pause",
         "asset_type": "action_prescription",
         "v23_source_id": "values_pause",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "values_sensitive",
@@ -1650,9 +1650,9 @@
     "shared_stability": {
       "zh-CN": {
         "title": "共享稳定责任",
-        "why_this_matters": "让稳定不只靠你一个人承担。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮我们整理下一步，但我们需要一起承担这个节奏。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我可以帮我们整理下一步，但我们需要一起承担这个节奏。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "让稳定不只靠你一个人承担。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以帮我们整理下一步，但我们需要一起承担这个节奏。”这句话。",
+        "script": "我可以帮我们整理下一步，但我们需要一起承担这个节奏。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1685,14 +1685,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「共享稳定责任」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Share the Stability Load",
-        "why_this_matters": "Make steadiness a shared process, not your private job. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I can help organize the next step, but we need to share responsibility for the pace.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I can help organize the next step, but we need to share responsibility for the pace. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Make steadiness a shared process, not your private job.",
+        "do_today": "Today, use one low-risk version of this sentence: “I can help organize the next step, but we need to share responsibility for the pace.”",
+        "script": "I can help organize the next step, but we need to share responsibility for the pace.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1725,15 +1725,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Share the Stability Load” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "shared_stability",
         "asset_type": "action_prescription",
         "v23_source_id": "shared_stability",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "team_stabilizer",
@@ -1744,9 +1744,9 @@
     "followthrough_bridge": {
       "zh-CN": {
         "title": "倾听后的跟进",
-        "why_this_matters": "把一次好的倾听转成一个可追踪的承诺。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听见了。我们约定一个具体时间回来确认进展。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我听见了。我们约定一个具体时间回来确认进展。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把一次好的倾听转成一个可追踪的承诺。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听见了。我们约定一个具体时间回来确认进展。”这句话。",
+        "script": "我听见了。我们约定一个具体时间回来确认进展。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1779,14 +1779,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「倾听后的跟进」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Follow Through After Listening",
-        "why_this_matters": "Turn good listening into a trackable commitment. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I hear you. Let’s set a specific time to check progress.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I hear you. Let’s set a specific time to check progress. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn good listening into a trackable commitment.",
+        "do_today": "Today, use one low-risk version of this sentence: “I hear you. Let’s set a specific time to check progress.”",
+        "script": "I hear you. Let’s set a specific time to check progress.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1819,15 +1819,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Follow Through After Listening” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "followthrough_bridge",
         "asset_type": "action_prescription",
         "v23_source_id": "followthrough_bridge",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "listening_without_followthrough",
@@ -1838,9 +1838,9 @@
     "small_conflict_step": {
       "zh-CN": {
         "title": "小步进入冲突",
-        "why_this_matters": "先处理一个小分歧，训练自己不再把所有张力都推迟。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不想把这个压下去。我们先谈其中一个具体点。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我不想把这个压下去。我们先谈其中一个具体点。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "先处理一个小分歧，训练自己不再把所有张力都推迟。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不想把这个压下去。我们先谈其中一个具体点。”这句话。",
+        "script": "我不想把这个压下去。我们先谈其中一个具体点。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1873,14 +1873,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「小步进入冲突」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Take a Small Conflict Step",
-        "why_this_matters": "Address one small disagreement first so tension does not always get postponed. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I do not want to bury this. Let’s start with one specific point.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I do not want to bury this. Let’s start with one specific point. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Address one small disagreement first so tension does not always get postponed.",
+        "do_today": "Today, use one low-risk version of this sentence: “I do not want to bury this. Let’s start with one specific point.”",
+        "script": "I do not want to bury this. Let’s start with one specific point.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1913,15 +1913,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Take a Small Conflict Step” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "small_conflict_step",
         "asset_type": "action_prescription",
         "v23_source_id": "small_conflict_step",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "conflict_avoider",
@@ -1932,9 +1932,9 @@
     "boundary_before_advice": {
       "zh-CN": {
         "title": "建议前先设边界",
-        "why_this_matters": "在给建议之前先说明你能投入的范围。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在给建议之前先说明你能投入的范围。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。”这句话。",
+        "script": "我可以陪你想二十分钟，但之后本次结果提示可以先自己决定。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -1967,14 +1967,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「建议前先设边界」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Set the Boundary Before Advice",
-        "why_this_matters": "Before giving advice, state the amount of time, energy, or responsibility you can offer. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I can think this through with you for twenty minutes, and then the decision needs to be yours.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I can think this through with you for twenty minutes, and then the decision needs to be yours. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before giving advice, state the amount of time, energy, or responsibility you can offer.",
+        "do_today": "Today, use one low-risk version of this sentence: “I can think this through with you for twenty minutes, and then the decision needs to be yours.”",
+        "script": "I can think this through with you for twenty minutes, and then the decision needs to be yours.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2007,15 +2007,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Set the Boundary Before Advice” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "boundary_before_advice",
         "asset_type": "action_prescription",
         "v23_source_id": "boundary_before_advice",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "over_responsible_helper",
@@ -2026,9 +2026,9 @@
     "repair_without_self_blame": {
       "zh-CN": {
         "title": "修复但不自责",
-        "why_this_matters": "承认影响，不把整个自我都判成失败。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "承认影响，不把整个自我都判成失败。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。”这句话。",
+        "script": "我看到这句话影响了你。我会修正表达，但我也想具体看哪里需要改。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2061,14 +2061,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「修复但不自责」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Repair Without Self-Blame",
-        "why_this_matters": "Acknowledge the impact without turning your whole self into the problem. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I see that what I said affected you. I will adjust it, and I want to understand the specific part to change. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Acknowledge the impact without turning your whole self into the problem.",
+        "do_today": "Today, use one low-risk version of this sentence: “I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.”",
+        "script": "I see that what I said affected you. I will adjust it, and I want to understand the specific part to change.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2101,15 +2101,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Repair Without Self-Blame” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "repair_without_self_blame",
         "asset_type": "action_prescription",
         "v23_source_id": "repair_without_self_blame",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "feedback_absorber",
@@ -2120,9 +2120,9 @@
     "name_the_request": {
       "zh-CN": {
         "title": "说出请求",
-        "why_this_matters": "把委屈或沉默转成一个清楚请求。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我真正需要的是……你能不能……？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我真正需要的是……你能不能……？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把委屈或沉默转成一个清楚请求。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我真正需要的是……你能不能……？”这句话。",
+        "script": "我真正需要的是……你能不能……？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2155,14 +2155,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「说出请求」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Name the Request",
-        "why_this_matters": "Turn resentment or silence into a clear request. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “What I actually need is... Would you be willing to...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "What I actually need is... Would you be willing to...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn resentment or silence into a clear request.",
+        "do_today": "Today, use one low-risk version of this sentence: “What I actually need is... Would you be willing to...?”",
+        "script": "What I actually need is... Would you be willing to...?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2195,15 +2195,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Name the Request” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "name_the_request",
         "asset_type": "action_prescription",
         "v23_source_id": "name_the_request",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "relationship_first_self_later",
@@ -2214,9 +2214,9 @@
     "slow_the_reply": {
       "zh-CN": {
         "title": "放慢回复",
-        "why_this_matters": "当你想马上回应时，先把回应拆成草稿和发送。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先写下来，但不立刻发。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我先写下来，但不立刻发。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "当你想马上回应时，先把回应拆成草稿和发送。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我先写下来，但不立刻发。”这句话。",
+        "script": "我先写下来，但不立刻发。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2249,14 +2249,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「放慢回复」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Slow the Reply",
-        "why_this_matters": "When you want to answer immediately, separate drafting from sending. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I will write it first, but I will not send it immediately.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I will write it first, but I will not send it immediately. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "When you want to answer immediately, separate drafting from sending.",
+        "do_today": "Today, use one low-risk version of this sentence: “I will write it first, but I will not send it immediately.”",
+        "script": "I will write it first, but I will not send it immediately.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2289,15 +2289,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Slow the Reply” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "slow_the_reply",
         "asset_type": "action_prescription",
         "v23_source_id": "slow_the_reply",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "fast_reactor",
@@ -2308,9 +2308,9 @@
     "make_empathy_visible": {
       "zh-CN": {
         "title": "让共情被看见",
-        "why_this_matters": "把心里的理解说出来，让对方不是只能猜。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听到你其实是在担心……对吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我听到你其实是在担心……对吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把心里的理解说出来，让对方不是只能猜。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我听到你其实是在担心……对吗？”这句话。",
+        "script": "我听到你其实是在担心……对吗？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2343,14 +2343,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「让共情被看见」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Make Empathy Visible",
-        "why_this_matters": "Say the understanding out loud so the other person does not have to guess it. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “What I hear is that you are worried about... Is that right?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "What I hear is that you are worried about... Is that right? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Say the understanding out loud so the other person does not have to guess it.",
+        "do_today": "Today, use one low-risk version of this sentence: “What I hear is that you are worried about... Is that right?”",
+        "script": "What I hear is that you are worried about... Is that right?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2383,15 +2383,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Make Empathy Visible” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "make_empathy_visible",
         "asset_type": "action_prescription",
         "v23_source_id": "make_empathy_visible",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "EM",
         "best_for": [
           "quiet_empathy",
@@ -2402,9 +2402,9 @@
     "repair_the_tone": {
       "zh-CN": {
         "title": "修复语气",
-        "why_this_matters": "内容不一定错，但语气需要被修复。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想保留我的观点，但刚才语气太硬了。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我想保留我的观点，但刚才语气太硬了。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "内容不一定错，但语气需要被修复。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我想保留我的观点，但刚才语气太硬了。”这句话。",
+        "script": "我想保留我的观点，但刚才语气太硬了。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2437,14 +2437,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「修复语气」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Repair the Tone",
-        "why_this_matters": "The content may be valid, but the tone may need repair. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I stand by the point, but my tone was too hard.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I stand by the point, but my tone was too hard. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "The content may be valid, but the tone may need repair.",
+        "do_today": "Today, use one low-risk version of this sentence: “I stand by the point, but my tone was too hard.”",
+        "script": "I stand by the point, but my tone was too hard.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2477,15 +2477,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Repair the Tone” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "repair_the_tone",
         "asset_type": "action_prescription",
         "v23_source_id": "repair_the_tone",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "direct_without_softening",
@@ -2496,9 +2496,9 @@
     "protect_recovery_time": {
       "zh-CN": {
         "title": "保护恢复时间",
-        "why_this_matters": "把恢复时间当成结果质量的一部分，而不是偷懒。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要恢复一下，之后会给你更清楚的回应。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我需要恢复一下，之后会给你更清楚的回应。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把恢复时间当成结果质量的一部分，而不是偷懒。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我需要恢复一下，之后会给你更清楚的回应。”这句话。",
+        "script": "我需要恢复一下，之后会给你更清楚的回应。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2531,14 +2531,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「保护恢复时间」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Protect Recovery Time",
-        "why_this_matters": "Treat recovery time as part of the quality of your response, not as avoidance. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I need to recover first so I can give you a clearer response later.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I need to recover first so I can give you a clearer response later. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Treat recovery time as part of the quality of your response, not as avoidance.",
+        "do_today": "Today, use one low-risk version of this sentence: “I need to recover first so I can give you a clearer response later.”",
+        "script": "I need to recover first so I can give you a clearer response later.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2571,15 +2571,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Protect Recovery Time” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "protect_recovery_time",
         "asset_type": "action_prescription",
         "v23_source_id": "protect_recovery_time",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "ER",
         "best_for": [
           "sensitive_absorber",
@@ -2590,9 +2590,9 @@
     "clarify_before_concluding": {
       "zh-CN": {
         "title": "先澄清再下结论",
-        "why_this_matters": "在判断对方意图前，先用一个问题确认。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不确定我理解对了。你是指……吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我不确定我理解对了。你是指……吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "在判断对方意图前，先用一个问题确认。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我不确定我理解对了。你是指……吗？”这句话。",
+        "script": "我不确定我理解对了。你是指……吗？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2625,14 +2625,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「先澄清再下结论」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Clarify Before Concluding",
-        "why_this_matters": "Before deciding what someone meant, check with one question. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “I want to make sure I understood. Do you mean...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "I want to make sure I understood. Do you mean...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Before deciding what someone meant, check with one question.",
+        "do_today": "Today, use one low-risk version of this sentence: “I want to make sure I understood. Do you mean...?”",
+        "script": "I want to make sure I understood. Do you mean...?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2665,15 +2665,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Clarify Before Concluding” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "clarify_before_concluding",
         "asset_type": "action_prescription",
         "v23_source_id": "clarify_before_concluding",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "strategic_listener",
@@ -2684,9 +2684,9 @@
     "turn_stability_into_process": {
       "zh-CN": {
         "title": "把稳定变流程",
-        "why_this_matters": "不要只靠你当下状态好，把稳定步骤写成流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们可以用三个步骤来处理：事实、感受、下一步。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我们可以用三个步骤来处理：事实、感受、下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "不要只靠你当下状态好，把稳定步骤写成流程。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们可以用三个步骤来处理：事实、感受、下一步。”这句话。",
+        "script": "我们可以用三个步骤来处理：事实、感受、下一步。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2719,14 +2719,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「把稳定变流程」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Turn Stability Into a Process",
-        "why_this_matters": "Do not rely only on being in a good state; turn steadiness into a process. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “We can handle this in three steps: facts, feelings, next action.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "We can handle this in three steps: facts, feelings, next action. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Do not rely only on being in a good state; turn steadiness into a process.",
+        "do_today": "Today, use one low-risk version of this sentence: “We can handle this in three steps: facts, feelings, next action.”",
+        "script": "We can handle this in three steps: facts, feelings, next action.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2759,15 +2759,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Turn Stability Into a Process” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "turn_stability_into_process",
         "asset_type": "action_prescription",
         "v23_source_id": "turn_stability_into_process",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "balanced_integrated",
@@ -2778,9 +2778,9 @@
     "integrated_maintenance": {
       "zh-CN": {
         "title": "整合优势维护",
-        "why_this_matters": "把已经可用的觉察、调节、共情和关系行动固定成可重复流程。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们按三步来：事实、感受、下一步。”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我们按三步来：事实、感受、下一步。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把已经可用的觉察、调节、共情和关系行动固定成可重复流程。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我们按三步来：事实、感受、下一步。”这句话。",
+        "script": "我们按三步来：事实、感受、下一步。",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2813,14 +2813,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「整合优势维护」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "Maintain Integrated Strength",
-        "why_this_matters": "Turn existing awareness, regulation, empathy, and relationship action into a repeatable routine. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “Let’s use three steps: facts, feelings, next action.” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "Let’s use three steps: facts, feelings, next action. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn existing awareness, regulation, empathy, and relationship action into a repeatable routine.",
+        "do_today": "Today, use one low-risk version of this sentence: “Let’s use three steps: facts, feelings, next action.”",
+        "script": "Let’s use three steps: facts, feelings, next action.",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2853,15 +2853,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “Maintain Integrated Strength” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "integrated_maintenance",
         "asset_type": "action_prescription",
         "v23_source_id": "integrated_maintenance",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "RM",
         "best_for": [
           "balanced_integrated",
@@ -2872,9 +2872,9 @@
     "express_need_clearly": {
       "zh-CN": {
         "title": "清楚表达需要",
-        "why_this_matters": "把内在稳定转成别人能听懂的需求，而不是只在心里处理。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在需要的是……你可以……吗？”这句话。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "script": "我现在需要的是……你可以……吗？ 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
+        "why_this_matters": "把内在稳定转成别人能听懂的需求，而不是只在心里处理。",
+        "do_today": "今天只做一个动作：在一个低风险场景里使用“我现在需要的是……你可以……吗？”这句话。",
+        "script": "我现在需要的是……你可以……吗？",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2907,14 +2907,14 @@
         ],
         "common_failure": "最常见失败不是不会做，而是等到情绪已经很满才想起来做。",
         "repair_move": "如果没做到，不要重开整套计划；只复盘一个触发点和下一次第一句话。",
-        "watch_out": "不要把练习变成要求自己完美稳定。先追求多一次停顿、多一句清楚表达。 这只适合作为低风险反思练习，不是治疗、确定有效干预，也不适用于不安全、胁迫、虐待或危机场景。 这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。",
-        "do_not_overread": "这个练习只适合低风险反思，不是治疗、危机处理、关系干预或保证有效的训练。"
+        "watch_out": "不要把这个练习当成必须立刻改变自己或改变对方的任务。优先选择低风险、可退出、没有明显权力压迫的场景，只观察一次更清楚的停顿、表达或复盘。",
+        "do_not_overread": "请把「清楚表达需要」当作低风险自我观察和沟通准备，不是治疗、危机处理、关系修复保证，也不适用于不安全、胁迫、虐待、创伤触发或明显权力不对等的场景。若涉及安全、持续困扰或高冲突关系，应优先寻求可信支持或专业帮助。"
       },
       "en": {
         "title": "State the Need Clearly",
-        "why_this_matters": "Turn internal steadiness into a request another person can actually understand. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_today": "Today, use one low-risk version of this sentence: “What I need right now is... Would you be willing to...?” This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "script": "What I need right now is... Would you be willing to...? This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
+        "why_this_matters": "Turn internal steadiness into a request another person can actually understand.",
+        "do_today": "Today, use one low-risk version of this sentence: “What I need right now is... Would you be willing to...?”",
+        "script": "What I need right now is... Would you be willing to...?",
         "seven_day_plan": [
           {
             "day": 1,
@@ -2947,15 +2947,15 @@
         ],
         "common_failure": "The common failure is not lack of knowledge. It is remembering the tool only after the emotion is already high.",
         "repair_move": "If you miss it, do not restart the whole plan. Review one trigger and one first sentence for next time.",
-        "watch_out": "Do not turn the practice into a demand to be perfectly steady. Aim for one extra pause or one clearer sentence. Use this only as a low-risk reflection practice. It is not therapy, a guaranteed intervention, or advice for unsafe, coercive, abusive, or crisis situations. This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect.",
-        "do_not_overread": "This is a low-risk reflection practice, not therapy, crisis support, relationship intervention, or a guaranteed training effect."
+        "watch_out": "Do not treat this practice as a demand to change yourself or another person immediately. Use it only in low-risk, exit-safe situations without clear coercion or power pressure, and look for one clearer pause, sentence, or review.",
+        "do_not_overread": "Treat “State the Need Clearly” as low-risk self-observation and communication preparation, not therapy, crisis support, a guarantee of relationship repair, or advice for unsafe, coercive, abusive, trauma-triggering, or clearly power-imbalanced situations. If safety, ongoing distress, or high-conflict dynamics are involved, prioritize trusted support or professional help."
       },
       "meta": {
         "id": "express_need_clearly",
         "asset_type": "action_prescription",
         "v23_source_id": "express_need_clearly",
         "claim_risk": "medium",
-        "risk_notes": "Action guidance is low-risk reflection only; no treatment or outcome guarantee. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries.",
+        "risk_notes": "Action guidance is low-risk reflection only; no treatment, crisis support, relationship repair guarantee, behavior prediction, or outcome promise. Keep scripts out of unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.",
         "development_lever": "SA",
         "best_for": [
           "regulated_but_private",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69375,9 +69375,9 @@
       "PR-EQ-ASSET-SCI-05",
       "PR-EQ-ASSET-SCI-13"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "dd39f528ee6e66c1fbb55d74bedb1f348673fec5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2655",
     "checks": [
       {
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
@@ -69478,6 +69478,11 @@
         "at": "2026-07-03T03:25:11Z",
         "status": "local_validation_passed",
         "notes": "Reduced action_prescription intervention claims, removed duplicated boundary text from primary action fields, retained high-risk boundaries in watch_out/do_not_overread, and passed local validation."
+      },
+      {
+        "at": "2026-07-03T03:25:55Z",
+        "status": "pr_open",
+        "notes": "Opened PR #2655 for PR-EQ-ASSET-SCI-09; GitHub checks pending."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69375,25 +69375,109 @@
       "PR-EQ-ASSET-SCI-05",
       "PR-EQ-ASSET-SCI-13"
     ],
-    "status": "user_authorized",
+    "status": "local_validation_passed",
     "commit_sha": null,
     "pr_url": null,
-    "checks": [],
+    "checks": [
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; scoped report assets compiled output retained and mirrored."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 432 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed_with_warnings",
+        "summary": "14 tests passed, 706 assertions; PHPUnit reported environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 208 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed_with_warnings",
+        "summary": "4 tests passed, 130 assertions; PHPUnit reported environment file_get_contents warnings only."
+      },
+      {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed_with_warnings",
+        "summary": "1 test passed, 16 assertions; PHPUnit reported environment file_get_contents warning only."
+      },
+      {
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')\"",
+        "status": "passed",
+        "summary": "PR train manifest YAML parsed successfully."
+      },
+      {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed",
+        "summary": "PR train state JSON parsed successfully."
+      },
+      {
+        "command": "cmp EQ_60 and EQ_EMOTIONAL_INTELLIGENCE action_prescriptions raw and compiled report assets",
+        "status": "passed",
+        "summary": "Raw action_prescriptions and compiled report_assets are mirrored between EQ_60 and EQ_EMOTIONAL_INTELLIGENCE."
+      },
+      {
+        "command": "action boundary placement scan",
+        "status": "passed",
+        "summary": "No duplicated low-risk boundary clauses remain in why_this_matters, do_today, or script; scripts do not contain therapy/crisis/guarantee boundary terms."
+      },
+      {
+        "command": "scope validation against PR-EQ-ASSET-SCI-09 allowed_paths",
+        "status": "passed",
+        "summary": "Changed files are confined to action_prescriptions raw assets, compiled report_assets, and PR train state."
+      },
+      {
+        "command": "git diff --check && git diff --cached --check",
+        "status": "passed",
+        "summary": "No whitespace errors in unstaged or staged diff."
+      }
+    ],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "status": "pass",
+      "changed_files": [
+        "backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json",
+        "backend/content_packs/EQ_60/v1/raw/report_assets/action_prescriptions.json",
+        "backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json",
+        "backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/action_prescriptions.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "outside_scope_files": [],
+      "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-09 allowed_paths."
     },
     "transitions": [
       {
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      }
+    ],
+    "events": [
+      {
+        "at": "2026-07-03T03:21:17Z",
+        "status": "in_progress",
+        "notes": "Started PR-EQ-ASSET-SCI-09 from origin/main after PR-EQ-ASSET-SCI-13 merged; scope limited to action_prescriptions assets, compiled report assets, and train state."
+      },
+      {
+        "at": "2026-07-03T03:25:11Z",
+        "status": "local_validation_passed",
+        "notes": "Reduced action_prescription intervention claims, removed duplicated boundary text from primary action fields, retained high-risk boundaries in watch_out/do_not_overread, and passed local validation."
       }
     ]
   },
@@ -69555,8 +69639,8 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-12"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "75deb547d2165a77d9e2bb0e2a1b05667363f95c",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "79361b155e57c869305d42b4524db19cd79bc932",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2652",
     "checks": [
       {
@@ -69618,12 +69702,17 @@
         "command": "git diff --check && git diff --cached --check",
         "status": "passed",
         "summary": "No whitespace errors in unstaged or staged diff."
+      },
+      {
+        "command": "gh pr view 2652 --json state,mergeCommit && git merge-base --is-ancestor 79361b155e57c869305d42b4524db19cd79bc932 origin/main",
+        "status": "passed",
+        "summary": "Reconciled PR-EQ-ASSET-SCI-13 as merged; merge commit 79361b155e57c869305d42b4524db19cd79bc932 is present in origin/main, remote branch was deleted, and the temporary worktree/local branch were cleaned."
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-03T03:18:19Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "status": "pass",
       "changed_files": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69375,8 +69375,8 @@
       "PR-EQ-ASSET-SCI-05",
       "PR-EQ-ASSET-SCI-13"
     ],
-    "status": "pr_open",
-    "commit_sha": "dd39f528ee6e66c1fbb55d74bedb1f348673fec5",
+    "status": "ready_to_merge",
+    "commit_sha": "2b10f70a40f7d66eb6a59637a868aecb7721fe45",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2655",
     "checks": [
       {
@@ -69483,6 +69483,11 @@
         "at": "2026-07-03T03:25:55Z",
         "status": "pr_open",
         "notes": "Opened PR #2655 for PR-EQ-ASSET-SCI-09; GitHub checks pending."
+      },
+      {
+        "at": "2026-07-03T03:32:01Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub checks passed, mergeStateStatus CLEAN, and scope revalidation passed for PR #2655."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Repaired all EQ action prescription assets so the primary action fields stay readable and do not repeat risk-boundary boilerplate.
- Centralized intervention boundaries in `watch_out`, `do_not_overread`, and `meta.risk_notes` across zh-CN/en.
- Mirrored the same raw and compiled report assets into `EQ_EMOTIONAL_INTELLIGENCE`.
- Reconciled the merged `PR-EQ-ASSET-SCI-13` dependency state required by this PR.

## Why
Action prescriptions should be low-risk reflection and communication preparation. They should not read like therapy, guaranteed training, crisis support, or relationship repair guarantees, and they must not be applied to unsafe, coercive, abusive, trauma-triggering, or power-imbalanced situations.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest`
- YAML/JSON parse, mirror checks, action boundary placement scan, scope validation, `git diff --check`, `git diff --cached --check`

PHPUnit emitted existing environment `file_get_contents` warnings only; all commands exited successfully.

## Deferred
- No frontend changes.
- No scoring, question, reverse-key, norm, composer-selection, SJT, commerce, CMS, import, smoke, or deploy changes.
