### PR TITLE
ENNEA-RP-06: fix(enneagram): repair dominance gap boundary

### DIFF
--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -798,10 +798,21 @@ final class EnneagramReportComposer
             'visible',
             'all',
             [
+                'title' => '主次线索差距',
+                'subtitle' => '只比较本次同一表单内 Top1 与 Top2 的相对距离。',
                 'dominance_gap_abs' => data_get($projectionV2, 'classification.dominance_gap_abs'),
                 'dominance_gap_pct' => data_get($projectionV2, 'classification.dominance_gap_pct'),
                 'normalized_gap' => data_get($projectionV2, 'classification.dominance.normalized_gap'),
                 'profile_entropy' => data_get($projectionV2, 'classification.dominance.profile_entropy'),
+                'score_space_note' => '这个差距只在当前 form、当前计分空间内有意义。E105 与 FC144 的题型、计分单位和候选生成方式不同，不能把 gap 当成跨表单、跨人群或跨时间的统一尺子。',
+                'boundary_note' => 'gap 较大时，页面可以用更集中的主型解释；gap 较小时，页面会转向 close-call、diffuse 或观察建议。它不是测量误差范围、统计置信区间、常模排名、外部效度证明或人格确定性。',
+                'metric_guide' => [
+                    'dominance_gap_abs' => 'Top1 与 Top2 在当前 score space 中的原始差距，用来判断主次线索是否拉开。',
+                    'dominance_gap_pct' => '把主次差距换算成百分比读法，便于页面选择解释语气；不是准确率。',
+                    'normalized_gap' => '相对分布形状的标准化差距，只用于内部解释规则。',
+                    'profile_entropy' => '九个类型线索的分散程度；越分散越需要降低单一主型结论的确定语气。',
+                ],
+                'not_for' => ['cross_form_comparison', 'norm_ranking', 'measurement_error_interval', 'validity_proof', 'personality_verdict'],
                 'unavailable' => data_get($projectionV2, '_meta.unavailable.classification', []),
             ],
             [

--- a/backend/content_packs/ENNEAGRAM/v2/registry/technical_note_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/technical_note_registry.json
@@ -47,7 +47,7 @@
         {
             "section_key": "dominance_gap",
             "title": "Dominance Gap",
-            "body": "Dominance Gap 描述的是同一 form 内 Top1 与 Top2 的差距，用来帮助系统选择 clear、close-call 或 diffuse 的保守语气。它是 operational 指标，不是临床置信区间。",
+            "body": "Dominance Gap 描述的是同一 form、同一 score space 内 Top1 与 Top2 的相对差距，用来帮助系统选择 clear、close-call 或 diffuse 的保守语气。E105 与 FC144 的题型和计分单位不同，gap 不能被当成跨表单、跨人群或跨时间的统一尺子；它也不是测量误差范围、统计置信区间、常模排名、外部效度证明或人格确定性。",
             "metric_refs": [
                 "top_gap_distribution"
             ],

--- a/backend/tests/Unit/Services/Content/EnneagramTechnicalNoteRegistryContentTest.php
+++ b/backend/tests/Unit/Services/Content/EnneagramTechnicalNoteRegistryContentTest.php
@@ -18,6 +18,10 @@ final class EnneagramTechnicalNoteRegistryContentTest extends TestCase
         $this->assertFalse($entries->contains(fn ($entry): bool => trim((string) ($entry['body'] ?? '')) === ''));
         $this->assertFalse($entries->contains(fn ($entry): bool => ! is_array($entry['metric_refs'] ?? null)));
         $this->assertFalse($entries->contains(fn ($entry): bool => str_contains((string) ($entry['body'] ?? ''), '准确率 92%')));
+        $dominanceGap = (string) ($entries->firstWhere('section_key', 'dominance_gap')['body'] ?? '');
+        $this->assertStringContainsString('同一 form、同一 score space', $dominanceGap);
+        $this->assertStringContainsString('不能被当成跨表单、跨人群或跨时间的统一尺子', $dominanceGap);
+        $this->assertStringContainsString('不是测量误差范围、统计置信区间、常模排名、外部效度证明或人格确定性', $dominanceGap);
         $this->assertSame('planned', (string) ($entries->firstWhere('section_key', 'retake_stability')['data_status'] ?? ''));
         $this->assertSame('collecting', (string) ($entries->firstWhere('section_key', 'resonance_feedback')['data_status'] ?? ''));
     }

--- a/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
+++ b/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
@@ -156,6 +156,32 @@ final class EnneagramReportComposerV2Test extends TestCase
         $this->assertStringNotContainsString('中等置信结果', $encoded);
     }
 
+    public function test_dominance_gap_card_marks_gap_as_same_form_score_space_signal(): void
+    {
+        $payload = $this->composeReportV2($this->syntheticProjectionInput('enneagram_likert_105', [
+            'T3' => 89.0,
+            'T8' => 62.0,
+            'T1' => 55.0,
+            'T6' => 37.0,
+            'T2' => 28.0,
+            'T7' => 24.0,
+            'T4' => 21.0,
+            'T5' => 16.0,
+            'T9' => 13.0,
+        ]));
+
+        $content = (array) data_get($this->module($payload, 'dominance_gap_card'), 'content');
+
+        $this->assertSame('主次线索差距', $content['title'] ?? null);
+        $this->assertStringContainsString('当前 form、当前计分空间内有意义', (string) ($content['score_space_note'] ?? ''));
+        $this->assertStringContainsString('不是测量误差范围、统计置信区间、常模排名、外部效度证明或人格确定性', (string) ($content['boundary_note'] ?? ''));
+        $this->assertStringContainsString('不是准确率', (string) data_get($content, 'metric_guide.dominance_gap_pct'));
+        $this->assertSame(
+            ['cross_form_comparison', 'norm_ranking', 'measurement_error_interval', 'validity_proof', 'personality_verdict'],
+            $content['not_for'] ?? null
+        );
+    }
+
     public function test_unavailable_v2_report_uses_public_error_code_without_registry_exception_details(): void
     {
         $composer = app(EnneagramReportComposer::class);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -671,9 +671,9 @@
     "depends_on": [
       "ENNEA-RP-05"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "2c2d606bbdb6d63d3e5d5c357a4f6e3fff1708be",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2656",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -753,6 +753,11 @@
         "at": "2026-07-03T05:24:00Z",
         "status": "local_validation_passed",
         "notes": "Implemented dominance gap score-space and error-boundary language; required local validation passed."
+      },
+      {
+        "at": "2026-07-03T05:27:00Z",
+        "status": "pr_opened",
+        "notes": "Opened PR #2656 for dominance gap boundary repair; awaiting GitHub required checks."
       }
     ]
   },
@@ -66007,7 +66012,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T05:24:00Z",
+  "updated_at": "2026-07-03T05:27:00Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -671,8 +671,8 @@
     "depends_on": [
       "ENNEA-RP-05"
     ],
-    "status": "pr_opened",
-    "commit_sha": "2c2d606bbdb6d63d3e5d5c357a4f6e3fff1708be",
+    "status": "ready_to_merge",
+    "commit_sha": "c163f63c3a4c82f0395c0647fa539c4d20306b0f",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2656",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -721,6 +721,11 @@
         "status": "pass",
         "command": "git diff --check",
         "evidence": "No whitespace errors."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2656 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All reported checks for PR #2656 passed on head c163f63c3a4c82f0395c0647fa539c4d20306b0f, including hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, and Semgrep checks."
       }
     },
     "scope_validation": {
@@ -758,6 +763,11 @@
         "at": "2026-07-03T05:27:00Z",
         "status": "pr_opened",
         "notes": "Opened PR #2656 for dominance gap boundary repair; awaiting GitHub required checks."
+      },
+      {
+        "at": "2026-07-03T05:36:00Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub required checks passed; recording ready-to-merge before squash merge per train policy."
       }
     ]
   },
@@ -66012,7 +66022,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T05:27:00Z",
+  "updated_at": "2026-07-03T05:36:00Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -558,12 +558,12 @@
     "depends_on": [
       "ENNEA-RP-04"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "6cfcccf59d0925968c8a76c76295d2ed071153b1",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "b14f98b5766265d93aacc967390838e7c66d4bb0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2653",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-03T03:26:05Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "failure_reason": null,
     "checks": {
       "authorization": {
@@ -608,6 +608,10 @@
         "status": "pass",
         "command": "gh pr checks 2653 --repo fermatmind/fap-api --watch --interval 15",
         "evidence": "All reported checks for PR #2653 passed on head 6cfcccf59d0925968c8a76c76295d2ed071153b1, including hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, and Semgrep checks."
+      },
+      "post_merge_cleanup": {
+        "status": "pass",
+        "evidence": "PR #2653 is MERGED; merge commit b14f98b5766265d93aacc967390838e7c66d4bb0 is contained in origin/main; local main fast-forwarded to origin/main; local branch codex/ennea-rp-05-confidence-band-card deleted; remote branch absent."
       }
     },
     "scope_validation": {
@@ -649,6 +653,11 @@
         "at": "2026-07-03T05:12:00Z",
         "status": "ready_to_merge",
         "notes": "GitHub required checks passed; recording ready-to-merge before squash merge per train policy."
+      },
+      {
+        "at": "2026-07-03T03:31:00Z",
+        "status": "merged_post_merge_revalidated",
+        "notes": "Post-merge cleanup completed; no staging deploy wait or production deploy performed."
       }
     ]
   },
@@ -662,8 +671,8 @@
     "depends_on": [
       "ENNEA-RP-05"
     ],
-    "status": "pending_dependency",
-    "commit_sha": "882d05e090af473825a1e7173f7f6e9ca14a7e82",
+    "status": "local_validation_passed",
+    "commit_sha": null,
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -673,6 +682,45 @@
       "authorization": {
         "status": "pass",
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-05 merged as PR #2653 and merge commit b14f98b5766265d93aacc967390838e7c66d4bb0 is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All ENNEAGRAM v2 registry JSON files parsed successfully."
+      },
+      "type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed: 2 warnings, 14509 assertions."
+      },
+      "registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Passed: 3 warnings, 26 assertions."
+      },
+      "composer_v2_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Passed: 14 warnings, 121 assertions."
+      },
+      "technical_note_content_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTechnicalNoteRegistryContentTest",
+        "evidence": "Passed: 1 warning, 9 assertions."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed: 261 warnings, 2 passed, 83402 assertions, duration 33.21s."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
       }
     },
     "scope_validation": {
@@ -684,13 +732,27 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "changed_files": [
+        "backend/app/Services/Report/EnneagramReportComposer.php",
+        "backend/content_packs/ENNEAGRAM/v2/registry/technical_note_registry.json",
+        "backend/tests/Unit/Services/Content/EnneagramTechnicalNoteRegistryContentTest.php",
+        "backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php",
+        "docs/codex/pr-train-state.json"
+      ],
+      "outside_scope_files": [],
+      "status": "pass",
+      "evidence": "Changed files are confined to dominance_gap_card composer content, dominance_gap technical note registry copy, related Enneagram tests, and train ledger reconciliation."
     },
     "events": [
       {
         "at": "2026-07-02T16:10:24Z",
         "status": "pending_dependency",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge."
+      },
+      {
+        "at": "2026-07-03T05:24:00Z",
+        "status": "local_validation_passed",
+        "notes": "Implemented dominance gap score-space and error-boundary language; required local validation passed."
       }
     ]
   },
@@ -65945,7 +66007,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T05:12:00Z",
+  "updated_at": "2026-07-03T05:24:00Z",
   "PR-EQ-V20-01": {
     "repo": "fap-api",
     "base": "main",


### PR DESCRIPTION
## What changed\n- Added dominance_gap_card reader-facing title, score-space note, metric guide, boundary note, and explicit non-use cases.\n- Expanded dominance_gap technical note copy to clarify same-form score space and non-validity boundaries.\n- Added Enneagram composer and technical-note registry assertions.\n- Reconciled ENNEA-RP-05 post-merge cleanup state in the train ledger.\n\n## Why\nDominance gap should guide result-page interpretation tone within one form's score space, not imply cross-form comparability, norm ranking, statistical confidence interval, measurement error bounds, validity proof, or fixed personality certainty.\n\n## Validation\n- cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json\n- cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest\n- cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest\n- cd backend && php artisan test --filter=EnneagramReportComposerV2Test\n- cd backend && php artisan test --filter=EnneagramTechnicalNoteRegistryContentTest\n- cd backend && php artisan test --filter=Enneagram\n- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"\n- git diff --check\n- git diff --cached --check\n\n## Intentionally deferred\n- No staging deploy wait.\n- No server deployment verification.\n- No registry release activation.\n- No production deploy or CMS write.