### PR TITLE
PR-EQ-ASSET-SCI-10: keep EQ sjt_bridge planned unavailable

### DIFF
--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-03T03:24:01.377499Z",
+    "generated_at": "2026-07-03T03:43:55.951527Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -25852,132 +25852,132 @@
             "assets": {
                 "eq.sjt_bridge.planned": {
                     "zh-CN": {
-                        "title": "未来情境判断模块 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "未来情境判断模块",
                         "status": "planned_unavailable",
-                        "description": "你现在看到的是自我报告结果。未来的情境判断模块会补充你在反馈、冲突、边界和压力场景中倾向选择的回应。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "你现在看到的是 EQ-60 自我报告结果。EQ-SJT 16 题情境判断模块仍在规划中，未来只会作为补充层，用来观察用户在反馈、冲突、边界和压力场景中的选择倾向。当前没有题库入口或综合报告。",
+                        "what_it_adds": "未来会补充情境选择、压力下回应、边界处理和修复策略等线索，用来比较“自我感知”与“情境选择倾向”的一致与差距。",
+                        "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，不是临床诊断、招聘筛选或职业预测工具，也不会替代 EQ-60 自我报告。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "当前模块未开放。不要把页面中的 SJT 说明理解为已经可以作答、已经验证稳定，或能测量真实情绪能力。"
                     },
                     "en": {
-                        "title": "Future scenario module EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "Future Scenario Module",
                         "status": "planned_unavailable",
-                        "description": "You are seeing a self-report result. A future scenario module will add how you tend to choose responses in feedback, conflict, boundary, and pressure situations. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "You are seeing the EQ-60 self-report result. The 16-item EQ-SJT scenario module is still planned and would only serve as a supplemental layer, describing response-choice tendencies in feedback, conflict, boundary, and pressure situations. There is no item entry or integrated report yet.",
+                        "what_it_adds": "It would add signals about scenario choices, responses under pressure, boundary handling, and repair strategies, helping compare self-perception with scenario-choice tendencies.",
+                        "what_it_is_not": "It is not MSCEIT, not a certified ability test, not a clinical diagnostic tool, not a hiring screen, and not a career-prediction instrument. It also would not replace the EQ-60 self-report.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "This module is not open. Do not read the SJT note as meaning that items are available, that validation is complete, or that the module measures true emotional ability."
                     },
                     "meta": {
                         "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "risk_notes": "SJT bridge must remain planned/unavailable. It may describe future scenario-choice tendencies only; no item entry, no integrated report, no ability-test, MSCEIT-like, certified, diagnostic, hiring, career-prediction, or paid-unlock claim."
                     }
                 },
                 "eq.sjt_bridge.what_it_adds": {
                     "zh-CN": {
-                        "title": "它会补充什么 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "它会补充什么",
                         "status": "planned_unavailable",
-                        "description": "它会补充情境选择、压力下回应、边界和修复策略等信息，帮助形成自我感知 × 情境选择的综合报告。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "EQ-SJT 未来会补充“在情绪与关系场景中更倾向如何选择”的信息，而不是再给一个更高或更低的情商分。它的价值在于帮助用户看到自我感知和情境选择之间是否一致。",
+                        "what_it_adds": "可能补充的线索包括：反馈中的反应选择、冲突中的降温方式、边界情境中的表达方式、压力下的暂停与修复策略。",
+                        "what_it_is_not": "它不会证明用户在现实中一定会这样做，也不会给出能力认证、临床判断、招聘结论或职业适配结论。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "这些说明只是未来模块定位，不代表当前已经存在可作答题库、评分报告或综合解释。"
                     },
                     "en": {
-                        "title": "What it will add EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "What It Will Add",
                         "status": "planned_unavailable",
-                        "description": "It will add response choices, pressure reactions, boundary patterns, and repair strategies, supporting an integrated self-perception × scenario-choice report. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "The future EQ-SJT would add information about likely choices in emotional and relationship scenarios, rather than producing a higher-or-lower EQ score. Its value would be to compare self-perception with scenario-choice tendencies.",
+                        "what_it_adds": "Possible signals include response choices in feedback, de-escalation in conflict, expression in boundary situations, and pause or repair strategies under pressure.",
+                        "what_it_is_not": "It would not prove how someone will behave in real life, and it would not provide ability certification, clinical judgment, hiring conclusions, or career-fit conclusions.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "This is a positioning note for a future module, not evidence that an item set, scoring report, or integrated interpretation is currently available."
                     },
                     "meta": {
                         "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "risk_notes": "Describe future supplemental scenario-choice information without claiming predictive accuracy, ability measurement, certification, hiring suitability, or clinical validity."
                     }
                 },
                 "eq.sjt_bridge.what_it_is_not": {
                     "zh-CN": {
-                        "title": "它不是什么 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "它不是什么",
                         "status": "planned_unavailable",
-                        "description": "它不是受控专业能力工具，不提供资格凭证，不用于高风险判断。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "EQ-SJT 不应被描述为 MSCEIT，也不应被描述为认证能力测验、临床诊断、招聘筛选、职业预测或高风险决策工具。它最多只能作为 EQ-60 自我报告之外的情境选择补充层。",
+                        "what_it_adds": "未来如果开放，它会帮助比较自我感知和情境选择倾向，但仍需要清楚标注方法边界、样本状态和解释限制。",
+                        "what_it_is_not": "它不是测量“真实情商能力”的工具，不给资格证明，不判断一个人是否适合某份工作，也不替代心理健康、法律、人事或临床专业判断。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "不要把情境题形式误读为客观能力测验。情境选择题仍会受到文化、语境、社会期许和作答策略影响。"
                     },
                     "en": {
-                        "title": "What it is not EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "What It Is Not",
                         "status": "planned_unavailable",
-                        "description": "It is not a controlled professional ability instrument, does not provide a credential, and is not for high-stakes decisions. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "EQ-SJT should not be described as MSCEIT, a certified ability test, a clinical diagnostic instrument, a hiring screen, a career-prediction tool, or a high-stakes decision tool. At most, it would be a scenario-choice supplement to the EQ-60 self-report.",
+                        "what_it_adds": "If opened later, it would help compare self-perception with scenario-choice tendencies, while still requiring clear method boundaries, sample-status notes, and interpretation limits.",
+                        "what_it_is_not": "It does not measure “true emotional ability,” does not provide a credential, does not judge whether someone is suitable for a job, and does not replace mental-health, legal, HR, or clinical professional judgment.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "Do not treat scenario-item format as objective ability testing. Scenario choices are still influenced by culture, context, social desirability, and response strategy."
                     },
                     "meta": {
-                        "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "claim_risk": "high",
+                        "risk_notes": "This boundary asset must block MSCEIT-like, true-ability, certified, clinical, hiring, career-prediction, and high-stakes claims. Keep module unavailable."
                     }
                 },
                 "eq.sjt_bridge.future_integrated_report": {
                     "zh-CN": {
-                        "title": "未来综合报告 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "未来综合报告",
                         "status": "planned_unavailable",
-                        "description": "未来综合报告会比较你如何看待自己，以及你在情境中倾向如何选择，从而显示一致处和差距。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "如果未来 EQ-SJT 开放，综合报告会尝试并列呈现 EQ-60 的自我感知结果和情境选择结果，重点看一致处、差距和需要继续观察的问题，而不是把两者合成一个绝对总分。",
+                        "what_it_adds": "未来可能加入：情境判断摘要、压力回应模式、自我感知与情境选择差距、沟通脚本和低风险练习建议。",
+                        "what_it_is_not": "综合报告也不会成为能力认证、职业录用依据、临床判断或对现实表现的保证。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "当前结果页仍只代表 EQ-60 自我报告。不要把未来综合报告说明理解为当前已经生成了 integrated EQ report。"
                     },
                     "en": {
-                        "title": "Future integrated report EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "Future Integrated Report",
                         "status": "planned_unavailable",
-                        "description": "The future integrated report will compare how you see yourself with how you tend to choose in scenarios, showing alignment and gaps. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "If EQ-SJT is opened later, the integrated report would present EQ-60 self-perception results alongside scenario-choice results, focusing on alignment, gaps, and questions for further observation rather than combining them into an absolute total score.",
+                        "what_it_adds": "Future modules may add a scenario-judgment summary, pressure-response pattern, self-perception versus scenario-choice gap, communication scripts, and low-risk practice suggestions.",
+                        "what_it_is_not": "The integrated report would still not be an ability credential, hiring basis, clinical judgment, or guarantee of real-world performance.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "The current result page remains an EQ-60 self-report result. Do not read the future integrated-report note as meaning that an integrated EQ report has already been generated."
                     },
                     "meta": {
                         "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "risk_notes": "Future integrated-report copy must avoid total-score absolutism, ability credentialing, hiring/clinical claims, and guarantees of real-world behavior."
                     }
                 },
                 "eq.sjt_bridge.unavailable_note": {
                     "zh-CN": {
-                        "title": "暂未开放说明 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "暂未开放说明",
                         "status": "planned_unavailable",
-                        "description": "该模块仍在 planned 状态。前端不应提供可点击开始入口。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "EQ-SJT 目前只是计划中的后续模块。产品不应展示可点击开始入口、题库入口、立即完成按钮或综合报告承诺。",
+                        "what_it_adds": "当前页面可以说明未来方向，但不应让用户以为现在已经可以完成 16 题情境判断。",
+                        "what_it_is_not": "暂未开放状态下，不应出现“继续作答”“开始情境题”、综合报告承诺或访问门槛式表达。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "如果未来开放，仍需以明确版本、题库、评分、质量规则和科学边界为准。当前不要暗示 SJT 已验证稳定。"
                     },
                     "en": {
-                        "title": "Unavailable note EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "Unavailable Note",
                         "status": "planned_unavailable",
-                        "description": "This module remains planned. The frontend should not provide a clickable start entry. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "EQ-SJT is currently only a planned follow-up module. The product should not show a clickable start entry, item-bank entry, immediate-completion button, or integrated-report promise.",
+                        "what_it_adds": "The current page may explain the future direction, but should not make users think the 16 scenario items can be completed now.",
+                        "what_it_is_not": "While unavailable, wording such as “continue items,” “start scenarios,” integrated-report promises, or access-wall language should not appear.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "If opened later, it must depend on a clear version, item set, scoring rules, quality rules, and scientific boundaries. Do not imply that SJT is already stably validated."
                     },
                     "meta": {
-                        "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "claim_risk": "high",
+                        "risk_notes": "Keep product behavior and copy unavailable: no clickable entry, no take route, no integrated-report promise, no access-wall language, and no stable-validation claim."
                     }
                 }
             }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/sjt_bridge.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/sjt_bridge.json
@@ -4,132 +4,132 @@
   "assets": {
     "eq.sjt_bridge.planned": {
       "zh-CN": {
-        "title": "未来情境判断模块 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "未来情境判断模块",
         "status": "planned_unavailable",
-        "description": "你现在看到的是自我报告结果。未来的情境判断模块会补充你在反馈、冲突、边界和压力场景中倾向选择的回应。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "你现在看到的是 EQ-60 自我报告结果。EQ-SJT 16 题情境判断模块仍在规划中，未来只会作为补充层，用来观察用户在反馈、冲突、边界和压力场景中的选择倾向。当前没有题库入口或综合报告。",
+        "what_it_adds": "未来会补充情境选择、压力下回应、边界处理和修复策略等线索，用来比较“自我感知”与“情境选择倾向”的一致与差距。",
+        "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，不是临床诊断、招聘筛选或职业预测工具，也不会替代 EQ-60 自我报告。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "当前模块未开放。不要把页面中的 SJT 说明理解为已经可以作答、已经验证稳定，或能测量真实情绪能力。"
       },
       "en": {
-        "title": "Future scenario module EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "Future Scenario Module",
         "status": "planned_unavailable",
-        "description": "You are seeing a self-report result. A future scenario module will add how you tend to choose responses in feedback, conflict, boundary, and pressure situations. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "You are seeing the EQ-60 self-report result. The 16-item EQ-SJT scenario module is still planned and would only serve as a supplemental layer, describing response-choice tendencies in feedback, conflict, boundary, and pressure situations. There is no item entry or integrated report yet.",
+        "what_it_adds": "It would add signals about scenario choices, responses under pressure, boundary handling, and repair strategies, helping compare self-perception with scenario-choice tendencies.",
+        "what_it_is_not": "It is not MSCEIT, not a certified ability test, not a clinical diagnostic tool, not a hiring screen, and not a career-prediction instrument. It also would not replace the EQ-60 self-report.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "This module is not open. Do not read the SJT note as meaning that items are available, that validation is complete, or that the module measures true emotional ability."
       },
       "meta": {
         "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "risk_notes": "SJT bridge must remain planned/unavailable. It may describe future scenario-choice tendencies only; no item entry, no integrated report, no ability-test, MSCEIT-like, certified, diagnostic, hiring, career-prediction, or paid-unlock claim."
       }
     },
     "eq.sjt_bridge.what_it_adds": {
       "zh-CN": {
-        "title": "它会补充什么 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "它会补充什么",
         "status": "planned_unavailable",
-        "description": "它会补充情境选择、压力下回应、边界和修复策略等信息，帮助形成自我感知 × 情境选择的综合报告。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "EQ-SJT 未来会补充“在情绪与关系场景中更倾向如何选择”的信息，而不是再给一个更高或更低的情商分。它的价值在于帮助用户看到自我感知和情境选择之间是否一致。",
+        "what_it_adds": "可能补充的线索包括：反馈中的反应选择、冲突中的降温方式、边界情境中的表达方式、压力下的暂停与修复策略。",
+        "what_it_is_not": "它不会证明用户在现实中一定会这样做，也不会给出能力认证、临床判断、招聘结论或职业适配结论。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "这些说明只是未来模块定位，不代表当前已经存在可作答题库、评分报告或综合解释。"
       },
       "en": {
-        "title": "What it will add EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "What It Will Add",
         "status": "planned_unavailable",
-        "description": "It will add response choices, pressure reactions, boundary patterns, and repair strategies, supporting an integrated self-perception × scenario-choice report. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "The future EQ-SJT would add information about likely choices in emotional and relationship scenarios, rather than producing a higher-or-lower EQ score. Its value would be to compare self-perception with scenario-choice tendencies.",
+        "what_it_adds": "Possible signals include response choices in feedback, de-escalation in conflict, expression in boundary situations, and pause or repair strategies under pressure.",
+        "what_it_is_not": "It would not prove how someone will behave in real life, and it would not provide ability certification, clinical judgment, hiring conclusions, or career-fit conclusions.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "This is a positioning note for a future module, not evidence that an item set, scoring report, or integrated interpretation is currently available."
       },
       "meta": {
         "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "risk_notes": "Describe future supplemental scenario-choice information without claiming predictive accuracy, ability measurement, certification, hiring suitability, or clinical validity."
       }
     },
     "eq.sjt_bridge.what_it_is_not": {
       "zh-CN": {
-        "title": "它不是什么 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "它不是什么",
         "status": "planned_unavailable",
-        "description": "它不是受控专业能力工具，不提供资格凭证，不用于高风险判断。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "EQ-SJT 不应被描述为 MSCEIT，也不应被描述为认证能力测验、临床诊断、招聘筛选、职业预测或高风险决策工具。它最多只能作为 EQ-60 自我报告之外的情境选择补充层。",
+        "what_it_adds": "未来如果开放，它会帮助比较自我感知和情境选择倾向，但仍需要清楚标注方法边界、样本状态和解释限制。",
+        "what_it_is_not": "它不是测量“真实情商能力”的工具，不给资格证明，不判断一个人是否适合某份工作，也不替代心理健康、法律、人事或临床专业判断。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "不要把情境题形式误读为客观能力测验。情境选择题仍会受到文化、语境、社会期许和作答策略影响。"
       },
       "en": {
-        "title": "What it is not EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "What It Is Not",
         "status": "planned_unavailable",
-        "description": "It is not a controlled professional ability instrument, does not provide a credential, and is not for high-stakes decisions. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "EQ-SJT should not be described as MSCEIT, a certified ability test, a clinical diagnostic instrument, a hiring screen, a career-prediction tool, or a high-stakes decision tool. At most, it would be a scenario-choice supplement to the EQ-60 self-report.",
+        "what_it_adds": "If opened later, it would help compare self-perception with scenario-choice tendencies, while still requiring clear method boundaries, sample-status notes, and interpretation limits.",
+        "what_it_is_not": "It does not measure “true emotional ability,” does not provide a credential, does not judge whether someone is suitable for a job, and does not replace mental-health, legal, HR, or clinical professional judgment.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "Do not treat scenario-item format as objective ability testing. Scenario choices are still influenced by culture, context, social desirability, and response strategy."
       },
       "meta": {
-        "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "claim_risk": "high",
+        "risk_notes": "This boundary asset must block MSCEIT-like, true-ability, certified, clinical, hiring, career-prediction, and high-stakes claims. Keep module unavailable."
       }
     },
     "eq.sjt_bridge.future_integrated_report": {
       "zh-CN": {
-        "title": "未来综合报告 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "未来综合报告",
         "status": "planned_unavailable",
-        "description": "未来综合报告会比较你如何看待自己，以及你在情境中倾向如何选择，从而显示一致处和差距。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "如果未来 EQ-SJT 开放，综合报告会尝试并列呈现 EQ-60 的自我感知结果和情境选择结果，重点看一致处、差距和需要继续观察的问题，而不是把两者合成一个绝对总分。",
+        "what_it_adds": "未来可能加入：情境判断摘要、压力回应模式、自我感知与情境选择差距、沟通脚本和低风险练习建议。",
+        "what_it_is_not": "综合报告也不会成为能力认证、职业录用依据、临床判断或对现实表现的保证。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "当前结果页仍只代表 EQ-60 自我报告。不要把未来综合报告说明理解为当前已经生成了 integrated EQ report。"
       },
       "en": {
-        "title": "Future integrated report EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "Future Integrated Report",
         "status": "planned_unavailable",
-        "description": "The future integrated report will compare how you see yourself with how you tend to choose in scenarios, showing alignment and gaps. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "If EQ-SJT is opened later, the integrated report would present EQ-60 self-perception results alongside scenario-choice results, focusing on alignment, gaps, and questions for further observation rather than combining them into an absolute total score.",
+        "what_it_adds": "Future modules may add a scenario-judgment summary, pressure-response pattern, self-perception versus scenario-choice gap, communication scripts, and low-risk practice suggestions.",
+        "what_it_is_not": "The integrated report would still not be an ability credential, hiring basis, clinical judgment, or guarantee of real-world performance.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "The current result page remains an EQ-60 self-report result. Do not read the future integrated-report note as meaning that an integrated EQ report has already been generated."
       },
       "meta": {
         "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "risk_notes": "Future integrated-report copy must avoid total-score absolutism, ability credentialing, hiring/clinical claims, and guarantees of real-world behavior."
       }
     },
     "eq.sjt_bridge.unavailable_note": {
       "zh-CN": {
-        "title": "暂未开放说明 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "暂未开放说明",
         "status": "planned_unavailable",
-        "description": "该模块仍在 planned 状态。前端不应提供可点击开始入口。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "EQ-SJT 目前只是计划中的后续模块。产品不应展示可点击开始入口、题库入口、立即完成按钮或综合报告承诺。",
+        "what_it_adds": "当前页面可以说明未来方向，但不应让用户以为现在已经可以完成 16 题情境判断。",
+        "what_it_is_not": "暂未开放状态下，不应出现“继续作答”“开始情境题”、综合报告承诺或访问门槛式表达。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "如果未来开放，仍需以明确版本、题库、评分、质量规则和科学边界为准。当前不要暗示 SJT 已验证稳定。"
       },
       "en": {
-        "title": "Unavailable note EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "Unavailable Note",
         "status": "planned_unavailable",
-        "description": "This module remains planned. The frontend should not provide a clickable start entry. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "EQ-SJT is currently only a planned follow-up module. The product should not show a clickable start entry, item-bank entry, immediate-completion button, or integrated-report promise.",
+        "what_it_adds": "The current page may explain the future direction, but should not make users think the 16 scenario items can be completed now.",
+        "what_it_is_not": "While unavailable, wording such as “continue items,” “start scenarios,” integrated-report promises, or access-wall language should not appear.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "If opened later, it must depend on a clear version, item set, scoring rules, quality rules, and scientific boundaries. Do not imply that SJT is already stably validated."
       },
       "meta": {
-        "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "claim_risk": "high",
+        "risk_notes": "Keep product behavior and copy unavailable: no clickable entry, no take route, no integrated-report promise, no access-wall language, and no stable-validation claim."
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-03T03:24:01.377499Z",
+    "generated_at": "2026-07-03T03:42:57.426655Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -25852,132 +25852,132 @@
             "assets": {
                 "eq.sjt_bridge.planned": {
                     "zh-CN": {
-                        "title": "未来情境判断模块 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "未来情境判断模块",
                         "status": "planned_unavailable",
-                        "description": "你现在看到的是自我报告结果。未来的情境判断模块会补充你在反馈、冲突、边界和压力场景中倾向选择的回应。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "你现在看到的是 EQ-60 自我报告结果。EQ-SJT 16 题情境判断模块仍在规划中，未来只会作为补充层，用来观察用户在反馈、冲突、边界和压力场景中的选择倾向。当前没有题库入口或综合报告。",
+                        "what_it_adds": "未来会补充情境选择、压力下回应、边界处理和修复策略等线索，用来比较“自我感知”与“情境选择倾向”的一致与差距。",
+                        "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，不是临床诊断、招聘筛选或职业预测工具，也不会替代 EQ-60 自我报告。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "当前模块未开放。不要把页面中的 SJT 说明理解为已经可以作答、已经验证稳定，或能测量真实情绪能力。"
                     },
                     "en": {
-                        "title": "Future scenario module EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "Future Scenario Module",
                         "status": "planned_unavailable",
-                        "description": "You are seeing a self-report result. A future scenario module will add how you tend to choose responses in feedback, conflict, boundary, and pressure situations. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "You are seeing the EQ-60 self-report result. The 16-item EQ-SJT scenario module is still planned and would only serve as a supplemental layer, describing response-choice tendencies in feedback, conflict, boundary, and pressure situations. There is no item entry or integrated report yet.",
+                        "what_it_adds": "It would add signals about scenario choices, responses under pressure, boundary handling, and repair strategies, helping compare self-perception with scenario-choice tendencies.",
+                        "what_it_is_not": "It is not MSCEIT, not a certified ability test, not a clinical diagnostic tool, not a hiring screen, and not a career-prediction instrument. It also would not replace the EQ-60 self-report.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "This module is not open. Do not read the SJT note as meaning that items are available, that validation is complete, or that the module measures true emotional ability."
                     },
                     "meta": {
                         "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "risk_notes": "SJT bridge must remain planned/unavailable. It may describe future scenario-choice tendencies only; no item entry, no integrated report, no ability-test, MSCEIT-like, certified, diagnostic, hiring, career-prediction, or paid-unlock claim."
                     }
                 },
                 "eq.sjt_bridge.what_it_adds": {
                     "zh-CN": {
-                        "title": "它会补充什么 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "它会补充什么",
                         "status": "planned_unavailable",
-                        "description": "它会补充情境选择、压力下回应、边界和修复策略等信息，帮助形成自我感知 × 情境选择的综合报告。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "EQ-SJT 未来会补充“在情绪与关系场景中更倾向如何选择”的信息，而不是再给一个更高或更低的情商分。它的价值在于帮助用户看到自我感知和情境选择之间是否一致。",
+                        "what_it_adds": "可能补充的线索包括：反馈中的反应选择、冲突中的降温方式、边界情境中的表达方式、压力下的暂停与修复策略。",
+                        "what_it_is_not": "它不会证明用户在现实中一定会这样做，也不会给出能力认证、临床判断、招聘结论或职业适配结论。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "这些说明只是未来模块定位，不代表当前已经存在可作答题库、评分报告或综合解释。"
                     },
                     "en": {
-                        "title": "What it will add EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "What It Will Add",
                         "status": "planned_unavailable",
-                        "description": "It will add response choices, pressure reactions, boundary patterns, and repair strategies, supporting an integrated self-perception × scenario-choice report. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "The future EQ-SJT would add information about likely choices in emotional and relationship scenarios, rather than producing a higher-or-lower EQ score. Its value would be to compare self-perception with scenario-choice tendencies.",
+                        "what_it_adds": "Possible signals include response choices in feedback, de-escalation in conflict, expression in boundary situations, and pause or repair strategies under pressure.",
+                        "what_it_is_not": "It would not prove how someone will behave in real life, and it would not provide ability certification, clinical judgment, hiring conclusions, or career-fit conclusions.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "This is a positioning note for a future module, not evidence that an item set, scoring report, or integrated interpretation is currently available."
                     },
                     "meta": {
                         "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "risk_notes": "Describe future supplemental scenario-choice information without claiming predictive accuracy, ability measurement, certification, hiring suitability, or clinical validity."
                     }
                 },
                 "eq.sjt_bridge.what_it_is_not": {
                     "zh-CN": {
-                        "title": "它不是什么 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "它不是什么",
                         "status": "planned_unavailable",
-                        "description": "它不是受控专业能力工具，不提供资格凭证，不用于高风险判断。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "EQ-SJT 不应被描述为 MSCEIT，也不应被描述为认证能力测验、临床诊断、招聘筛选、职业预测或高风险决策工具。它最多只能作为 EQ-60 自我报告之外的情境选择补充层。",
+                        "what_it_adds": "未来如果开放，它会帮助比较自我感知和情境选择倾向，但仍需要清楚标注方法边界、样本状态和解释限制。",
+                        "what_it_is_not": "它不是测量“真实情商能力”的工具，不给资格证明，不判断一个人是否适合某份工作，也不替代心理健康、法律、人事或临床专业判断。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "不要把情境题形式误读为客观能力测验。情境选择题仍会受到文化、语境、社会期许和作答策略影响。"
                     },
                     "en": {
-                        "title": "What it is not EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "What It Is Not",
                         "status": "planned_unavailable",
-                        "description": "It is not a controlled professional ability instrument, does not provide a credential, and is not for high-stakes decisions. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "EQ-SJT should not be described as MSCEIT, a certified ability test, a clinical diagnostic instrument, a hiring screen, a career-prediction tool, or a high-stakes decision tool. At most, it would be a scenario-choice supplement to the EQ-60 self-report.",
+                        "what_it_adds": "If opened later, it would help compare self-perception with scenario-choice tendencies, while still requiring clear method boundaries, sample-status notes, and interpretation limits.",
+                        "what_it_is_not": "It does not measure “true emotional ability,” does not provide a credential, does not judge whether someone is suitable for a job, and does not replace mental-health, legal, HR, or clinical professional judgment.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "Do not treat scenario-item format as objective ability testing. Scenario choices are still influenced by culture, context, social desirability, and response strategy."
                     },
                     "meta": {
-                        "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "claim_risk": "high",
+                        "risk_notes": "This boundary asset must block MSCEIT-like, true-ability, certified, clinical, hiring, career-prediction, and high-stakes claims. Keep module unavailable."
                     }
                 },
                 "eq.sjt_bridge.future_integrated_report": {
                     "zh-CN": {
-                        "title": "未来综合报告 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "未来综合报告",
                         "status": "planned_unavailable",
-                        "description": "未来综合报告会比较你如何看待自己，以及你在情境中倾向如何选择，从而显示一致处和差距。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "如果未来 EQ-SJT 开放，综合报告会尝试并列呈现 EQ-60 的自我感知结果和情境选择结果，重点看一致处、差距和需要继续观察的问题，而不是把两者合成一个绝对总分。",
+                        "what_it_adds": "未来可能加入：情境判断摘要、压力回应模式、自我感知与情境选择差距、沟通脚本和低风险练习建议。",
+                        "what_it_is_not": "综合报告也不会成为能力认证、职业录用依据、临床判断或对现实表现的保证。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "当前结果页仍只代表 EQ-60 自我报告。不要把未来综合报告说明理解为当前已经生成了 integrated EQ report。"
                     },
                     "en": {
-                        "title": "Future integrated report EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "Future Integrated Report",
                         "status": "planned_unavailable",
-                        "description": "The future integrated report will compare how you see yourself with how you tend to choose in scenarios, showing alignment and gaps. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "If EQ-SJT is opened later, the integrated report would present EQ-60 self-perception results alongside scenario-choice results, focusing on alignment, gaps, and questions for further observation rather than combining them into an absolute total score.",
+                        "what_it_adds": "Future modules may add a scenario-judgment summary, pressure-response pattern, self-perception versus scenario-choice gap, communication scripts, and low-risk practice suggestions.",
+                        "what_it_is_not": "The integrated report would still not be an ability credential, hiring basis, clinical judgment, or guarantee of real-world performance.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "The current result page remains an EQ-60 self-report result. Do not read the future integrated-report note as meaning that an integrated EQ report has already been generated."
                     },
                     "meta": {
                         "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "risk_notes": "Future integrated-report copy must avoid total-score absolutism, ability credentialing, hiring/clinical claims, and guarantees of real-world behavior."
                     }
                 },
                 "eq.sjt_bridge.unavailable_note": {
                     "zh-CN": {
-                        "title": "暂未开放说明 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "title": "暂未开放说明",
                         "status": "planned_unavailable",
-                        "description": "该模块仍在 planned 状态。前端不应提供可点击开始入口。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-                        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+                        "description": "EQ-SJT 目前只是计划中的后续模块。产品不应展示可点击开始入口、题库入口、立即完成按钮或综合报告承诺。",
+                        "what_it_adds": "当前页面可以说明未来方向，但不应让用户以为现在已经可以完成 16 题情境判断。",
+                        "what_it_is_not": "暂未开放状态下，不应出现“继续作答”“开始情境题”、综合报告承诺或访问门槛式表达。",
                         "button_label": "暂未开放",
                         "available": false,
-                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                        "do_not_overread": "如果未来开放，仍需以明确版本、题库、评分、质量规则和科学边界为准。当前不要暗示 SJT 已验证稳定。"
                     },
                     "en": {
-                        "title": "Unavailable note EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "title": "Unavailable Note",
                         "status": "planned_unavailable",
-                        "description": "This module remains planned. The frontend should not provide a clickable start entry. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-                        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+                        "description": "EQ-SJT is currently only a planned follow-up module. The product should not show a clickable start entry, item-bank entry, immediate-completion button, or integrated-report promise.",
+                        "what_it_adds": "The current page may explain the future direction, but should not make users think the 16 scenario items can be completed now.",
+                        "what_it_is_not": "While unavailable, wording such as “continue items,” “start scenarios,” integrated-report promises, or access-wall language should not appear.",
                         "button_label": "Not available yet",
                         "available": false,
-                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                        "do_not_overread": "If opened later, it must depend on a clear version, item set, scoring rules, quality rules, and scientific boundaries. Do not imply that SJT is already stably validated."
                     },
                     "meta": {
-                        "claim_risk": "medium",
-                        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+                        "claim_risk": "high",
+                        "risk_notes": "Keep product behavior and copy unavailable: no clickable entry, no take route, no integrated-report promise, no access-wall language, and no stable-validation claim."
                     }
                 }
             }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/sjt_bridge.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/sjt_bridge.json
@@ -4,132 +4,132 @@
   "assets": {
     "eq.sjt_bridge.planned": {
       "zh-CN": {
-        "title": "未来情境判断模块 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "未来情境判断模块",
         "status": "planned_unavailable",
-        "description": "你现在看到的是自我报告结果。未来的情境判断模块会补充你在反馈、冲突、边界和压力场景中倾向选择的回应。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "你现在看到的是 EQ-60 自我报告结果。EQ-SJT 16 题情境判断模块仍在规划中，未来只会作为补充层，用来观察用户在反馈、冲突、边界和压力场景中的选择倾向。当前没有题库入口或综合报告。",
+        "what_it_adds": "未来会补充情境选择、压力下回应、边界处理和修复策略等线索，用来比较“自我感知”与“情境选择倾向”的一致与差距。",
+        "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，不是临床诊断、招聘筛选或职业预测工具，也不会替代 EQ-60 自我报告。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "当前模块未开放。不要把页面中的 SJT 说明理解为已经可以作答、已经验证稳定，或能测量真实情绪能力。"
       },
       "en": {
-        "title": "Future scenario module EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "Future Scenario Module",
         "status": "planned_unavailable",
-        "description": "You are seeing a self-report result. A future scenario module will add how you tend to choose responses in feedback, conflict, boundary, and pressure situations. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "You are seeing the EQ-60 self-report result. The 16-item EQ-SJT scenario module is still planned and would only serve as a supplemental layer, describing response-choice tendencies in feedback, conflict, boundary, and pressure situations. There is no item entry or integrated report yet.",
+        "what_it_adds": "It would add signals about scenario choices, responses under pressure, boundary handling, and repair strategies, helping compare self-perception with scenario-choice tendencies.",
+        "what_it_is_not": "It is not MSCEIT, not a certified ability test, not a clinical diagnostic tool, not a hiring screen, and not a career-prediction instrument. It also would not replace the EQ-60 self-report.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "This module is not open. Do not read the SJT note as meaning that items are available, that validation is complete, or that the module measures true emotional ability."
       },
       "meta": {
         "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "risk_notes": "SJT bridge must remain planned/unavailable. It may describe future scenario-choice tendencies only; no item entry, no integrated report, no ability-test, MSCEIT-like, certified, diagnostic, hiring, career-prediction, or paid-unlock claim."
       }
     },
     "eq.sjt_bridge.what_it_adds": {
       "zh-CN": {
-        "title": "它会补充什么 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "它会补充什么",
         "status": "planned_unavailable",
-        "description": "它会补充情境选择、压力下回应、边界和修复策略等信息，帮助形成自我感知 × 情境选择的综合报告。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "EQ-SJT 未来会补充“在情绪与关系场景中更倾向如何选择”的信息，而不是再给一个更高或更低的情商分。它的价值在于帮助用户看到自我感知和情境选择之间是否一致。",
+        "what_it_adds": "可能补充的线索包括：反馈中的反应选择、冲突中的降温方式、边界情境中的表达方式、压力下的暂停与修复策略。",
+        "what_it_is_not": "它不会证明用户在现实中一定会这样做，也不会给出能力认证、临床判断、招聘结论或职业适配结论。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "这些说明只是未来模块定位，不代表当前已经存在可作答题库、评分报告或综合解释。"
       },
       "en": {
-        "title": "What it will add EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "What It Will Add",
         "status": "planned_unavailable",
-        "description": "It will add response choices, pressure reactions, boundary patterns, and repair strategies, supporting an integrated self-perception × scenario-choice report. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "The future EQ-SJT would add information about likely choices in emotional and relationship scenarios, rather than producing a higher-or-lower EQ score. Its value would be to compare self-perception with scenario-choice tendencies.",
+        "what_it_adds": "Possible signals include response choices in feedback, de-escalation in conflict, expression in boundary situations, and pause or repair strategies under pressure.",
+        "what_it_is_not": "It would not prove how someone will behave in real life, and it would not provide ability certification, clinical judgment, hiring conclusions, or career-fit conclusions.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "This is a positioning note for a future module, not evidence that an item set, scoring report, or integrated interpretation is currently available."
       },
       "meta": {
         "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "risk_notes": "Describe future supplemental scenario-choice information without claiming predictive accuracy, ability measurement, certification, hiring suitability, or clinical validity."
       }
     },
     "eq.sjt_bridge.what_it_is_not": {
       "zh-CN": {
-        "title": "它不是什么 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "它不是什么",
         "status": "planned_unavailable",
-        "description": "它不是受控专业能力工具，不提供资格凭证，不用于高风险判断。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "EQ-SJT 不应被描述为 MSCEIT，也不应被描述为认证能力测验、临床诊断、招聘筛选、职业预测或高风险决策工具。它最多只能作为 EQ-60 自我报告之外的情境选择补充层。",
+        "what_it_adds": "未来如果开放，它会帮助比较自我感知和情境选择倾向，但仍需要清楚标注方法边界、样本状态和解释限制。",
+        "what_it_is_not": "它不是测量“真实情商能力”的工具，不给资格证明，不判断一个人是否适合某份工作，也不替代心理健康、法律、人事或临床专业判断。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "不要把情境题形式误读为客观能力测验。情境选择题仍会受到文化、语境、社会期许和作答策略影响。"
       },
       "en": {
-        "title": "What it is not EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "What It Is Not",
         "status": "planned_unavailable",
-        "description": "It is not a controlled professional ability instrument, does not provide a credential, and is not for high-stakes decisions. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "EQ-SJT should not be described as MSCEIT, a certified ability test, a clinical diagnostic instrument, a hiring screen, a career-prediction tool, or a high-stakes decision tool. At most, it would be a scenario-choice supplement to the EQ-60 self-report.",
+        "what_it_adds": "If opened later, it would help compare self-perception with scenario-choice tendencies, while still requiring clear method boundaries, sample-status notes, and interpretation limits.",
+        "what_it_is_not": "It does not measure “true emotional ability,” does not provide a credential, does not judge whether someone is suitable for a job, and does not replace mental-health, legal, HR, or clinical professional judgment.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "Do not treat scenario-item format as objective ability testing. Scenario choices are still influenced by culture, context, social desirability, and response strategy."
       },
       "meta": {
-        "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "claim_risk": "high",
+        "risk_notes": "This boundary asset must block MSCEIT-like, true-ability, certified, clinical, hiring, career-prediction, and high-stakes claims. Keep module unavailable."
       }
     },
     "eq.sjt_bridge.future_integrated_report": {
       "zh-CN": {
-        "title": "未来综合报告 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "未来综合报告",
         "status": "planned_unavailable",
-        "description": "未来综合报告会比较你如何看待自己，以及你在情境中倾向如何选择，从而显示一致处和差距。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "如果未来 EQ-SJT 开放，综合报告会尝试并列呈现 EQ-60 的自我感知结果和情境选择结果，重点看一致处、差距和需要继续观察的问题，而不是把两者合成一个绝对总分。",
+        "what_it_adds": "未来可能加入：情境判断摘要、压力回应模式、自我感知与情境选择差距、沟通脚本和低风险练习建议。",
+        "what_it_is_not": "综合报告也不会成为能力认证、职业录用依据、临床判断或对现实表现的保证。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "当前结果页仍只代表 EQ-60 自我报告。不要把未来综合报告说明理解为当前已经生成了 integrated EQ report。"
       },
       "en": {
-        "title": "Future integrated report EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "Future Integrated Report",
         "status": "planned_unavailable",
-        "description": "The future integrated report will compare how you see yourself with how you tend to choose in scenarios, showing alignment and gaps. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "If EQ-SJT is opened later, the integrated report would present EQ-60 self-perception results alongside scenario-choice results, focusing on alignment, gaps, and questions for further observation rather than combining them into an absolute total score.",
+        "what_it_adds": "Future modules may add a scenario-judgment summary, pressure-response pattern, self-perception versus scenario-choice gap, communication scripts, and low-risk practice suggestions.",
+        "what_it_is_not": "The integrated report would still not be an ability credential, hiring basis, clinical judgment, or guarantee of real-world performance.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "The current result page remains an EQ-60 self-report result. Do not read the future integrated-report note as meaning that an integrated EQ report has already been generated."
       },
       "meta": {
         "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "risk_notes": "Future integrated-report copy must avoid total-score absolutism, ability credentialing, hiring/clinical claims, and guarantees of real-world behavior."
       }
     },
     "eq.sjt_bridge.unavailable_note": {
       "zh-CN": {
-        "title": "暂未开放说明 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "title": "暂未开放说明",
         "status": "planned_unavailable",
-        "description": "该模块仍在 planned 状态。前端不应提供可点击开始入口。 当前只作为未来模块说明，不提供可点击入口。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_adds": "未来补充情境选择信息。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
-        "what_it_is_not": "未来情境模块当前未开放；它不是 MSCEIT，不是能力测验，也不是认证。 EQ-SJT 仍是 planned/unavailable 的后续模块；它将补充自我报告，但不是 MSCEIT、认证能力测验、诊断或招聘筛选工具。",
+        "description": "EQ-SJT 目前只是计划中的后续模块。产品不应展示可点击开始入口、题库入口、立即完成按钮或综合报告承诺。",
+        "what_it_adds": "当前页面可以说明未来方向，但不应让用户以为现在已经可以完成 16 题情境判断。",
+        "what_it_is_not": "暂未开放状态下，不应出现“继续作答”“开始情境题”、综合报告承诺或访问门槛式表达。",
         "button_label": "暂未开放",
         "available": false,
-        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+        "do_not_overread": "如果未来开放，仍需以明确版本、题库、评分、质量规则和科学边界为准。当前不要暗示 SJT 已验证稳定。"
       },
       "en": {
-        "title": "Unavailable note EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "title": "Unavailable Note",
         "status": "planned_unavailable",
-        "description": "This module remains planned. The frontend should not provide a clickable start entry. It is currently informational only and does not provide a take entry. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_adds": "It supplements self-report with future scenario choices. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
-        "what_it_is_not": "The planned scenario module is not live, not MSCEIT, not an ability test, and not a certification. EQ-SJT remains a planned/unavailable follow-up module; it may complement self-report later, but it is not MSCEIT, a certified ability test, a diagnostic tool, or a hiring screen.",
+        "description": "EQ-SJT is currently only a planned follow-up module. The product should not show a clickable start entry, item-bank entry, immediate-completion button, or integrated-report promise.",
+        "what_it_adds": "The current page may explain the future direction, but should not make users think the 16 scenario items can be completed now.",
+        "what_it_is_not": "While unavailable, wording such as “continue items,” “start scenarios,” integrated-report promises, or access-wall language should not appear.",
         "button_label": "Not available yet",
         "available": false,
-        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+        "do_not_overread": "If opened later, it must depend on a clear version, item set, scoring rules, quality rules, and scientific boundaries. Do not imply that SJT is already stably validated."
       },
       "meta": {
-        "claim_risk": "medium",
-        "risk_notes": "SJT bridge must stay planned/unavailable and non-ability. Keep this as self-report interpretation with explicit non-clinical, non-hiring, and non-ability boundaries."
+        "claim_risk": "high",
+        "risk_notes": "Keep product behavior and copy unavailable: no clickable entry, no take route, no integrated-report promise, no access-wall language, and no stable-validation claim."
       }
     }
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69583,9 +69583,9 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-03"
     ],
-    "status": "in_progress",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open_checks_pending",
+    "commit_sha": "f9c01dcfe",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2658",
     "checks": [
       {
         "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan content:lint --pack=EQ_60 --pack-version=v1",
@@ -69660,6 +69660,11 @@
         "status": "local_checks_passed",
         "timestamp": "2026-07-03T11:56:00+08:00",
         "notes": "All required local checks and SJT bridge guard scan passed; ready to commit and open PR."
+      },
+      {
+        "status": "pr_open_checks_pending",
+        "timestamp": "2026-07-03T12:00:00+08:00",
+        "notes": "Opened PR #2658 for PR-EQ-ASSET-SCI-10; GitHub checks pending."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69446,8 +69446,8 @@
       "PR-EQ-ASSET-SCI-05",
       "PR-EQ-ASSET-SCI-13"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "2b10f70a40f7d66eb6a59637a868aecb7721fe45",
+    "status": "merged_post_merge_revalidated",
+    "commit_sha": "acf77a56a7a371a635d9642701fa32a9da070fef",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2655",
     "checks": [
       {
@@ -69514,12 +69514,17 @@
         "command": "git diff --check && git diff --cached --check",
         "status": "passed",
         "summary": "No whitespace errors in unstaged or staged diff."
+      },
+      {
+        "command": "post-merge cleanup verification",
+        "status": "passed",
+        "notes": "Verified PR #2655 merged at acf77a56a7a371a635d9642701fa32a9da070fef; origin/main contains merge commit; task branch and temp worktree cleaned before starting PR-EQ-ASSET-SCI-10."
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-03T03:37:22Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "status": "pass",
       "changed_files": [
@@ -69560,6 +69565,13 @@
         "status": "ready_to_merge",
         "notes": "GitHub checks passed, mergeStateStatus CLEAN, and scope revalidation passed for PR #2655."
       }
+    ],
+    "history": [
+      {
+        "status": "merged_post_merge_revalidated",
+        "timestamp": "2026-07-03T11:45:00+08:00",
+        "notes": "Ledger reconciled inside PR-EQ-ASSET-SCI-10 after GitHub merge and cleanup of PR-EQ-ASSET-SCI-09."
+      }
     ]
   },
   "PR-EQ-ASSET-SCI-10": {
@@ -69571,25 +69583,83 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-03"
     ],
-    "status": "user_authorized",
+    "status": "in_progress",
     "commit_sha": null,
     "pr_url": null,
-    "checks": [],
+    "checks": [
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; scoped report_assets compiled output retained and mirrored."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warnings; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warnings; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "YAML/JSON parse, EQ pack mirror cmp, scope validation, sjt bridge guard scan, git diff --check, git diff --cached --check",
+        "status": "passed",
+        "summary": "Manifest/state parsed, raw and compiled mirrors match, changed files are within SCI-10 scope, SJT bridge remains unavailable, and no whitespace errors were found."
+      }
+    ],
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "status": "pass",
+      "changed_files": [
+        "backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json",
+        "backend/content_packs/EQ_60/v1/raw/report_assets/sjt_bridge.json",
+        "backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json",
+        "backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/sjt_bridge.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-10 allowed_paths."
     },
     "transitions": [
       {
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      }
+    ],
+    "history": [
+      {
+        "status": "in_progress",
+        "timestamp": "2026-07-03T11:45:00+08:00",
+        "notes": "Started PR-EQ-ASSET-SCI-10 from origin/main after PR-EQ-ASSET-SCI-09 merged; scope limited to sjt_bridge assets, compiled report assets, and train state."
+      },
+      {
+        "status": "local_checks_passed",
+        "timestamp": "2026-07-03T11:56:00+08:00",
+        "notes": "All required local checks and SJT bridge guard scan passed; ready to commit and open PR."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -69583,8 +69583,8 @@
     "depends_on": [
       "PR-EQ-ASSET-SCI-03"
     ],
-    "status": "pr_open_checks_pending",
-    "commit_sha": "f9c01dcfe",
+    "status": "ready_to_merge",
+    "commit_sha": "721d00045697f9aafc98744b91b5509f4c9d66ec",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2658",
     "checks": [
       {
@@ -69626,6 +69626,11 @@
         "command": "YAML/JSON parse, EQ pack mirror cmp, scope validation, sjt bridge guard scan, git diff --check, git diff --cached --check",
         "status": "passed",
         "summary": "Manifest/state parsed, raw and compiled mirrors match, changed files are within SCI-10 scope, SJT bridge remains unavailable, and no whitespace errors were found."
+      },
+      {
+        "command": "GitHub PR checks and merge-state review",
+        "status": "passed",
+        "summary": "All GitHub checks passed; mergeStateStatus CLEAN; scope revalidation passed."
       }
     ],
     "failure_reason": null,
@@ -69665,6 +69670,11 @@
         "status": "pr_open_checks_pending",
         "timestamp": "2026-07-03T12:00:00+08:00",
         "notes": "Opened PR #2658 for PR-EQ-ASSET-SCI-10; GitHub checks pending."
+      },
+      {
+        "status": "ready_to_merge",
+        "timestamp": "2026-07-03T12:06:00+08:00",
+        "notes": "GitHub checks passed, mergeStateStatus CLEAN, and scope revalidation passed for PR #2658."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Rewrote EQ `sjt_bridge` report assets so the future EQ-SJT module stays clearly planned/unavailable.
- Removed repeated boilerplate from user-facing titles/descriptions and moved boundaries into the right fields.
- Mirrored raw and compiled report assets to `EQ_EMOTIONAL_INTELLIGENCE/v1`.
- Reconciled the preceding SCI-09 ledger state after merge/cleanup and recorded SCI-10 local validation.

## Why
EQ-SJT is not implemented yet. The result page should only describe it as a future supplemental scenario-choice layer, without implying available items, integrated reports, ability testing, MSCEIT-like status, certification, hiring/clinical use, career prediction, paid unlock, or stable validation.

## Validation
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest`
- YAML/JSON parse
- EQ raw/compiled mirror `cmp`
- SCI-10 scope validation
- SJT bridge guard scan for unavailable status, no clickable/take labels, no commerce wording, and non-claimy titles
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No SJT implementation, item bank, scorer, route, take flow, or integrated report.
- No frontend changes.
- No scoring, question, norm, commerce, CMS, staging, or production deployment changes.
