### PR TITLE
ENNEA-RP-09: fix(enneagram): repair center summary boundary

### DIFF
--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -473,7 +473,7 @@ final class EnneagramReportComposer
             'dominance_gap_card' => $this->buildDominanceGapModule($projectionV2, $indexes),
             'close_call_card' => $this->buildCloseCallModule($projectionV2, $indexes),
             'blind_spot_card' => $this->buildBlindSpotModule($projectionV2, $indexes, 'blind_spot_card'),
-            'center_summary' => $this->buildUnavailableShapeModule($projectionV2, $indexes, 'center_summary', 'summary_card', 'dynamics.center_scores'),
+            'center_summary' => $this->buildCenterSummaryModule($projectionV2, $indexes),
             'stance_summary' => $this->buildUnavailableShapeModule($projectionV2, $indexes, 'stance_summary', 'summary_card', 'dynamics.stance_scores'),
             'harmonic_summary' => $this->buildUnavailableShapeModule($projectionV2, $indexes, 'harmonic_summary', 'summary_card', 'dynamics.harmonic_scores'),
             'wing_hint_visual' => $this->buildWingHintModule($projectionV2, $indexes),
@@ -914,6 +914,58 @@ final class EnneagramReportComposer
             ['enneagram_group_registry'],
             [],
             $this->registryMeta($indexes, 'enneagram_group_registry')
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $projectionV2
+     * @param  array<string,mixed>  $indexes
+     * @return array<string,mixed>
+     */
+    private function buildCenterSummaryModule(array $projectionV2, array $indexes): array
+    {
+        $centerEntries = array_values(array_filter(
+            (array) ($indexes['group_entries'] ?? []),
+            static fn (mixed $entry): bool => is_array($entry) && ($entry['group_type'] ?? null) === 'center'
+        ));
+
+        $groups = array_map(static fn (array $entry): array => [
+            'group_key' => $entry['group_key'] ?? null,
+            'type_ids' => $entry['type_ids'] ?? [],
+            'description' => $entry['description'] ?? null,
+            'strength_expression' => $entry['strength_expression'] ?? null,
+            'cost_expression' => $entry['cost_expression'] ?? null,
+            'stress_signal' => $entry['stress_signal'] ?? null,
+            'observation_question' => $entry['observation_question'] ?? null,
+            'boundary_note' => $entry['boundary_note'] ?? null,
+            'availability_note' => $entry['availability_note'] ?? null,
+            'not_for' => $entry['not_for'] ?? [],
+        ], $centerEntries);
+
+        return $this->module(
+            'center_summary',
+            'summary_card',
+            'unavailable',
+            'all',
+            [
+                'status' => 'unavailable',
+                'interpretation_scope' => 'unavailable',
+                'reason' => data_get($projectionV2, '_meta.unavailable.dynamics.center_scores.reason'),
+                'availability_note' => '当前公开结果页不把作答轮廓换算为中心分数或中心判定；以下内容只保留理论边界和观察问题。',
+                'boundary_note' => '中心组来自九型理论语言，可用于整理注意力线索，但不能作为诊断、健康层级、能力评价或固定人格分类。',
+                'not_for' => ['center_classification', 'diagnosis', 'health_level_judgement', 'ability_rating'],
+                'groups' => $groups,
+            ],
+            ['dynamics.center_scores'],
+            array_values(array_filter(array_merge(
+                ['enneagram_group_registry'],
+                array_map(
+                    static fn (array $entry): string => 'enneagram_group_registry:center:'.(string) ($entry['group_key'] ?? ''),
+                    $centerEntries
+                )
+            ))),
+            [],
+            $this->mergeEntryMeta($centerEntries, $this->registryMeta($indexes, 'enneagram_group_registry'))
         );
     }
 
@@ -1628,13 +1680,13 @@ final class EnneagramReportComposer
 
     private function normalizeModuleState(string $state, array $content): string
     {
-        if (in_array($state, ['clear', 'close_call', 'diffuse', 'low_quality'], true)) {
+        if (in_array($state, ['clear', 'close_call', 'diffuse', 'low_quality', 'unavailable'], true)) {
             return $state;
         }
 
         $derived = trim((string) ($content['interpretation_scope'] ?? ''));
 
-        return in_array($derived, ['clear', 'close_call', 'diffuse', 'low_quality'], true) ? $derived : 'clear';
+        return in_array($derived, ['clear', 'close_call', 'diffuse', 'low_quality', 'unavailable'], true) ? $derived : 'clear';
     }
 
     /**

--- a/backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json
@@ -28,6 +28,14 @@
             "cost_expression": "当身体层面的不对劲累积时，愤怒、僵硬或控制欲可能先于解释出现。",
             "stress_signal": "开始绷紧、急着纠偏、直接顶上或把自己压得很硬。",
             "observation_question": "今天你最先感到的是身体里的不对劲，还是脑中的解释和推理？",
+            "boundary_note": "中心组是九型理论中的解释框架，只能帮助观察注意力可能先落在哪里；当前结果页不会据此确认你的中心类型、情绪机制或身心状态。",
+            "availability_note": "本模块先展示理论边界与观察问题，不把当前作答直接换算成中心分数或中心判定。",
+            "not_for": [
+                "center_classification",
+                "diagnosis",
+                "health_level_judgement",
+                "ability_rating"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"
@@ -45,6 +53,14 @@
             "cost_expression": "容易把自我价值绑在回应、认可、差异感或外部评价上。",
             "stress_signal": "开始过度比较、过度在意关系位置，或把情绪体验和价值感捆得太紧。",
             "observation_question": "今天你最在意的是事情有没有做成，还是自己被怎样看见？",
+            "boundary_note": "中心组是九型理论中的解释框架，只能帮助观察注意力可能先落在哪里；当前结果页不会据此确认你的中心类型、情绪机制或关系价值。",
+            "availability_note": "本模块先展示理论边界与观察问题，不把当前作答直接换算成中心分数或中心判定。",
+            "not_for": [
+                "center_classification",
+                "diagnosis",
+                "health_level_judgement",
+                "ability_rating"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"
@@ -62,6 +78,14 @@
             "cost_expression": "容易让思考、预演或选项管理拖慢真实进入和承诺。",
             "stress_signal": "开始反复推演、保持选项、迟迟不进场，或用想法替代体验。",
             "observation_question": "今天你的判断是在帮助行动，还是让你更晚进入现实互动？",
+            "boundary_note": "中心组是九型理论中的解释框架，只能帮助观察注意力可能先落在哪里；当前结果页不会据此确认你的中心类型、焦虑水平或认知能力。",
+            "availability_note": "本模块先展示理论边界与观察问题，不把当前作答直接换算成中心分数或中心判定。",
+            "not_for": [
+                "center_classification",
+                "diagnosis",
+                "health_level_judgement",
+                "ability_rating"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"

--- a/backend/tests/Unit/Services/Content/EnneagramGroupRegistryCoverageTest.php
+++ b/backend/tests/Unit/Services/Content/EnneagramGroupRegistryCoverageTest.php
@@ -34,5 +34,15 @@ final class EnneagramGroupRegistryCoverageTest extends TestCase
         ], $keys);
         $this->assertFalse($entries->contains(fn ($entry): bool => trim((string) ($entry['stress_signal'] ?? '')) === ''));
         $this->assertFalse($entries->contains(fn ($entry): bool => ($entry['content_maturity'] ?? null) !== 'p0_ready'));
+
+        $centerEntries = $entries->filter(fn ($entry): bool => ($entry['group_type'] ?? null) === 'center');
+        $this->assertFalse($centerEntries->contains(fn ($entry): bool => trim((string) ($entry['boundary_note'] ?? '')) === ''));
+        $this->assertFalse($centerEntries->contains(fn ($entry): bool => trim((string) ($entry['availability_note'] ?? '')) === ''));
+        $this->assertFalse($centerEntries->contains(fn ($entry): bool => ($entry['not_for'] ?? []) !== [
+            'center_classification',
+            'diagnosis',
+            'health_level_judgement',
+            'ability_rating',
+        ]));
     }
 }

--- a/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
+++ b/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
@@ -128,6 +128,34 @@ final class EnneagramReportComposerV2Test extends TestCase
         $this->assertSame('这不是常模分数、诊断标签、能力评价或固定人格定论。', $first['score_boundary_note'] ?? null);
     }
 
+    public function test_center_summary_is_theory_boundary_not_center_classification(): void
+    {
+        $payload = $this->composeReportV2($this->syntheticProjectionInput('enneagram_likert_105', [
+            'T8' => 88.0,
+            'T1' => 61.0,
+            'T9' => 53.0,
+            'T6' => 39.0,
+            'T3' => 34.0,
+            'T2' => 29.0,
+            'T5' => 23.0,
+            'T7' => 18.0,
+            'T4' => 14.0,
+        ]));
+
+        $module = $this->module($payload, 'center_summary');
+
+        $this->assertSame('unavailable', data_get($module, 'state'));
+        $this->assertSame('unavailable', data_get($module, 'content.status'));
+        $this->assertStringContainsString('不把作答轮廓换算为中心分数或中心判定', (string) data_get($module, 'content.availability_note'));
+        $this->assertStringContainsString('不能作为诊断、健康层级、能力评价或固定人格分类', (string) data_get($module, 'content.boundary_note'));
+        $this->assertSame(
+            ['center_classification', 'diagnosis', 'health_level_judgement', 'ability_rating'],
+            data_get($module, 'content.not_for')
+        );
+        $this->assertCount(3, (array) data_get($module, 'content.groups'));
+        $this->assertStringContainsString('不把当前作答直接换算成中心分数或中心判定', (string) data_get($module, 'content.groups.0.availability_note'));
+    }
+
     public function test_confidence_band_card_frames_confidence_as_interpretation_stability_not_accuracy(): void
     {
         $payload = $this->composeReportV2($this->syntheticProjectionInput('enneagram_likert_105', [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12533,8 +12533,8 @@
     "depends_on": [
       "ENNEA-RP-08"
     ],
-    "status": "pr_opened",
-    "commit_sha": "b2f6ae1ff3314f6d3d0628bc85186bdee6f62e07",
+    "status": "ready_to_merge",
+    "commit_sha": "48df5c772da52838431b5a83173f15d83cbc6998",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2663",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -12583,6 +12583,11 @@
         "status": "pass",
         "command": "git diff --check",
         "evidence": "No whitespace errors."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2663 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All required GitHub checks passed on PR #2663 head 48df5c772da52838431b5a83173f15d83cbc6998."
       }
     },
     "scope_validation": {
@@ -12625,6 +12630,11 @@
         "at": "2026-07-03T07:15:00Z",
         "status": "pr_opened",
         "notes": "Opened PR #2663 for center summary boundary repair; awaiting GitHub required checks."
+      },
+      {
+        "at": "2026-07-03T07:25:00Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub required checks passed for PR #2663; scope remains confined to center summary boundary content, runtime projection, tests, and train ledger."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12410,91 +12410,71 @@
     "train_scope": "enneagram_result_page_content_asset_repair"
   },
   "ENNEA-RP-08": {
+    "id": "ENNEA-RP-08",
+    "repo": "fap-api",
     "base": "main",
     "branch": "codex/ennea-rp-08-blind-spot-card",
-    "checks": {
-      "authorization": {
-        "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
-        "status": "pass"
-      },
-      "composer_v2_test": {
-        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
-        "evidence": "Passed: 14 warnings, 121 assertions.",
-        "status": "pass"
-      },
-      "dependency": {
-        "evidence": "ENNEA-RP-07 merged as PR #2659 and merge commit 3f0305df4e07753948d3ce5caf8a40dd213eec76 is present in origin/main.",
-        "status": "pass"
-      },
-      "diff_check": {
-        "command": "git diff --check",
-        "evidence": "No whitespace errors.",
-        "status": "pass"
-      },
-      "enneagram_filter": {
-        "command": "cd backend && php artisan test --filter=Enneagram",
-        "evidence": "Passed: 261 warnings, 2 passed, 83402 assertions, duration 144.25s.",
-        "status": "pass"
-      },
-      "github_required_checks": {
-        "command": "gh pr checks 2660 --repo fermatmind/fap-api --watch --interval 15",
-        "evidence": "All required GitHub checks passed on PR #2660 head a48725a02fc1f40218e24125a8272aa4bf4c4050.",
-        "status": "pass"
-      },
-      "jq_registry_json": {
-        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
-        "evidence": "All ENNEAGRAM v2 registry JSON files parsed successfully.",
-        "status": "pass"
-      },
-      "registry_pack_load": {
-        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
-        "evidence": "Passed: 3 warnings, 26 assertions.",
-        "status": "pass"
-      },
-      "type_registry_coverage": {
-        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
-        "evidence": "Passed: 2 warnings, 14509 assertions.",
-        "status": "pass"
-      }
-    },
-    "commit_sha": "a48725a02fc1f40218e24125a8272aa4bf4c4050",
+    "title": "ENNEA-RP-08: fix(enneagram): repair blind spot content",
+    "train_scope": "enneagram_result_page_content_asset_repair",
     "depends_on": [
       "ENNEA-RP-07"
     ],
-    "events": [
-      {
-        "at": "2026-07-02T16:10:24Z",
-        "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
-        "status": "pending_dependency"
-      },
-      {
-        "at": "2026-07-03T06:31:00Z",
-        "notes": "Started from latest origin/main on branch codex/ennea-rp-08-blind-spot-card; scope is type_registry blind_spot_copy repair plus train ledger only.",
-        "status": "in_progress"
-      },
-      {
-        "at": "2026-07-03T06:40:00Z",
-        "notes": "Repaired blind_spot_copy for all nine types as low-activation observation hypotheses; required local validation passed.",
-        "status": "local_validation_passed"
-      },
-      {
-        "at": "2026-07-03T06:43:00Z",
-        "notes": "Opened PR #2660 for blind spot content repair; awaiting GitHub required checks.",
-        "status": "pr_opened"
-      },
-      {
-        "at": "2026-07-03T06:50:00Z",
-        "notes": "GitHub required checks passed for PR #2660; scope remains confined to blind-spot type registry content and train ledger.",
-        "status": "ready_to_merge"
-      }
-    ],
-    "failure_reason": null,
-    "id": "ENNEA-RP-08",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "status": "merged",
+    "commit_sha": "c523627329e72cb7a07949962016fa4d37b1bfa7",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2660",
-    "remote_branch_deleted": false,
-    "repo": "fap-api",
+    "merged_at": "2026-07-03T04:15:22Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
+    "failure_reason": null,
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-07 merged as PR #2659 and merge commit 3f0305df4e07753948d3ce5caf8a40dd213eec76 is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All ENNEAGRAM v2 registry JSON files parsed successfully."
+      },
+      "type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed: 2 warnings, 14509 assertions."
+      },
+      "registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Passed: 3 warnings, 26 assertions."
+      },
+      "composer_v2_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Passed: 14 warnings, 121 assertions."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed: 261 warnings, 2 passed, 83402 assertions, duration 144.25s."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2660 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All required GitHub checks passed on PR #2660 head a48725a02fc1f40218e24125a8272aa4bf4c4050."
+      },
+      "post_merge_revalidate": {
+        "status": "pass",
+        "evidence": "PR #2660 is MERGED; origin/main contains merge commit c523627329e72cb7a07949962016fa4d37b1bfa7; local main fast-forwarded to origin/main; worktree clean; local branch deleted; remote branch absent."
+      }
+    },
     "scope_validation": {
       "allowed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
@@ -12506,41 +12486,105 @@
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
         "docs/codex/pr-train-state.json"
       ],
-      "evidence": "Changed files are confined to type_registry blind_spot_copy content and train ledger reconciliation.",
       "outside_scope_files": [],
-      "status": "pass"
+      "status": "pass",
+      "evidence": "Changed files are confined to type_registry blind_spot_copy content and train ledger reconciliation."
     },
-    "status": "ready_to_merge",
-    "title": "ENNEA-RP-08: fix(enneagram): repair blind spot content",
-    "train_scope": "enneagram_result_page_content_asset_repair"
-  },
-  "ENNEA-RP-09": {
-    "base": "main",
-    "branch": "codex/ennea-rp-09-center-summary",
-    "checks": {
-      "authorization": {
-        "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
-        "status": "pass"
-      }
-    },
-    "commit_sha": null,
-    "depends_on": [
-      "ENNEA-RP-08"
-    ],
     "events": [
       {
         "at": "2026-07-02T16:10:24Z",
-        "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
-        "status": "pending_dependency"
+        "status": "pending_dependency",
+        "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge."
+      },
+      {
+        "at": "2026-07-03T06:31:00Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-08-blind-spot-card; scope is type_registry blind_spot_copy repair plus train ledger only."
+      },
+      {
+        "at": "2026-07-03T06:40:00Z",
+        "status": "local_validation_passed",
+        "notes": "Repaired blind_spot_copy for all nine types as low-activation observation hypotheses; required local validation passed."
+      },
+      {
+        "at": "2026-07-03T06:43:00Z",
+        "status": "pr_opened",
+        "notes": "Opened PR #2660 for blind spot content repair; awaiting GitHub required checks."
+      },
+      {
+        "at": "2026-07-03T06:50:00Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub required checks passed for PR #2660; scope remains confined to blind-spot type registry content and train ledger."
+      },
+      {
+        "at": "2026-07-03T07:05:00Z",
+        "status": "merged",
+        "notes": "PR #2660 squash-merged; merge commit present in origin/main; local main synced and task branch cleaned up."
       }
-    ],
-    "failure_reason": null,
+    ]
+  },
+  "ENNEA-RP-09": {
     "id": "ENNEA-RP-09",
-    "local_cleanup_executed": false,
-    "merged_at": null,
-    "pr_url": null,
-    "remote_branch_deleted": false,
     "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/ennea-rp-09-center-summary",
+    "title": "ENNEA-RP-09: fix(enneagram): repair center summary boundary",
+    "train_scope": "enneagram_result_page_content_asset_repair",
+    "depends_on": [
+      "ENNEA-RP-08"
+    ],
+    "status": "local_validation_passed",
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "failure_reason": null,
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-08 merged as PR #2660 and merge commit c523627329e72cb7a07949962016fa4d37b1bfa7 is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All ENNEAGRAM v2 registry JSON files parsed successfully."
+      },
+      "group_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramGroupRegistryCoverageTest",
+        "evidence": "Passed: 1 warning, 6 assertions."
+      },
+      "type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed: 2 warnings, 14509 assertions."
+      },
+      "registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Passed: 3 warnings, 26 assertions."
+      },
+      "composer_v2_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Passed: 15 warnings, 128 assertions."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed: 262 warnings, 2 passed, 83412 assertions, duration 39.01s."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
+      }
+    },
     "scope_validation": {
       "allowed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json",
@@ -12550,11 +12594,34 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "changed_files": [
+        "backend/app/Services/Report/EnneagramReportComposer.php",
+        "backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json",
+        "backend/tests/Unit/Services/Content/EnneagramGroupRegistryCoverageTest.php",
+        "backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php",
+        "docs/codex/pr-train-state.json"
+      ],
+      "outside_scope_files": [],
+      "status": "pass",
+      "evidence": "Changed files are confined to center summary group registry content, center runtime projection, Enneagram tests, and train ledger reconciliation."
     },
-    "status": "pending_dependency",
-    "title": "ENNEA-RP-09: fix(enneagram): repair center summary boundary",
-    "train_scope": "enneagram_result_page_content_asset_repair"
+    "events": [
+      {
+        "at": "2026-07-02T16:10:24Z",
+        "status": "pending_dependency",
+        "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge."
+      },
+      {
+        "at": "2026-07-03T07:06:00Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-09-center-summary; scope is center summary registry/runtime boundary plus Enneagram tests and train ledger only."
+      },
+      {
+        "at": "2026-07-03T07:12:00Z",
+        "status": "local_validation_passed",
+        "notes": "Implemented center_summary as unavailable theory-boundary content with center group observation fields; required local validation passed."
+      }
+    ]
   },
   "ENNEA-RP-10": {
     "base": "main",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12534,7 +12534,7 @@
       "ENNEA-RP-08"
     ],
     "status": "ready_to_merge",
-    "commit_sha": "70e92a6a20c4c8ced8d75791f46802e5b60c0623",
+    "commit_sha": "e52577d9a9daf469cc23233a2c096a3a71b530b3",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2663",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -12585,9 +12585,9 @@
         "evidence": "No whitespace errors."
       },
       "github_required_checks": {
-        "status": "pending",
+        "status": "pass",
         "command": "gh pr checks 2663 --repo fermatmind/fap-api --watch --interval 15",
-        "evidence": "Rebased head 70e92a6a20c4c8ced8d75791f46802e5b60c0623 requires a fresh GitHub required-check run after force-with-lease push."
+        "evidence": "All required GitHub checks passed on rebased PR #2663 head e52577d9a9daf469cc23233a2c096a3a71b530b3."
       },
       "post_rebase_local_validation": {
         "status": "pass",
@@ -12644,6 +12644,11 @@
         "at": "2026-07-03T07:42:00Z",
         "status": "rebased_local_validation_passed",
         "notes": "Rebased PR #2663 onto latest origin/main at head 70e92a6a20c4c8ced8d75791f46802e5b60c0623; required local validation and scope validation passed again."
+      },
+      {
+        "at": "2026-07-03T07:50:00Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub required checks passed after rebase for PR #2663 head e52577d9a9daf469cc23233a2c096a3a71b530b3; ready for merge subject to final branch protection checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12534,7 +12534,7 @@
       "ENNEA-RP-08"
     ],
     "status": "ready_to_merge",
-    "commit_sha": "48df5c772da52838431b5a83173f15d83cbc6998",
+    "commit_sha": "70e92a6a20c4c8ced8d75791f46802e5b60c0623",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2663",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -12585,9 +12585,13 @@
         "evidence": "No whitespace errors."
       },
       "github_required_checks": {
-        "status": "pass",
+        "status": "pending",
         "command": "gh pr checks 2663 --repo fermatmind/fap-api --watch --interval 15",
-        "evidence": "All required GitHub checks passed on PR #2663 head 48df5c772da52838431b5a83173f15d83cbc6998."
+        "evidence": "Rebased head 70e92a6a20c4c8ced8d75791f46802e5b60c0623 requires a fresh GitHub required-check run after force-with-lease push."
+      },
+      "post_rebase_local_validation": {
+        "status": "pass",
+        "evidence": "After rebasing onto latest origin/main, reran jq registry validation, EnneagramReportComposerV2Test, EnneagramTypeRegistryCoverageTest, EnneagramRegistryPackLoadTest, php artisan test --filter=Enneagram, git diff --check, and scope validation successfully."
       }
     },
     "scope_validation": {
@@ -12608,7 +12612,7 @@
       ],
       "outside_scope_files": [],
       "status": "pass",
-      "evidence": "Changed files are confined to center summary group registry content, center runtime projection, Enneagram tests, and train ledger reconciliation."
+      "evidence": "After rebase, changed files remain confined to center summary group registry content, center runtime projection, Enneagram tests, and train ledger reconciliation."
     },
     "events": [
       {
@@ -12635,6 +12639,11 @@
         "at": "2026-07-03T07:25:00Z",
         "status": "ready_to_merge",
         "notes": "GitHub required checks passed for PR #2663; scope remains confined to center summary boundary content, runtime projection, tests, and train ledger."
+      },
+      {
+        "at": "2026-07-03T07:42:00Z",
+        "status": "rebased_local_validation_passed",
+        "notes": "Rebased PR #2663 onto latest origin/main at head 70e92a6a20c4c8ced8d75791f46802e5b60c0623; required local validation and scope validation passed again."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12533,9 +12533,9 @@
     "depends_on": [
       "ENNEA-RP-08"
     ],
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_opened",
+    "commit_sha": "b2f6ae1ff3314f6d3d0628bc85186bdee6f62e07",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2663",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -12620,6 +12620,11 @@
         "at": "2026-07-03T07:12:00Z",
         "status": "local_validation_passed",
         "notes": "Implemented center_summary as unavailable theory-boundary content with center group observation fields; required local validation passed."
+      },
+      {
+        "at": "2026-07-03T07:15:00Z",
+        "status": "pr_opened",
+        "notes": "Opened PR #2663 for center summary boundary repair; awaiting GitHub required checks."
       }
     ]
   },


### PR DESCRIPTION
What changed:\n- Added center-group theory boundary and unavailable notes to the Enneagram group registry.\n- Added a center_summary runtime builder that exposes center groups as observation prompts while keeping the module unavailable for center scoring/classification.\n- Added coverage for center registry boundary fields and composer output.\n- Reconciled ENNEA-RP-08 post-merge ledger state and recorded ENNEA-RP-09 local validation.\n\nWhy:\n- Center summaries should be clearly framed as theory-based observation scaffolding, not hard center classification, diagnosis, health-level judgment, or ability rating.\n\nValidation:\n- cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json\n- cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest\n- cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest\n- cd backend && php artisan test --filter=EnneagramReportComposerV2Test\n- cd backend && php artisan test --filter=Enneagram\n- git diff --check\n\nIntentionally deferred:\n- no fap-web changes\n- no route/migration changes\n- no staging deploy wait\n- no server verification\n- no registry activation\n- no production deploy