### PR TITLE
ENNEA-RP-10: fix(enneagram): repair stance summary content

### DIFF
--- a/backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json
@@ -98,11 +98,18 @@
                 "7",
                 "8"
             ],
-            "description": "更容易主动推进、占位、拉动节奏，而不是等待环境先变清楚。",
-            "strength_expression": "能带动局面、扛住压力、让事情往前走，也更敢于先动。",
-            "cost_expression": "较难停下来承认疲惫、限制、失落或关系代价。",
-            "stress_signal": "节奏越来越快、强度越来越高，也更难承认自己其实已经过载。",
-            "observation_question": "今天你的推进是在服务目标，还是让停顿、脆弱或限制更难被看见？",
+            "description": "在九型 stance 理论里，assertive 组常被用来描述一种较快向外推进、占位或拉动节奏的倾向。它只能作为情境观察线索，不能说明你在所有场景都主动、强势或外向。",
+            "strength_expression": "在目标清楚、局面停滞或需要有人先动时，这组线索可能帮助你带动节奏、承接压力、把下一步推出去。",
+            "cost_expression": "如果推进成了默认反应，你可能较晚看见疲惫、限制、失落或关系代价；这需要结合具体情境复盘，不能当作固定缺陷。",
+            "stress_signal": "可观察的压力信号包括节奏变快、强度升高、停顿变难，或把脆弱和限制先放到一边。",
+            "observation_question": "今天你主动推进时，实际保护的是目标、关系、边界还是不确定感？有没有一个场景说明你也能停下来调整节奏？",
+            "boundary_note": "stance 是理论分组，不是行为风格测量、外向性判断、领导力评分或稳定人格分类。",
+            "not_for": [
+                "behavior_style_measurement",
+                "extraversion_judgement",
+                "leadership_rating",
+                "personality_verdict"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"
@@ -115,11 +122,18 @@
                 "2",
                 "6"
             ],
-            "description": "更容易参考责任、规则、关系义务或外部期待，再决定自己怎么行动。",
-            "strength_expression": "会守住责任、看见义务和共同体要求，也更容易持续承担。",
-            "cost_expression": "容易把“我认同”与“我应该”混在一起，长期压低真实需要。",
-            "stress_signal": "开始过度扛责、反复确认、过度照顾别人，或很难停下内在的“应该”。",
-            "observation_question": "今天你做这件事，是因为认同它，还是因为觉得自己应该这样做？",
+            "description": "在九型 stance 理论里，compliant 组常被用来描述一种会参考责任、规则、关系义务或可信标准再行动的倾向。它只能作为情境观察线索，不能说明你总是顺从、讨好或缺少主见。",
+            "strength_expression": "在承诺需要兑现、规则需要被看见或关系需要有人负责时，这组线索可能帮助你持续承担、照顾共同体要求并维持可靠性。",
+            "cost_expression": "如果责任感成了默认反应，你可能把“我认同”与“我应该”混在一起，较晚说出真实需要；这需要用具体事件校准。",
+            "stress_signal": "可观察的压力信号包括过度扛责、反复确认、过度照顾别人，或很难停下内在的“应该”。",
+            "observation_question": "今天你承担某件事时，实际来自认同、关系责任、风险预判还是害怕让人失望？有没有一个场景说明你也能清楚拒绝或重新协商？",
+            "boundary_note": "stance 是理论分组，不是服从性测量、道德评价、关系诊断或稳定人格分类。",
+            "not_for": [
+                "obedience_measurement",
+                "moral_judgement",
+                "relationship_diagnosis",
+                "personality_verdict"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"
@@ -132,11 +146,18 @@
                 "5",
                 "9"
             ],
-            "description": "更容易先向内处理感受、能量和理解，再决定何时进入现场。",
-            "strength_expression": "能保留空间、沉淀感受，也能看见更深层的动机与内在线索。",
-            "cost_expression": "容易后退过久，让观察、麻木或自我世界替代真实行动。",
-            "stress_signal": "变得更安静、更抽离、更拖延，也更难把立场带回现实互动。",
-            "observation_question": "今天你退后之后，有没有重新进入，还是一直停在自己的内部世界里？",
+            "description": "在九型 stance 理论里，withdrawn 组常被用来描述一种先向内整理感受、能量、理解或节奏，再决定何时进入现场的倾向。它只能作为情境观察线索，不能说明你总是逃避、冷淡或行动力不足。",
+            "strength_expression": "在信息过载、情绪需要沉淀或现场节奏太快时，这组线索可能帮助你保留空间、整理内在线索，并避免被即时反应带走。",
+            "cost_expression": "如果后退成了默认反应，你可能较晚回到现场，让观察、麻木或自我世界替代真实行动；这需要用具体情境核对。",
+            "stress_signal": "可观察的压力信号包括更安静、更抽离、更拖延，或难以把立场和需要带回现实互动。",
+            "observation_question": "今天你退后时，实际是在恢复能量、整理信息、保护关系还是避开冲突？有没有一个场景说明你也能重新进入并表达立场？",
+            "boundary_note": "stance 是理论分组，不是回避程度测量、社交能力评价、临床判断或稳定人格分类。",
+            "not_for": [
+                "avoidance_measurement",
+                "social_ability_rating",
+                "clinical_judgement",
+                "personality_verdict"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12750,7 +12750,7 @@
         "evidence": "No whitespace errors."
       }
     },
-    "commit_sha": null,
+    "commit_sha": "05a91171b06ce0fb683c439a2e2091d410462eb6",
     "depends_on": [
       "ENNEA-RP-09"
     ],
@@ -12769,13 +12769,18 @@
         "at": "2026-07-03T08:08:00Z",
         "status": "local_validation_passed",
         "notes": "Repaired stance summary wording for assertive, compliant, and withdrawn groups with lower-certainty contextual boundaries; required local validation passed."
+      },
+      {
+        "at": "2026-07-03T08:12:00Z",
+        "status": "pr_opened",
+        "notes": "Opened PR #2666 for stance summary content repair; awaiting GitHub required checks."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-10",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2666",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
@@ -12793,7 +12798,7 @@
       "status": "pass",
       "evidence": "Changed files are confined to stance summary group registry content and train ledger reconciliation."
     },
-    "status": "local_validation_passed",
+    "status": "pr_opened",
     "title": "ENNEA-RP-10: fix(enneagram): repair stance summary content",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12748,9 +12748,14 @@
         "status": "pass",
         "command": "git diff --check",
         "evidence": "No whitespace errors."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2666 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All required GitHub checks passed on PR #2666 head 1a631bdd75392a5a976b9f3682c043f27c439234."
       }
     },
-    "commit_sha": "05a91171b06ce0fb683c439a2e2091d410462eb6",
+    "commit_sha": "1a631bdd75392a5a976b9f3682c043f27c439234",
     "depends_on": [
       "ENNEA-RP-09"
     ],
@@ -12774,6 +12779,11 @@
         "at": "2026-07-03T08:12:00Z",
         "status": "pr_opened",
         "notes": "Opened PR #2666 for stance summary content repair; awaiting GitHub required checks."
+      },
+      {
+        "at": "2026-07-03T08:22:00Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub required checks passed for PR #2666; scope remains confined to stance group registry content and train ledger."
       }
     ],
     "failure_reason": null,
@@ -12798,7 +12808,7 @@
       "status": "pass",
       "evidence": "Changed files are confined to stance summary group registry content and train ledger reconciliation."
     },
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "title": "ENNEA-RP-10: fix(enneagram): repair stance summary content",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12579,12 +12579,12 @@
     "depends_on": [
       "ENNEA-RP-08"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "e52577d9a9daf469cc23233a2c096a3a71b530b3",
+    "status": "merged",
+    "commit_sha": "2169710cee7ec4ef889e27737a75bd4a6bfddb95",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2663",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-03T04:46:50Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "failure_reason": null,
     "checks": {
       "authorization": {
@@ -12638,6 +12638,10 @@
       "post_rebase_local_validation": {
         "status": "pass",
         "evidence": "After rebasing onto latest origin/main, reran jq registry validation, EnneagramReportComposerV2Test, EnneagramTypeRegistryCoverageTest, EnneagramRegistryPackLoadTest, php artisan test --filter=Enneagram, git diff --check, and scope validation successfully."
+      },
+      "post_merge_revalidate": {
+        "status": "pass",
+        "evidence": "PR #2663 is MERGED; origin/main contains merge commit 2169710cee7ec4ef889e27737a75bd4a6bfddb95; local main fast-forwarded to origin/main; worktree clean; local branch deleted; remote branch absent."
       }
     },
     "scope_validation": {
@@ -12695,6 +12699,11 @@
         "at": "2026-07-03T07:50:00Z",
         "status": "ready_to_merge",
         "notes": "GitHub required checks passed after rebase for PR #2663 head e52577d9a9daf469cc23233a2c096a3a71b530b3; ready for merge subject to final branch protection checks."
+      },
+      {
+        "at": "2026-07-03T08:00:00Z",
+        "status": "merged",
+        "notes": "PR #2663 squash-merged; merge commit present in origin/main; local main synced and task branch cleaned up."
       }
     ]
   },
@@ -12705,6 +12714,40 @@
       "authorization": {
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
         "status": "pass"
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-09 merged as PR #2663 and merge commit 2169710cee7ec4ef889e27737a75bd4a6bfddb95 is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All ENNEAGRAM v2 registry JSON files parsed successfully."
+      },
+      "type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed: 2 warnings, 14509 assertions."
+      },
+      "registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Passed: 3 warnings, 26 assertions."
+      },
+      "composer_v2_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Passed: 15 warnings, 128 assertions."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed: 262 warnings, 2 passed, 83412 assertions, duration 36.19s."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
       }
     },
     "commit_sha": null,
@@ -12716,6 +12759,16 @@
         "at": "2026-07-02T16:10:24Z",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
         "status": "pending_dependency"
+      },
+      {
+        "at": "2026-07-03T08:01:00Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-10-stance-summary; scope is stance group registry content plus train ledger only."
+      },
+      {
+        "at": "2026-07-03T08:08:00Z",
+        "status": "local_validation_passed",
+        "notes": "Repaired stance summary wording for assertive, compliant, and withdrawn groups with lower-certainty contextual boundaries; required local validation passed."
       }
     ],
     "failure_reason": null,
@@ -12732,9 +12785,15 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "changed_files": [
+        "backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "outside_scope_files": [],
+      "status": "pass",
+      "evidence": "Changed files are confined to stance summary group registry content and train ledger reconciliation."
     },
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "title": "ENNEA-RP-10: fix(enneagram): repair stance summary content",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },


### PR DESCRIPTION
What changed:\n- Rewrote assertive, compliant, and withdrawn stance group copy with lower-certainty, context-bound wording.\n- Added stance-specific boundary notes and not_for fields to prevent behavior-style, morality, clinical, leadership, social ability, and fixed personality interpretations.\n- Reconciled ENNEA-RP-09 post-merge ledger state and recorded ENNEA-RP-10 local validation.\n\nWhy:\n- Stance content should remain a theory-based observation frame, not a high-certainty behavioral classification or evaluative label.\n\nValidation:\n- cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json\n- cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest\n- cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest\n- cd backend && php artisan test --filter=EnneagramReportComposerV2Test\n- cd backend && php artisan test --filter=Enneagram\n- git diff --check\n\nIntentionally deferred:\n- no fap-web changes\n- no runtime/API changes\n- no staging deploy wait\n- no server verification\n- no registry activation\n- no production deploy