### PR TITLE
ENNEA-RP-11: fix(enneagram): repair harmonic summary content

### DIFF
--- a/backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json
@@ -170,11 +170,18 @@
                 "7",
                 "9"
             ],
-            "description": "遇到失望和摩擦时，更容易先把局面缓和、重构、转轻或重新找出口。",
-            "strength_expression": "能提供希望、维持气氛，也能帮系统先别垮掉。",
-            "cost_expression": "可能过早把问题抹平，让需要面对的议题被延后。",
-            "stress_signal": "总想尽快翻篇、说服自己没事，或用善意、乐观与顺着走掩住现实代价。",
-            "observation_question": "今天你有没有太快说“没事”，以至于重要问题还没被看清？",
+            "description": "在九型 harmonic 理论里，positive outlook 组常被用来观察人在失望、摩擦或压力中，是否倾向先缓和局面、重构意义、转轻气氛或寻找出口。它不是乐观能力测量，也不能说明你总是回避问题。",
+            "strength_expression": "在短期承压、团队气氛下沉或关系需要先稳住时，这组线索可能帮助你保留希望、降低崩盘感，并为后续处理争取空间。",
+            "cost_expression": "如果缓和成了默认反应，你可能过早把问题抹平，让真实损失、边界或冲突议题被延后；这需要回到具体事件核对。",
+            "stress_signal": "可观察的压力信号包括急着翻篇、说服自己没事，或用善意、乐观、转移话题与顺着走掩住现实代价。",
+            "observation_question": "今天你说“没事”或想把气氛转轻时，实际是在恢复弹性、保护关系，还是让重要问题暂时不被看见？",
+            "boundary_note": "harmonic 是压力应对线索，不是情绪调节能力评分、心理健康判断、道德评价或稳定人格分类。",
+            "not_for": [
+                "emotion_regulation_rating",
+                "mental_health_judgement",
+                "moral_judgement",
+                "personality_verdict"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"
@@ -187,11 +194,18 @@
                 "3",
                 "5"
             ],
-            "description": "遇到问题时，更容易先用标准、效率、结构或能力把局面重新拉回可执行。",
-            "strength_expression": "能把混乱重新组织起来，也擅长把问题转成可处理的任务。",
-            "cost_expression": "容易跳过情绪与关系成本，把人的问题只当成技术问题。",
-            "stress_signal": "开始更冷、更快、更像在解决系统，而不是在面对正在受影响的人。",
-            "observation_question": "今天你有没有只想把问题做掉，却忽略了人和关系也在付出代价？",
+            "description": "在九型 harmonic 理论里，competency 组常被用来观察人在问题、压力或失控感中，是否倾向先用标准、效率、结构或可执行步骤把局面拉回秩序。它不是能力测量，也不能说明你总是理性或冷漠。",
+            "strength_expression": "在混乱、信息分散或责任需要落地时，这组线索可能帮助你组织问题、拆成任务，并让下一步重新可执行。",
+            "cost_expression": "如果处理问题成了默认反应，你可能跳过情绪与关系成本，把人的问题过早技术化；这需要结合当时谁受到影响来复盘。",
+            "stress_signal": "可观察的压力信号包括表达变冷、速度变快、过度强调正确做法，或像在解决系统而不是面对正在受影响的人。",
+            "observation_question": "今天你把问题转成任务时，实际是在恢复秩序、避免失控，还是绕开了人和关系正在承受的代价？",
+            "boundary_note": "harmonic 是压力应对线索，不是能力评价、理性程度评分、情绪成熟度判断或稳定人格分类。",
+            "not_for": [
+                "ability_rating",
+                "rationality_rating",
+                "emotional_maturity_judgement",
+                "personality_verdict"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"
@@ -204,11 +218,18 @@
                 "6",
                 "8"
             ],
-            "description": "遇到不真、不稳、不公时，更容易先反应，把张力表达出来。",
-            "strength_expression": "能让问题快速浮出水面，也不容易对关键裂缝装作没看见。",
-            "cost_expression": "反应强度可能过高，表达的力量先被看见，需要本身反而被盖住。",
-            "stress_signal": "开始更快起反应、更快防守或测试别人，也更难在表达需要和保护伤口之间区分。",
-            "observation_question": "今天你的反应是在表达需要，还是在先保护自己更敏感的部分？",
+            "description": "在九型 harmonic 理论里，reactive 组常被用来观察人在不真实、不稳定、不公平或受威胁的情境中，是否倾向先把张力表达出来。它不是情绪化标签，也不能说明你总是冲动或难相处。",
+            "strength_expression": "在问题被压住、风险被轻描淡写或边界被侵犯时，这组线索可能帮助你让裂缝快速浮出水面，不轻易假装没事。",
+            "cost_expression": "如果强反应成了默认反应，表达的力量可能先被看见，而真正的需要、担心或受伤点反而被盖住；这需要回到触发点复盘。",
+            "stress_signal": "可观察的压力信号包括更快起反应、更快防守或测试别人，也更难区分自己是在表达需要还是先保护伤口。",
+            "observation_question": "今天你的强反应实际在保护什么：真实、公平、安全、边界，还是某个更敏感的受伤点？",
+            "boundary_note": "harmonic 是压力应对线索，不是情绪稳定性诊断、冲动性测量、关系风险标签或稳定人格分类。",
+            "not_for": [
+                "emotional_stability_diagnosis",
+                "impulsivity_measurement",
+                "relationship_risk_label",
+                "personality_verdict"
+            ],
             "content_maturity": "p0_ready",
             "evidence_level": "theory_based",
             "fallback_policy": "optional"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3928,7 +3928,7 @@
     "base": "main",
     "branch": "codex/big5-canonical-profiles-scientific-repair-01",
     "checks": [],
-    "commit_sha": null,
+    "commit_sha": "1b338c59df6c6cce7ca7fad29ad2e2b105461540",
     "depends_on": [
       "BIG5-RENDERED-SURFACE-QA-CONTENT-REPAIR-01"
     ],
@@ -12879,13 +12879,18 @@
         "at": "2026-07-03T13:27:00Z",
         "status": "local_validation_passed",
         "notes": "Repaired harmonic summary wording for positive_outlook, competency, and reactive groups with stress-response framing and non-diagnostic boundaries; required local validation passed."
+      },
+      {
+        "at": "2026-07-03T13:31:00Z",
+        "status": "pr_opened",
+        "notes": "Opened PR #2669 for harmonic summary content repair; awaiting GitHub required checks."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-11",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2669",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
@@ -12903,7 +12908,7 @@
       "status": "pass",
       "evidence": "Changed files are confined to harmonic summary group registry content and train ledger reconciliation."
     },
-    "status": "local_validation_passed",
+    "status": "pr_opened",
     "title": "ENNEA-RP-11: fix(enneagram): repair harmonic summary content",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12858,9 +12858,14 @@
         "status": "pass",
         "command": "git diff --check",
         "evidence": "No whitespace errors."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2669 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All required GitHub checks passed on PR #2669 head e07f3b7ac860976634a3fc7bac7ba71ea869e924."
       }
     },
-    "commit_sha": null,
+    "commit_sha": "e07f3b7ac860976634a3fc7bac7ba71ea869e924",
     "depends_on": [
       "ENNEA-RP-10"
     ],
@@ -12884,6 +12889,11 @@
         "at": "2026-07-03T13:31:00Z",
         "status": "pr_opened",
         "notes": "Opened PR #2669 for harmonic summary content repair; awaiting GitHub required checks."
+      },
+      {
+        "at": "2026-07-03T13:38:00Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub required checks passed for PR #2669 and mergeStateStatus was CLEAN; scope remains confined to harmonic group registry content and train ledger."
       }
     ],
     "failure_reason": null,
@@ -12908,7 +12918,7 @@
       "status": "pass",
       "evidence": "Changed files are confined to harmonic summary group registry content and train ledger reconciliation."
     },
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "title": "ENNEA-RP-11: fix(enneagram): repair harmonic summary content",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -12784,14 +12784,19 @@
         "at": "2026-07-03T08:22:00Z",
         "status": "ready_to_merge",
         "notes": "GitHub required checks passed for PR #2666; scope remains confined to stance group registry content and train ledger."
+      },
+      {
+        "at": "2026-07-03T05:02:18Z",
+        "status": "merged",
+        "notes": "PR #2666 squash-merged as c3d5f352a102e4bbccfa987d26509ae585616758; merge commit present in origin/main; local main synced and task branch cleaned up before ENNEA-RP-11."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-10",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-03T05:02:18Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2666",
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "allowed_files": [
@@ -12808,7 +12813,7 @@
       "status": "pass",
       "evidence": "Changed files are confined to stance summary group registry content and train ledger reconciliation."
     },
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "ENNEA-RP-10: fix(enneagram): repair stance summary content",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },
@@ -12819,6 +12824,40 @@
       "authorization": {
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
         "status": "pass"
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-10 merged as PR #2666 and merge commit c3d5f352a102e4bbccfa987d26509ae585616758 is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All ENNEAGRAM v2 registry JSON files parsed successfully."
+      },
+      "type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed: 2 warnings, 14509 assertions."
+      },
+      "registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Passed: 3 warnings, 26 assertions."
+      },
+      "composer_v2_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Passed: 15 warnings, 128 assertions."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed: 262 warnings, 2 passed, 83412 assertions, duration 32.40s."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
       }
     },
     "commit_sha": null,
@@ -12830,6 +12869,16 @@
         "at": "2026-07-02T16:10:24Z",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
         "status": "pending_dependency"
+      },
+      {
+        "at": "2026-07-03T13:18:00Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-11-harmonic-summary; scope is harmonic group registry content plus train ledger only."
+      },
+      {
+        "at": "2026-07-03T13:27:00Z",
+        "status": "local_validation_passed",
+        "notes": "Repaired harmonic summary wording for positive_outlook, competency, and reactive groups with stress-response framing and non-diagnostic boundaries; required local validation passed."
       }
     ],
     "failure_reason": null,
@@ -12846,9 +12895,15 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "changed_files": [
+        "backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "outside_scope_files": [],
+      "status": "pass",
+      "evidence": "Changed files are confined to harmonic summary group registry content and train ledger reconciliation."
     },
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "title": "ENNEA-RP-11: fix(enneagram): repair harmonic summary content",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },


### PR DESCRIPTION
What changed:
- Rewrote positive_outlook, competency, and reactive harmonic group copy as pressure-response observation clues.
- Added harmonic-specific boundary notes and not_for fields to prevent ability, mental-health, morality, impulsivity, relationship-risk, and fixed personality interpretations.
- Reconciled ENNEA-RP-10 post-merge ledger state and recorded ENNEA-RP-11 local validation.

Why:
- Harmonic content should remain a theory-based stress-response frame, not an ability trait, emotionality label, or evaluative personality verdict.

Validation:
- cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json
- cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest
- cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest
- cd backend && php artisan test --filter=EnneagramReportComposerV2Test
- cd backend && php artisan test --filter=Enneagram
- git diff --check

Scope validation:
- Changed files are confined to backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json and docs/codex/pr-train-state.json.

Intentionally deferred:
- no fap-web changes
- no runtime/API changes
- no staging deploy wait
- no server verification
- no registry activation
- no production deploy
