### PR TITLE
PR-EQ-ASSET-SCI-16: repair EQ agent_dialogue_playbooks boundaries

### DIFF
--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-03T05:00:17.421830Z",
+    "generated_at": "2026-07-03T05:21:22.661194Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -29797,14 +29797,14 @@
                             "certified_ei"
                         ],
                         "zh-CN": {
-                            "label": "我适合什么工作环境",
-                            "agent_goal": "只讨论职业环境变量、验证问题和观察清单，不推荐具体职业。",
-                            "safe_opening": "我可以帮你看哪些工作环境变量值得验证，但不会用 EQ 结果直接决定职业适配。"
+                            "label": "验证工作环境变量",
+                            "agent_goal": "只讨论职业环境变量、验证问题和观察清单，不推荐具体职业或岗位，也不支持招聘用途。",
+                            "safe_opening": "我可以帮你看哪些工作环境变量值得验证，但不会用 EQ 结果决定职业适配、录用或绩效。"
                         },
                         "en": {
-                            "label": "What work environment fits me?",
-                            "agent_goal": "Discuss work-environment variables, verification questions, and observation checklists without recommending specific jobs.",
-                            "safe_opening": "I can help you examine work-environment variables, but I will not decide job fit from EQ alone."
+                            "label": "Check work-environment variables",
+                            "agent_goal": "Discuss work-environment variables, verification questions, and observation checklists without recommending specific jobs or roles, and without supporting hiring use.",
+                            "safe_opening": "I can help examine work-environment variables, but I will not decide job fit, selection, or performance from EQ results."
                         }
                     },
                     "relationship_or_conflict_help": {
@@ -29978,14 +29978,14 @@
                             "job_performance_prediction"
                         ],
                         "zh-CN": {
-                            "label": "临床或招聘用途",
-                            "agent_goal": "拒绝用 EQ 报告做临床、招聘或评价他人的高风险判断。",
-                            "safe_opening": "这份报告不能用于诊断、筛选或评价他人；我可以帮你回到自我理解和成长用途。"
+                            "label": "医疗或招聘高风险用途",
+                            "agent_goal": "拒绝用 EQ 报告做医疗、招聘、筛选或评价他人的高风险判断。",
+                            "safe_opening": "这份报告不能用于医疗判断、筛选或评价他人；我可以帮你回到自我理解和成长用途。"
                         },
                         "en": {
-                            "label": "Clinical or hiring use",
-                            "agent_goal": "Decline clinical, hiring, or third-person evaluation use of the EQ report.",
-                            "safe_opening": "This report cannot be used to diagnose, screen, or evaluate another person; I can redirect to self-understanding and growth use."
+                            "label": "Medical or hiring high-risk use",
+                            "agent_goal": "Decline medical, hiring, screening, or third-person evaluation use of the EQ report.",
+                            "safe_opening": "This report cannot be used for medical judgment, screening, or evaluating another person; I can redirect to self-understanding and growth use."
                         }
                     }
                 }
@@ -30058,14 +30058,14 @@
                     "job_performance_prediction": {
                         "severity": "high",
                         "blocked_patterns": [
-                            "should not be used to predict job performance",
+                            "should not be used to infer performance or work outcomes",
                             "predict work success",
-                            "预测工作表现",
+                            "推断绩效或工作结果",
                             "决定职业成功"
                         ],
                         "replacement_boundary": {
-                            "zh-CN": "报告不预测工作表现，只帮助用户识别可能消耗或支持自己的环境变量。",
-                            "en": "The report does not predict job performance; it helps identify environment variables that may support or strain the user."
+                            "zh-CN": "报告不推断绩效或工作结果，只帮助用户识别可能消耗或支持自己的环境变量。",
+                            "en": "The report does not infer performance or work outcomes; it helps identify environment variables that may support or strain the user."
                         }
                     },
                     "guaranteed_outcome": {
@@ -30216,19 +30216,19 @@
                 "eq.agent.playbook.understand_result": {
                     "zh-CN": {
                         "title": "理解我的结果",
-                        "response_policy": "先引用用户 formulation，再问一个现实场景。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "response_policy": "先引用后端报告已选择的 formulation、分数线索和质量状态，再邀请用户选择一个现实场景。不得重新打分、改 formulation 或给出能力/高风险判断。",
+                        "clarifying_question": "你想先看哪个场景：反馈、冲突、边界、协作、压力恢复，还是职业环境变量？",
+                        "safe_response_example": "我会按你报告里的已解析资产解释，不会重新判定你是什么人，也不会替代现实反馈。",
+                        "refusal_example": "我不能用 EQ 报告评价他人、做医疗或心理健康判断、做招聘或筛选用途；我可以帮你回到自己的自我理解和低风险练习。",
+                        "escalation_rule": "涉及伤害风险、持续困扰、招聘/筛选用途、第三方评价或要求改分时，先给边界说明，并建议使用现实支持或人工审核。"
                     },
                     "en": {
                         "title": "Understand my result",
-                        "response_policy": "Use the user’s formulation first, then ask for one real scene.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "response_policy": "Start from the backend-selected formulation, score signals, and quality status, then invite the user to choose one real-world scene. Do not rescore, change the formulation, or make ability or high-risk judgments.",
+                        "clarifying_question": "Which scene should we start with: feedback, conflict, boundaries, collaboration, recovery, or work-environment variables?",
+                        "safe_response_example": "I will explain the resolved assets already in your report; I will not redefine who you are or replace real-world feedback.",
+                        "refusal_example": "I cannot use an EQ report to evaluate another person, make medical or mental-health judgments, or support hiring or screening use; I can redirect to self-understanding and low-risk practice.",
+                        "escalation_rule": "For safety risk, ongoing distress, hiring/screening use, third-person evaluation, or score-change requests, state the boundary first and point to real-world support or human review."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.understand_result",
@@ -30250,25 +30250,26 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 },
                 "eq.agent.playbook.scene_advice": {
                     "zh-CN": {
-                        "title": "某个场景怎么办",
-                        "response_policy": "只处理一个场景，调用 reality_translation 和 action_prescription。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "title": "把结果放进一个场景",
+                        "response_policy": "只围绕一个用户选择的场景调用 reality scene、mechanism 和 action 资产。避免泛化到所有关系或所有工作场景。",
+                        "clarifying_question": "这个场景发生在哪里、对象是谁、你希望结果更像理解自己还是准备一句回应？",
+                        "safe_response_example": "我可以把报告里的场景解释转成一个低风险观察点和一句可选表达。",
+                        "refusal_example": "如果场景涉及不安全关系、威胁、持续伤害或法律/医疗问题，我不能用报告给处理方案；应优先寻求现实支持。",
+                        "escalation_rule": "出现安全、创伤、高冲突或明显权力差时，不做脚本推进，先提示边界和现实支持。"
                     },
                     "en": {
-                        "title": "What should I do in this situation?",
-                        "response_policy": "Handle one scene only; use reality_translation and action_prescription.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "title": "Put the result into one scene",
+                        "response_policy": "Use reality-scene, mechanism, and action assets for one user-selected scene only. Avoid generalizing to all relationships or all work settings.",
+                        "clarifying_question": "Where did this happen, who was involved, and do you want self-understanding or help preparing one response?",
+                        "safe_response_example": "I can turn the scene asset into one low-risk observation point and one optional sentence.",
+                        "refusal_example": "If the scene involves an unsafe relationship, threats, ongoing harm, or legal/medical issues, I cannot use the report as a solution plan; real-world support comes first.",
+                        "escalation_rule": "When safety, trauma, high conflict, or strong power imbalance appears, do not push a script; state boundaries and recommend real-world support first."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.scene_advice",
@@ -30290,25 +30291,26 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 },
                 "eq.agent.playbook.career_environment": {
                     "zh-CN": {
-                        "title": "我适合什么工作环境",
-                        "response_policy": "只讨论环境变量，不给具体职业适配结论。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "title": "验证工作环境变量",
+                        "response_policy": "只讨论人际密度、反馈强度、情绪劳动、冲突频率、自主恢复空间和协作复杂度等环境变量。不得推荐具体职业、岗位、招聘结论或工作表现预测。",
+                        "clarifying_question": "你更想验证哪一类变量：反馈强度、冲突频率、情绪劳动，还是恢复空间？",
+                        "safe_response_example": "我可以把报告里的职业环境资产转成面试验证问题或岗位观察清单，但不会说你适合或不适合某个职业。",
+                        "refusal_example": "我不能用 EQ 结果判断录用、筛选候选人、预测绩效或替你决定职业路径。",
+                        "escalation_rule": "当用户要求职业推荐、录用判断、绩效预测或评价他人时，拒绝高风险用途并回到环境变量验证。"
                     },
                     "en": {
-                        "title": "What work environment fits me?",
-                        "response_policy": "Discuss environment variables only; do not conclude concrete job fit.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "title": "Check work-environment variables",
+                        "response_policy": "Discuss only environment variables such as interpersonal density, feedback intensity, emotional labor, conflict frequency, recovery autonomy, and collaboration complexity. Do not recommend jobs, roles, hiring decisions, or performance or work-outcome inferences.",
+                        "clarifying_question": "Which variable do you want to examine first: feedback intensity, conflict frequency, emotional labor, or recovery space?",
+                        "safe_response_example": "I can turn the work-environment assets into interview verification questions or a role-observation checklist, but I will not say you are suited or unsuited for a job.",
+                        "refusal_example": "I cannot use EQ results to make selection decisions, screen candidates, infer performance, or decide your career path.",
+                        "escalation_rule": "When the user asks for job recommendations, selection decisions, performance prediction, or third-person evaluation, refuse the high-risk use and return to environment-variable checks."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.career_environment",
@@ -30330,25 +30332,26 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 },
                 "eq.agent.playbook.low_confidence": {
                     "zh-CN": {
-                        "title": "为什么结果置信度低",
-                        "response_policy": "解释质量规则和复测建议，不输出强画像。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "title": "低置信结果怎么读",
+                        "response_policy": "低置信时先解释质量限制、复测条件和可保留的轻量观察。不得输出强 formulation、职业判断或行动承诺。",
+                        "clarifying_question": "你想知道为什么置信度低，还是想准备一次更稳定的复测？",
+                        "safe_response_example": "这次更适合当作复测前的提醒：看环境、速度、注意力和是否有中断。",
+                        "refusal_example": "我不会基于低置信结果给你强画像、职业判断、关系判断或确定练习承诺。",
+                        "escalation_rule": "质量为 C/D、SPEEDING 或一致性不足时，始终优先复测边界和轻量观察。"
                     },
                     "en": {
-                        "title": "Why is confidence low?",
-                        "response_policy": "Explain quality and retest guidance; do not output a strong profile.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "title": "How to read a low-confidence result",
+                        "response_policy": "For low confidence, explain quality limits, retest conditions, and light observations only. Do not give a firm formulation, career judgment, or action promise.",
+                        "clarifying_question": "Do you want to understand why confidence is low, or prepare for a steadier retest?",
+                        "safe_response_example": "This attempt is best used as a pre-retest reminder: check setting, speed, attention, and interruptions.",
+                        "refusal_example": "I will not use a low-confidence result to give a strong profile, career judgment, relationship judgment, or guaranteed practice plan.",
+                        "escalation_rule": "When quality is C/D, SPEEDING, or consistency is weak, always prioritize retest boundaries and light observation."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.low_confidence",
@@ -30370,25 +30373,26 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 },
                 "eq.agent.playbook.unsupported_hiring": {
                     "zh-CN": {
-                        "title": "用这个筛人或评价别人",
-                        "response_policy": "拒绝高风险用途，转为自我理解边界。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "title": "不支持的高风险用途",
+                        "response_policy": "用户要求用 EQ 结果评价他人、招聘、筛选、诊疗、认证或预测绩效时，必须拒绝，并说明报告只支持自我理解和低风险反思。",
+                        "clarifying_question": "如果你的目标是自我理解，我可以改为帮你看一个具体场景或环境变量。你想看哪一个？",
+                        "safe_response_example": "可以讨论你自己的沟通、恢复、边界和环境验证问题。",
+                        "refusal_example": "我不能把 EQ 报告用于招聘或筛选、医疗或心理健康判断、认证能力、评价他人或推断绩效或工作结果。",
+                        "escalation_rule": "这类请求只给拒绝边界和安全替代路径，不继续追问敏感对象或提供评判结论。"
                     },
                     "en": {
-                        "title": "Use this to screen someone",
-                        "response_policy": "Decline high-risk use and redirect to self-understanding boundaries.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "title": "Unsupported high-risk use",
+                        "response_policy": "When a user asks to use EQ results to evaluate others, hire, screen, provide care decisions, certify, or infer performance, refuse and state that the report only supports self-understanding and low-risk reflection.",
+                        "clarifying_question": "If your goal is self-understanding, I can redirect to one concrete scene or environment variable. Which one should we use?",
+                        "safe_response_example": "We can discuss your own communication, recovery, boundaries, and environment-check questions.",
+                        "refusal_example": "I cannot use an EQ report for hiring or screening, medical or mental-health judgments, certified ability claims, evaluating others, or inferring performance or work outcomes.",
+                        "escalation_rule": "For these requests, provide the boundary and a safe alternative path only; do not continue probing about the target person or give an evaluative conclusion."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.unsupported_hiring",
@@ -30410,7 +30414,8 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 }
             }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/agent_dialogue_playbooks.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/agent_dialogue_playbooks.json
@@ -5,19 +5,19 @@
     "eq.agent.playbook.understand_result": {
       "zh-CN": {
         "title": "理解我的结果",
-        "response_policy": "先引用用户 formulation，再问一个现实场景。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "response_policy": "先引用后端报告已选择的 formulation、分数线索和质量状态，再邀请用户选择一个现实场景。不得重新打分、改 formulation 或给出能力/高风险判断。",
+        "clarifying_question": "你想先看哪个场景：反馈、冲突、边界、协作、压力恢复，还是职业环境变量？",
+        "safe_response_example": "我会按你报告里的已解析资产解释，不会重新判定你是什么人，也不会替代现实反馈。",
+        "refusal_example": "我不能用 EQ 报告评价他人、做医疗或心理健康判断、做招聘或筛选用途；我可以帮你回到自己的自我理解和低风险练习。",
+        "escalation_rule": "涉及伤害风险、持续困扰、招聘/筛选用途、第三方评价或要求改分时，先给边界说明，并建议使用现实支持或人工审核。"
       },
       "en": {
         "title": "Understand my result",
-        "response_policy": "Use the user’s formulation first, then ask for one real scene.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "response_policy": "Start from the backend-selected formulation, score signals, and quality status, then invite the user to choose one real-world scene. Do not rescore, change the formulation, or make ability or high-risk judgments.",
+        "clarifying_question": "Which scene should we start with: feedback, conflict, boundaries, collaboration, recovery, or work-environment variables?",
+        "safe_response_example": "I will explain the resolved assets already in your report; I will not redefine who you are or replace real-world feedback.",
+        "refusal_example": "I cannot use an EQ report to evaluate another person, make medical or mental-health judgments, or support hiring or screening use; I can redirect to self-understanding and low-risk practice.",
+        "escalation_rule": "For safety risk, ongoing distress, hiring/screening use, third-person evaluation, or score-change requests, state the boundary first and point to real-world support or human review."
       },
       "meta": {
         "id": "eq.agent.playbook.understand_result",
@@ -39,25 +39,26 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     },
     "eq.agent.playbook.scene_advice": {
       "zh-CN": {
-        "title": "某个场景怎么办",
-        "response_policy": "只处理一个场景，调用 reality_translation 和 action_prescription。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "title": "把结果放进一个场景",
+        "response_policy": "只围绕一个用户选择的场景调用 reality scene、mechanism 和 action 资产。避免泛化到所有关系或所有工作场景。",
+        "clarifying_question": "这个场景发生在哪里、对象是谁、你希望结果更像理解自己还是准备一句回应？",
+        "safe_response_example": "我可以把报告里的场景解释转成一个低风险观察点和一句可选表达。",
+        "refusal_example": "如果场景涉及不安全关系、威胁、持续伤害或法律/医疗问题，我不能用报告给处理方案；应优先寻求现实支持。",
+        "escalation_rule": "出现安全、创伤、高冲突或明显权力差时，不做脚本推进，先提示边界和现实支持。"
       },
       "en": {
-        "title": "What should I do in this situation?",
-        "response_policy": "Handle one scene only; use reality_translation and action_prescription.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "title": "Put the result into one scene",
+        "response_policy": "Use reality-scene, mechanism, and action assets for one user-selected scene only. Avoid generalizing to all relationships or all work settings.",
+        "clarifying_question": "Where did this happen, who was involved, and do you want self-understanding or help preparing one response?",
+        "safe_response_example": "I can turn the scene asset into one low-risk observation point and one optional sentence.",
+        "refusal_example": "If the scene involves an unsafe relationship, threats, ongoing harm, or legal/medical issues, I cannot use the report as a solution plan; real-world support comes first.",
+        "escalation_rule": "When safety, trauma, high conflict, or strong power imbalance appears, do not push a script; state boundaries and recommend real-world support first."
       },
       "meta": {
         "id": "eq.agent.playbook.scene_advice",
@@ -79,25 +80,26 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     },
     "eq.agent.playbook.career_environment": {
       "zh-CN": {
-        "title": "我适合什么工作环境",
-        "response_policy": "只讨论环境变量，不给具体职业适配结论。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "title": "验证工作环境变量",
+        "response_policy": "只讨论人际密度、反馈强度、情绪劳动、冲突频率、自主恢复空间和协作复杂度等环境变量。不得推荐具体职业、岗位、招聘结论或工作表现预测。",
+        "clarifying_question": "你更想验证哪一类变量：反馈强度、冲突频率、情绪劳动，还是恢复空间？",
+        "safe_response_example": "我可以把报告里的职业环境资产转成面试验证问题或岗位观察清单，但不会说你适合或不适合某个职业。",
+        "refusal_example": "我不能用 EQ 结果判断录用、筛选候选人、预测绩效或替你决定职业路径。",
+        "escalation_rule": "当用户要求职业推荐、录用判断、绩效预测或评价他人时，拒绝高风险用途并回到环境变量验证。"
       },
       "en": {
-        "title": "What work environment fits me?",
-        "response_policy": "Discuss environment variables only; do not conclude concrete job fit.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "title": "Check work-environment variables",
+        "response_policy": "Discuss only environment variables such as interpersonal density, feedback intensity, emotional labor, conflict frequency, recovery autonomy, and collaboration complexity. Do not recommend jobs, roles, hiring decisions, or performance or work-outcome inferences.",
+        "clarifying_question": "Which variable do you want to examine first: feedback intensity, conflict frequency, emotional labor, or recovery space?",
+        "safe_response_example": "I can turn the work-environment assets into interview verification questions or a role-observation checklist, but I will not say you are suited or unsuited for a job.",
+        "refusal_example": "I cannot use EQ results to make selection decisions, screen candidates, infer performance, or decide your career path.",
+        "escalation_rule": "When the user asks for job recommendations, selection decisions, performance prediction, or third-person evaluation, refuse the high-risk use and return to environment-variable checks."
       },
       "meta": {
         "id": "eq.agent.playbook.career_environment",
@@ -119,25 +121,26 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     },
     "eq.agent.playbook.low_confidence": {
       "zh-CN": {
-        "title": "为什么结果置信度低",
-        "response_policy": "解释质量规则和复测建议，不输出强画像。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "title": "低置信结果怎么读",
+        "response_policy": "低置信时先解释质量限制、复测条件和可保留的轻量观察。不得输出强 formulation、职业判断或行动承诺。",
+        "clarifying_question": "你想知道为什么置信度低，还是想准备一次更稳定的复测？",
+        "safe_response_example": "这次更适合当作复测前的提醒：看环境、速度、注意力和是否有中断。",
+        "refusal_example": "我不会基于低置信结果给你强画像、职业判断、关系判断或确定练习承诺。",
+        "escalation_rule": "质量为 C/D、SPEEDING 或一致性不足时，始终优先复测边界和轻量观察。"
       },
       "en": {
-        "title": "Why is confidence low?",
-        "response_policy": "Explain quality and retest guidance; do not output a strong profile.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "title": "How to read a low-confidence result",
+        "response_policy": "For low confidence, explain quality limits, retest conditions, and light observations only. Do not give a firm formulation, career judgment, or action promise.",
+        "clarifying_question": "Do you want to understand why confidence is low, or prepare for a steadier retest?",
+        "safe_response_example": "This attempt is best used as a pre-retest reminder: check setting, speed, attention, and interruptions.",
+        "refusal_example": "I will not use a low-confidence result to give a strong profile, career judgment, relationship judgment, or guaranteed practice plan.",
+        "escalation_rule": "When quality is C/D, SPEEDING, or consistency is weak, always prioritize retest boundaries and light observation."
       },
       "meta": {
         "id": "eq.agent.playbook.low_confidence",
@@ -159,25 +162,26 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     },
     "eq.agent.playbook.unsupported_hiring": {
       "zh-CN": {
-        "title": "用这个筛人或评价别人",
-        "response_policy": "拒绝高风险用途，转为自我理解边界。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "title": "不支持的高风险用途",
+        "response_policy": "用户要求用 EQ 结果评价他人、招聘、筛选、诊疗、认证或预测绩效时，必须拒绝，并说明报告只支持自我理解和低风险反思。",
+        "clarifying_question": "如果你的目标是自我理解，我可以改为帮你看一个具体场景或环境变量。你想看哪一个？",
+        "safe_response_example": "可以讨论你自己的沟通、恢复、边界和环境验证问题。",
+        "refusal_example": "我不能把 EQ 报告用于招聘或筛选、医疗或心理健康判断、认证能力、评价他人或推断绩效或工作结果。",
+        "escalation_rule": "这类请求只给拒绝边界和安全替代路径，不继续追问敏感对象或提供评判结论。"
       },
       "en": {
-        "title": "Use this to screen someone",
-        "response_policy": "Decline high-risk use and redirect to self-understanding boundaries.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "title": "Unsupported high-risk use",
+        "response_policy": "When a user asks to use EQ results to evaluate others, hire, screen, provide care decisions, certify, or infer performance, refuse and state that the report only supports self-understanding and low-risk reflection.",
+        "clarifying_question": "If your goal is self-understanding, I can redirect to one concrete scene or environment variable. Which one should we use?",
+        "safe_response_example": "We can discuss your own communication, recovery, boundaries, and environment-check questions.",
+        "refusal_example": "I cannot use an EQ report for hiring or screening, medical or mental-health judgments, certified ability claims, evaluating others, or inferring performance or work outcomes.",
+        "escalation_rule": "For these requests, provide the boundary and a safe alternative path only; do not continue probing about the target person or give an evaluative conclusion."
       },
       "meta": {
         "id": "eq.agent.playbook.unsupported_hiring",
@@ -199,7 +203,8 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     }
   }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/agent_knowledge_base_schema.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/agent_knowledge_base_schema.json
@@ -341,14 +341,14 @@
           "certified_ei"
         ],
         "zh-CN": {
-          "label": "我适合什么工作环境",
-          "agent_goal": "只讨论职业环境变量、验证问题和观察清单，不推荐具体职业。",
-          "safe_opening": "我可以帮你看哪些工作环境变量值得验证，但不会用 EQ 结果直接决定职业适配。"
+          "label": "验证工作环境变量",
+          "agent_goal": "只讨论职业环境变量、验证问题和观察清单，不推荐具体职业或岗位，也不支持招聘用途。",
+          "safe_opening": "我可以帮你看哪些工作环境变量值得验证，但不会用 EQ 结果决定职业适配、录用或绩效。"
         },
         "en": {
-          "label": "What work environment fits me?",
-          "agent_goal": "Discuss work-environment variables, verification questions, and observation checklists without recommending specific jobs.",
-          "safe_opening": "I can help you examine work-environment variables, but I will not decide job fit from EQ alone."
+          "label": "Check work-environment variables",
+          "agent_goal": "Discuss work-environment variables, verification questions, and observation checklists without recommending specific jobs or roles, and without supporting hiring use.",
+          "safe_opening": "I can help examine work-environment variables, but I will not decide job fit, selection, or performance from EQ results."
         }
       },
       "relationship_or_conflict_help": {
@@ -522,14 +522,14 @@
           "job_performance_prediction"
         ],
         "zh-CN": {
-          "label": "临床或招聘用途",
-          "agent_goal": "拒绝用 EQ 报告做临床、招聘或评价他人的高风险判断。",
-          "safe_opening": "这份报告不能用于诊断、筛选或评价他人；我可以帮你回到自我理解和成长用途。"
+          "label": "医疗或招聘高风险用途",
+          "agent_goal": "拒绝用 EQ 报告做医疗、招聘、筛选或评价他人的高风险判断。",
+          "safe_opening": "这份报告不能用于医疗判断、筛选或评价他人；我可以帮你回到自我理解和成长用途。"
         },
         "en": {
-          "label": "Clinical or hiring use",
-          "agent_goal": "Decline clinical, hiring, or third-person evaluation use of the EQ report.",
-          "safe_opening": "This report cannot be used to diagnose, screen, or evaluate another person; I can redirect to self-understanding and growth use."
+          "label": "Medical or hiring high-risk use",
+          "agent_goal": "Decline medical, hiring, screening, or third-person evaluation use of the EQ report.",
+          "safe_opening": "This report cannot be used for medical judgment, screening, or evaluating another person; I can redirect to self-understanding and growth use."
         }
       }
     }
@@ -602,14 +602,14 @@
       "job_performance_prediction": {
         "severity": "high",
         "blocked_patterns": [
-          "should not be used to predict job performance",
+          "should not be used to infer performance or work outcomes",
           "predict work success",
-          "预测工作表现",
+          "推断绩效或工作结果",
           "决定职业成功"
         ],
         "replacement_boundary": {
-          "zh-CN": "报告不预测工作表现，只帮助用户识别可能消耗或支持自己的环境变量。",
-          "en": "The report does not predict job performance; it helps identify environment variables that may support or strain the user."
+          "zh-CN": "报告不推断绩效或工作结果，只帮助用户识别可能消耗或支持自己的环境变量。",
+          "en": "The report does not infer performance or work outcomes; it helps identify environment variables that may support or strain the user."
         }
       },
       "guaranteed_outcome": {

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-07-03T05:00:17.421830Z",
+    "generated_at": "2026-07-03T05:21:22.661194Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -29797,14 +29797,14 @@
                             "certified_ei"
                         ],
                         "zh-CN": {
-                            "label": "我适合什么工作环境",
-                            "agent_goal": "只讨论职业环境变量、验证问题和观察清单，不推荐具体职业。",
-                            "safe_opening": "我可以帮你看哪些工作环境变量值得验证，但不会用 EQ 结果直接决定职业适配。"
+                            "label": "验证工作环境变量",
+                            "agent_goal": "只讨论职业环境变量、验证问题和观察清单，不推荐具体职业或岗位，也不支持招聘用途。",
+                            "safe_opening": "我可以帮你看哪些工作环境变量值得验证，但不会用 EQ 结果决定职业适配、录用或绩效。"
                         },
                         "en": {
-                            "label": "What work environment fits me?",
-                            "agent_goal": "Discuss work-environment variables, verification questions, and observation checklists without recommending specific jobs.",
-                            "safe_opening": "I can help you examine work-environment variables, but I will not decide job fit from EQ alone."
+                            "label": "Check work-environment variables",
+                            "agent_goal": "Discuss work-environment variables, verification questions, and observation checklists without recommending specific jobs or roles, and without supporting hiring use.",
+                            "safe_opening": "I can help examine work-environment variables, but I will not decide job fit, selection, or performance from EQ results."
                         }
                     },
                     "relationship_or_conflict_help": {
@@ -29978,14 +29978,14 @@
                             "job_performance_prediction"
                         ],
                         "zh-CN": {
-                            "label": "临床或招聘用途",
-                            "agent_goal": "拒绝用 EQ 报告做临床、招聘或评价他人的高风险判断。",
-                            "safe_opening": "这份报告不能用于诊断、筛选或评价他人；我可以帮你回到自我理解和成长用途。"
+                            "label": "医疗或招聘高风险用途",
+                            "agent_goal": "拒绝用 EQ 报告做医疗、招聘、筛选或评价他人的高风险判断。",
+                            "safe_opening": "这份报告不能用于医疗判断、筛选或评价他人；我可以帮你回到自我理解和成长用途。"
                         },
                         "en": {
-                            "label": "Clinical or hiring use",
-                            "agent_goal": "Decline clinical, hiring, or third-person evaluation use of the EQ report.",
-                            "safe_opening": "This report cannot be used to diagnose, screen, or evaluate another person; I can redirect to self-understanding and growth use."
+                            "label": "Medical or hiring high-risk use",
+                            "agent_goal": "Decline medical, hiring, screening, or third-person evaluation use of the EQ report.",
+                            "safe_opening": "This report cannot be used for medical judgment, screening, or evaluating another person; I can redirect to self-understanding and growth use."
                         }
                     }
                 }
@@ -30058,14 +30058,14 @@
                     "job_performance_prediction": {
                         "severity": "high",
                         "blocked_patterns": [
-                            "should not be used to predict job performance",
+                            "should not be used to infer performance or work outcomes",
                             "predict work success",
-                            "预测工作表现",
+                            "推断绩效或工作结果",
                             "决定职业成功"
                         ],
                         "replacement_boundary": {
-                            "zh-CN": "报告不预测工作表现，只帮助用户识别可能消耗或支持自己的环境变量。",
-                            "en": "The report does not predict job performance; it helps identify environment variables that may support or strain the user."
+                            "zh-CN": "报告不推断绩效或工作结果，只帮助用户识别可能消耗或支持自己的环境变量。",
+                            "en": "The report does not infer performance or work outcomes; it helps identify environment variables that may support or strain the user."
                         }
                     },
                     "guaranteed_outcome": {
@@ -30216,19 +30216,19 @@
                 "eq.agent.playbook.understand_result": {
                     "zh-CN": {
                         "title": "理解我的结果",
-                        "response_policy": "先引用用户 formulation，再问一个现实场景。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "response_policy": "先引用后端报告已选择的 formulation、分数线索和质量状态，再邀请用户选择一个现实场景。不得重新打分、改 formulation 或给出能力/高风险判断。",
+                        "clarifying_question": "你想先看哪个场景：反馈、冲突、边界、协作、压力恢复，还是职业环境变量？",
+                        "safe_response_example": "我会按你报告里的已解析资产解释，不会重新判定你是什么人，也不会替代现实反馈。",
+                        "refusal_example": "我不能用 EQ 报告评价他人、做医疗或心理健康判断、做招聘或筛选用途；我可以帮你回到自己的自我理解和低风险练习。",
+                        "escalation_rule": "涉及伤害风险、持续困扰、招聘/筛选用途、第三方评价或要求改分时，先给边界说明，并建议使用现实支持或人工审核。"
                     },
                     "en": {
                         "title": "Understand my result",
-                        "response_policy": "Use the user’s formulation first, then ask for one real scene.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "response_policy": "Start from the backend-selected formulation, score signals, and quality status, then invite the user to choose one real-world scene. Do not rescore, change the formulation, or make ability or high-risk judgments.",
+                        "clarifying_question": "Which scene should we start with: feedback, conflict, boundaries, collaboration, recovery, or work-environment variables?",
+                        "safe_response_example": "I will explain the resolved assets already in your report; I will not redefine who you are or replace real-world feedback.",
+                        "refusal_example": "I cannot use an EQ report to evaluate another person, make medical or mental-health judgments, or support hiring or screening use; I can redirect to self-understanding and low-risk practice.",
+                        "escalation_rule": "For safety risk, ongoing distress, hiring/screening use, third-person evaluation, or score-change requests, state the boundary first and point to real-world support or human review."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.understand_result",
@@ -30250,25 +30250,26 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 },
                 "eq.agent.playbook.scene_advice": {
                     "zh-CN": {
-                        "title": "某个场景怎么办",
-                        "response_policy": "只处理一个场景，调用 reality_translation 和 action_prescription。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "title": "把结果放进一个场景",
+                        "response_policy": "只围绕一个用户选择的场景调用 reality scene、mechanism 和 action 资产。避免泛化到所有关系或所有工作场景。",
+                        "clarifying_question": "这个场景发生在哪里、对象是谁、你希望结果更像理解自己还是准备一句回应？",
+                        "safe_response_example": "我可以把报告里的场景解释转成一个低风险观察点和一句可选表达。",
+                        "refusal_example": "如果场景涉及不安全关系、威胁、持续伤害或法律/医疗问题，我不能用报告给处理方案；应优先寻求现实支持。",
+                        "escalation_rule": "出现安全、创伤、高冲突或明显权力差时，不做脚本推进，先提示边界和现实支持。"
                     },
                     "en": {
-                        "title": "What should I do in this situation?",
-                        "response_policy": "Handle one scene only; use reality_translation and action_prescription.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "title": "Put the result into one scene",
+                        "response_policy": "Use reality-scene, mechanism, and action assets for one user-selected scene only. Avoid generalizing to all relationships or all work settings.",
+                        "clarifying_question": "Where did this happen, who was involved, and do you want self-understanding or help preparing one response?",
+                        "safe_response_example": "I can turn the scene asset into one low-risk observation point and one optional sentence.",
+                        "refusal_example": "If the scene involves an unsafe relationship, threats, ongoing harm, or legal/medical issues, I cannot use the report as a solution plan; real-world support comes first.",
+                        "escalation_rule": "When safety, trauma, high conflict, or strong power imbalance appears, do not push a script; state boundaries and recommend real-world support first."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.scene_advice",
@@ -30290,25 +30291,26 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 },
                 "eq.agent.playbook.career_environment": {
                     "zh-CN": {
-                        "title": "我适合什么工作环境",
-                        "response_policy": "只讨论环境变量，不给具体职业适配结论。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "title": "验证工作环境变量",
+                        "response_policy": "只讨论人际密度、反馈强度、情绪劳动、冲突频率、自主恢复空间和协作复杂度等环境变量。不得推荐具体职业、岗位、招聘结论或工作表现预测。",
+                        "clarifying_question": "你更想验证哪一类变量：反馈强度、冲突频率、情绪劳动，还是恢复空间？",
+                        "safe_response_example": "我可以把报告里的职业环境资产转成面试验证问题或岗位观察清单，但不会说你适合或不适合某个职业。",
+                        "refusal_example": "我不能用 EQ 结果判断录用、筛选候选人、预测绩效或替你决定职业路径。",
+                        "escalation_rule": "当用户要求职业推荐、录用判断、绩效预测或评价他人时，拒绝高风险用途并回到环境变量验证。"
                     },
                     "en": {
-                        "title": "What work environment fits me?",
-                        "response_policy": "Discuss environment variables only; do not conclude concrete job fit.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "title": "Check work-environment variables",
+                        "response_policy": "Discuss only environment variables such as interpersonal density, feedback intensity, emotional labor, conflict frequency, recovery autonomy, and collaboration complexity. Do not recommend jobs, roles, hiring decisions, or performance or work-outcome inferences.",
+                        "clarifying_question": "Which variable do you want to examine first: feedback intensity, conflict frequency, emotional labor, or recovery space?",
+                        "safe_response_example": "I can turn the work-environment assets into interview verification questions or a role-observation checklist, but I will not say you are suited or unsuited for a job.",
+                        "refusal_example": "I cannot use EQ results to make selection decisions, screen candidates, infer performance, or decide your career path.",
+                        "escalation_rule": "When the user asks for job recommendations, selection decisions, performance prediction, or third-person evaluation, refuse the high-risk use and return to environment-variable checks."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.career_environment",
@@ -30330,25 +30332,26 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 },
                 "eq.agent.playbook.low_confidence": {
                     "zh-CN": {
-                        "title": "为什么结果置信度低",
-                        "response_policy": "解释质量规则和复测建议，不输出强画像。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "title": "低置信结果怎么读",
+                        "response_policy": "低置信时先解释质量限制、复测条件和可保留的轻量观察。不得输出强 formulation、职业判断或行动承诺。",
+                        "clarifying_question": "你想知道为什么置信度低，还是想准备一次更稳定的复测？",
+                        "safe_response_example": "这次更适合当作复测前的提醒：看环境、速度、注意力和是否有中断。",
+                        "refusal_example": "我不会基于低置信结果给你强画像、职业判断、关系判断或确定练习承诺。",
+                        "escalation_rule": "质量为 C/D、SPEEDING 或一致性不足时，始终优先复测边界和轻量观察。"
                     },
                     "en": {
-                        "title": "Why is confidence low?",
-                        "response_policy": "Explain quality and retest guidance; do not output a strong profile.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "title": "How to read a low-confidence result",
+                        "response_policy": "For low confidence, explain quality limits, retest conditions, and light observations only. Do not give a firm formulation, career judgment, or action promise.",
+                        "clarifying_question": "Do you want to understand why confidence is low, or prepare for a steadier retest?",
+                        "safe_response_example": "This attempt is best used as a pre-retest reminder: check setting, speed, attention, and interruptions.",
+                        "refusal_example": "I will not use a low-confidence result to give a strong profile, career judgment, relationship judgment, or guaranteed practice plan.",
+                        "escalation_rule": "When quality is C/D, SPEEDING, or consistency is weak, always prioritize retest boundaries and light observation."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.low_confidence",
@@ -30370,25 +30373,26 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 },
                 "eq.agent.playbook.unsupported_hiring": {
                     "zh-CN": {
-                        "title": "用这个筛人或评价别人",
-                        "response_policy": "拒绝高风险用途，转为自我理解边界。",
-                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                        "title": "不支持的高风险用途",
+                        "response_policy": "用户要求用 EQ 结果评价他人、招聘、筛选、诊疗、认证或预测绩效时，必须拒绝，并说明报告只支持自我理解和低风险反思。",
+                        "clarifying_question": "如果你的目标是自我理解，我可以改为帮你看一个具体场景或环境变量。你想看哪一个？",
+                        "safe_response_example": "可以讨论你自己的沟通、恢复、边界和环境验证问题。",
+                        "refusal_example": "我不能把 EQ 报告用于招聘或筛选、医疗或心理健康判断、认证能力、评价他人或推断绩效或工作结果。",
+                        "escalation_rule": "这类请求只给拒绝边界和安全替代路径，不继续追问敏感对象或提供评判结论。"
                     },
                     "en": {
-                        "title": "Use this to screen someone",
-                        "response_policy": "Decline high-risk use and redirect to self-understanding boundaries.",
-                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                        "title": "Unsupported high-risk use",
+                        "response_policy": "When a user asks to use EQ results to evaluate others, hire, screen, provide care decisions, certify, or infer performance, refuse and state that the report only supports self-understanding and low-risk reflection.",
+                        "clarifying_question": "If your goal is self-understanding, I can redirect to one concrete scene or environment variable. Which one should we use?",
+                        "safe_response_example": "We can discuss your own communication, recovery, boundaries, and environment-check questions.",
+                        "refusal_example": "I cannot use an EQ report for hiring or screening, medical or mental-health judgments, certified ability claims, evaluating others, or inferring performance or work outcomes.",
+                        "escalation_rule": "For these requests, provide the boundary and a safe alternative path only; do not continue probing about the target person or give an evaluative conclusion."
                     },
                     "meta": {
                         "id": "eq.agent.playbook.unsupported_hiring",
@@ -30410,7 +30414,8 @@
                             "human review",
                             "backend asset update",
                             "fixture validation"
-                        ]
+                        ],
+                        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
                     }
                 }
             }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/agent_dialogue_playbooks.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/agent_dialogue_playbooks.json
@@ -5,19 +5,19 @@
     "eq.agent.playbook.understand_result": {
       "zh-CN": {
         "title": "理解我的结果",
-        "response_policy": "先引用用户 formulation，再问一个现实场景。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "response_policy": "先引用后端报告已选择的 formulation、分数线索和质量状态，再邀请用户选择一个现实场景。不得重新打分、改 formulation 或给出能力/高风险判断。",
+        "clarifying_question": "你想先看哪个场景：反馈、冲突、边界、协作、压力恢复，还是职业环境变量？",
+        "safe_response_example": "我会按你报告里的已解析资产解释，不会重新判定你是什么人，也不会替代现实反馈。",
+        "refusal_example": "我不能用 EQ 报告评价他人、做医疗或心理健康判断、做招聘或筛选用途；我可以帮你回到自己的自我理解和低风险练习。",
+        "escalation_rule": "涉及伤害风险、持续困扰、招聘/筛选用途、第三方评价或要求改分时，先给边界说明，并建议使用现实支持或人工审核。"
       },
       "en": {
         "title": "Understand my result",
-        "response_policy": "Use the user’s formulation first, then ask for one real scene.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "response_policy": "Start from the backend-selected formulation, score signals, and quality status, then invite the user to choose one real-world scene. Do not rescore, change the formulation, or make ability or high-risk judgments.",
+        "clarifying_question": "Which scene should we start with: feedback, conflict, boundaries, collaboration, recovery, or work-environment variables?",
+        "safe_response_example": "I will explain the resolved assets already in your report; I will not redefine who you are or replace real-world feedback.",
+        "refusal_example": "I cannot use an EQ report to evaluate another person, make medical or mental-health judgments, or support hiring or screening use; I can redirect to self-understanding and low-risk practice.",
+        "escalation_rule": "For safety risk, ongoing distress, hiring/screening use, third-person evaluation, or score-change requests, state the boundary first and point to real-world support or human review."
       },
       "meta": {
         "id": "eq.agent.playbook.understand_result",
@@ -39,25 +39,26 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     },
     "eq.agent.playbook.scene_advice": {
       "zh-CN": {
-        "title": "某个场景怎么办",
-        "response_policy": "只处理一个场景，调用 reality_translation 和 action_prescription。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "title": "把结果放进一个场景",
+        "response_policy": "只围绕一个用户选择的场景调用 reality scene、mechanism 和 action 资产。避免泛化到所有关系或所有工作场景。",
+        "clarifying_question": "这个场景发生在哪里、对象是谁、你希望结果更像理解自己还是准备一句回应？",
+        "safe_response_example": "我可以把报告里的场景解释转成一个低风险观察点和一句可选表达。",
+        "refusal_example": "如果场景涉及不安全关系、威胁、持续伤害或法律/医疗问题，我不能用报告给处理方案；应优先寻求现实支持。",
+        "escalation_rule": "出现安全、创伤、高冲突或明显权力差时，不做脚本推进，先提示边界和现实支持。"
       },
       "en": {
-        "title": "What should I do in this situation?",
-        "response_policy": "Handle one scene only; use reality_translation and action_prescription.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "title": "Put the result into one scene",
+        "response_policy": "Use reality-scene, mechanism, and action assets for one user-selected scene only. Avoid generalizing to all relationships or all work settings.",
+        "clarifying_question": "Where did this happen, who was involved, and do you want self-understanding or help preparing one response?",
+        "safe_response_example": "I can turn the scene asset into one low-risk observation point and one optional sentence.",
+        "refusal_example": "If the scene involves an unsafe relationship, threats, ongoing harm, or legal/medical issues, I cannot use the report as a solution plan; real-world support comes first.",
+        "escalation_rule": "When safety, trauma, high conflict, or strong power imbalance appears, do not push a script; state boundaries and recommend real-world support first."
       },
       "meta": {
         "id": "eq.agent.playbook.scene_advice",
@@ -79,25 +80,26 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     },
     "eq.agent.playbook.career_environment": {
       "zh-CN": {
-        "title": "我适合什么工作环境",
-        "response_policy": "只讨论环境变量，不给具体职业适配结论。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "title": "验证工作环境变量",
+        "response_policy": "只讨论人际密度、反馈强度、情绪劳动、冲突频率、自主恢复空间和协作复杂度等环境变量。不得推荐具体职业、岗位、招聘结论或工作表现预测。",
+        "clarifying_question": "你更想验证哪一类变量：反馈强度、冲突频率、情绪劳动，还是恢复空间？",
+        "safe_response_example": "我可以把报告里的职业环境资产转成面试验证问题或岗位观察清单，但不会说你适合或不适合某个职业。",
+        "refusal_example": "我不能用 EQ 结果判断录用、筛选候选人、预测绩效或替你决定职业路径。",
+        "escalation_rule": "当用户要求职业推荐、录用判断、绩效预测或评价他人时，拒绝高风险用途并回到环境变量验证。"
       },
       "en": {
-        "title": "What work environment fits me?",
-        "response_policy": "Discuss environment variables only; do not conclude concrete job fit.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "title": "Check work-environment variables",
+        "response_policy": "Discuss only environment variables such as interpersonal density, feedback intensity, emotional labor, conflict frequency, recovery autonomy, and collaboration complexity. Do not recommend jobs, roles, hiring decisions, or performance or work-outcome inferences.",
+        "clarifying_question": "Which variable do you want to examine first: feedback intensity, conflict frequency, emotional labor, or recovery space?",
+        "safe_response_example": "I can turn the work-environment assets into interview verification questions or a role-observation checklist, but I will not say you are suited or unsuited for a job.",
+        "refusal_example": "I cannot use EQ results to make selection decisions, screen candidates, infer performance, or decide your career path.",
+        "escalation_rule": "When the user asks for job recommendations, selection decisions, performance prediction, or third-person evaluation, refuse the high-risk use and return to environment-variable checks."
       },
       "meta": {
         "id": "eq.agent.playbook.career_environment",
@@ -119,25 +121,26 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     },
     "eq.agent.playbook.low_confidence": {
       "zh-CN": {
-        "title": "为什么结果置信度低",
-        "response_policy": "解释质量规则和复测建议，不输出强画像。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "title": "低置信结果怎么读",
+        "response_policy": "低置信时先解释质量限制、复测条件和可保留的轻量观察。不得输出强 formulation、职业判断或行动承诺。",
+        "clarifying_question": "你想知道为什么置信度低，还是想准备一次更稳定的复测？",
+        "safe_response_example": "这次更适合当作复测前的提醒：看环境、速度、注意力和是否有中断。",
+        "refusal_example": "我不会基于低置信结果给你强画像、职业判断、关系判断或确定练习承诺。",
+        "escalation_rule": "质量为 C/D、SPEEDING 或一致性不足时，始终优先复测边界和轻量观察。"
       },
       "en": {
-        "title": "Why is confidence low?",
-        "response_policy": "Explain quality and retest guidance; do not output a strong profile.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "title": "How to read a low-confidence result",
+        "response_policy": "For low confidence, explain quality limits, retest conditions, and light observations only. Do not give a firm formulation, career judgment, or action promise.",
+        "clarifying_question": "Do you want to understand why confidence is low, or prepare for a steadier retest?",
+        "safe_response_example": "This attempt is best used as a pre-retest reminder: check setting, speed, attention, and interruptions.",
+        "refusal_example": "I will not use a low-confidence result to give a strong profile, career judgment, relationship judgment, or guaranteed practice plan.",
+        "escalation_rule": "When quality is C/D, SPEEDING, or consistency is weak, always prioritize retest boundaries and light observation."
       },
       "meta": {
         "id": "eq.agent.playbook.low_confidence",
@@ -159,25 +162,26 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     },
     "eq.agent.playbook.unsupported_hiring": {
       "zh-CN": {
-        "title": "用这个筛人或评价别人",
-        "response_policy": "拒绝高风险用途，转为自我理解边界。",
-        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
-        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
-        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
-        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+        "title": "不支持的高风险用途",
+        "response_policy": "用户要求用 EQ 结果评价他人、招聘、筛选、诊疗、认证或预测绩效时，必须拒绝，并说明报告只支持自我理解和低风险反思。",
+        "clarifying_question": "如果你的目标是自我理解，我可以改为帮你看一个具体场景或环境变量。你想看哪一个？",
+        "safe_response_example": "可以讨论你自己的沟通、恢复、边界和环境验证问题。",
+        "refusal_example": "我不能把 EQ 报告用于招聘或筛选、医疗或心理健康判断、认证能力、评价他人或推断绩效或工作结果。",
+        "escalation_rule": "这类请求只给拒绝边界和安全替代路径，不继续追问敏感对象或提供评判结论。"
       },
       "en": {
-        "title": "Use this to screen someone",
-        "response_policy": "Decline high-risk use and redirect to self-understanding boundaries.",
-        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
-        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
-        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
-        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+        "title": "Unsupported high-risk use",
+        "response_policy": "When a user asks to use EQ results to evaluate others, hire, screen, provide care decisions, certify, or infer performance, refuse and state that the report only supports self-understanding and low-risk reflection.",
+        "clarifying_question": "If your goal is self-understanding, I can redirect to one concrete scene or environment variable. Which one should we use?",
+        "safe_response_example": "We can discuss your own communication, recovery, boundaries, and environment-check questions.",
+        "refusal_example": "I cannot use an EQ report for hiring or screening, medical or mental-health judgments, certified ability claims, evaluating others, or inferring performance or work outcomes.",
+        "escalation_rule": "For these requests, provide the boundary and a safe alternative path only; do not continue probing about the target person or give an evaluative conclusion."
       },
       "meta": {
         "id": "eq.agent.playbook.unsupported_hiring",
@@ -199,7 +203,8 @@
           "human review",
           "backend asset update",
           "fixture validation"
-        ]
+        ],
+        "risk_notes": "Read-only agent playbook. Refuse ability, certification, hiring/screening, medical or mental-health judgment, third-person evaluation, performance or work-outcome inference, paid access, SJT enablement, score changes, and report mutation."
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/agent_knowledge_base_schema.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/agent_knowledge_base_schema.json
@@ -341,14 +341,14 @@
           "certified_ei"
         ],
         "zh-CN": {
-          "label": "我适合什么工作环境",
-          "agent_goal": "只讨论职业环境变量、验证问题和观察清单，不推荐具体职业。",
-          "safe_opening": "我可以帮你看哪些工作环境变量值得验证，但不会用 EQ 结果直接决定职业适配。"
+          "label": "验证工作环境变量",
+          "agent_goal": "只讨论职业环境变量、验证问题和观察清单，不推荐具体职业或岗位，也不支持招聘用途。",
+          "safe_opening": "我可以帮你看哪些工作环境变量值得验证，但不会用 EQ 结果决定职业适配、录用或绩效。"
         },
         "en": {
-          "label": "What work environment fits me?",
-          "agent_goal": "Discuss work-environment variables, verification questions, and observation checklists without recommending specific jobs.",
-          "safe_opening": "I can help you examine work-environment variables, but I will not decide job fit from EQ alone."
+          "label": "Check work-environment variables",
+          "agent_goal": "Discuss work-environment variables, verification questions, and observation checklists without recommending specific jobs or roles, and without supporting hiring use.",
+          "safe_opening": "I can help examine work-environment variables, but I will not decide job fit, selection, or performance from EQ results."
         }
       },
       "relationship_or_conflict_help": {
@@ -522,14 +522,14 @@
           "job_performance_prediction"
         ],
         "zh-CN": {
-          "label": "临床或招聘用途",
-          "agent_goal": "拒绝用 EQ 报告做临床、招聘或评价他人的高风险判断。",
-          "safe_opening": "这份报告不能用于诊断、筛选或评价他人；我可以帮你回到自我理解和成长用途。"
+          "label": "医疗或招聘高风险用途",
+          "agent_goal": "拒绝用 EQ 报告做医疗、招聘、筛选或评价他人的高风险判断。",
+          "safe_opening": "这份报告不能用于医疗判断、筛选或评价他人；我可以帮你回到自我理解和成长用途。"
         },
         "en": {
-          "label": "Clinical or hiring use",
-          "agent_goal": "Decline clinical, hiring, or third-person evaluation use of the EQ report.",
-          "safe_opening": "This report cannot be used to diagnose, screen, or evaluate another person; I can redirect to self-understanding and growth use."
+          "label": "Medical or hiring high-risk use",
+          "agent_goal": "Decline medical, hiring, screening, or third-person evaluation use of the EQ report.",
+          "safe_opening": "This report cannot be used for medical judgment, screening, or evaluating another person; I can redirect to self-understanding and growth use."
         }
       }
     }
@@ -602,14 +602,14 @@
       "job_performance_prediction": {
         "severity": "high",
         "blocked_patterns": [
-          "should not be used to predict job performance",
+          "should not be used to infer performance or work outcomes",
           "predict work success",
-          "预测工作表现",
+          "推断绩效或工作结果",
           "决定职业成功"
         ],
         "replacement_boundary": {
-          "zh-CN": "报告不预测工作表现，只帮助用户识别可能消耗或支持自己的环境变量。",
-          "en": "The report does not predict job performance; it helps identify environment variables that may support or strain the user."
+          "zh-CN": "报告不推断绩效或工作结果，只帮助用户识别可能消耗或支持自己的环境变量。",
+          "en": "The report does not infer performance or work outcomes; it helps identify environment variables that may support or strain the user."
         }
       },
       "guaranteed_outcome": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -185,7 +185,9 @@
       }
     ],
     "commit_sha": "265e1dcc58edd5a122627ff0e61594c5e3dbeeab",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01",
     "local_cleanup_executed": false,
@@ -297,7 +299,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_cleanup_complete",
     "title": "ANALYTICS-FUNNEL-GA4-BAIDU-MAPPING-SCAN-01 freeze GA4 Baidu funnel mapping",
     "transitions": [
@@ -671,7 +675,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "ci_fix_local_checks_passed",
     "title": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 connect Ops 7-day funnel to unified taxonomy read model",
     "transitions": [
@@ -764,7 +770,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03 freeze purchase report truth bridge",
     "transitions": [
@@ -1003,7 +1011,9 @@
       "git_diff_cached_check": null,
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_deployed_reconciled",
     "title": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02 fix share_click SQL compatibility",
     "transitions": [
@@ -1711,7 +1721,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2015",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "ready_to_merge",
     "title": "ARTICLE-H1-04: fix(ops): constrain article editor heading controls",
     "train_scope": "article_h1_single_dom",
@@ -2460,7 +2472,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_and_cleaned",
     "title": "AUDIT-SEC-RESULT-IDENTITY-01 harden result recovery identity boundary",
     "transitions": [
@@ -2538,7 +2552,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -3471,7 +3487,9 @@
       }
     },
     "commit_sha": "d62cbe6317f08d4307bd9488e5cf9059c3bcbf1d",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
@@ -3695,7 +3713,9 @@
       }
     },
     "commit_sha": "79b7931eb59d29b9c778b0333bbcb9ccbcc45cd0",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
@@ -3927,7 +3947,9 @@
   "BIG5-CANONICAL-PROFILES-SCIENTIFIC-REPAIR-01": {
     "base": "main",
     "branch": "codex/big5-canonical-profiles-scientific-repair-01",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": "1b338c59df6c6cce7ca7fad29ad2e2b105461540",
     "depends_on": [
       "BIG5-RENDERED-SURFACE-QA-CONTENT-REPAIR-01"
@@ -3996,7 +4018,9 @@
       }
     },
     "commit_sha": "595811fa6f8aa2047b5f057aa4d8a96176871e609",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
@@ -4086,7 +4110,9 @@
     "commit_sha": "dcab310011707b7c6174ee3171ccf82a54f5750d",
     "content_authority": "backend",
     "database_mutation": false,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "deploy_allowed": false,
     "events": [
       {
@@ -4159,7 +4185,9 @@
       }
     },
     "commit_sha": "aad0bbd600a8519d2d55d54ba001467edc587c36",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "BIG5-CONTENT-ASSET-SCIENTIFIC-AUDIT-MAPPING-01",
     "local_cleanup_executed": true,
@@ -4214,7 +4242,9 @@
   "BIG5-CONTENT-ASSET-SCIENTIFIC-REPAIR-FULL-QA-01": {
     "base": "main",
     "branch": "codex/big5-content-asset-scientific-repair-full-qa-01",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": null,
     "depends_on": [
       "BIG5-SCENARIO-ACTION-SCIENTIFIC-REPAIR-01"
@@ -4992,7 +5022,9 @@
   "BIG5-LOW-QUALITY-SCIENTIFIC-REPAIR-01": {
     "base": "main",
     "branch": "codex/big5-low-quality-scientific-repair-01",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": null,
     "depends_on": [
       "BIG5-SHARE-SAFETY-SCIENTIFIC-REPAIR-01"
@@ -5236,7 +5268,9 @@
   "BIG5-NORM-UNAVAILABLE-SCIENTIFIC-REPAIR-01": {
     "base": "main",
     "branch": "codex/big5-norm-unavailable-scientific-repair-01",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": null,
     "depends_on": [
       "BIG5-LOW-QUALITY-SCIENTIFIC-REPAIR-01"
@@ -5334,7 +5368,9 @@
   "BIG5-RENDERED-SURFACE-QA-CONTENT-REPAIR-01": {
     "base": "main",
     "branch": "codex/big5-rendered-surface-qa-content-repair-01",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": null,
     "depends_on": [
       "BIG5-NORM-UNAVAILABLE-SCIENTIFIC-REPAIR-01"
@@ -5717,7 +5753,9 @@
       }
     },
     "commit_sha": "ca9af5079add9914ed8d52fb18fb948585c138bf",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-22T16:34:43Z",
@@ -6307,7 +6345,9 @@
   "BIG5-SCENARIO-ACTION-SCIENTIFIC-REPAIR-01": {
     "base": "main",
     "branch": "codex/big5-scenario-action-scientific-repair-01",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": null,
     "depends_on": [
       "BIG5-CANONICAL-PROFILES-SCIENTIFIC-REPAIR-01"
@@ -6682,7 +6722,9 @@
       }
     ],
     "commit_sha": "e30f96f4e068c2a7b62e1fe67950ffab6b061c72",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "CAREER-1046-OPS-SCOPE-RECONCILIATION-01",
     "local_cleanup_executed": true,
@@ -6696,7 +6738,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "completed",
     "title": "CAREER-1046-OPS-SCOPE-RECONCILIATION-01 reconcile public 1046 career runtime with CMS/Ops 378 scope",
     "transitions": [
@@ -7044,7 +7088,9 @@
       }
     },
     "commit_sha": "68f2b2dfc0b3b587a53ad85dc52a4b0f4b2eabcf",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": "Sidecar only: full Pint reports out-of-scope EQ test formatting issues; scoped current PR files and current-scope CI fixes passed locally.",
     "history": [
       {
@@ -8158,7 +8204,9 @@
       }
     },
     "commit_sha": "24288ec8713900f6709cd472b51f2d097ef263af",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; current PR focused test, route:list, scoped Pint, composer validate/audit, JSON/YAML, and diff checks pass.",
     "id": "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01",
     "local_cleanup_executed": true,
@@ -8511,14 +8559,18 @@
       }
     },
     "commit_sha": "af382b46070d1455f6b7e2d9fe9af18ba7cb0e55",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-09T15:28:28Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2020",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity",
     "train_scope": "career_zh_display_parity",
@@ -8984,14 +9036,18 @@
       }
     },
     "commit_sha": "12fab79a192c5f0537f2f61fbdc6614653fea9a9",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-11T02:45:32Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2025",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "CAREER-ZH-PARITY-FIX-01: fix(career): compact zh parity workbook readiness",
     "train_scope": "career_zh_parity_fix",
@@ -9838,7 +9894,9 @@
       "git_diff_cached_check": true,
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -10900,7 +10958,9 @@
       }
     ],
     "commit_sha": "6716bf50c3cd22691d4609434f8a2b12442b2c8a",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "DETAIL_READY_1046_DELTA_AUTHORITY_REPAIR-01",
     "local_cleanup_executed": false,
@@ -10914,7 +10974,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1046_DELTA_AUTHORITY_REPAIR-01 clean 1046 delta authority manifest",
     "transitions": [
@@ -11001,7 +11063,9 @@
       }
     ],
     "commit_sha": "67e95aac7a4344a407c5c1b563c4131a27d2d7aa",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": "blocked_backend_deploy_required: production backend REVISION 16c01f81b60bb9a5452a867c6c57a78aa77e57bc does not include required PR #1747 merge commit 6716bf50c3cd22691d4609434f8a2b12442b2c8a",
     "id": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01",
     "local_cleanup_executed": false,
@@ -11015,7 +11079,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01 production preflight for clean 1046 rollout apply",
     "transitions": [
@@ -11087,7 +11153,9 @@
       }
     ],
     "commit_sha": "09ec7f599b05d7d555ad186af81633010f5c47f3",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "DETAIL_READY_1046_ROLLOUT_NO_AUDIT_DRY_RUN-01",
     "local_cleanup_executed": false,
@@ -11101,7 +11169,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1046_ROLLOUT_NO_AUDIT_DRY_RUN-01 no-write career rollout dry-run",
     "transitions": [
@@ -11173,7 +11243,9 @@
       }
     ],
     "commit_sha": "e5cbc6816d70383ad33c9da985bd76d6c00c3b73",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "DETAIL_READY_1047_DELTA_AUTHORITY_REPAIR-01",
     "local_cleanup_executed": false,
@@ -11187,7 +11259,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1047_DELTA_AUTHORITY_REPAIR-01 clean 1047 delta authority manifest",
     "transitions": [
@@ -11259,7 +11333,9 @@
       }
     ],
     "commit_sha": "05f7dda0b1350e523c02ea38daccbbedd91ce7e4",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01",
     "local_cleanup_executed": false,
@@ -11273,7 +11349,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01 replacement index-state runtime projection conflict report",
     "transitions": [
@@ -11466,7 +11544,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01 replacement authority source repair",
     "transitions": [
@@ -11669,7 +11749,9 @@
       }
     },
     "commit_sha": "b20330097483c7283509633656a333d1b6d2007a",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "events": [
       {
         "at": "2026-07-02T16:10:24Z",
@@ -11724,7 +11806,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to ENNEA-RP-01 instant_summary registry copy, focused composer test, and user-authorized PR train metadata.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -11873,7 +11957,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to ENNEA-RP-02 type_registry Top3 card fields and PR train state reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -11981,7 +12067,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files remain confined to ENNEA-RP-03 type_registry deep_dive summary fields and PR train state metadata after rebase.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "ready_to_merge",
@@ -12117,7 +12205,9 @@
         "docs/codex/pr-train.yaml"
       ],
       "evidence": "Changed files are confined to ENNEA-RP-04 all9 profile runtime labels, related Enneagram tests, PR train metadata, and the required BigFive runtime-freeze guard exemption for the two Enneagram result-page runtime contract files.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -12230,7 +12320,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to confidence-band projection labels, confidence_band_card composer content, related Enneagram composer test, and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -12349,7 +12441,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to dominance_gap_card composer content, dominance_gap technical note registry copy, related Enneagram tests, and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -12465,7 +12559,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to close-call UI copy, pair fallback close-call guidance, and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -12549,7 +12645,9 @@
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "evidence": "Changed files are confined to type_registry blind_spot_copy content and train ledger reconciliation."
     },
@@ -12677,7 +12775,9 @@
         "backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "evidence": "After rebase, changed files remain confined to center summary group registry content, center runtime projection, Enneagram tests, and train ledger reconciliation."
     },
@@ -12826,7 +12926,9 @@
         "backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "evidence": "Changed files are confined to stance summary group registry content and train ledger reconciliation."
     },
@@ -12931,7 +13033,9 @@
         "backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "evidence": "Changed files are confined to harmonic summary group registry content and train ledger reconciliation."
     },
@@ -12973,7 +13077,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-12: fix(enneagram): repair wing hint visual boundary",
@@ -13014,7 +13120,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-13: fix(enneagram): repair methodology boundary card",
@@ -13056,7 +13164,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-14: fix(enneagram): repair diffuse boundary content",
@@ -13098,7 +13208,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-15: fix(enneagram): repair low-quality boundary content",
@@ -13139,7 +13251,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-16: fix(enneagram): repair work style summary",
@@ -13179,7 +13293,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-17: fix(enneagram): repair collaboration strengths",
@@ -13219,7 +13335,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-18: fix(enneagram): repair collaboration friction",
@@ -13259,7 +13377,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-19: fix(enneagram): repair leadership pattern",
@@ -13299,7 +13419,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-20: fix(enneagram): repair managed-by-others content",
@@ -13339,7 +13461,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-21: fix(enneagram): repair workplace triggers",
@@ -13381,7 +13505,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-22: fix(enneagram): repair context mode placeholder",
@@ -13421,7 +13547,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-23: fix(enneagram): repair growth axis",
@@ -13462,7 +13590,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-24: fix(enneagram): repair strength expression",
@@ -13503,7 +13633,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-25: fix(enneagram): repair cost expression",
@@ -13543,7 +13675,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-26: fix(enneagram): repair stress trigger",
@@ -13584,7 +13718,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-27: fix(enneagram): repair recovery action",
@@ -13625,7 +13761,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-28: fix(enneagram): repair state spectrum",
@@ -13665,7 +13803,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-29: fix(enneagram): repair arrow placeholder",
@@ -13706,7 +13846,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-30: fix(enneagram): repair relationship need",
@@ -13746,7 +13888,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-31: fix(enneagram): repair relationship strengths",
@@ -13786,7 +13930,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-32: fix(enneagram): repair misread by others",
@@ -13827,7 +13973,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-33: fix(enneagram): repair conflict script",
@@ -13868,7 +14016,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-34: fix(enneagram): repair communication manual",
@@ -13908,7 +14058,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-35: fix(enneagram): repair relationship blind spot",
@@ -13948,7 +14100,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-36: fix(enneagram): repair method boundary",
@@ -13988,7 +14142,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-37: fix(enneagram): repair seven-day observation",
@@ -14029,7 +14185,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-38: fix(enneagram): repair resonance feedback placeholder",
@@ -14070,7 +14228,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-39: fix(enneagram): repair history share retake placeholder",
@@ -14112,7 +14272,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-40: fix(enneagram): repair form recommendation",
@@ -14152,7 +14314,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-41: fix(enneagram): repair sample report link",
@@ -14193,7 +14357,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-42: fix(enneagram): repair technical note link",
@@ -14235,7 +14401,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pending_dependency",
     "title": "ENNEA-RP-43: test(enneagram): enforce registry scientific and style guards",
@@ -14310,7 +14478,9 @@
           "docs/codex/pr-train.yaml"
         ],
         "evidence": "Changed files are confined to Enneagram forced-choice compiled question pack/manifest, focused Enneagram locale test, Big Five freeze classifier test-only allowance for the Enneagram pack files, and authorized PR-train metadata.",
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "pass"
       }
     },
@@ -14416,7 +14586,9 @@
       }
     },
     "commit_sha": "186ee67162d8ad287c2c6279f51950aca1d73ee2",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-22T11:44:35Z",
@@ -15141,7 +15313,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1684",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01": {
@@ -22134,7 +22308,9 @@
       }
     },
     "commit_sha": "9eeb91f57477072fe472b8269ac30ba83004691b",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-23T08:17:44Z",
@@ -22736,7 +22912,9 @@
       }
     },
     "commit_sha": "2d08bb46555389226adf6dbce80dcc9111e2b82a",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "events": [
       {
         "at": "2026-05-25T12:00:00Z",
@@ -22953,7 +23131,9 @@
           "docs/codex/pr-train.yaml"
         ],
         "evidence": "Final branch diff is confined to MBTI controller projection, MBTI English sidecar pack data, focused test, and PR train metadata; shared QuestionsService is no longer in the branch diff.",
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "pass"
       }
     },
@@ -23190,7 +23370,9 @@
     "commit_sha": "44f569449afa97e5a2e39c6dbf21ebdb87ba2c78",
     "content_authority": "backend",
     "database_mutation": false,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "deploy_allowed": false,
     "events": [
       {
@@ -23263,7 +23445,9 @@
       }
     },
     "commit_sha": "614af7ed2aa38dfa2201cb723f48e0f49de471a8",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-26T13:18:57Z",
@@ -23638,7 +23822,9 @@
       }
     },
     "commit_sha": null,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "events": [
       {
         "at": "2026-07-01T14:30:04.421Z",
@@ -23672,7 +23858,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pr_open",
     "title": "MBTI-PDF-SNAPSHOT-SYNC-GUARD-H1: add PDF snapshot render-source cache guard",
@@ -23739,7 +23927,9 @@
       }
     ],
     "commit_sha": "93556a55fbcf71aa998566eb4f276218cda48788",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "OPS-API-INTERNAL-RESOLVE-PROOF",
     "local_cleanup_executed": false,
@@ -23862,7 +24052,9 @@
     "base": "main",
     "branch": "codex/ops-ci-codescan-api-01",
     "checks": {
-      "github": [],
+      "github": [
+
+      ],
       "local": {
         "git_diff_check": "passed",
         "json_validation": "passed",
@@ -23871,7 +24063,9 @@
       }
     },
     "commit_sha": "962be45f81044d1eec60088ef34235f8e020032e",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "history": [
       {
@@ -23938,7 +24132,9 @@
       }
     },
     "commit_sha": "a194a0bb1d0cf83e130cce205cb9410cb48d725b",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "history": [
       {
@@ -23964,7 +24160,9 @@
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "github_checks_passed",
     "title": "fix(ci): eliminate CiScaleImpact Semgrep findings"
   },
@@ -24069,7 +24267,9 @@
       "git_diff_cached_check": null,
       "git_diff_check": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -24290,7 +24490,9 @@
         "backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php"
       ]
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -24314,7 +24516,9 @@
     "base": "main",
     "branch": "codex/ops-release-workflow-01",
     "checks": {
-      "github": [],
+      "github": [
+
+      ],
       "local": {
         "git_diff_check": "passed",
         "json_parse": "passed",
@@ -24357,7 +24561,9 @@
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "docs(ops): codify release operator workflow and deploy incident governance"
   },
@@ -24420,7 +24626,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "docs(ops): codify canonical healthz and release-only deploy policy"
   },
@@ -24657,7 +24865,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "github_checks_passed",
     "title": "PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03 classify Alipay owner mismatch paid orders",
     "transitions": [
@@ -24795,7 +25005,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "github_checks_failed_fix_prepared",
     "title": "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01 schedule Alipay pending payment compensation",
     "transitions": [
@@ -25043,7 +25255,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler",
     "transitions": [
@@ -25704,7 +25918,9 @@
       }
     },
     "commit_sha": "ec0ee01f84204e64f9891f33d6126a7de344a97d",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-25T22:19:24+08:00",
@@ -26597,7 +26813,9 @@
         "docs/audits/eq/eq_agent_runtime_acceptance_2026-06-25.md",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "passed"
     },
     "status": "pr_open_p0_blocked_report",
@@ -27476,7 +27694,9 @@
       }
     ],
     "commit_sha": "5d47789f391d0c7cf2c68c63ad3edc22bbd10ea4",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "PR-EQ-ASSET-AUDIT-00",
     "local_cleanup_executed": true,
@@ -28404,7 +28624,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-09 allowed_paths.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -28839,7 +29061,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-13 allowed_paths.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -29070,8 +29294,49 @@
   "PR-EQ-ASSET-SCI-16": {
     "base": "main",
     "branch": "codex/pr-eq-asset-sci-16-agent-playbooks",
-    "checks": [],
-    "commit_sha": null,
+    "checks": [
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; scoped report_assets compiled output retained and mirrored."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warnings; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warnings; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "YAML/JSON parse, EQ pack mirror cmp, scope validation, agent playbook guard scan, git diff --check, git diff --cached --check",
+        "status": "passed",
+        "summary": "Manifest/state parsed, raw and compiled mirrors match, changed files are within SCI-16 scope, agent playbooks contain required bilingual guard fields and no blocked high-risk/commerce/SJT wording, and no whitespace errors were found."
+      }
+    ],
+    "commit_sha": "e1b3bcb542d2104fb1ebedde1e6672ad848d0f38",
     "depends_on": [
       "PR-EQ-ASSET-SCI-03",
       "PR-EQ-ASSET-SCI-12"
@@ -29080,16 +29345,23 @@
     "id": "PR-EQ-ASSET-SCI-16",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2671",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
-      "allowed_paths_only": null,
-      "github_checks_green": null,
-      "local_validation_passed": null,
-      "post_merge_revalidated": null
+      "status": "pass",
+      "changed_files": [
+        "backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json",
+        "backend/content_packs/EQ_60/v1/raw/report_assets/agent_dialogue_playbooks.json",
+        "backend/content_packs/EQ_60/v1/raw/report_assets/agent_knowledge_base_schema.json",
+        "backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json",
+        "backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/agent_dialogue_playbooks.json",
+        "backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/agent_knowledge_base_schema.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-16 allowed_paths."
     },
-    "status": "user_authorized",
+    "status": "ready_to_merge",
     "title": "PR-EQ-ASSET-SCI-16: repair EQ agent_dialogue_playbooks boundaries",
     "transitions": [
       {
@@ -29097,12 +29369,35 @@
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
       }
-    ]
+    ],
+    "history": [
+      {
+        "status": "local_checks_passed",
+        "timestamp": "2026-07-03T14:36:00+08:00",
+        "notes": "All required local checks and agent playbook guard scan passed; ready to commit and open PR."
+      },
+      {
+        "status": "pr_open_checks_pending",
+        "timestamp": "2026-07-03T13:24:35+08:00",
+        "notes": "Opened PR #2671 for PR-EQ-ASSET-SCI-16; GitHub checks pending."
+      },
+      {
+        "status": "ready_to_merge",
+        "timestamp": "2026-07-03T13:33:52+08:00",
+        "notes": "GitHub checks passed and PR #2671 is clean; ready to squash merge."
+      }
+    ],
+    "github_checks": {
+      "status": "passed",
+      "summary": "GitHub checks passed for PR #2671; mergeStateStatus CLEAN."
+    }
   },
   "PR-EQ-ASSET-SCI-17": {
     "base": "main",
     "branch": "codex/pr-eq-asset-sci-17-backend-contract",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": null,
     "depends_on": [
       "PR-EQ-ASSET-SCI-16"
@@ -29133,7 +29428,9 @@
   "PR-EQ-ASSET-SCI-18": {
     "base": "main",
     "branch": "codex/pr-eq-asset-sci-18-route-matrix",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": null,
     "depends_on": [
       "PR-EQ-ASSET-SCI-05",
@@ -29210,7 +29507,9 @@
       ]
     },
     "commit_sha": "2523eb2b4abb0c7c9aa6a26ab359fbfb6e659a4b",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "events": [
       {
         "at": "2026-06-26T15:21:54.232288+00:00",
@@ -30195,7 +30494,9 @@
       }
     },
     "commit_sha": "322bf0d8f0884c48730fc23c2713710315d19863",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": "Sidecar only: direct macOS curl to api.fermatmind.com still reports LibreSSL SSL_ERROR_SYSCALL; Node HTTPS and apex same-origin public API reads are healthy.",
     "history": [
       {
@@ -30899,7 +31200,9 @@
           "backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -31016,7 +31319,9 @@
           "git diff --check",
           "git diff --cached --check"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -31099,7 +31404,9 @@
           "git diff --check",
           "git diff --cached --check"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -31188,7 +31495,9 @@
           "git diff --check",
           "git diff --cached --check"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -31275,7 +31584,9 @@
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -31437,7 +31748,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1673",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "RESULT-EN-PARITY-06": {
@@ -31510,7 +31823,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1675",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "RIASEC-CONTENT-140CTA-01": {
@@ -33306,7 +33621,9 @@
       }
     },
     "commit_sha": "2ff9a76b669b356232cddb54dbada9452caa7071",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "RIASEC-CONTENT-SCIENCE-00",
     "local_cleanup_executed": true,
@@ -33600,7 +33917,9 @@
           "docs/codex/pr-train.yaml"
         ],
         "evidence": "Changed files are confined to RIASEC compiled question packs/manifests, focused RIASEC locale test, Big Five freeze classifier test-only allowance for the RIASEC pack files, and authorized PR-train metadata.",
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "pass"
       }
     },
@@ -33801,7 +34120,9 @@
     "next_pr": "RIASEC-FULL-CONTENT-PACK-04",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1484",
     "remote_branch_deleted": true,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "RIASEC-FULL-CONTENT-PACK-03-PREFLIGHT": {
@@ -33875,7 +34196,9 @@
     "next_pr": "RIASEC-FULL-CONTENT-PACK-03",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1483",
     "remote_branch_deleted": true,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "RIASEC-FULL-CONTENT-PACK-04": {
@@ -33956,7 +34279,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-04: Top3 code chain strategy asset import"
   },
@@ -34045,7 +34370,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-05: Import backend-authoritative RIASEC activity/task examples asset"
   },
@@ -34139,7 +34466,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-05-PREFLIGHT: Activity/task examples asset preflight"
   },
@@ -34223,7 +34552,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-06: Import backend-authoritative RIASEC occupation examples boundary asset"
   },
@@ -34311,7 +34642,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-06-PREFLIGHT: Occupation examples asset preflight"
   },
@@ -34405,7 +34738,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-07: 140Q task/environment/role narrative asset import"
   },
@@ -34497,7 +34832,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-08: Low quality / confidence / near-tie copy asset import"
   },
@@ -34576,7 +34913,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-09: Import backend-authoritative aspirations and disagree path assets"
   },
@@ -34666,7 +35005,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-09-PREFLIGHT: Aspirations and disagree path asset preflight"
   },
@@ -34939,7 +35280,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-11-BE: Backend lifecycle copy import for Share/PDF/History/FAQ/Technical Note"
   },
@@ -35032,7 +35375,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-11-BE-PREFLIGHT: Share/PDF/History/FAQ/Technical Note lifecycle copy backend preflight"
   },
@@ -35123,7 +35468,9 @@
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "pr_opened_github_checks_pending",
     "title": "RIASEC-FULL-CONTENT-PACK-13-BE: Backend full content fixture matrix and forbidden claim freeze"
   },
@@ -35360,7 +35707,9 @@
       "yaml_parse_pr_train_manifest": "passed"
     },
     "commit_sha": "03ecc9ad1f037e05206d319c0051629a98053664",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merge_commit": "fa0333b68ff4cb261e01be6658c73b4f9a82c7d0",
@@ -35590,7 +35939,9 @@
       }
     },
     "commit_sha": "436c62975f66236c5fca8f42994efde7e78453dd",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-21T14:20:02Z",
@@ -37068,7 +37419,9 @@
     "commit_sha": "56b0035ef9a880dcf1c98f1b2fe8c57b49bc6079",
     "content_authority": "backend",
     "database_mutation": false,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "deploy_allowed": false,
     "events": [
       {
@@ -37775,7 +38128,9 @@
     "commit_sha": "cb375f6b832be73dc3d2dbb96fbbede577646cf7",
     "content_authority": "backend",
     "database_mutation": false,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "deploy_allowed": false,
     "events": [
       {
@@ -38090,7 +38445,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to API-03 allowed PDF token, Gotenberg URL, locked MBTI PDF access, config, and train state paths.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -38265,7 +38622,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to API-04 allowed PDF artifact descriptor, DSAR purge, lifecycle residual audit, BigFive runtime-freeze classifier, and train manifest/state paths.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -41188,7 +41547,9 @@
       }
     },
     "commit_sha": "89ba8ee1a64d5a7269c55402ceccee4e83198af6",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-05T03:12:58Z",
@@ -41284,7 +41645,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "result": {
-      "blockers": [],
+      "blockers": [
+
+      ],
       "cms_draft_created": false,
       "content_blocked": false,
       "content_safe": true,
@@ -41589,7 +41952,9 @@
       }
     },
     "commit_sha": "933d82e204cf01930424b1635258926c9803777a",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-05T00:46:15Z",
@@ -41758,7 +42123,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -41840,7 +42207,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -42098,7 +42467,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -42181,7 +42552,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -42248,7 +42621,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -42434,7 +42809,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -42491,7 +42868,9 @@
       "local_validation_passed": null,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_external_dependency",
     "transitions": [
       {
@@ -42504,7 +42883,9 @@
   },
   "SEO-CMS-CANARY-PREVIEW-01": {
     "branch": "codex/seo-cms-canary-preview-01",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": "11e82c0c7000bc90f2ec550b83d80a9b941465dc",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
@@ -42596,7 +42977,9 @@
       "origin_main_contains_merge_commit": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -42682,7 +43065,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -42901,7 +43286,9 @@
   },
   "SEO-CONTENT-P1-09": {
     "branch": "codex/seo-content-p1-09",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": "6547f4e08aebd665da98916dd5787a4a23adfed9",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
@@ -43157,7 +43544,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2011",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily",
     "train_scope": "seo_conversion_tracking",
@@ -43282,7 +43671,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2010",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "SEO-CONV-INGEST-02: feat(analytics): accept canonical SEO conversion funnel ingest",
     "train_scope": "seo_conversion_tracking",
@@ -43410,7 +43801,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2012",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "github_checks_passed_ready_to_merge",
     "title": "SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts",
     "train_scope": "seo_conversion_tracking",
@@ -43528,7 +43921,9 @@
       "runtime_code_edit_performed": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "docs(seo): reconcile seo_intel schema and read-only API contract",
     "train_scope": "search_intelligence_schema_api_contract",
@@ -43688,7 +44083,9 @@
       "read_only_api": true,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "feat(seo): add seo_intel read-only dashboard API contract",
     "train_scope": "seo_intel_read_only_dashboard_api",
@@ -43804,7 +44201,9 @@
       "scheduler_enabled": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "docs(seo): define post-migration collector dry-run readiness",
     "train_scope": "seo_intel_collector_dry_run_readiness",
@@ -43912,7 +44311,9 @@
       "scheduler_enabled": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_cleanup_complete",
     "title": "docs(seo): record collector dry-run smoke evidence",
     "train_scope": "seo_intel_collector_dry_run_smoke_evidence",
@@ -44019,7 +44420,9 @@
       "scheduler_enabled": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "docs(seo): define controlled collector write gate",
     "train_scope": "seo_intel_controlled_collector_write_gate",
@@ -44117,7 +44520,9 @@
       "runtime_route_changed": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "docs(seo): define seo_intel migration readiness gate",
     "train_scope": "seo_intel_migration_readiness_gate",
@@ -44243,7 +44648,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1466",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "state": "merged",
     "status": "merged"
   },
@@ -44512,7 +44919,9 @@
       }
     },
     "commit_sha": "42ef31190f68ebda879a9362bad511052d50a7a9",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-25T21:12:00+08:00",
@@ -45588,7 +45997,9 @@
       }
     },
     "commit_sha": "70bce0cbc971fe52f85d49d338bf79b284806862",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-08T17:03:46Z",
@@ -45797,7 +46208,9 @@
       }
     },
     "commit_sha": "302e4171f9eb5ace6d913f2fdb310b3379e6cbd2",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
@@ -45866,7 +46279,9 @@
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -45959,12 +46374,16 @@
           "docs/codex/pr-train.yaml"
         ],
         "evidence": "Changed files are confined to read-only scan artifacts, focused test, and PR train metadata.",
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "pass"
       }
     },
     "commit_sha": "75b26a54aa2e66cb892d58e88b526f7848d6ac4c",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "history": [
       {
@@ -46090,8 +46509,12 @@
       "scope_type": "cn_proxy_public_owner_reviewed_manifest_gate_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -46281,7 +46704,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1627",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "updated_at": "2026-05-24T02:08:03+08:00"
     },
@@ -46317,7 +46742,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "schema_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "open",
       "title": "feat(api): add career canonical eligibility audit schema"
     },
@@ -46410,7 +46837,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_cohort_readiness_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "draft_pr_open",
       "title": "feat(api): add career 80 cohort readiness plan"
     },
@@ -46497,7 +46926,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "manifest_train_generator_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_local_checks_passed_pending_github_rerun",
       "title": "feat(api): add career canonical expansion manifest train generator"
     },
@@ -46584,7 +47015,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "batch_live_acceptance_v2_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "open",
       "title": "feat(api): add career batch live acceptance v2"
     },
@@ -46667,7 +47100,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "full_audit_artifact_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career 2786 full audit artifact report"
     },
@@ -46708,7 +47143,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "source_resolver_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career public resolution plan resolver"
     },
@@ -46800,7 +47237,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "entity_inventory_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career occupation entity inventory audit"
     },
@@ -46894,8 +47333,12 @@
       "scope_type": "baseline_metadata_inventory_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed after AUDIT-4 allowlist fix in unrelated BigFive norm/content tests with SQLSTATE[HY000]: General error: 5 database is locked against /tmp/fap-ci.sqlite.",
             "Scoped AUDIT-4 tests, AUDIT-1/2/3 regressions, pint, git diff --check, and BigFive runtime freeze path gate passed."
@@ -47000,7 +47443,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "index_state_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career index-state authority audit"
     },
@@ -47091,7 +47536,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "runtime_projection_truth_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career runtime projection truth eligibility audit"
     },
@@ -47186,7 +47633,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "seo_geo_readiness_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career seo geo readiness audit"
     },
@@ -47276,7 +47725,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "surface_readiness_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career surface readiness audit"
     },
@@ -47372,7 +47823,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "canonical_eligibility_command_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career canonical eligibility audit command"
     },
@@ -48093,7 +48546,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "high",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_committed",
       "title": "fix(security): redact IQ answer keys and locked report payloads",
       "train_scope": "security_audit_remediation"
@@ -48188,7 +48643,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_pending",
       "title": "fix(security): scope ops release failure audits by org",
       "train_scope": "security_audit_remediation"
@@ -48367,7 +48824,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1633",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "CAREER-1046-FRONTEND-DISCOVERY-UX-01": {
@@ -48398,7 +48857,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "CAREER-1046-FRONTEND-DISCOVERY-UX-01 career discovery UX",
       "transitions": [
@@ -48473,7 +48934,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01 career internal linking authority",
       "transitions": [
@@ -48577,7 +49040,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "CAREER-1046-OBSERVABILITY-SLO-01 career runtime observability SLO",
       "transitions": [
@@ -48684,7 +49149,9 @@
         }
       },
       "commit_sha": "b2713e384d5a6d0b650df56222eac19831df21b8",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "id": "CAREER-1046-OPS-READ-MODEL-REPAIR-01",
       "local_cleanup_executed": true,
@@ -48700,7 +49167,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "CAREER-1046-OPS-READ-MODEL-REPAIR-01 career runtime read model repair",
       "transitions": [
@@ -49460,7 +49929,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_search_channel_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add 360 Sogou Shenma adapter contracts",
       "train_scope": "china_search_domestic_adapter_contracts"
@@ -49567,7 +50038,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_crawler_log_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add Chinese crawler log collector foundation",
       "train_scope": "chinese_crawler_log_collector_foundation"
@@ -49684,7 +50157,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -49736,7 +50211,9 @@
         }
       },
       "commit_sha": null,
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": "Initial GitHub verify-bigfive failed because the first pushed history added a backend/app runtime file. The branch is being rewritten to test-support-only scope and revalidated.",
       "id": "CLINICAL-LAUNCH-01",
       "local_cleanup_executed": false,
@@ -49784,7 +50261,9 @@
     "CLINICAL-LAUNCH-02": {
       "base": "main",
       "branch": "codex/clinical-launch-02",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-01"
@@ -49803,15 +50282,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-02 claim boundary naming and disclaimer gate",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-03": {
       "base": "main",
       "branch": "codex/clinical-launch-03",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-02"
@@ -49830,15 +50315,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-03 SDS source and suitability audit",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-04": {
       "base": "main",
       "branch": "codex/clinical-launch-04",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-03"
@@ -49857,15 +50348,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-04 crisis sentinel gate",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-05": {
       "base": "main",
       "branch": "codex/clinical-launch-05",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-04"
@@ -49884,15 +50381,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-05 locale-aware crisis resources",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-06": {
       "base": "main",
       "branch": "codex/clinical-launch-06",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-05"
@@ -49911,15 +50414,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-06 sensitive health data consent and retention gate",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-07": {
       "base": "main",
       "branch": "codex/clinical-launch-07",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-06"
@@ -49938,15 +50447,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-07 free safety and paid report boundary",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-08": {
       "base": "main",
       "branch": "codex/clinical-launch-08",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-07"
@@ -49965,15 +50480,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-08 clinical related article authority plan",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-09": {
       "base": "main",
       "branch": "codex/clinical-launch-09",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-08"
@@ -49992,15 +50513,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-09 robots contract and launch-state SEO gate",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-10": {
       "base": "main",
       "branch": "codex/clinical-launch-10",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-09"
@@ -50019,15 +50546,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-10 SDS canary and Clinical staged noindex enforcement",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-11": {
       "base": "main",
       "branch": "codex/clinical-launch-11",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-10"
@@ -50046,15 +50579,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-11 SDS commercial launch content authority",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-12": {
       "base": "main",
       "branch": "codex/clinical-launch-12",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-11"
@@ -50073,15 +50612,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-12 SDS report personalization authority",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-13": {
       "base": "main",
       "branch": "codex/clinical-launch-13",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-12"
@@ -50100,15 +50645,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-13 Clinical Combo staged content authority",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-14": {
       "base": "main",
       "branch": "codex/clinical-launch-14",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-13"
@@ -50127,15 +50678,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-14 Clinical Combo report personalization authority",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-15": {
       "base": "main",
       "branch": "codex/clinical-launch-15",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-14"
@@ -50154,15 +50711,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-15 clinical media and article import package",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-16": {
       "base": "main",
       "branch": "codex/clinical-launch-16",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-15"
@@ -50181,15 +50744,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-16 Ops clinical launch governance surfaces",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-17": {
       "base": "main",
       "branch": "codex/clinical-launch-17",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-16"
@@ -50208,15 +50777,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-17 frontend clinical UX polish handoff",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-18": {
       "base": "main",
       "branch": "codex/clinical-launch-18",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-17"
@@ -50235,15 +50810,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-18 clinical commerce and recovery validation",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-19": {
       "base": "main",
       "branch": "codex/clinical-launch-19",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-18"
@@ -50262,15 +50843,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-19 SDS Search Channel production preflight",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-20": {
       "base": "main",
       "branch": "codex/clinical-launch-20",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-19"
@@ -50289,10 +50876,14 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-20 SDS canary submission and review",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CMD-FIX-1": {
       "branch": "fix/career-audit-command-layer-orchestration",
@@ -50318,7 +50909,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_command_orchestration_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): wire career eligibility audit command to layer services"
     },
@@ -50499,7 +51092,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1628",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "updated_at": "2026-05-24T02:40:27+08:00"
     },
@@ -50621,7 +51216,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -50770,7 +51367,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -51972,7 +52571,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_context_consumer_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_passed",
       "title": "fix(api): add career audit entity index context inputs"
     },
@@ -52026,7 +52627,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_context_producer_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged_reconciled",
       "title": "feat(api): add career audit db context exporters"
     },
@@ -52082,7 +52685,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "surface_context_producer_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career surface context export producer"
     },
@@ -52117,7 +52722,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1629",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01": {
@@ -52187,7 +52794,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1741",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "local_validation_passed",
       "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01 controlled replacement authority import path",
       "transitions": [
@@ -52513,7 +53122,9 @@
         }
       },
       "commit_sha": "32fb9a3a",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "history": [
         {
@@ -52543,7 +53154,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "low",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "chore(security): add docs shell safety guard",
       "train_scope": "storage_runtime_hygiene"
@@ -52588,7 +53201,9 @@
         }
       },
       "commit_sha": "a95de5c9ff047851336ee1f7c35b2255ac8ba683",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-25T04:07:01.632393+00:00",
@@ -52805,7 +53420,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1667",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "EN-PARITY-03": {
@@ -52894,7 +53511,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1672",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "EN-PARITY-04": {
@@ -52969,7 +53588,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1674",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "local_validation_passed"
     },
     "EN-PARITY-05": {
@@ -53048,7 +53669,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1676",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "EN-PARITY-06": {
@@ -53565,7 +54188,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 article English counterpart draft package"
     },
@@ -53684,7 +54309,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-CAREER-CONTENT-BATCH-05 career content English draft package"
     },
@@ -53846,7 +54473,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01 human-reviewed content/help/policy English translation batch"
     },
@@ -53908,7 +54537,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1690",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "GLOBAL-EN-ZH-GLOBAL-UI-I18N-BATCH-08": {
@@ -53959,7 +54590,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "manifest_registered",
       "title": "GLOBAL-EN-ZH-GLOBAL-UI-I18N-BATCH-08 global UI i18n parity review and frontend consumer follow-up"
     },
@@ -54114,7 +54747,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_local_validation_passed",
       "title": "GLOBAL-EN-ZH-MEDIA-ALT-VISUAL-REVIEW-BATCH-07 media alt and visual review package"
     },
@@ -54190,7 +54825,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1681",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_pending"
     },
     "GLOBAL-EN-ZH-PARITY-SCAN-00": {
@@ -54231,7 +54868,9 @@
         }
       },
       "commit_sha": "87345d16c4b7b22a23ead480925bb1f4c58d2721",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-25T11:36:50.288480+00:00",
@@ -54392,7 +55031,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-RESEARCH-CLAIM-REVIEW-BATCH-04 research English translation and claim review package"
     },
@@ -54499,7 +55140,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-RESULT-REPORT-ASSET-BATCH-06 result report English asset draft package"
     },
@@ -54614,7 +55257,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-TOPIC-TEST-LANDING-BATCH-03 topic test landing English parity draft package"
     },
@@ -54687,7 +55332,9 @@
     "IQ-CMS-MEDIA-02": {
       "base": "main",
       "branch": "codex/iq-cms-media-02-rendering-guard",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "IQ-CMS-MEDIA-01"
       ],
@@ -54801,7 +55448,9 @@
         }
       },
       "commit_sha": "f305f93a",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "id": "IQ-NORM-01",
       "local_cleanup_executed": true,
@@ -55278,7 +55927,9 @@
     "IQ-PAID-REPORT-01": {
       "base": "main",
       "branch": "codex/iq-paid-report-01-entitlement-contract",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": "60eabe326f7e24e71a1bef555493dc9a1d6e6f13",
       "depends_on": [
         "IQ-NORM-03"
@@ -55316,7 +55967,9 @@
     "IQ-PAID-REPORT-02": {
       "base": "main",
       "branch": "codex/iq-paid-report-02-render-entitlement-states",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "IQ-PAID-REPORT-01"
       ],
@@ -55346,7 +55999,9 @@
     "IQ-RELEASE-01": {
       "base": "main",
       "branch": "codex/iq-release-01-launch-readiness-ledger",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "IQ-OBS-01"
       ],
@@ -55468,7 +56123,9 @@
     "IQ-SEO-RAMP-02": {
       "base": "main",
       "branch": "codex/iq-seo-ramp-02-indexation-gate",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "IQ-SEO-RAMP-01"
       ],
@@ -55777,7 +56434,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add Metabase ops access runbook"
     },
@@ -55906,7 +56565,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add Ops Portal SEO auth audit contract"
     },
@@ -55963,7 +56624,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(ops): add SEO dashboard access shell"
     },
@@ -56020,7 +56683,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add private Metabase access bridge contract"
     },
@@ -56084,7 +56749,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add Ops Portal SEO access verification contract"
     },
@@ -56126,7 +56793,9 @@
       "remote_branch_deleted": null,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "verified",
       "title": "/ops/seo production access verification"
     },
@@ -56236,7 +56905,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1626",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "OPS-SECURITY-STORAGE-PATH-SAFETY-01": {
@@ -56298,7 +56969,9 @@
         }
       },
       "commit_sha": "c5d45863c786b8825e1514db97a7db28fa2a9808",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-24T01:05:00+08:00",
@@ -56323,7 +56996,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1625",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "PERSONALITY-ENNEAGRAM-COMPAT-01": {
@@ -56419,7 +57094,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1640",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "local_validated"
     },
     "PR-2": {
@@ -56896,7 +57573,9 @@
       "branch": "codex/pr-audit-be-01-ci-supply-chain",
       "checks": {
         "github_required_checks": {
-          "failed": [],
+          "failed": [
+
+          ],
           "passed": [
             "hygiene",
             "supply-chain",
@@ -56909,7 +57588,9 @@
           "status": "passed"
         },
         "local": {
-          "failed": [],
+          "failed": [
+
+          ],
           "passed": [
             "cd backend && composer validate --strict",
             "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
@@ -56925,7 +57606,9 @@
         }
       },
       "commit_sha": "c87d9bc11f4e1cf90e60c06660b472e8afeb10a0",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-24T07:16:21.665+00:00",
@@ -56964,7 +57647,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1644",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "updated_at": "2026-05-24T07:40:49.781Z"
     },
@@ -56973,7 +57658,9 @@
       "checks": {
         "github_required_checks": {
           "evidence": "PR #1645 passed required GitHub checks and was squash-merged as 0338122739bbe4fd9645943d4f08372a3881f560.",
-          "failed": [],
+          "failed": [
+
+          ],
           "head_sha": "1051d5a87f12f518eb0a6cff7270ebb7be5dbcc2",
           "passed": [
             "hygiene",
@@ -57105,7 +57792,9 @@
         },
         "github": {
           "evidence": "GitHub required checks passed on PR #1648 after adding the scoped runtime-freeze classifier evidence for the attempt_quality retirement migration.",
-          "failed": [],
+          "failed": [
+
+          ],
           "head_sha": "4aa43fd17a91dfca4f4b4035e3c77f9862f211dc",
           "passed": [
             "hygiene",
@@ -57121,7 +57810,9 @@
         },
         "github_required_checks": {
           "evidence": "GitHub PR #1648 is MERGED and origin/main contains merge commit d18c0cc36a84ce50b823c995e4226b188551b0d0.",
-          "failed": [],
+          "failed": [
+
+          ],
           "head_sha": "ac79f977b060252b0f4c0bde711643b2069c7380",
           "passed": [
             "hygiene",
@@ -57195,7 +57886,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1648",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "updated_at": "2026-05-24T10:46:53.618Z"
     },
@@ -57469,7 +58162,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "controlled_codex_assisted_cms_publish_sop",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "PR-CMS-04｜Controlled Codex-Assisted CMS Publish SOP"
     },
@@ -57557,7 +58252,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "semantic_content_gate_architecture",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "PR-CMS-FIX-MASTER｜Scalable Semantic Content Gate Architecture"
     },
@@ -58102,7 +58799,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "article_multi_test_graph_edges",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_local_checks_passed",
       "title": "PR-GRAPH-01｜Article Multi-Test Graph Edges"
     },
@@ -58174,7 +58873,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "PR-HIRING-01 hiring content authority package",
       "transitions": [
@@ -58282,7 +58983,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1418",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "PR-MEDIA-01｜CMS Media Library OSS/CDN Upload Automation"
     },
@@ -58398,7 +59101,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -58503,7 +59208,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(cms): add Research Asset backend MVP"
     },
@@ -58577,7 +59284,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(research): add SEO GEO search channel contract"
     },
@@ -58700,7 +59409,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "article_authority_import_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): import six SEO articles with SVG covers"
     },
@@ -58781,7 +59492,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "article_graph_authority_closure_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): close six-article graph recommendation authority"
     },
@@ -58862,7 +59575,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "article_baseline_republish_projection_convergence_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "open",
       "title": "fix(api): republish article baseline and complete public projection"
     },
@@ -58954,7 +59669,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "chore(cms): add article publish smoke for cover image propagation",
       "train_scope": "publishing_reliability"
@@ -59010,7 +59727,9 @@
         }
       },
       "commit_sha": "5a609e81aaeaaecf0577f7b68fec99f28588f0f8",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "history": [
         {
@@ -59040,7 +59759,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(cms-media): enforce public article media origin and variant readiness",
       "train_scope": "publishing_reliability"
@@ -59237,8 +59958,12 @@
       "scope_type": "final_2786_public_resolution_partition_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -59339,8 +60064,12 @@
       "scope_type": "final_2786_public_owner_partition_authority_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -59440,7 +60169,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "final_2786_software_manual_hold_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): account software manual hold in 2786 readiness"
     },
@@ -59493,7 +60224,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "delta_rollout_manifest_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career 51-delta rollout manifest"
     },
@@ -59546,7 +60279,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_80_candidate_selector_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career 80 candidate readiness selector"
     },
@@ -59600,7 +60335,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_runtime_candidate_pool_planner_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "committed",
       "title": "feat(api): add career 80 runtime candidate pool planner"
     },
@@ -59658,7 +60395,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "career_80_live_surface_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): align career 80 live surface with runtime authority"
     },
@@ -59711,7 +60450,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_manifest_train_command_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "feat(api): add career 80 manifest train command"
     },
@@ -59764,7 +60505,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_readiness_command_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career 80 cohort readiness command"
     },
@@ -59817,7 +60560,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_readiness_selection_gate_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): tighten career 80 readiness candidate selection"
     },
@@ -59871,7 +60616,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "80_target_delta_decomposition_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career 80 target delta decomposition"
     },
@@ -59925,7 +60672,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "career_80_total_live_acceptance_report_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): add career 80 total live acceptance report"
     },
@@ -60026,7 +60775,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_baseline_metadata_mapping_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): map career workbook baseline metadata for audit"
     },
@@ -60077,7 +60828,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "candidate_aware_audit_policy_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "github_checks_passed_human_review_pending",
       "title": "fix(api): accept candidate-aware runtime states for delta planning"
     },
@@ -60148,7 +60901,9 @@
       "failure_reason": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1431",
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): add guarded CN proxy noindex public-owner surface"
     },
@@ -60236,7 +60991,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium_publication_authority",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "committed",
       "title": "fix(api): add CN proxy visible detail policy authority",
       "train_scope": "cn_proxy_visible_detail_policy_authority"
@@ -60317,7 +61074,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "delta_rollout_apply_batch_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): repair career delta rollout apply batch authority"
     },
@@ -60370,7 +61129,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "delta_rollout_gate_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career delta rollout gate semantics"
     },
@@ -60451,7 +61212,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): promote display-backed directory draft jobs in list authority",
       "train_scope": "career_directory_detail_pending_authority"
@@ -60543,7 +61306,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): align directory list with runtime detail authority",
       "train_scope": "career_directory_list_detail_api_authority"
@@ -60597,7 +61362,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_occupation_entity_remediation_planning_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "committed",
       "title": "fix(api): add career occupation entity remediation planning"
     },
@@ -60673,8 +61440,12 @@
       "scope_type": "explicit_rollout_batch_ledger_authority_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed BigFiveResultPageV2CoreBodyPreviewTest::runtime_paths_have_no_uncommitted_diff while reporting CMS test-edge files from the parent worktree, not the current PR files.",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at compiled directory assertions.",
@@ -60789,7 +61560,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_index_state_remediation_planning_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_local_checks_passed",
       "title": "fix(api): add career index-state remediation planning"
     },
@@ -60846,7 +61619,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "readiness_policy_classification_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): classify career readiness policy blockers"
     },
@@ -60902,7 +61677,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "index_state_remediation_gate_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): add guarded career index state remediation command"
     },
@@ -60961,7 +61738,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "post_rollout_runtime_projection_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): include verified rollout batches in career runtime projection"
     },
@@ -60998,7 +61777,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): align career 2786 product claim authority",
       "train_scope": "career_product_claim_authority"
@@ -61061,8 +61842,12 @@
       "scope_type": "progressive_closeout_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive closeout command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -61078,8 +61863,12 @@
           "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure"
         },
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
             "Current PR does not modify backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
@@ -61152,8 +61941,12 @@
       "scope_type": "progressive_cohort_target_delta_planning_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed only Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive audit/command/test/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -61229,8 +62022,12 @@
       "scope_type": "progressive_live_acceptance_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive live acceptance command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -61246,8 +62043,12 @@
           "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure"
         },
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
             "Current PR does not modify backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
@@ -61323,8 +62124,12 @@
       "scope_type": "progressive_live_verification_scaling_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at tests/Feature/Content/PacksPublishBig5Test.php:94 asserting File::isDirectory($target.'/compiled').",
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at tests/Feature/Content/PacksRollbackBig5Test.php:97 asserting File::isDirectory($target.'/compiled').",
@@ -61412,7 +62217,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "progressive_readiness_cn_proxy_exclusion_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): exclude CN proxy rows from progressive readiness"
     },
@@ -61470,7 +62277,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "progressive_readiness_occupation_aware_selection_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): make progressive readiness selection occupation-aware"
     },
@@ -61526,7 +62335,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "progressive_readiness_selection_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "committed",
       "title": "fix(api): add progressive career readiness selection"
     },
@@ -61603,8 +62414,12 @@
       "scope_type": "progressive_readiness_software_manual_hold_exclusion_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksPublishBig5Test at the target compiled directory assertion.",
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksRollbackBig5Test at the target compiled directory assertion.",
@@ -61679,8 +62494,12 @@
       "scope_type": "progressive_rollout_manifest_gate_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive rollout manifest/gate command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -61756,8 +62575,12 @@
       "scope_type": "progressive_runtime_artifact_refresh_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career runtime artifact refresh command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -61829,7 +62652,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "progressive_runtime_candidate_pool_selection_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): consume progressive delta slugs in runtime candidate pool"
     },
@@ -61890,8 +62715,12 @@
       "scope_type": "progressive_runtime_candidate_preparation_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career runtime candidate prep command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -61978,7 +62807,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "rollout_command_candidate_aware_artifact_normalization_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): normalize candidate-aware rollout projection artifacts"
     },
@@ -62010,7 +62841,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_run_context_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): make career audit run context explicit"
     },
@@ -62115,7 +62948,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_runtime_authority_classification_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): classify career runtime authority gaps for audit"
     },
@@ -62168,7 +63003,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "runtime_artifact_refresh_plan_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career runtime artifact refresh plan"
     },
@@ -62226,7 +63063,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "candidate_aware_runtime_artifact_refresh_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "github_checks_failed_scoped_fix_local_passed",
       "title": "fix(api): add candidate-aware runtime artifact refresh"
     },
@@ -62279,7 +63118,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "runtime_candidate_prep_planner_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career runtime candidate preparation planner"
     },
@@ -62334,7 +63175,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "runtime_candidate_prep_apply_gate_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add guarded runtime candidate preparation command"
     },
@@ -62402,8 +63245,12 @@
       "scope_type": "runtime_projection_lookup_latest_selection_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksPublishBig5Test at compiled directory assertion.",
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksRollbackBig5Test at compiled directory assertion.",
@@ -62522,7 +63369,9 @@
             "en",
             "zh"
           ],
-          "affected_slugs": [],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "SCAN-3 counts_by_reason_layer maps required_display_field_missing to baseline, not seo_geo.",
             "REPAIR-BASELINE-1 is the next train item and explicitly owns baseline/display metadata mapping."
@@ -62591,7 +63440,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_surface_context_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career surface context artifact support"
     },
@@ -62697,7 +63548,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_title_source_mapping_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): use workbook english titles in career audit"
     },
@@ -62756,7 +63609,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add Research report URL Truth observation"
     },
@@ -62809,7 +63664,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "github_checks_passed_pending_merge",
       "title": "docs(research): add first Research publish readiness checklist"
     },
@@ -62967,7 +63824,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1668",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_pending"
     },
     "RESULT-EN-PARITY-02": {
@@ -63042,7 +63901,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1669",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "RESULT-EN-PARITY-03": {
@@ -63122,7 +63983,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1670",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "RESULT-EN-PARITY-04": {
@@ -63217,7 +64080,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1671",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_rebased_github_checks_pending"
     },
     "RIASEC-AH-04": {
@@ -63387,7 +64252,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1632",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "RIASEC-DEEP-COPY-01": {
@@ -63453,7 +64320,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_deep_copy_slot_schema_contract_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): harden deep copy slot schema contract"
     },
@@ -63517,7 +64386,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_dimension_deep_copy_slots_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add dimension deep copy runtime slots"
     },
@@ -63958,7 +64829,9 @@
         }
       },
       "commit_sha": "7207f737cd469883370ccae25c6d175ff75c951d",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "local_cleanup_executed": true,
       "merged_at": "2026-05-13T07:06:00Z",
@@ -63966,7 +64839,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "train_registration_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(codex): register RIASEC personalization train"
     },
@@ -64019,7 +64894,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_interpretation_contract_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add interpretation rule spec v2 contract"
     },
@@ -64068,7 +64945,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_quality_contract_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add quality rule spec v2 contract"
     },
@@ -64113,7 +64992,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_projection_extension_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): extend projection v2 with interpretation state"
     },
@@ -64160,7 +65041,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_module_selector_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add report module selector contract"
     },
@@ -64205,7 +65088,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "backend_content_registry_readiness_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add content registry readiness contract"
     },
@@ -64217,7 +65102,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "branch": "codex/riasec-personalization-06-frontend-fail-closed",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": "bb01c378674b28857b98ddbdf3d657144ef3b83e",
       "depends_on": [
         "RIASEC-PERSONALIZATION-03",
@@ -64230,7 +65117,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-web",
       "scope_type": "frontend_fail_closed_consumer_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): consume backend personalization state fail-closed"
     },
@@ -64241,7 +65130,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "branch": "codex/riasec-personalization-07-fixture-matrix",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": "7740b1b09ce6dddb693ac5dbcf8a1d027b0db08b",
       "depends_on": [
         "RIASEC-PERSONALIZATION-01",
@@ -64258,14 +65149,18 @@
       "remote_branch_deleted": false,
       "repo": "fap-web",
       "scope_type": "fixture_matrix_contracts_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pending",
       "title": "test(riasec): add personalization fixture matrix contracts"
     },
     "SEARCH-CHANNEL-LIVE-MBTI-01": {
       "branch": "codex/search-channel-live-mbti-01-preflight",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_live_preflight_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveMbti01Preflight --no-ansi (1 test, 25 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -64323,7 +65218,9 @@
     "SEARCH-CHANNEL-LIVE-MBTI-02": {
       "branch": "codex/search-channel-live-mbti-02",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_live_submission_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveMbti02 --no-ansi (1 test, 14 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -64393,7 +65290,9 @@
     "SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW": {
       "branch": "codex/search-channel-live-mbti-02-24h-review",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_twenty_four_hour_review_test": "passed_with_warnings: php artisan test --filter=SeoIntelSearchChannelLiveMbti02TwentyFourHourReview --no-ansi exited 0 with 1 warning and 14 assertions",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -64814,7 +65713,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -64877,7 +65778,9 @@
         }
       },
       "commit_sha": "dc96157c0c226ed39c2036a27670c092bc54013f",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "local_cleanup_executed": true,
       "merged_at": "2026-06-02T11:46:03Z",
@@ -64891,7 +65794,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "transitions": [
         {
@@ -65507,7 +66412,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_collector",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_passed",
       "title": "feat(seo-intel): add drift collector and crawler log foundation",
       "train_scope": "search_intelligence_drift_collector_crawler_log_foundation"
@@ -65633,7 +66540,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_aggregate_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add attribution and revenue builders",
       "train_scope": "search_intelligence_backend_attribution_revenue_builders"
@@ -65757,7 +66666,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_search_channel_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add disabled GSC collector",
       "train_scope": "search_intelligence_gsc_disabled_collector"
@@ -65857,7 +66768,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium_disabled_search_channel_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add Baidu and IndexNow collector foundations",
       "train_scope": "search_intelligence_baidu_indexnow_disabled_collectors"
@@ -65967,7 +66880,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "low_docs_contract_no_deploy",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add Metabase MVP dashboard spec",
       "train_scope": "metabase_mvp_dashboard_policy_sanitized_views"
@@ -66090,7 +67005,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_issue_queue_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "github_checks_passed",
       "title": "feat(seo-intel): add CMS issue queue summary",
       "train_scope": "cms_issue_queue_summary_foundation"
@@ -66142,7 +67059,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): finalize SEO Dash MVP online closeout"
     },
@@ -66439,7 +67358,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium_migration_scope_no_production_execution",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(seo-intel): isolate seo_intel migrations",
       "train_scope": "seo_intel_migration_isolation"
@@ -66563,7 +67484,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "low_docs_contract_no_execution",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "title": "docs(seo-intel): add controlled write enablement plan",
@@ -66691,7 +67614,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_runtime_guard_no_production_execution",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "title": "feat(seo-intel): add bounded URL truth inventory canary",
@@ -66915,7 +67840,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -67033,7 +67960,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -67745,7 +68674,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B": {
       "branch": "codex/seo-growth-mbti-action-01b-enqueue",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_enqueue_report_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bSearchChannelEnqueue --no-ansi (5 tests, 31 assertions)",
           "git_diff_check": "passed: git diff --check",
@@ -67801,7 +68732,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-01": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-01",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "command_help": "passed: php artisan seo-intel:search-channel-queue --help exposes --canonical-url and --enqueue",
           "focused_single_url_command_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommand --no-ansi (9 tests, 64 assertions)",
@@ -67854,7 +68787,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_url_truth_alignment_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignment --no-ansi (1 test, 34 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -67979,7 +68914,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-preflight",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_prod_preflight_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdPreflight --no-ansi (5 tests, 29 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -68289,7 +69226,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-www-cleanup-plan",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_www_cleanup_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlan --no-ansi (4 tests, 30 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -68540,7 +69479,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-R2": {
       "branch": "codex/seo-growth-mbti-action-01b-r2-enqueue",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_enqueue_report_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueue --no-ansi (1 test, 17 assertions)",
           "git_diff_check": "passed: git diff --check",
@@ -68762,7 +69703,9 @@
         }
       },
       "commit_sha": "8208e69422a7487d272df57107a5b5e1cacf6b68",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-25T02:53:27.627612+00:00",
@@ -69135,7 +70078,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1631",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00": {
@@ -69227,7 +70172,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add two-stage URL Truth handoff"
     },
@@ -69266,7 +70213,9 @@
       },
       "commit_sha": "9d0b26e4ca234354963d9747f0f27438588856bc",
       "crawler_log_read": false,
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "deploy": false,
       "env_edit": false,
       "external_api_live_activation": false,
@@ -69829,7 +70778,9 @@
         }
       },
       "commit_sha": "59b2bf59703a02efa3d640593355b6d9c288475f",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "history": [
         {
@@ -69859,7 +70810,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "low",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "chore(storage): add read-only release roots audit",
       "train_scope": "storage_runtime_hygiene"
@@ -70160,7 +71113,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1284",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ready_to_merge"
     },
     "career-runtime-publish-projection": {
@@ -70332,7 +71287,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1356",
       "remote_branch_deleted": false,
       "repo": "fap-web",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pending_dependency"
     },
     "frontend-result-email-gate": {
@@ -70358,12 +71315,16 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1451",
       "remote_branch_deleted": false,
       "repo": "fap-web",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pending_dependency"
     },
     "iq-commerce-unlock-199-500": {
       "branch": "codex/iq-commerce-unlock-199-500",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "iq-report-builder-three-dimension-result-schema"
       ],
@@ -71211,7 +72172,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1742",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "local_validation_passed",
       "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01 replacement authority candidate reselect",
       "transitions": [
@@ -71336,7 +72299,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1750",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "EMAIL-DIRECTMAIL-SMTP-READINESS-01 DirectMail SMTP readiness docs env and outbox test",
       "transitions": [
@@ -71777,7 +72742,9 @@
         }
       },
       "commit_sha": "e934e8a5617ec669f6f326e1177e0c6044f9cb22",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "history": [
         {
@@ -73351,7 +74318,9 @@
         }
       },
       "commit_sha": null,
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "external_api_credentials_required": false,
       "failure_reason": null,
       "history": [


### PR DESCRIPTION
## What changed
- Hardened EQ `agent_dialogue_playbooks` for EQ_60 and EQ_EMOTIONAL_INTELLIGENCE.
- Tightened read-only response policies, clarification prompts, refusal examples, and escalation rules.
- Reframed career/work prompts from “fit” language to work-environment variable validation.
- Updated the relevant agent knowledge intent labels/openings to match the safer wording.
- Refreshed scoped compiled report assets and reconciled train state after SCI-15.

## Why
- Agent-facing assets must preserve backend report authority and prevent score/report mutation, formulation override, SJT enablement, high-risk judgments, paywall language, and raw technical tag leakage.
- Playbooks need clear, user-safe boundaries before any runtime or future LLM layer consumes them.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- Raw and compiled EQ_60/EQ_EMOTIONAL_INTELLIGENCE mirror comparisons
- SCI-16 scope validation
- Agent playbook guard scan
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No live Agent runtime behavior changes.
- No LLM/provider integration.
- No scoring, question, reverse-key, norm algorithm, frontend, SJT, commerce, CMS, deployment, or report-composer behavior changes.

## Repository rule impact
- Content authority remains backend content pack / composer. Agent assets remain read-only guidance over authoritative report assets.
