### PR TITLE
ENNEA-RP-13: fix(enneagram): repair methodology boundary card

### DIFF
--- a/backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json
@@ -19,7 +19,7 @@
             "method_key": "e105_standard_methodology",
             "form_variant": "e105",
             "display_context": "result_page",
-            "copy": "E105 标准版使用 Likert 强度作答，可用于第一次建立全谱结果、Top3、Dominance Gap 与 close-call 阅读框架。",
+            "copy": "E105 标准版使用 Likert 强度作答，适合先建立一次全谱轮廓、Top3、Dominance Gap 与 close-call 阅读框架。它呈现的是同一题型内部的相对信号，不是九型人格的临床量表、能力测量或稳定人格定论。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -27,7 +27,7 @@
             "method_key": "fc144_forced_choice_methodology",
             "form_variant": "fc144",
             "display_context": "result_page",
-            "copy": "FC144 深度版使用 forced-choice 配对选择，可用于 close-call 后的深度辨析，但它与 E105 不共享同一分数来源。",
+            "copy": "FC144 使用 forced-choice 配对选择，更适合在 close-call 后观察你在两难取舍中反复选择的线索。它不是比 E105 更“准确”的版本，也不与 E105 共享同一分数来源；两者结果应按各自题型边界阅读。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -35,7 +35,7 @@
             "method_key": "same_model_not_same_score_space",
             "form_variant": "all",
             "display_context": "technical_note",
-            "copy": "E105 与 FC144 属于同一 ENNEAGRAM 模型，但不处在同一 score space。它们可以共用结果页结构与解释边界，不默认直接比较数值高低。",
+            "copy": "E105 与 FC144 属于同一 ENNEAGRAM 模型和解释框架，但题型、作答任务与计分来源不同，不处在同一 score space。它们可以共用结果页结构与安全边界，但不默认直接比较数值高低，也不把跨 form 差异解释为人格变化。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -51,7 +51,7 @@
             "method_key": "non_diagnostic_boundary",
             "form_variant": "all",
             "display_context": "technical_note",
-            "copy": "本结果用于人格模式理解与自我观察，不用于临床诊断、心理治疗建议、招聘筛选或对个体做绝对定性。",
+            "copy": "本结果只用于人格模式理解、自我观察与反思对话。它不用于临床诊断、心理治疗建议、心理健康判断、招聘筛选、岗位匹配、能力评价或对个体做绝对定性；高分、主候选、close-call 与低质量提示都应被看作解释假设，而不是事实判决。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },

--- a/backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json
@@ -33,11 +33,11 @@
         },
         "form_badge.e105": {
             "label": "E105 标准版",
-            "body_template": "第一次了解自己的九型结构时，可用它建立全谱与 Top3 阅读。"
+            "body_template": "适合先建立一次全谱与 Top3 阅读；分数只在 E105 题型内部解释。"
         },
         "form_badge.fc144": {
             "label": "FC144 深度版",
-            "body_template": "它和 E105 同属一套模型，但采用 forced-choice 题型，分数空间不同。"
+            "body_template": "采用 forced-choice 题型观察取舍线索；它和 E105 同属一套模型，但分数空间不同。"
         },
         "close_call_card.title": {
             "label": "Top1 vs Top2 辨析"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -4245,7 +4245,7 @@
     "checks": [
 
     ],
-    "commit_sha": null,
+    "commit_sha": "897093474e737e2954a5f9e42b66af693ca4535b",
     "depends_on": [
       "BIG5-SCENARIO-ACTION-SCIENTIFIC-REPAIR-01"
     ],
@@ -13230,13 +13230,18 @@
         "at": "2026-07-03T15:06:00Z",
         "status": "local_validation_passed",
         "notes": "Repaired methodology boundary copy for E105, FC144, score-space, non-diagnostic, and form badge fields; fixed current-scope method registry test anchor and required local validation passed."
+      },
+      {
+        "at": "2026-07-03T15:10:00Z",
+        "status": "pr_opened",
+        "notes": "Opened PR #2674 for methodology boundary card repair; awaiting GitHub required checks."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-13",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2674",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
@@ -13256,7 +13261,7 @@
       "status": "pass",
       "evidence": "Changed files are confined to methodology boundary method/ui registry content and train ledger reconciliation."
     },
-    "status": "local_validation_passed",
+    "status": "pr_opened",
     "title": "ENNEA-RP-13: fix(enneagram): repair methodology boundary card",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -13209,9 +13209,14 @@
         "status": "pass",
         "command": "git diff --check",
         "evidence": "No whitespace errors."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2674 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All required GitHub checks passed on PR #2674 head 7d696f4640068df89b0623e6820dbc3a5a3d21f0."
       }
     },
-    "commit_sha": null,
+    "commit_sha": "7d696f4640068df89b0623e6820dbc3a5a3d21f0",
     "depends_on": [
       "ENNEA-RP-12"
     ],
@@ -13235,6 +13240,11 @@
         "at": "2026-07-03T15:10:00Z",
         "status": "pr_opened",
         "notes": "Opened PR #2674 for methodology boundary card repair; awaiting GitHub required checks."
+      },
+      {
+        "at": "2026-07-03T15:20:00Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub required checks passed for PR #2674 and mergeStateStatus was CLEAN; scope remains confined to methodology boundary method/ui registry content and train ledger."
       }
     ],
     "failure_reason": null,
@@ -13261,7 +13271,7 @@
       "status": "pass",
       "evidence": "Changed files are confined to methodology boundary method/ui registry content and train ledger reconciliation."
     },
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "title": "ENNEA-RP-13: fix(enneagram): repair methodology boundary card",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -13130,14 +13130,19 @@
         "at": "2026-07-03T14:31:00Z",
         "status": "ready_to_merge",
         "notes": "GitHub required checks passed for PR #2670 after rebase and mergeStateStatus was CLEAN; scope remains confined to wing hint theory registry content and train ledger."
+      },
+      {
+        "at": "2026-07-03T05:48:52Z",
+        "status": "merged",
+        "notes": "PR #2670 squash-merged as 3cfe7d4170b254b46cdc7c14e808ecd573ea1818; merge commit present in origin/main; local main synced and task branch cleaned up before ENNEA-RP-13."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-12",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-03T05:48:52Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2670",
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "allowed_files": [
@@ -13154,7 +13159,7 @@
       "status": "pass",
       "evidence": "Changed files are confined to wing hint theory registry content and train ledger reconciliation."
     },
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "ENNEA-RP-12: fix(enneagram): repair wing hint visual boundary",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },
@@ -13165,6 +13170,45 @@
       "authorization": {
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
         "status": "pass"
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-12 merged as PR #2670 and merge commit 3cfe7d4170b254b46cdc7c14e808ecd573ea1818 is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All ENNEAGRAM v2 registry JSON files parsed successfully."
+      },
+      "type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed: 2 warnings, 14509 assertions."
+      },
+      "registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Passed: 3 warnings, 26 assertions."
+      },
+      "composer_v2_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Passed: 15 warnings, 128 assertions."
+      },
+      "method_registry_boundary": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramMethodRegistryBoundaryTest",
+        "evidence": "Passed: 1 warning, 4 assertions after preserving required same-model anchor phrase."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed: 262 warnings, 2 passed, 83412 assertions, duration 29.07s."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
       }
     },
     "commit_sha": null,
@@ -13176,6 +13220,16 @@
         "at": "2026-07-02T16:10:24Z",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
         "status": "pending_dependency"
+      },
+      {
+        "at": "2026-07-03T14:55:00Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-13-methodology-boundary-card; scope is methodology boundary method/ui registry content plus train ledger only."
+      },
+      {
+        "at": "2026-07-03T15:06:00Z",
+        "status": "local_validation_passed",
+        "notes": "Repaired methodology boundary copy for E105, FC144, score-space, non-diagnostic, and form badge fields; fixed current-scope method registry test anchor and required local validation passed."
       }
     ],
     "failure_reason": null,
@@ -13193,11 +13247,16 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [
-
-      ]
+      "changed_files": [
+        "backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json",
+        "backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "outside_scope_files": [],
+      "status": "pass",
+      "evidence": "Changed files are confined to methodology boundary method/ui registry content and train ledger reconciliation."
     },
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "title": "ENNEA-RP-13: fix(enneagram): repair methodology boundary card",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },


### PR DESCRIPTION
What changed:
- Rewrote E105, FC144, same-model/score-space, and non-diagnostic methodology copy with clearer scientific and use-case boundaries.
- Tightened form badge copy so E105/FC144 are framed as different task formats, not better/worse accuracy tiers.
- Reconciled ENNEA-RP-12 post-merge ledger state and recorded ENNEA-RP-13 local validation.

Why:
- Methodology boundary cards should explain form differences and interpretation limits without implying clinical validity, hiring suitability, ability measurement, or cross-form score comparability.

Validation:
- cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json
- cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest
- cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest
- cd backend && php artisan test --filter=EnneagramReportComposerV2Test
- cd backend && php artisan test --filter=EnneagramMethodRegistryBoundaryTest
- cd backend && php artisan test --filter=Enneagram
- git diff --check

Scope validation:
- Changed files are confined to backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json, backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json, and docs/codex/pr-train-state.json.

Intentionally deferred:
- no fap-web changes
- no runtime/API changes
- no staging deploy wait
- no server verification
- no registry activation
- no production deploy
