### PR TITLE
PR-EQ-ASSET-SCI-18: improve EQ personalization_route matrix differentiation

### DIFF
--- a/backend/content_packs/EQ_60/v1/raw/personalization_routes/route_matrix.json
+++ b/backend/content_packs/EQ_60/v1/raw/personalization_routes/route_matrix.json
@@ -20,7 +20,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "balanced_strength",
         "confidence": "normal",
         "requires_manual_review": false
@@ -47,15 +48,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“均衡整合型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Integrated Balance and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现均衡整合：四维相对均衡，适合维护已经可用的节奏。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows Integrated balance: the four dimensions sit relatively evenly; maintain what already works. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -63,17 +64,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "均衡整合型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“均衡整合型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：均衡整合",
+          "why_this_feels_specific": "四维相对均衡，适合维护已经可用的节奏；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "选一个高压场景，观察你的稳定做法如何被保持。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Integrated Balance This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Integrated Balance and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: Integrated balance",
+          "why_this_feels_specific": "The four dimensions sit relatively evenly; maintain what already works. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Pick one pressure scene and notice how your steady pattern is maintained.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -94,7 +95,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "empathy_regulation_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -121,15 +123,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“高共情，低恢复”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as High Empathy, Low Recovery and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现高共情、低恢复：共情信号突出，恢复与边界是优先观察点。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows high empathy with lower recovery: empathy signals are prominent; recovery and boundaries deserve first attention. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -137,17 +139,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "高共情，低恢复 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“高共情，低恢复”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：高共情、低恢复",
+          "why_this_feels_specific": "共情信号突出，恢复与边界是优先观察点；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先练一个边界句，再观察情绪恢复时间。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "High Empathy, Low Recovery This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as High Empathy, Low Recovery and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: high empathy with lower recovery",
+          "why_this_feels_specific": "Empathy signals are prominent; recovery and boundaries deserve first attention. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Practice one boundary sentence, then observe recovery time.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -168,7 +170,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "awareness_regulation_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -195,15 +198,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“有觉察，调节不足”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Aware, Not Yet Settled and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现觉察较清楚、调节仍在练习：能觉察触发点，但恢复步骤需要更具体。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows clearer awareness with regulation still developing: triggers are easier to notice than to settle. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -211,17 +214,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "有觉察，调节不足 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“有觉察，调节不足”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：觉察较清楚、调节仍在练习",
+          "why_this_feels_specific": "能觉察触发点，但恢复步骤需要更具体；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把一次触发拆成事实、感受、下一步三栏。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Aware, Not Yet Settled This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Aware, Not Yet Settled and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: clearer awareness with regulation still developing",
+          "why_this_feels_specific": "Triggers are easier to notice than to settle. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Split one trigger into facts, feelings, and next move.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -242,7 +245,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "regulation_empathy_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -269,15 +273,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“冷静稳定，但情绪回应偏弱”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Calm, but Hard to Read Warmly and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现稳定但回应偏收：调节感较强，但情绪回应可能不够可见。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows stable but less visibly warm: regulation looks stronger than visible emotional response. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -285,17 +289,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "冷静稳定，但情绪回应偏弱 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“冷静稳定，但情绪回应偏弱”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：稳定但回应偏收",
+          "why_this_feels_specific": "调节感较强，但情绪回应可能不够可见；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "在一个低风险对话里补一句感受确认。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Calm, but Hard to Read Warmly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Calm, but Hard to Read Warmly and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: stable but less visibly warm",
+          "why_this_feels_specific": "Regulation looks stronger than visible emotional response. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Add one feeling acknowledgement in a low-risk conversation.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -316,7 +320,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "relationship_self_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -343,15 +348,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“关系优先，自我后置”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Relationship First, Self Later and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现关系优先、自我后置：关系维护信号较强，自我需求容易被推迟。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows relationship-first with self-needs later: relationship maintenance is prominent while self-needs may be delayed. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -359,17 +364,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "关系优先，自我后置 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“关系优先，自我后置”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：关系优先、自我后置",
+          "why_this_feels_specific": "关系维护信号较强，自我需求容易被推迟；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先写下自己的底线，再决定回应方式。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Relationship First, Self Later This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Relationship First, Self Later and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: relationship-first with self-needs later",
+          "why_this_feels_specific": "Relationship maintenance is prominent while self-needs may be delayed. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Write your boundary first, then choose a response.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -390,7 +395,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "expression_repair_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -417,15 +423,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“自我清楚，修复不足”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Clear About Self, Less Practiced at Repair and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现自我清楚、修复较少：自我表达较明确，关系修复步骤需要更具体。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows self-clear with less repair practice: self-expression is clearer than repair follow-through. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -433,17 +439,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "自我清楚，修复不足 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“自我清楚，修复不足”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：自我清楚、修复较少",
+          "why_this_feels_specific": "自我表达较明确，关系修复步骤需要更具体；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "复盘一次冲突后补一个修复动作。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Clear About Self, Less Practiced at Repair This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Clear About Self, Less Practiced at Repair and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: self-clear with less repair practice",
+          "why_this_feels_specific": "Self-expression is clearer than repair follow-through. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "After reviewing one conflict, add one repair move.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -464,7 +470,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "regulation_relationship_strength",
         "confidence": "normal",
         "requires_manual_review": false
@@ -491,15 +498,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“稳定协作者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Steady Collaborator and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现稳定协作：调节与关系管理信号较稳，适合关注复杂协作中的耗损。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows steady collaboration: regulation and relationship-management signals look steady; watch cost in complex collaboration. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -507,17 +514,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "稳定协作者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“稳定协作者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：稳定协作",
+          "why_this_feels_specific": "调节与关系管理信号较稳，适合关注复杂协作中的耗损；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "选一个协作场景，标记哪里需要恢复空间。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Steady Collaborator This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Steady Collaborator and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: steady collaboration",
+          "why_this_feels_specific": "Regulation and relationship-management signals look steady; watch cost in complex collaboration. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Choose one collaboration scene and mark where recovery space is needed.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -538,7 +545,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "high_sensitivity",
         "confidence": "normal",
         "requires_manual_review": false
@@ -565,15 +573,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“高敏感，易吸收”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Sensitive and Absorbing and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现敏感且易吸收：觉察与共情信号突出，容易把外部情绪带进自身状态。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows sensitive and absorbing: awareness and empathy stand out, with a risk of carrying others’ emotions inward. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -581,17 +589,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "高敏感，易吸收 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“高敏感，易吸收”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：敏感且易吸收",
+          "why_this_feels_specific": "觉察与共情信号突出，容易把外部情绪带进自身状态；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把“我感受到的”和“我需要承担的”分开写。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Sensitive and Absorbing This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Sensitive and Absorbing and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: sensitive and absorbing",
+          "why_this_feels_specific": "Awareness and empathy stand out, with a risk of carrying others’ emotions inward. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Separate what you sense from what you need to carry.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -612,7 +620,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "foundational_development",
         "confidence": "normal",
         "requires_manual_review": false
@@ -639,15 +648,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“基础发展中”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Building the Foundation and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现基础策略仍在建立：多维自评都偏保守，先建立语言和低风险练习。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows foundation still forming: several self-ratings are conservative; start with language and low-risk practice. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -655,17 +664,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "基础发展中 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“基础发展中”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：基础策略仍在建立",
+          "why_this_feels_specific": "多维自评都偏保守，先建立语言和低风险练习；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先做一次情绪命名，不急着下长期结论。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Building the Foundation This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Building the Foundation and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: foundation still forming",
+          "why_this_feels_specific": "Several self-ratings are conservative; start with language and low-risk practice. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Start with one emotion label; do not rush to a long-term conclusion.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -686,14 +695,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "repair_confidence_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.underconfident_repairer",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.underconfident_repairer.primary",
           "eq.scene.conflict.underconfident_repairer.primary",
@@ -710,15 +722,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“低估自己的修复者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Underconfident Repairer and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现修复能力感偏低：修复意愿可能存在，但自我信心或可用脚本不足。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows low confidence in repair: repair intent may be present, but confidence or scripts may be limited. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -726,17 +738,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "低估自己的修复者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“低估自己的修复者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：修复能力感偏低",
+          "why_this_feels_specific": "修复意愿可能存在，但自我信心或可用脚本不足；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "准备一句简单修复开场，而不是立刻解释全部。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Underconfident Repairer This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Underconfident Repairer and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: low confidence in repair",
+          "why_this_feels_specific": "Repair intent may be present, but confidence or scripts may be limited. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Prepare one simple repair opener instead of explaining everything at once.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -757,14 +769,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "boundary_overhelping",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.over_responsible_helper",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.over_responsible_helper.primary",
           "eq.scene.conflict.over_responsible_helper.primary",
@@ -781,15 +796,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“过度负责的帮助者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Over-Responsible Helper and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现帮助责任感偏高：支持他人的信号较强，需要区分关心与承担。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows over-responsible helping: support signals are strong; separate care from taking over. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -797,17 +812,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "过度负责的帮助者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“过度负责的帮助者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：帮助责任感偏高",
+          "why_this_feels_specific": "支持他人的信号较强，需要区分关心与承担；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "帮忙前先问：这件事必须由我承担吗？",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Over-Responsible Helper This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Over-Responsible Helper and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: over-responsible helping",
+          "why_this_feels_specific": "Support signals are strong; separate care from taking over. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Before helping, ask: does this have to be mine to carry?",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -828,14 +843,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "speed_under_pressure",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.fast_reactor",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.fast_reactor.primary",
           "eq.scene.conflict.fast_reactor.primary",
@@ -852,15 +870,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“反应快，暂停短”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Fast Reactor and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现反应快、暂停短：压力下反应速度可能快于整理速度。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows fast reaction with short pause: response speed may exceed processing time under pressure. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -868,17 +886,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "反应快，暂停短 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“反应快，暂停短”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：反应快、暂停短",
+          "why_this_feels_specific": "压力下反应速度可能快于整理速度；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "给自己设置一句暂停语，再进入回应。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Fast Reactor This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Fast Reactor and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: fast reaction with short pause",
+          "why_this_feels_specific": "Response speed may exceed processing time under pressure. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Use one pause phrase before responding.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -899,14 +917,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "analysis_feeling_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.analytical_under_feeling",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.analytical_under_feeling.primary",
           "eq.scene.conflict.analytical_under_feeling.primary",
@@ -923,15 +944,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“先分析，后感受”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Analytical Before Feeling and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现先分析、后感受：认知整理较快，感受命名可能滞后。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows analysis before feeling: cognitive sorting may come before naming feelings. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -939,17 +960,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "先分析，后感受 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“先分析，后感受”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：先分析、后感受",
+          "why_this_feels_specific": "认知整理较快，感受命名可能滞后；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先允许一句“我还在感受里整理”。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Analytical Before Feeling This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Analytical Before Feeling and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: analysis before feeling",
+          "why_this_feels_specific": "Cognitive sorting may come before naming feelings. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Allow the sentence: I am still sorting what I feel.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -970,14 +991,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "quiet_empathy",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.quiet_empathy",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.quiet_empathy.primary",
           "eq.scene.conflict.quiet_empathy.primary",
@@ -994,15 +1018,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“安静共情型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Quiet Empathy and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现安静共情：理解他人的信号存在，但表达可能较克制。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows quiet empathy: understanding may be present while expression stays restrained. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1010,17 +1034,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "安静共情型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“安静共情型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：安静共情",
+          "why_this_feels_specific": "理解他人的信号存在，但表达可能较克制；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把一次理解转成一句可听见的回应。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Quiet Empathy This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Quiet Empathy and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: quiet empathy",
+          "why_this_feels_specific": "Understanding may be present while expression stays restrained. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Turn one understanding into an audible response.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1041,14 +1065,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "direct_expression",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.direct_without_softening",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.direct_without_softening.primary",
           "eq.scene.conflict.direct_without_softening.primary",
@@ -1065,15 +1092,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“直接表达，柔化不足”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Direct Without Softening and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现直接表达、柔化不足：自我表达较直接，关系缓冲需要补足。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows direct expression with less softening: self-expression is direct; relational buffering may need support. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1081,17 +1108,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "直接表达，柔化不足 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“直接表达，柔化不足”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：直接表达、柔化不足",
+          "why_this_feels_specific": "自我表达较直接，关系缓冲需要补足；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "在观点前加一句关系意图。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Direct Without Softening This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Direct Without Softening and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: direct expression with less softening",
+          "why_this_feels_specific": "Self-expression is direct; relational buffering may need support. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Add one relationship-intent sentence before the point.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1112,14 +1139,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "relationship_masking",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.relationship_masking",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.relationship_masking.primary",
           "eq.scene.conflict.relationship_masking.primary",
@@ -1136,15 +1166,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“用关系稳定掩盖真实感受”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Relationship Masking and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现关系稳定掩盖感受：关系维持较强，真实感受可能被延后处理。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows relationship stability masking feelings: relationship maintenance is strong while personal feelings may be postponed. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1152,17 +1182,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "用关系稳定掩盖真实感受 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“用关系稳定掩盖真实感受”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：关系稳定掩盖感受",
+          "why_this_feels_specific": "关系维持较强，真实感受可能被延后处理；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "对自己先说清：我真实在意的是什么？",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Relationship Masking This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Relationship Masking and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: relationship stability masking feelings",
+          "why_this_feels_specific": "Relationship maintenance is strong while personal feelings may be postponed. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "First ask yourself: what actually matters to me here?",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1183,14 +1213,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "feedback_absorption",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.feedback_absorber",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.feedback_absorber.primary",
           "eq.scene.conflict.feedback_absorber.primary",
@@ -1207,15 +1240,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“容易吸收反馈情绪”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Feedback Absorber and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现反馈情绪易吸收：反馈场景可能带来较多情绪残留。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows feedback absorption: feedback scenes may leave more emotional residue. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1223,17 +1256,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "容易吸收反馈情绪 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“容易吸收反馈情绪”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：反馈情绪易吸收",
+          "why_this_feels_specific": "反馈场景可能带来较多情绪残留；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "反馈后先分开信息和情绪，再决定行动。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Feedback Absorber This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Feedback Absorber and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: feedback absorption",
+          "why_this_feels_specific": "Feedback scenes may leave more emotional residue. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "After feedback, separate information from emotion before acting.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1254,14 +1287,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "balanced_moderate",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.balanced_moderate",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.balanced_moderate.primary",
           "eq.scene.conflict.balanced_moderate.primary",
@@ -1278,15 +1314,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“均衡但仍在打磨”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Balanced, Still Sharpening and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现均衡但仍在打磨：四维没有明显极端，重点是把可用策略做稳定。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows balanced but still sharpening: no dimension is extreme; the task is to make usable strategies steadier. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1294,17 +1330,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "均衡但仍在打磨 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“均衡但仍在打磨”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：均衡但仍在打磨",
+          "why_this_feels_specific": "四维没有明显极端，重点是把可用策略做稳定；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "选一个最常见场景做小幅优化。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Balanced, Still Sharpening This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Balanced, Still Sharpening and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: balanced but still sharpening",
+          "why_this_feels_specific": "No dimension is extreme; the task is to make usable strategies steadier. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Choose one common scene for a small improvement.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1325,14 +1361,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "private_regulation",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.regulated_but_private",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.regulated_but_private.primary",
           "eq.scene.conflict.regulated_but_private.primary",
@@ -1349,15 +1388,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“能稳住，但不易表达”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Regulated but Private and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现能稳住但不易表达：内部调节较强，外部表达可能偏少。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows regulated but private: internal regulation looks stronger than outward expression. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1365,17 +1404,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "能稳住，但不易表达 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“能稳住，但不易表达”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：能稳住但不易表达",
+          "why_this_feels_specific": "内部调节较强，外部表达可能偏少；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把内部判断转成一句可分享的状态说明。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Regulated but Private This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Regulated but Private and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: regulated but private",
+          "why_this_feels_specific": "Internal regulation looks stronger than outward expression. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Turn one inner judgment into a shareable status sentence.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1396,14 +1435,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "warm_avoidance",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.warm_but_avoidant",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.warm_but_avoidant.primary",
           "eq.scene.conflict.warm_but_avoidant.primary",
@@ -1420,15 +1462,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“温和但回避张力”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Warm but Avoidant and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现温和但回避张力：关系温度较好，但分歧场景可能被延后。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows warm but tension-avoidant: warmth is available, while disagreement may be delayed. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1436,17 +1478,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "温和但回避张力 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“温和但回避张力”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：温和但回避张力",
+          "why_this_feels_specific": "关系温度较好，但分歧场景可能被延后；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "挑一个小分歧练习温和说清。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Warm but Avoidant This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Warm but Avoidant and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: warm but tension-avoidant",
+          "why_this_feels_specific": "Warmth is available, while disagreement may be delayed. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Practice naming one small disagreement warmly.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1467,14 +1509,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "listening_strength",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.strategic_listener",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.strategic_listener.primary",
           "eq.scene.conflict.strategic_listener.primary",
@@ -1491,15 +1536,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“策略型倾听者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Strategic Listener and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现策略型倾听：倾听和判断信号较强，后续行动需要明确。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows strategic listening: listening and judgment look strong; follow-through needs clarity. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1507,17 +1552,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "策略型倾听者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“策略型倾听者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：策略型倾听",
+          "why_this_feels_specific": "倾听和判断信号较强，后续行动需要明确；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "听完后补一句“我下一步会做什么”。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Strategic Listener This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Strategic Listener and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: strategic listening",
+          "why_this_feels_specific": "Listening and judgment look strong; follow-through needs clarity. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "After listening, add what you will do next.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1538,14 +1583,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "delayed_processing",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.delayed_processor",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.delayed_processor.primary",
           "eq.scene.conflict.delayed_processor.primary",
@@ -1562,15 +1610,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“延迟处理型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Delayed Processor and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现延迟处理：当下回应可能保守，事后整理更清楚。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows delayed processing: in-the-moment response may be cautious; later processing may be clearer. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1578,17 +1626,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "延迟处理型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“延迟处理型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：延迟处理",
+          "why_this_feels_specific": "当下回应可能保守，事后整理更清楚；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "提前给自己一个“稍后回应”的脚本。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Delayed Processor This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Delayed Processor and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: delayed processing",
+          "why_this_feels_specific": "In-the-moment response may be cautious; later processing may be clearer. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Prepare a script for responding later.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1609,14 +1657,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "pressure_containment",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.pressure_contained",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.pressure_contained.primary",
           "eq.scene.conflict.pressure_contained.primary",
@@ -1633,15 +1684,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“压力内收型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Contained Under Pressure and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现压力内收：压力下更可能收住情绪，外界未必看见成本。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows contained under pressure: pressure may be held inward, so the cost may not be visible to others. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1649,17 +1700,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "压力内收型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“压力内收型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：压力内收",
+          "why_this_feels_specific": "压力下更可能收住情绪，外界未必看见成本；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "压力后安排一个短恢复窗口。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Contained Under Pressure This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Contained Under Pressure and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: contained under pressure",
+          "why_this_feels_specific": "Pressure may be held inward, so the cost may not be visible to others. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Schedule a short recovery window after pressure.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1680,14 +1731,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "empathy_action_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.empathy_to_action_gap",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.empathy_to_action_gap.primary",
           "eq.scene.conflict.empathy_to_action_gap.primary",
@@ -1704,15 +1758,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“懂别人，但行动转化慢”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Empathy-to-Action Gap and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现理解到行动有距离：能理解他人，但下一步行动可能需要明确化。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows empathy-to-action gap: understanding others may be easier than choosing the next move. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1720,17 +1774,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "懂别人，但行动转化慢 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“懂别人，但行动转化慢”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：理解到行动有距离",
+          "why_this_feels_specific": "能理解他人，但下一步行动可能需要明确化；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把理解转成一个具体可执行动作。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Empathy-to-Action Gap This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Empathy-to-Action Gap and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: empathy-to-action gap",
+          "why_this_feels_specific": "Understanding others may be easier than choosing the next move. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Turn understanding into one concrete action.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1751,14 +1805,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "protective_distance",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.self_protective_distance",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.self_protective_distance.primary",
           "eq.scene.conflict.self_protective_distance.primary",
@@ -1775,15 +1832,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“保护性距离”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Protective Distance and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现保护性距离：保持距离可能帮助稳定，也可能减少真实交换。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows protective distance: distance may protect stability while reducing real exchange. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1791,17 +1848,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "保护性距离 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“保护性距离”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：保护性距离",
+          "why_this_feels_specific": "保持距离可能帮助稳定，也可能减少真实交换；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "判断这次距离是在保护，还是在回避。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Protective Distance This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Protective Distance and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: protective distance",
+          "why_this_feels_specific": "Distance may protect stability while reducing real exchange. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Ask whether this distance is protection or avoidance.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1822,14 +1879,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "values_sensitivity",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.values_sensitive",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.values_sensitive.primary",
           "eq.scene.conflict.values_sensitive.primary",
@@ -1846,15 +1906,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“价值敏感型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Values-Sensitive Responder and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现价值敏感：价值触发时情绪反应可能更强，需要先辨认原则。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows values-sensitive response: value triggers may intensify the response; name the principle first. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1862,17 +1922,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "价值敏感型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“价值敏感型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：价值敏感",
+          "why_this_feels_specific": "价值触发时情绪反应可能更强，需要先辨认原则；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先写下被触发的价值，再决定表达强度。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Values-Sensitive Responder This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Values-Sensitive Responder and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: values-sensitive response",
+          "why_this_feels_specific": "Value triggers may intensify the response; name the principle first. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Name the value being triggered before choosing intensity.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1893,14 +1953,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "team_stabilizing",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.team_stabilizer",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.team_stabilizer.primary",
           "eq.scene.conflict.team_stabilizer.primary",
@@ -1917,15 +1980,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“团队稳定器”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Team Stabilizer and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现团队稳定：协作稳定信号较强，但别把所有调和都放到自己身上。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows team stabilizing: collaborative stability is strong, but not every repair has to be yours. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1933,17 +1996,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "团队稳定器 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“团队稳定器”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：团队稳定",
+          "why_this_feels_specific": "协作稳定信号较强，但别把所有调和都放到自己身上；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "区分我能稳定什么、团队需要共同承担什么。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Team Stabilizer This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Team Stabilizer and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: team stabilizing",
+          "why_this_feels_specific": "Collaborative stability is strong, but not every repair has to be yours. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Separate what you can stabilize from what the team must share.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1964,14 +2027,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "listening_action_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.listening_without_followthrough",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.listening_without_followthrough.primary",
           "eq.scene.conflict.listening_without_followthrough.primary",
@@ -1988,15 +2054,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“会听，但后续弱”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Listening Without Follow-Through and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现会听但后续弱：倾听信号较好，后续承诺和追踪需要更明确。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows listening without follow-through: listening looks available; follow-up commitments need clarity. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2004,17 +2070,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "会听，但后续弱 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“会听，但后续弱”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：会听但后续弱",
+          "why_this_feels_specific": "倾听信号较好，后续承诺和追踪需要更明确；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "听完后只承诺一个你能完成的小动作。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Listening Without Follow-Through This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Listening Without Follow-Through and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: listening without follow-through",
+          "why_this_feels_specific": "Listening looks available; follow-up commitments need clarity. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "After listening, commit to one small action you can complete.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -2035,14 +2101,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "conflict_avoidance",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.conflict_avoider",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.conflict_avoider.primary",
           "eq.scene.conflict.conflict_avoider.primary",
@@ -2059,15 +2128,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“冲突回避者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Conflict Avoider and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现冲突回避：分歧场景可能被推迟，短期平稳不等于长期解决。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows conflict avoidance: disagreement may be postponed; short-term calm is not the same as resolution. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2075,17 +2144,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "冲突回避者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“冲突回避者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：冲突回避",
+          "why_this_feels_specific": "分歧场景可能被推迟，短期平稳不等于长期解决；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先练习说出一个低风险不同意见。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Conflict Avoider This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Conflict Avoider and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: conflict avoidance",
+          "why_this_feels_specific": "Disagreement may be postponed; short-term calm is not the same as resolution. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Practice naming one low-risk disagreement.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -2106,7 +2175,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2134,15 +2204,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现均衡整合，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows Integrated balance, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2150,18 +2220,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "均衡整合型：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：均衡整合，先看最大差距",
+          "why_this_feels_specific": "四维相对均衡，适合维护已经可用的节奏；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Integrated Balance: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: Integrated balance; read the largest gap first",
+          "why_this_feels_specific": "The four dimensions sit relatively evenly; maintain what already works; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2181,7 +2251,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2209,15 +2280,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现高共情、低恢复，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows high empathy with lower recovery, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2225,18 +2296,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "高共情，低恢复：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：高共情、低恢复，先看最大差距",
+          "why_this_feels_specific": "共情信号突出，恢复与边界是优先观察点；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "High Empathy, Low Recovery: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: high empathy with lower recovery; read the largest gap first",
+          "why_this_feels_specific": "Empathy signals are prominent; recovery and boundaries deserve first attention; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2256,7 +2327,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2284,15 +2356,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现觉察较清楚、调节仍在练习，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows clearer awareness with regulation still developing, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2300,18 +2372,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "有觉察，调节不足：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：觉察较清楚、调节仍在练习，先看最大差距",
+          "why_this_feels_specific": "能觉察触发点，但恢复步骤需要更具体；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Aware, Not Yet Settled: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: clearer awareness with regulation still developing; read the largest gap first",
+          "why_this_feels_specific": "Triggers are easier to notice than to settle; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2331,7 +2403,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2359,15 +2432,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现稳定但回应偏收，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows stable but less visibly warm, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2375,18 +2448,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "冷静稳定，但情绪回应偏弱：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：稳定但回应偏收，先看最大差距",
+          "why_this_feels_specific": "调节感较强，但情绪回应可能不够可见；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Calm, but Hard to Read Warmly: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: stable but less visibly warm; read the largest gap first",
+          "why_this_feels_specific": "Regulation looks stronger than visible emotional response; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2406,7 +2479,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2434,15 +2508,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现关系优先、自我后置，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows relationship-first with self-needs later, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2450,18 +2524,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "关系优先，自我后置：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：关系优先、自我后置，先看最大差距",
+          "why_this_feels_specific": "关系维护信号较强，自我需求容易被推迟；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Relationship First, Self Later: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: relationship-first with self-needs later; read the largest gap first",
+          "why_this_feels_specific": "Relationship maintenance is prominent while self-needs may be delayed; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2481,7 +2555,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2509,15 +2584,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现自我清楚、修复较少，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows self-clear with less repair practice, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2525,18 +2600,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "自我清楚，修复不足：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：自我清楚、修复较少，先看最大差距",
+          "why_this_feels_specific": "自我表达较明确，关系修复步骤需要更具体；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Clear About Self, Less Practiced at Repair: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: self-clear with less repair practice; read the largest gap first",
+          "why_this_feels_specific": "Self-expression is clearer than repair follow-through; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2556,7 +2631,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2584,15 +2660,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现稳定协作，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows steady collaboration, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2600,18 +2676,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "稳定协作者：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：稳定协作，先看最大差距",
+          "why_this_feels_specific": "调节与关系管理信号较稳，适合关注复杂协作中的耗损；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Steady Collaborator: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: steady collaboration; read the largest gap first",
+          "why_this_feels_specific": "Regulation and relationship-management signals look steady; watch cost in complex collaboration; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2631,7 +2707,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2659,15 +2736,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现敏感且易吸收，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows sensitive and absorbing, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2675,18 +2752,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "高敏感，易吸收：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：敏感且易吸收，先看最大差距",
+          "why_this_feels_specific": "觉察与共情信号突出，容易把外部情绪带进自身状态；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Sensitive and Absorbing: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: sensitive and absorbing; read the largest gap first",
+          "why_this_feels_specific": "Awareness and empathy stand out, with a risk of carrying others’ emotions inward; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2706,7 +2783,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2734,15 +2812,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现基础策略仍在建立，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows foundation still forming, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2750,18 +2828,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "基础发展中：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：基础策略仍在建立，先看最大差距",
+          "why_this_feels_specific": "多维自评都偏保守，先建立语言和低风险练习；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Building the Foundation: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: foundation still forming; read the largest gap first",
+          "why_this_feels_specific": "Several self-ratings are conservative; start with language and low-risk practice; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2781,14 +2859,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.underconfident_repairer",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.underconfident_repairer.primary",
           "eq.scene.pressure_recovery.underconfident_repairer.primary",
@@ -2806,15 +2887,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现修复能力感偏低，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows low confidence in repair, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2822,18 +2903,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "低估自己的修复者：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：修复能力感偏低，先看最大差距",
+          "why_this_feels_specific": "修复意愿可能存在，但自我信心或可用脚本不足；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Underconfident Repairer: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: low confidence in repair; read the largest gap first",
+          "why_this_feels_specific": "Repair intent may be present, but confidence or scripts may be limited; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2853,14 +2934,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.over_responsible_helper",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.over_responsible_helper.primary",
           "eq.scene.pressure_recovery.over_responsible_helper.primary",
@@ -2878,15 +2962,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现帮助责任感偏高，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows over-responsible helping, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2894,18 +2978,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "过度负责的帮助者：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：帮助责任感偏高，先看最大差距",
+          "why_this_feels_specific": "支持他人的信号较强，需要区分关心与承担；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Over-Responsible Helper: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: over-responsible helping; read the largest gap first",
+          "why_this_feels_specific": "Support signals are strong; separate care from taking over; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2925,14 +3009,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.fast_reactor",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.fast_reactor.primary",
           "eq.scene.pressure_recovery.fast_reactor.primary",
@@ -2950,15 +3037,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现反应快、暂停短，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows fast reaction with short pause, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2966,18 +3053,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "反应快，暂停短：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：反应快、暂停短，先看最大差距",
+          "why_this_feels_specific": "压力下反应速度可能快于整理速度；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Fast Reactor: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: fast reaction with short pause; read the largest gap first",
+          "why_this_feels_specific": "Response speed may exceed processing time under pressure; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2997,14 +3084,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.analytical_under_feeling",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.analytical_under_feeling.primary",
           "eq.scene.pressure_recovery.analytical_under_feeling.primary",
@@ -3022,15 +3112,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现先分析、后感受，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows analysis before feeling, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3038,18 +3128,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "先分析，后感受：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：先分析、后感受，先看最大差距",
+          "why_this_feels_specific": "认知整理较快，感受命名可能滞后；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Analytical Before Feeling: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: analysis before feeling; read the largest gap first",
+          "why_this_feels_specific": "Cognitive sorting may come before naming feelings; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3069,14 +3159,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.quiet_empathy",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.quiet_empathy.primary",
           "eq.scene.pressure_recovery.quiet_empathy.primary",
@@ -3094,15 +3187,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现安静共情，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows quiet empathy, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3110,18 +3203,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "安静共情型：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：安静共情，先看最大差距",
+          "why_this_feels_specific": "理解他人的信号存在，但表达可能较克制；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Quiet Empathy: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: quiet empathy; read the largest gap first",
+          "why_this_feels_specific": "Understanding may be present while expression stays restrained; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3141,14 +3234,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.direct_without_softening",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.direct_without_softening.primary",
           "eq.scene.pressure_recovery.direct_without_softening.primary",
@@ -3166,15 +3262,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现直接表达、柔化不足，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows direct expression with less softening, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3182,18 +3278,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "直接表达，柔化不足：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：直接表达、柔化不足，先看最大差距",
+          "why_this_feels_specific": "自我表达较直接，关系缓冲需要补足；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Direct Without Softening: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: direct expression with less softening; read the largest gap first",
+          "why_this_feels_specific": "Self-expression is direct; relational buffering may need support; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3213,14 +3309,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.relationship_masking",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.relationship_masking.primary",
           "eq.scene.pressure_recovery.relationship_masking.primary",
@@ -3238,15 +3337,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现关系稳定掩盖感受，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows relationship stability masking feelings, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3254,18 +3353,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "用关系稳定掩盖真实感受：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：关系稳定掩盖感受，先看最大差距",
+          "why_this_feels_specific": "关系维持较强，真实感受可能被延后处理；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Relationship Masking: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: relationship stability masking feelings; read the largest gap first",
+          "why_this_feels_specific": "Relationship maintenance is strong while personal feelings may be postponed; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3285,14 +3384,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.feedback_absorber",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.feedback_absorber.primary",
           "eq.scene.pressure_recovery.feedback_absorber.primary",
@@ -3310,15 +3412,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现反馈情绪易吸收，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows feedback absorption, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3326,18 +3428,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "容易吸收反馈情绪：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：反馈情绪易吸收，先看最大差距",
+          "why_this_feels_specific": "反馈场景可能带来较多情绪残留；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Feedback Absorber: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: feedback absorption; read the largest gap first",
+          "why_this_feels_specific": "Feedback scenes may leave more emotional residue; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3357,14 +3459,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.balanced_moderate",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.balanced_moderate.primary",
           "eq.scene.pressure_recovery.balanced_moderate.primary",
@@ -3382,15 +3487,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现均衡但仍在打磨，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows balanced but still sharpening, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3398,18 +3503,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "均衡但仍在打磨：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：均衡但仍在打磨，先看最大差距",
+          "why_this_feels_specific": "四维没有明显极端，重点是把可用策略做稳定；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Balanced, Still Sharpening: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: balanced but still sharpening; read the largest gap first",
+          "why_this_feels_specific": "No dimension is extreme; the task is to make usable strategies steadier; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3429,14 +3534,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.regulated_but_private",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.regulated_but_private.primary",
           "eq.scene.pressure_recovery.regulated_but_private.primary",
@@ -3454,15 +3562,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现能稳住但不易表达，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows regulated but private, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3470,18 +3578,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "能稳住，但不易表达：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：能稳住但不易表达，先看最大差距",
+          "why_this_feels_specific": "内部调节较强，外部表达可能偏少；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Regulated but Private: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: regulated but private; read the largest gap first",
+          "why_this_feels_specific": "Internal regulation looks stronger than outward expression; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3501,14 +3609,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.warm_but_avoidant",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.warm_but_avoidant.primary",
           "eq.scene.pressure_recovery.warm_but_avoidant.primary",
@@ -3526,15 +3637,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现温和但回避张力，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows warm but tension-avoidant, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3542,18 +3653,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "温和但回避张力：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：温和但回避张力，先看最大差距",
+          "why_this_feels_specific": "关系温度较好，但分歧场景可能被延后；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Warm but Avoidant: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: warm but tension-avoidant; read the largest gap first",
+          "why_this_feels_specific": "Warmth is available, while disagreement may be delayed; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3573,14 +3684,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3595,15 +3709,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示作答速度偏快，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that responses were unusually fast, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3611,18 +3725,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：作答速度偏快",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先在更稳定的时间重测，再阅读完整解释。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: responses were unusually fast",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake at a steadier pace before relying on the full interpretation.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3642,14 +3756,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3664,15 +3781,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示连续相同作答较多，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that many repeated responses appeared, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3680,18 +3797,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：连续相同作答较多",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "重测时逐题判断，不急着归纳模式。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: many repeated responses appeared",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake item by item before drawing a pattern.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3711,14 +3828,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3733,15 +3853,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示中间选项比例偏高，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that many neutral responses appeared, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3749,18 +3869,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：中间选项比例偏高",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先标记几个你更有把握的真实场景。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: many neutral responses appeared",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "First mark several real scenes you feel more certain about.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3780,14 +3900,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3802,15 +3925,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示极端选项比例偏高，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that many extreme responses appeared, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3818,18 +3941,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：极端选项比例偏高",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先稳定状态，再重新区分不同场景。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: many extreme responses appeared",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake when steadier, then separate different scenes.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3849,14 +3972,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3871,15 +3997,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示一致性信号不足，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that response consistency was limited, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3887,18 +4013,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：一致性信号不足",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先复盘最近状态，再决定是否重测。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: response consistency was limited",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Review your recent state before deciding whether to retake.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3918,14 +4044,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3940,15 +4069,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示多个质量提示同时出现，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that multiple quality flags appeared, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3956,18 +4085,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：多个质量提示同时出现",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "把本次结果当作准备材料，优先重测。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: multiple quality flags appeared",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Use this result as preparation and prioritize retaking.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3987,14 +4116,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4009,15 +4141,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示用时过短，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that completion time was very short, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4025,18 +4157,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：用时过短",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "留出完整时间后重测，不急着使用结论。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: completion time was very short",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake with enough time before using the conclusions.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -4056,14 +4188,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4078,15 +4213,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示注意力信号偏弱，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that attention signals were limited, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4094,18 +4229,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：注意力信号偏弱",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "换一个干扰更少的环境再测。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: attention signals were limited",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake in a less distracting setting.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -4125,14 +4260,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4147,15 +4285,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示状态影响可能较大，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that current state may have shaped responses strongly, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4163,18 +4301,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：状态影响可能较大",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "等状态稳定一些，再对照本次结果。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: current state may have shaped responses strongly",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Compare this result after your state is steadier.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -4194,14 +4332,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4216,15 +4357,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示模式暂不清晰，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that the pattern is not yet clear, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4232,18 +4373,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：模式暂不清晰",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先记录两个真实场景，再决定是否重测。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: the pattern is not yet clear",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Record two real scenes before deciding whether to retake.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -4263,14 +4404,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4285,15 +4429,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示建议重测确认，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that a retake is the safer next step, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4301,18 +4445,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：建议重测确认",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "把本次结果当作草稿，不做长期判断。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: a retake is the safer next step",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Treat this result as a draft, not a long-term judgment.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/personalization_routes/route_matrix.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/personalization_routes/route_matrix.json
@@ -20,7 +20,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "balanced_strength",
         "confidence": "normal",
         "requires_manual_review": false
@@ -47,15 +48,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“均衡整合型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Integrated Balance and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现均衡整合：四维相对均衡，适合维护已经可用的节奏。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows Integrated balance: the four dimensions sit relatively evenly; maintain what already works. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -63,17 +64,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "均衡整合型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“均衡整合型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：均衡整合",
+          "why_this_feels_specific": "四维相对均衡，适合维护已经可用的节奏；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "选一个高压场景，观察你的稳定做法如何被保持。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Integrated Balance This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Integrated Balance and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: Integrated balance",
+          "why_this_feels_specific": "The four dimensions sit relatively evenly; maintain what already works. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Pick one pressure scene and notice how your steady pattern is maintained.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -94,7 +95,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "empathy_regulation_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -121,15 +123,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“高共情，低恢复”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as High Empathy, Low Recovery and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现高共情、低恢复：共情信号突出，恢复与边界是优先观察点。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows high empathy with lower recovery: empathy signals are prominent; recovery and boundaries deserve first attention. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -137,17 +139,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "高共情，低恢复 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“高共情，低恢复”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：高共情、低恢复",
+          "why_this_feels_specific": "共情信号突出，恢复与边界是优先观察点；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先练一个边界句，再观察情绪恢复时间。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "High Empathy, Low Recovery This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as High Empathy, Low Recovery and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: high empathy with lower recovery",
+          "why_this_feels_specific": "Empathy signals are prominent; recovery and boundaries deserve first attention. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Practice one boundary sentence, then observe recovery time.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -168,7 +170,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "awareness_regulation_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -195,15 +198,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“有觉察，调节不足”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Aware, Not Yet Settled and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现觉察较清楚、调节仍在练习：能觉察触发点，但恢复步骤需要更具体。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows clearer awareness with regulation still developing: triggers are easier to notice than to settle. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -211,17 +214,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "有觉察，调节不足 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“有觉察，调节不足”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：觉察较清楚、调节仍在练习",
+          "why_this_feels_specific": "能觉察触发点，但恢复步骤需要更具体；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把一次触发拆成事实、感受、下一步三栏。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Aware, Not Yet Settled This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Aware, Not Yet Settled and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: clearer awareness with regulation still developing",
+          "why_this_feels_specific": "Triggers are easier to notice than to settle. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Split one trigger into facts, feelings, and next move.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -242,7 +245,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "regulation_empathy_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -269,15 +273,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“冷静稳定，但情绪回应偏弱”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Calm, but Hard to Read Warmly and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现稳定但回应偏收：调节感较强，但情绪回应可能不够可见。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows stable but less visibly warm: regulation looks stronger than visible emotional response. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -285,17 +289,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "冷静稳定，但情绪回应偏弱 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“冷静稳定，但情绪回应偏弱”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：稳定但回应偏收",
+          "why_this_feels_specific": "调节感较强，但情绪回应可能不够可见；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "在一个低风险对话里补一句感受确认。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Calm, but Hard to Read Warmly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Calm, but Hard to Read Warmly and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: stable but less visibly warm",
+          "why_this_feels_specific": "Regulation looks stronger than visible emotional response. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Add one feeling acknowledgement in a low-risk conversation.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -316,7 +320,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "relationship_self_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -343,15 +348,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“关系优先，自我后置”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Relationship First, Self Later and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现关系优先、自我后置：关系维护信号较强，自我需求容易被推迟。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows relationship-first with self-needs later: relationship maintenance is prominent while self-needs may be delayed. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -359,17 +364,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "关系优先，自我后置 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“关系优先，自我后置”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：关系优先、自我后置",
+          "why_this_feels_specific": "关系维护信号较强，自我需求容易被推迟；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先写下自己的底线，再决定回应方式。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Relationship First, Self Later This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Relationship First, Self Later and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: relationship-first with self-needs later",
+          "why_this_feels_specific": "Relationship maintenance is prominent while self-needs may be delayed. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Write your boundary first, then choose a response.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -390,7 +395,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "expression_repair_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -417,15 +423,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“自我清楚，修复不足”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Clear About Self, Less Practiced at Repair and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现自我清楚、修复较少：自我表达较明确，关系修复步骤需要更具体。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows self-clear with less repair practice: self-expression is clearer than repair follow-through. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -433,17 +439,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "自我清楚，修复不足 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“自我清楚，修复不足”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：自我清楚、修复较少",
+          "why_this_feels_specific": "自我表达较明确，关系修复步骤需要更具体；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "复盘一次冲突后补一个修复动作。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Clear About Self, Less Practiced at Repair This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Clear About Self, Less Practiced at Repair and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: self-clear with less repair practice",
+          "why_this_feels_specific": "Self-expression is clearer than repair follow-through. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "After reviewing one conflict, add one repair move.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -464,7 +470,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "regulation_relationship_strength",
         "confidence": "normal",
         "requires_manual_review": false
@@ -491,15 +498,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“稳定协作者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Steady Collaborator and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现稳定协作：调节与关系管理信号较稳，适合关注复杂协作中的耗损。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows steady collaboration: regulation and relationship-management signals look steady; watch cost in complex collaboration. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -507,17 +514,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "稳定协作者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“稳定协作者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：稳定协作",
+          "why_this_feels_specific": "调节与关系管理信号较稳，适合关注复杂协作中的耗损；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "选一个协作场景，标记哪里需要恢复空间。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Steady Collaborator This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Steady Collaborator and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: steady collaboration",
+          "why_this_feels_specific": "Regulation and relationship-management signals look steady; watch cost in complex collaboration. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Choose one collaboration scene and mark where recovery space is needed.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -538,7 +545,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "high_sensitivity",
         "confidence": "normal",
         "requires_manual_review": false
@@ -565,15 +573,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“高敏感，易吸收”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Sensitive and Absorbing and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现敏感且易吸收：觉察与共情信号突出，容易把外部情绪带进自身状态。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows sensitive and absorbing: awareness and empathy stand out, with a risk of carrying others’ emotions inward. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -581,17 +589,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "高敏感，易吸收 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“高敏感，易吸收”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：敏感且易吸收",
+          "why_this_feels_specific": "觉察与共情信号突出，容易把外部情绪带进自身状态；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把“我感受到的”和“我需要承担的”分开写。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Sensitive and Absorbing This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Sensitive and Absorbing and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: sensitive and absorbing",
+          "why_this_feels_specific": "Awareness and empathy stand out, with a risk of carrying others’ emotions inward. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Separate what you sense from what you need to carry.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -612,7 +620,8 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "foundational_development",
         "confidence": "normal",
         "requires_manual_review": false
@@ -639,15 +648,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“基础发展中”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Building the Foundation and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现基础策略仍在建立：多维自评都偏保守，先建立语言和低风险练习。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows foundation still forming: several self-ratings are conservative; start with language and low-risk practice. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -655,17 +664,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "基础发展中 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“基础发展中”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：基础策略仍在建立",
+          "why_this_feels_specific": "多维自评都偏保守，先建立语言和低风险练习；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先做一次情绪命名，不急着下长期结论。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Building the Foundation This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Building the Foundation and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: foundation still forming",
+          "why_this_feels_specific": "Several self-ratings are conservative; start with language and low-risk practice. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Start with one emotion label; do not rush to a long-term conclusion.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -686,14 +695,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "repair_confidence_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.underconfident_repairer",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.underconfident_repairer.primary",
           "eq.scene.conflict.underconfident_repairer.primary",
@@ -710,15 +722,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“低估自己的修复者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Underconfident Repairer and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现修复能力感偏低：修复意愿可能存在，但自我信心或可用脚本不足。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows low confidence in repair: repair intent may be present, but confidence or scripts may be limited. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -726,17 +738,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "低估自己的修复者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“低估自己的修复者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：修复能力感偏低",
+          "why_this_feels_specific": "修复意愿可能存在，但自我信心或可用脚本不足；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "准备一句简单修复开场，而不是立刻解释全部。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Underconfident Repairer This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Underconfident Repairer and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: low confidence in repair",
+          "why_this_feels_specific": "Repair intent may be present, but confidence or scripts may be limited. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Prepare one simple repair opener instead of explaining everything at once.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -757,14 +769,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "boundary_overhelping",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.over_responsible_helper",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.over_responsible_helper.primary",
           "eq.scene.conflict.over_responsible_helper.primary",
@@ -781,15 +796,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“过度负责的帮助者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Over-Responsible Helper and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现帮助责任感偏高：支持他人的信号较强，需要区分关心与承担。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows over-responsible helping: support signals are strong; separate care from taking over. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -797,17 +812,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "过度负责的帮助者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“过度负责的帮助者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：帮助责任感偏高",
+          "why_this_feels_specific": "支持他人的信号较强，需要区分关心与承担；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "帮忙前先问：这件事必须由我承担吗？",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Over-Responsible Helper This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Over-Responsible Helper and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: over-responsible helping",
+          "why_this_feels_specific": "Support signals are strong; separate care from taking over. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Before helping, ask: does this have to be mine to carry?",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -828,14 +843,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "speed_under_pressure",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.fast_reactor",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.fast_reactor.primary",
           "eq.scene.conflict.fast_reactor.primary",
@@ -852,15 +870,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“反应快，暂停短”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Fast Reactor and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现反应快、暂停短：压力下反应速度可能快于整理速度。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows fast reaction with short pause: response speed may exceed processing time under pressure. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -868,17 +886,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "反应快，暂停短 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“反应快，暂停短”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：反应快、暂停短",
+          "why_this_feels_specific": "压力下反应速度可能快于整理速度；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "给自己设置一句暂停语，再进入回应。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Fast Reactor This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Fast Reactor and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: fast reaction with short pause",
+          "why_this_feels_specific": "Response speed may exceed processing time under pressure. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Use one pause phrase before responding.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -899,14 +917,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "analysis_feeling_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.analytical_under_feeling",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.analytical_under_feeling.primary",
           "eq.scene.conflict.analytical_under_feeling.primary",
@@ -923,15 +944,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“先分析，后感受”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Analytical Before Feeling and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现先分析、后感受：认知整理较快，感受命名可能滞后。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows analysis before feeling: cognitive sorting may come before naming feelings. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -939,17 +960,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "先分析，后感受 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“先分析，后感受”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：先分析、后感受",
+          "why_this_feels_specific": "认知整理较快，感受命名可能滞后；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先允许一句“我还在感受里整理”。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Analytical Before Feeling This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Analytical Before Feeling and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: analysis before feeling",
+          "why_this_feels_specific": "Cognitive sorting may come before naming feelings. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Allow the sentence: I am still sorting what I feel.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -970,14 +991,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "quiet_empathy",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.quiet_empathy",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.quiet_empathy.primary",
           "eq.scene.conflict.quiet_empathy.primary",
@@ -994,15 +1018,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“安静共情型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Quiet Empathy and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现安静共情：理解他人的信号存在，但表达可能较克制。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows quiet empathy: understanding may be present while expression stays restrained. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1010,17 +1034,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "安静共情型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“安静共情型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：安静共情",
+          "why_this_feels_specific": "理解他人的信号存在，但表达可能较克制；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把一次理解转成一句可听见的回应。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Quiet Empathy This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Quiet Empathy and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: quiet empathy",
+          "why_this_feels_specific": "Understanding may be present while expression stays restrained. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Turn one understanding into an audible response.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1041,14 +1065,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "direct_expression",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.direct_without_softening",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.direct_without_softening.primary",
           "eq.scene.conflict.direct_without_softening.primary",
@@ -1065,15 +1092,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“直接表达，柔化不足”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Direct Without Softening and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现直接表达、柔化不足：自我表达较直接，关系缓冲需要补足。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows direct expression with less softening: self-expression is direct; relational buffering may need support. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1081,17 +1108,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "直接表达，柔化不足 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“直接表达，柔化不足”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：直接表达、柔化不足",
+          "why_this_feels_specific": "自我表达较直接，关系缓冲需要补足；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "在观点前加一句关系意图。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Direct Without Softening This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Direct Without Softening and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: direct expression with less softening",
+          "why_this_feels_specific": "Self-expression is direct; relational buffering may need support. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Add one relationship-intent sentence before the point.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1112,14 +1139,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "relationship_masking",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.relationship_masking",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.relationship_masking.primary",
           "eq.scene.conflict.relationship_masking.primary",
@@ -1136,15 +1166,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“用关系稳定掩盖真实感受”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Relationship Masking and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现关系稳定掩盖感受：关系维持较强，真实感受可能被延后处理。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows relationship stability masking feelings: relationship maintenance is strong while personal feelings may be postponed. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1152,17 +1182,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "用关系稳定掩盖真实感受 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“用关系稳定掩盖真实感受”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：关系稳定掩盖感受",
+          "why_this_feels_specific": "关系维持较强，真实感受可能被延后处理；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "对自己先说清：我真实在意的是什么？",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Relationship Masking This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Relationship Masking and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: relationship stability masking feelings",
+          "why_this_feels_specific": "Relationship maintenance is strong while personal feelings may be postponed. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "First ask yourself: what actually matters to me here?",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1183,14 +1213,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "feedback_absorption",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.feedback_absorber",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.feedback_absorber.primary",
           "eq.scene.conflict.feedback_absorber.primary",
@@ -1207,15 +1240,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“容易吸收反馈情绪”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Feedback Absorber and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现反馈情绪易吸收：反馈场景可能带来较多情绪残留。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows feedback absorption: feedback scenes may leave more emotional residue. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1223,17 +1256,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "容易吸收反馈情绪 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“容易吸收反馈情绪”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：反馈情绪易吸收",
+          "why_this_feels_specific": "反馈场景可能带来较多情绪残留；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "反馈后先分开信息和情绪，再决定行动。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Feedback Absorber This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Feedback Absorber and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: feedback absorption",
+          "why_this_feels_specific": "Feedback scenes may leave more emotional residue. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "After feedback, separate information from emotion before acting.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1254,14 +1287,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "balanced_moderate",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.balanced_moderate",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.balanced_moderate.primary",
           "eq.scene.conflict.balanced_moderate.primary",
@@ -1278,15 +1314,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“均衡但仍在打磨”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Balanced, Still Sharpening and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现均衡但仍在打磨：四维没有明显极端，重点是把可用策略做稳定。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows balanced but still sharpening: no dimension is extreme; the task is to make usable strategies steadier. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1294,17 +1330,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "均衡但仍在打磨 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“均衡但仍在打磨”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：均衡但仍在打磨",
+          "why_this_feels_specific": "四维没有明显极端，重点是把可用策略做稳定；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "选一个最常见场景做小幅优化。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Balanced, Still Sharpening This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Balanced, Still Sharpening and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: balanced but still sharpening",
+          "why_this_feels_specific": "No dimension is extreme; the task is to make usable strategies steadier. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Choose one common scene for a small improvement.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1325,14 +1361,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "private_regulation",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.regulated_but_private",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.regulated_but_private.primary",
           "eq.scene.conflict.regulated_but_private.primary",
@@ -1349,15 +1388,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“能稳住，但不易表达”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Regulated but Private and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现能稳住但不易表达：内部调节较强，外部表达可能偏少。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows regulated but private: internal regulation looks stronger than outward expression. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1365,17 +1404,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "能稳住，但不易表达 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“能稳住，但不易表达”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：能稳住但不易表达",
+          "why_this_feels_specific": "内部调节较强，外部表达可能偏少；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把内部判断转成一句可分享的状态说明。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Regulated but Private This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Regulated but Private and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: regulated but private",
+          "why_this_feels_specific": "Internal regulation looks stronger than outward expression. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Turn one inner judgment into a shareable status sentence.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1396,14 +1435,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "warm_avoidance",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.warm_but_avoidant",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.warm_but_avoidant.primary",
           "eq.scene.conflict.warm_but_avoidant.primary",
@@ -1420,15 +1462,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“温和但回避张力”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Warm but Avoidant and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现温和但回避张力：关系温度较好，但分歧场景可能被延后。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows warm but tension-avoidant: warmth is available, while disagreement may be delayed. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1436,17 +1478,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "温和但回避张力 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“温和但回避张力”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：温和但回避张力",
+          "why_this_feels_specific": "关系温度较好，但分歧场景可能被延后；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "挑一个小分歧练习温和说清。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Warm but Avoidant This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Warm but Avoidant and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: warm but tension-avoidant",
+          "why_this_feels_specific": "Warmth is available, while disagreement may be delayed. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Practice naming one small disagreement warmly.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1467,14 +1509,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "listening_strength",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.strategic_listener",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.strategic_listener.primary",
           "eq.scene.conflict.strategic_listener.primary",
@@ -1491,15 +1536,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“策略型倾听者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Strategic Listener and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现策略型倾听：倾听和判断信号较强，后续行动需要明确。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows strategic listening: listening and judgment look strong; follow-through needs clarity. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1507,17 +1552,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "策略型倾听者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“策略型倾听者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：策略型倾听",
+          "why_this_feels_specific": "倾听和判断信号较强，后续行动需要明确；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "听完后补一句“我下一步会做什么”。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Strategic Listener This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Strategic Listener and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: strategic listening",
+          "why_this_feels_specific": "Listening and judgment look strong; follow-through needs clarity. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "After listening, add what you will do next.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1538,14 +1583,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "delayed_processing",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.delayed_processor",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.delayed_processor.primary",
           "eq.scene.conflict.delayed_processor.primary",
@@ -1562,15 +1610,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“延迟处理型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Delayed Processor and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现延迟处理：当下回应可能保守，事后整理更清楚。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows delayed processing: in-the-moment response may be cautious; later processing may be clearer. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1578,17 +1626,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "延迟处理型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“延迟处理型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：延迟处理",
+          "why_this_feels_specific": "当下回应可能保守，事后整理更清楚；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "提前给自己一个“稍后回应”的脚本。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Delayed Processor This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Delayed Processor and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: delayed processing",
+          "why_this_feels_specific": "In-the-moment response may be cautious; later processing may be clearer. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Prepare a script for responding later.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1609,14 +1657,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "pressure_containment",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.pressure_contained",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.pressure_contained.primary",
           "eq.scene.conflict.pressure_contained.primary",
@@ -1633,15 +1684,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“压力内收型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Contained Under Pressure and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现压力内收：压力下更可能收住情绪，外界未必看见成本。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows contained under pressure: pressure may be held inward, so the cost may not be visible to others. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1649,17 +1700,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "压力内收型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“压力内收型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：压力内收",
+          "why_this_feels_specific": "压力下更可能收住情绪，外界未必看见成本；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "压力后安排一个短恢复窗口。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Contained Under Pressure This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Contained Under Pressure and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: contained under pressure",
+          "why_this_feels_specific": "Pressure may be held inward, so the cost may not be visible to others. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Schedule a short recovery window after pressure.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1680,14 +1731,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "empathy_action_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.empathy_to_action_gap",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.empathy_to_action_gap.primary",
           "eq.scene.conflict.empathy_to_action_gap.primary",
@@ -1704,15 +1758,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“懂别人，但行动转化慢”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Empathy-to-Action Gap and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现理解到行动有距离：能理解他人，但下一步行动可能需要明确化。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows empathy-to-action gap: understanding others may be easier than choosing the next move. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1720,17 +1774,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "懂别人，但行动转化慢 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“懂别人，但行动转化慢”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：理解到行动有距离",
+          "why_this_feels_specific": "能理解他人，但下一步行动可能需要明确化；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "把理解转成一个具体可执行动作。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Empathy-to-Action Gap This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Empathy-to-Action Gap and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: empathy-to-action gap",
+          "why_this_feels_specific": "Understanding others may be easier than choosing the next move. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Turn understanding into one concrete action.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1751,14 +1805,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "protective_distance",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.self_protective_distance",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.self_protective_distance.primary",
           "eq.scene.conflict.self_protective_distance.primary",
@@ -1775,15 +1832,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“保护性距离”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Protective Distance and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现保护性距离：保持距离可能帮助稳定，也可能减少真实交换。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows protective distance: distance may protect stability while reducing real exchange. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1791,17 +1848,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "保护性距离 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“保护性距离”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：保护性距离",
+          "why_this_feels_specific": "保持距离可能帮助稳定，也可能减少真实交换；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "判断这次距离是在保护，还是在回避。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Protective Distance This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Protective Distance and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: protective distance",
+          "why_this_feels_specific": "Distance may protect stability while reducing real exchange. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Ask whether this distance is protection or avoidance.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1822,14 +1879,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "values_sensitivity",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.values_sensitive",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.values_sensitive.primary",
           "eq.scene.conflict.values_sensitive.primary",
@@ -1846,15 +1906,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“价值敏感型”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Values-Sensitive Responder and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现价值敏感：价值触发时情绪反应可能更强，需要先辨认原则。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows values-sensitive response: value triggers may intensify the response; name the principle first. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1862,17 +1922,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "价值敏感型 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“价值敏感型”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：价值敏感",
+          "why_this_feels_specific": "价值触发时情绪反应可能更强，需要先辨认原则；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先写下被触发的价值，再决定表达强度。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Values-Sensitive Responder This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Values-Sensitive Responder and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: values-sensitive response",
+          "why_this_feels_specific": "Value triggers may intensify the response; name the principle first. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Name the value being triggered before choosing intensity.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1893,14 +1953,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "team_stabilizing",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.team_stabilizer",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.team_stabilizer.primary",
           "eq.scene.conflict.team_stabilizer.primary",
@@ -1917,15 +1980,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“团队稳定器”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Team Stabilizer and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现团队稳定：协作稳定信号较强，但别把所有调和都放到自己身上。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows team stabilizing: collaborative stability is strong, but not every repair has to be yours. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -1933,17 +1996,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "团队稳定器 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“团队稳定器”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：团队稳定",
+          "why_this_feels_specific": "协作稳定信号较强，但别把所有调和都放到自己身上；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "区分我能稳定什么、团队需要共同承担什么。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Team Stabilizer This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Team Stabilizer and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: team stabilizing",
+          "why_this_feels_specific": "Collaborative stability is strong, but not every repair has to be yours. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Separate what you can stabilize from what the team must share.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -1964,14 +2027,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "listening_action_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.listening_without_followthrough",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.listening_without_followthrough.primary",
           "eq.scene.conflict.listening_without_followthrough.primary",
@@ -1988,15 +2054,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“会听，但后续弱”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Listening Without Follow-Through and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现会听但后续弱：倾听信号较好，后续承诺和追踪需要更明确。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows listening without follow-through: listening looks available; follow-up commitments need clarity. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2004,17 +2070,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "会听，但后续弱 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“会听，但后续弱”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：会听但后续弱",
+          "why_this_feels_specific": "倾听信号较好，后续承诺和追踪需要更明确；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "听完后只承诺一个你能完成的小动作。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Listening Without Follow-Through This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Listening Without Follow-Through and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: listening without follow-through",
+          "why_this_feels_specific": "Listening looks available; follow-up commitments need clarity. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "After listening, commit to one small action you can complete.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -2035,14 +2101,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "conflict_avoidance",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.conflict_avoider",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.conflict_avoider.primary",
           "eq.scene.conflict.conflict_avoider.primary",
@@ -2059,15 +2128,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这个路线把你的主要信号组织为“冲突回避者”，并优先展示最相关的机制、场景和行动。",
-        "en": "This route organizes your strongest signals as Conflict Avoider and prioritizes the most relevant mechanisms, scenes, and practices."
+        "zh-CN": "本次自评主要呈现冲突回避：分歧场景可能被推迟，短期平稳不等于长期解决。路线优先展示能解释这个模式的机制、场景和行动。",
+        "en": "This self-report result mainly shows conflict avoidance: disagreement may be postponed; short-term calm is not the same as resolution. The route prioritizes mechanisms, scenes, and actions that explain this pattern."
       },
       "do_not_overread": {
-        "zh-CN": "这是一条内容路由，不是评分规则，也不是固定人格标签。",
-        "en": "This is a content route, not a scoring rule or fixed identity label."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2075,17 +2144,17 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "冲突回避者 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这个路线把你的主要信号组织为“冲突回避者”，并优先展示最相关的机制、场景和行动。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：冲突回避",
+          "why_this_feels_specific": "分歧场景可能被推迟，短期平稳不等于长期解决；这只是本次作答组织出的阅读路线，不是对你的固定定义。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、四维相对位置、质量信号和已选资产。",
+          "next_best_action": "先练习说出一个低风险不同意见。",
+          "save_reason": "保存这条路线，之后可用真实互动检验它是否仍然贴近。"
         },
         "en": {
-          "route_headline": "Conflict Avoider This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route organizes your strongest signals as Conflict Avoider and prioritizes the most relevant mechanisms, scenes, and practices.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
+          "route_headline": "Self-report pattern: conflict avoidance",
+          "why_this_feels_specific": "Disagreement may be postponed; short-term calm is not the same as resolution. This is a reading route organized from this response session, not a fixed definition of you.",
+          "evidence_snapshot_label": "Route evidence: core formulation, relative dimension positions, response-quality signals, and selected assets.",
+          "next_best_action": "Practice naming one low-risk disagreement.",
           "save_reason": "Save this route so you can compare it with real interactions later."
         }
       }
@@ -2106,7 +2175,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2134,15 +2204,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现均衡整合，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows Integrated balance, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2150,18 +2220,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "均衡整合型：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：均衡整合，先看最大差距",
+          "why_this_feels_specific": "四维相对均衡，适合维护已经可用的节奏；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Integrated Balance: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: Integrated balance; read the largest gap first",
+          "why_this_feels_specific": "The four dimensions sit relatively evenly; maintain what already works; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2181,7 +2251,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2209,15 +2280,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现高共情、低恢复，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows high empathy with lower recovery, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2225,18 +2296,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "高共情，低恢复：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：高共情、低恢复，先看最大差距",
+          "why_this_feels_specific": "共情信号突出，恢复与边界是优先观察点；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "High Empathy, Low Recovery: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: high empathy with lower recovery; read the largest gap first",
+          "why_this_feels_specific": "Empathy signals are prominent; recovery and boundaries deserve first attention; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2256,7 +2327,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2284,15 +2356,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现觉察较清楚、调节仍在练习，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows clearer awareness with regulation still developing, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2300,18 +2372,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "有觉察，调节不足：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：觉察较清楚、调节仍在练习，先看最大差距",
+          "why_this_feels_specific": "能觉察触发点，但恢复步骤需要更具体；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Aware, Not Yet Settled: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: clearer awareness with regulation still developing; read the largest gap first",
+          "why_this_feels_specific": "Triggers are easier to notice than to settle; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2331,7 +2403,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2359,15 +2432,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现稳定但回应偏收，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows stable but less visibly warm, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2375,18 +2448,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "冷静稳定，但情绪回应偏弱：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：稳定但回应偏收，先看最大差距",
+          "why_this_feels_specific": "调节感较强，但情绪回应可能不够可见；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Calm, but Hard to Read Warmly: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: stable but less visibly warm; read the largest gap first",
+          "why_this_feels_specific": "Regulation looks stronger than visible emotional response; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2406,7 +2479,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2434,15 +2508,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现关系优先、自我后置，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows relationship-first with self-needs later, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2450,18 +2524,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "关系优先，自我后置：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：关系优先、自我后置，先看最大差距",
+          "why_this_feels_specific": "关系维护信号较强，自我需求容易被推迟；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Relationship First, Self Later: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: relationship-first with self-needs later; read the largest gap first",
+          "why_this_feels_specific": "Relationship maintenance is prominent while self-needs may be delayed; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2481,7 +2555,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2509,15 +2584,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现自我清楚、修复较少，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows self-clear with less repair practice, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2525,18 +2600,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "自我清楚，修复不足：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：自我清楚、修复较少，先看最大差距",
+          "why_this_feels_specific": "自我表达较明确，关系修复步骤需要更具体；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Clear About Self, Less Practiced at Repair: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: self-clear with less repair practice; read the largest gap first",
+          "why_this_feels_specific": "Self-expression is clearer than repair follow-through; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2556,7 +2631,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2584,15 +2660,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现稳定协作，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows steady collaboration, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2600,18 +2676,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "稳定协作者：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：稳定协作，先看最大差距",
+          "why_this_feels_specific": "调节与关系管理信号较稳，适合关注复杂协作中的耗损；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Steady Collaborator: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: steady collaboration; read the largest gap first",
+          "why_this_feels_specific": "Regulation and relationship-management signals look steady; watch cost in complex collaboration; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2631,7 +2707,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2659,15 +2736,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现敏感且易吸收，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows sensitive and absorbing, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2675,18 +2752,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "高敏感，易吸收：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：敏感且易吸收，先看最大差距",
+          "why_this_feels_specific": "觉察与共情信号突出，容易把外部情绪带进自身状态；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Sensitive and Absorbing: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: sensitive and absorbing; read the largest gap first",
+          "why_this_feels_specific": "Awareness and empathy stand out, with a risk of carrying others’ emotions inward; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2706,7 +2783,8 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
@@ -2734,15 +2812,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现基础策略仍在建立，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows foundation still forming, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2750,18 +2828,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "基础发展中：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：基础策略仍在建立，先看最大差距",
+          "why_this_feels_specific": "多维自评都偏保守，先建立语言和低风险练习；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Building the Foundation: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: foundation still forming; read the largest gap first",
+          "why_this_feels_specific": "Several self-ratings are conservative; start with language and low-risk practice; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2781,14 +2859,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.underconfident_repairer",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.underconfident_repairer.primary",
           "eq.scene.pressure_recovery.underconfident_repairer.primary",
@@ -2806,15 +2887,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现修复能力感偏低，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows low confidence in repair, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2822,18 +2903,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "低估自己的修复者：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：修复能力感偏低，先看最大差距",
+          "why_this_feels_specific": "修复意愿可能存在，但自我信心或可用脚本不足；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Underconfident Repairer: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: low confidence in repair; read the largest gap first",
+          "why_this_feels_specific": "Repair intent may be present, but confidence or scripts may be limited; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2853,14 +2934,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.over_responsible_helper",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.over_responsible_helper.primary",
           "eq.scene.pressure_recovery.over_responsible_helper.primary",
@@ -2878,15 +2962,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现帮助责任感偏高，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows over-responsible helping, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2894,18 +2978,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "过度负责的帮助者：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：帮助责任感偏高，先看最大差距",
+          "why_this_feels_specific": "支持他人的信号较强，需要区分关心与承担；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Over-Responsible Helper: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: over-responsible helping; read the largest gap first",
+          "why_this_feels_specific": "Support signals are strong; separate care from taking over; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2925,14 +3009,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.fast_reactor",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.fast_reactor.primary",
           "eq.scene.pressure_recovery.fast_reactor.primary",
@@ -2950,15 +3037,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现反应快、暂停短，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows fast reaction with short pause, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -2966,18 +3053,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "反应快，暂停短：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：反应快、暂停短，先看最大差距",
+          "why_this_feels_specific": "压力下反应速度可能快于整理速度；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Fast Reactor: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: fast reaction with short pause; read the largest gap first",
+          "why_this_feels_specific": "Response speed may exceed processing time under pressure; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -2997,14 +3084,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.analytical_under_feeling",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.analytical_under_feeling.primary",
           "eq.scene.pressure_recovery.analytical_under_feeling.primary",
@@ -3022,15 +3112,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现先分析、后感受，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows analysis before feeling, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3038,18 +3128,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "先分析，后感受：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：先分析、后感受，先看最大差距",
+          "why_this_feels_specific": "认知整理较快，感受命名可能滞后；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Analytical Before Feeling: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: analysis before feeling; read the largest gap first",
+          "why_this_feels_specific": "Cognitive sorting may come before naming feelings; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3069,14 +3159,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.quiet_empathy",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.quiet_empathy.primary",
           "eq.scene.pressure_recovery.quiet_empathy.primary",
@@ -3094,15 +3187,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现安静共情，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows quiet empathy, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3110,18 +3203,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "安静共情型：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：安静共情，先看最大差距",
+          "why_this_feels_specific": "理解他人的信号存在，但表达可能较克制；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Quiet Empathy: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: quiet empathy; read the largest gap first",
+          "why_this_feels_specific": "Understanding may be present while expression stays restrained; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3141,14 +3234,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.direct_without_softening",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.direct_without_softening.primary",
           "eq.scene.pressure_recovery.direct_without_softening.primary",
@@ -3166,15 +3262,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现直接表达、柔化不足，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows direct expression with less softening, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3182,18 +3278,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "直接表达，柔化不足：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：直接表达、柔化不足，先看最大差距",
+          "why_this_feels_specific": "自我表达较直接，关系缓冲需要补足；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Direct Without Softening: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: direct expression with less softening; read the largest gap first",
+          "why_this_feels_specific": "Self-expression is direct; relational buffering may need support; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3213,14 +3309,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.relationship_masking",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.relationship_masking.primary",
           "eq.scene.pressure_recovery.relationship_masking.primary",
@@ -3238,15 +3337,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现关系稳定掩盖感受，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows relationship stability masking feelings, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3254,18 +3353,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "用关系稳定掩盖真实感受：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：关系稳定掩盖感受，先看最大差距",
+          "why_this_feels_specific": "关系维持较强，真实感受可能被延后处理；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Relationship Masking: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: relationship stability masking feelings; read the largest gap first",
+          "why_this_feels_specific": "Relationship maintenance is strong while personal feelings may be postponed; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3285,14 +3384,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.feedback_absorber",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.feedback_absorber.primary",
           "eq.scene.pressure_recovery.feedback_absorber.primary",
@@ -3310,15 +3412,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现反馈情绪易吸收，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows feedback absorption, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3326,18 +3428,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "容易吸收反馈情绪：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：反馈情绪易吸收，先看最大差距",
+          "why_this_feels_specific": "反馈场景可能带来较多情绪残留；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Feedback Absorber: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: feedback absorption; read the largest gap first",
+          "why_this_feels_specific": "Feedback scenes may leave more emotional residue; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3357,14 +3459,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.balanced_moderate",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.balanced_moderate.primary",
           "eq.scene.pressure_recovery.balanced_moderate.primary",
@@ -3382,15 +3487,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现均衡但仍在打磨，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows balanced but still sharpening, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3398,18 +3503,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "均衡但仍在打磨：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：均衡但仍在打磨，先看最大差距",
+          "why_this_feels_specific": "四维没有明显极端，重点是把可用策略做稳定；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Balanced, Still Sharpening: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: balanced but still sharpening; read the largest gap first",
+          "why_this_feels_specific": "No dimension is extreme; the task is to make usable strategies steadier; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3429,14 +3534,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.regulated_but_private",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.regulated_but_private.primary",
           "eq.scene.pressure_recovery.regulated_but_private.primary",
@@ -3454,15 +3562,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现能稳住但不易表达，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows regulated but private, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3470,18 +3578,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "能稳住，但不易表达：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：能稳住但不易表达，先看最大差距",
+          "why_this_feels_specific": "内部调节较强，外部表达可能偏少；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Regulated but Private: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: regulated but private; read the largest gap first",
+          "why_this_feels_specific": "Internal regulation looks stronger than outward expression; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3501,14 +3609,17 @@
           "EM": "mixed",
           "RM": "mixed"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "largest_gap",
         "confidence": "normal",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.warm_but_avoidant",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.team_collaboration.warm_but_avoidant.primary",
           "eq.scene.pressure_recovery.warm_but_avoidant.primary",
@@ -3526,15 +3637,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-        "en": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes."
+        "zh-CN": "本次自评主要呈现温和但回避张力，但维度差距更值得先看；路线会把注意力放在差距相关场景和低风险行动上。",
+        "en": "This self-report result mainly shows warm but tension-avoidant, but the dimension gap deserves first attention; the route prioritizes gap-related scenes and low-risk action."
       },
       "do_not_overread": {
-        "zh-CN": "差距只代表当前报告中的相对信号，不应理解为现实中的确定结果。",
-        "en": "A gap is a relative signal in this report, not a certainty about every situation."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "medium",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3542,18 +3653,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "温和但回避张力：差距聚焦 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "当维度差距比单个高分更能解释结果时，这条路线优先展示机制和现实场景。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次自我报告呈现：温和但回避张力，先看最大差距",
+          "why_this_feels_specific": "关系温度较好，但分歧场景可能被延后；同时，维度之间的差距会影响你先读哪些场景。",
+          "evidence_snapshot_label": "路线依据：核心 formulation、最大维度差距、质量信号和已选资产。",
+          "next_best_action": "先读差距相关场景，再做一个不涉及高风险关系的微练习。",
+          "save_reason": "保存这条路线，之后可观察最大差距是否也出现在真实互动中。"
         },
         "en": {
-          "route_headline": "Warm but Avoidant: gap focus This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "When the gap between dimensions explains more than a single high score, this route prioritizes mechanisms and real-life scenes.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Self-report pattern: warm but tension-avoidant; read the largest gap first",
+          "why_this_feels_specific": "Warmth is available, while disagreement may be delayed; the dimension gap also changes which scenes should be read first.",
+          "evidence_snapshot_label": "Route evidence: core formulation, largest dimension gap, response-quality signals, and selected assets.",
+          "next_best_action": "Read the gap-related scene first, then try one low-risk practice outside high-stakes relationships.",
+          "save_reason": "Save this route so you can later check whether the largest gap appears in real interactions."
         }
       }
     },
@@ -3573,14 +3684,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3595,15 +3709,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示作答速度偏快，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that responses were unusually fast, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3611,18 +3725,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：作答速度偏快",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先在更稳定的时间重测，再阅读完整解释。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: responses were unusually fast",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake at a steadier pace before relying on the full interpretation.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3642,14 +3756,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3664,15 +3781,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示连续相同作答较多，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that many repeated responses appeared, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3680,18 +3797,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：连续相同作答较多",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "重测时逐题判断，不急着归纳模式。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: many repeated responses appeared",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake item by item before drawing a pattern.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3711,14 +3828,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3733,15 +3853,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示中间选项比例偏高，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that many neutral responses appeared, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3749,18 +3869,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：中间选项比例偏高",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先标记几个你更有把握的真实场景。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: many neutral responses appeared",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "First mark several real scenes you feel more certain about.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3780,14 +3900,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3802,15 +3925,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示极端选项比例偏高，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that many extreme responses appeared, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3818,18 +3941,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：极端选项比例偏高",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先稳定状态，再重新区分不同场景。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: many extreme responses appeared",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake when steadier, then separate different scenes.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3849,14 +3972,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3871,15 +3997,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示一致性信号不足，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that response consistency was limited, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3887,18 +4013,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：一致性信号不足",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先复盘最近状态，再决定是否重测。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: response consistency was limited",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Review your recent state before deciding whether to retake.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3918,14 +4044,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -3940,15 +4069,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示多个质量提示同时出现，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that multiple quality flags appeared, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -3956,18 +4085,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：多个质量提示同时出现",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "把本次结果当作准备材料，优先重测。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: multiple quality flags appeared",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Use this result as preparation and prioritize retaking.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -3987,14 +4116,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4009,15 +4141,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示用时过短，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that completion time was very short, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4025,18 +4157,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：用时过短",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "留出完整时间后重测，不急着使用结论。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: completion time was very short",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake with enough time before using the conclusions.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -4056,14 +4188,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4078,15 +4213,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示注意力信号偏弱，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that attention signals were limited, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4094,18 +4229,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：注意力信号偏弱",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "换一个干扰更少的环境再测。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: attention signals were limited",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Retake in a less distracting setting.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -4125,14 +4260,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4147,15 +4285,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示状态影响可能较大，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that current state may have shaped responses strongly, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4163,18 +4301,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：状态影响可能较大",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "等状态稳定一些，再对照本次结果。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: current state may have shaped responses strongly",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Compare this result after your state is steadier.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -4194,14 +4332,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4216,15 +4357,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示模式暂不清晰，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that the pattern is not yet clear, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4232,18 +4373,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：模式暂不清晰",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "先记录两个真实场景，再决定是否重测。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: the pattern is not yet clear",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Record two real scenes before deciding whether to retake.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     },
@@ -4263,14 +4404,17 @@
           "EM": "any",
           "RM": "any"
         },
-        "score_gap_pattern": {},
+        "score_gap_pattern": {
+        },
         "score_gap_pattern_label": "not_used_for_strong_interpretation",
         "confidence": "low",
         "requires_manual_review": false
       },
       "selected_asset_ids": {
         "core_formulation": "eq.formulation.low_confidence_result",
-        "mechanisms": [],
+        "mechanisms": [
+
+        ],
         "scenes": [
           "eq.scene.feedback.low_confidence_result.primary",
           "eq.scene.pressure_recovery.low_confidence_result.primary"
@@ -4285,15 +4429,15 @@
         ]
       },
       "why_this_route_exists": {
-        "zh-CN": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-        "en": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation."
+        "zh-CN": "质量信号提示建议重测确认，因此本路线只提供谨慎阅读、轻量反思和复测准备。",
+        "en": "Quality signals indicate that a retake is the safer next step, so this route provides cautious reading, light reflection, and retake preparation only."
       },
       "do_not_overread": {
-        "zh-CN": "不要根据本次结果做重大判断。",
-        "en": "Do not use this result as a basis for major decisions."
+        "zh-CN": "这是一条自我报告内容路由，用于决定先读哪些资产；它不是评分规则、固定人格标签、能力判断、诊断、人事筛选或职业预测。",
+        "en": "This is a self-report content route used to decide which assets to read first. It is not a scoring rule, fixed identity label, capacity judgment, diagnosis, personnel-screening tool, or career prediction."
       },
       "claim_risk": "high",
-      "risk_notes": "Route selection is deterministic self-report interpretation, not precision profiling.",
+      "risk_notes": "Route selection is deterministic self-report interpretation. It should guide reading order and selected assets, not define identity, capacity, diagnostic claim, personnel-screening use, relationship quality, or work outcomes.",
       "commercial_depth": {
         "first_screen_strategy": "route_headline + evidence label + next best action",
         "reader_trust_strategy": "explain why this route was selected without exposing scoring internals",
@@ -4301,18 +4445,18 @@
       },
       "locales": {
         "zh-CN": {
-          "route_headline": "本次结果谨慎阅读 这是本次自我报告结果的摘要，不是能力或人格定论。",
-          "why_this_feels_specific": "这条路线在作答质量提示出现时启用，优先解释置信度，而不是输出强个人判断。",
-          "evidence_snapshot_label": "本路线依据：核心 formulation、维度组合、质量信号和已选内容资产。",
-          "next_best_action": "先读路线中的场景卡，再选择一个行动处方练 7 天。",
-          "save_reason": "保存这条路线，之后可对照真实互动验证它是否准确。"
+          "route_headline": "本次结果先谨慎阅读：建议重测确认",
+          "why_this_feels_specific": "这条路线不是在解释你是什么类型，而是在说明本次作答为什么不适合下强结论。",
+          "evidence_snapshot_label": "路线依据：质量信号、作答一致性提示和低置信保护规则。",
+          "next_best_action": "把本次结果当作草稿，不做长期判断。",
+          "save_reason": "保存本次结果只用于对照重测前后的差异，不作为长期判断。"
         },
         "en": {
-          "route_headline": "Read this result lightly This is a summary of this self-report result, not an ability claim or fixed identity conclusion.",
-          "why_this_feels_specific": "This route is used when response-quality signals suggest caution. It prioritizes confidence explanation over strong personal interpretation.",
-          "evidence_snapshot_label": "Route evidence: core formulation, dimension pattern, response-quality signals, and selected assets.",
-          "next_best_action": "Read the selected scenes first, then practice one prescription for seven days.",
-          "save_reason": "Save this route so you can compare it with real interactions later."
+          "route_headline": "Read this result cautiously: a retake is the safer next step",
+          "why_this_feels_specific": "This route is not explaining what type of person you are; it explains why this response session should not carry strong conclusions.",
+          "evidence_snapshot_label": "Route evidence: response-quality signals, consistency cues, and low-confidence protection rules.",
+          "next_best_action": "Treat this result as a draft, not a long-term judgment.",
+          "save_reason": "Save this result only to compare it with a later retake, not as a long-term judgment."
         }
       }
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -13150,7 +13150,9 @@
         "backend/content_packs/ENNEAGRAM/v2/registry/theory_hint_registry.json",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "evidence": "Changed files are confined to wing hint theory registry content and train ledger reconciliation."
     },
@@ -29515,16 +29517,16 @@
         "summary": "Manifest/state parsed, raw and compiled mirrors match, changed files are within SCI-17 scope, backend integration contract has required bilingual fields/user_visible=false/risk_notes and no blocked commerce/SJT/ability-like wording, and no whitespace errors were found."
       }
     ],
-    "commit_sha": "6e5c796e5ecfd0d147cff919bbf3d74c02ccda15",
+    "commit_sha": "4c0264bbb8b5d5cb3eefd5316ae5b2106552c009",
     "depends_on": [
       "PR-EQ-ASSET-SCI-16"
     ],
     "failure_reason": null,
     "id": "PR-EQ-ASSET-SCI-17",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-03T05:58:39Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2673",
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "status": "pass",
@@ -29536,7 +29538,7 @@
       ],
       "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-17 allowed_paths."
     },
-    "status": "ready_to_merge",
+    "status": "merged_post_merge_revalidated",
     "title": "PR-EQ-ASSET-SCI-17: clean EQ backend_integration_contract authority boundary",
     "transitions": [
       {
@@ -29560,6 +29562,11 @@
         "status": "ready_to_merge",
         "timestamp": "2026-07-03T13:52:13+08:00",
         "notes": "GitHub checks passed and PR #2673 is clean; ready to squash merge."
+      },
+      {
+        "status": "merged_post_merge_revalidated",
+        "timestamp": "2026-07-03T14:04:40+08:00",
+        "notes": "Verified PR #2673 merged, origin/main contains merge commit 4c0264bbb8b5d5cb3eefd5316ae5b2106552c009, local temp worktree/branch cleaned."
       }
     ],
     "github_checks": {
@@ -29571,9 +29578,48 @@
     "base": "main",
     "branch": "codex/pr-eq-asset-sci-18-route-matrix",
     "checks": [
-
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan content:lint --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content lint passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan content:compile --pack=EQ_60 --pack-version=v1",
+        "status": "passed",
+        "summary": "EQ_60 content compile passed; generated compiled outputs were restored because SCI-18 is raw route matrix scope."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60ContentGateTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60V5ReportContractTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warnings; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60GoldenCasesTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60ReportPaywallTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warnings; assertions passed."
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60SubmitQualityContractTest",
+        "status": "passed",
+        "summary": "Passed with existing fixture path warning; assertions passed."
+      },
+      {
+        "command": "YAML/JSON parse, route matrix mirror cmp, scope validation, route matrix guard scan, git diff --check, git diff --cached --check",
+        "status": "passed",
+        "summary": "Manifest/state parsed, EQ route matrix mirrors match, changed files are within SCI-18 scope, 60 routes retain required bilingual route fields with 11 low-confidence routes and no blocked commerce/SJT/ability-like wording, and no whitespace errors were found."
+      }
     ],
-    "commit_sha": null,
+    "commit_sha": "3f213a52380f4cd7cacaae98a44f5ca58c73c8b5",
     "depends_on": [
       "PR-EQ-ASSET-SCI-05",
       "PR-EQ-ASSET-SCI-06",
@@ -29585,22 +29631,46 @@
     "id": "PR-EQ-ASSET-SCI-18",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2675",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
-      "allowed_paths_only": null,
-      "github_checks_green": null,
-      "local_validation_passed": null,
-      "post_merge_revalidated": null
+      "status": "pass",
+      "changed_files": [
+        "backend/content_packs/EQ_60/v1/raw/personalization_routes/route_matrix.json",
+        "backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/personalization_routes/route_matrix.json"
+      ],
+      "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-18 allowed_paths."
     },
-    "status": "user_authorized",
+    "github_checks": {
+      "status": "passed",
+      "summary": "GitHub checks passed for PR #2675 at head 3f213a52380f4cd7cacaae98a44f5ca58c73c8b5 before ready-to-merge ledger update; final amend will be rechecked before merge.",
+      "merge_state_status": "CLEAN"
+    },
+    "status": "ready_to_merge",
     "title": "PR-EQ-ASSET-SCI-18: improve EQ personalization_route matrix differentiation",
     "transitions": [
       {
         "at": "2026-07-02T16:12:11.904905Z",
         "status": "user_authorized",
         "summary": "User explicitly authorized adding this EQ asset science repair PR train item and executing it in sequence."
+      }
+    ],
+    "history": [
+      {
+        "status": "local_checks_passed",
+        "timestamp": "2026-07-03T14:04:40+08:00",
+        "notes": "All required local checks and personalization route matrix guard scan passed; ready to commit and open PR."
+      },
+      {
+        "status": "pr_open_checks_pending",
+        "timestamp": "2026-07-03T14:05:47+08:00",
+        "notes": "Opened PR #2675 for PR-EQ-ASSET-SCI-18; GitHub checks pending."
+      },
+      {
+        "status": "ready_to_merge",
+        "timestamp": "2026-07-03T06:12:10.937760Z",
+        "notes": "GitHub checks passed and mergeStateStatus was CLEAN; recording ready_to_merge before final amend/push."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Reworked all 60 EQ personalization routes with more differentiated self-report bounded route headlines, specificity explanations, evidence labels, next actions, and save reasons.
- Preserved the 11 low-confidence routes as cautious-reading/retest routes without strong interpretation.
- Mirrored the route matrix to EQ_EMOTIONAL_INTELLIGENCE and reconciled PR-EQ-ASSET-SCI-17 post-merge ledger state.

## Why
- SCI-18 improves deterministic route readability and personalization depth while keeping route selection as a backend-owned self-report content routing layer.
- The updated copy avoids fixed identity, capacity, diagnostic, personnel-screening, career-prediction, SJT, and commerce framing.

## Validation
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest
- YAML/JSON parse, route matrix mirror cmp, scope validation, route matrix guard scan
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No composer selection changes.
- No canonical fixture regeneration beyond existing contract tests.
- No scoring, question, norm, frontend, SJT, commerce, CMS, staging deploy, or production deploy changes.

## Repository rule impact
- Backend personalization route matrix remains the content authority for route copy and selected route metadata.
- Frontend remains a deterministic consumer of backend-resolved route assets.
