### PR TITLE
ENNEA-RP-29: fix(enneagram): repair arrow placeholder

### DIFF
--- a/backend/content_packs/ENNEAGRAM/v2/registry/theory_hint_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/theory_hint_registry.json
@@ -40,8 +40,8 @@
             "theory_key": "arrow_growth_reference_placeholder",
             "visibility_scope": "p1_visible",
             "hard_judgement_allowed": false,
-            "boundary_copy": "箭头方向位只作为方法参考，不在 P0 做硬判断。",
-            "user_facing_boundary": "当前版本不会把 arrow 写成系统定论；即使引用，也只用于帮助你阅读压力与成长时的常见倾向。",
+            "boundary_copy": "箭头方向位目前只作为未来模块占位，不参与当前结果页解释，也不把箭头写成压力、成长或发展路径判断。",
+            "user_facing_boundary": "当前版本不会根据 arrow 推出你的压力方向、成长方向或固定路径；如果未来展示，也只会作为理论背景提示，并要求结合真实情境验证。",
             "content_maturity": "experimental",
             "evidence_level": "descriptive"
         },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15150,13 +15150,19 @@
         "status": "committed",
         "commit_sha": "54aba963de2fe7c2fecf5ddd39e279966d89b402",
         "notes": "Implementation commit created after local validation."
+      },
+      {
+        "at": "2026-07-03T10:45:49.837Z",
+        "status": "pr_opened_github_checks_pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2696",
+        "notes": "PR opened; waiting for required GitHub checks."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-29",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2696",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
@@ -15174,7 +15180,7 @@
       ],
       "evidence": "Changed files are confined to arrow placeholder copy in theory_hint_registry plus train ledger reconciliation/status for ENNEA-RP-28/29."
     },
-    "status": "committed",
+    "status": "pr_opened_github_checks_pending",
     "title": "ENNEA-RP-29: fix(enneagram): repair arrow placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15123,6 +15123,11 @@
       "git_diff_check": {
         "status": "pass",
         "command": "git diff --check"
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2696 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All reported GitHub checks passed for PR #2696 before ready_to_merge ledger update."
       }
     },
     "commit_sha": "54aba963de2fe7c2fecf5ddd39e279966d89b402",
@@ -15156,6 +15161,11 @@
         "status": "pr_opened_github_checks_pending",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2696",
         "notes": "PR opened; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-07-03T10:51:29.988Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub checks passed; PR is ready to merge after final head-check confirmation."
       }
     ],
     "failure_reason": null,
@@ -15180,7 +15190,7 @@
       ],
       "evidence": "Changed files are confined to arrow placeholder copy in theory_hint_registry plus train ledger reconciliation/status for ENNEA-RP-28/29."
     },
-    "status": "pr_opened_github_checks_pending",
+    "status": "ready_to_merge",
     "title": "ENNEA-RP-29: fix(enneagram): repair arrow placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15125,7 +15125,7 @@
         "command": "git diff --check"
       }
     },
-    "commit_sha": null,
+    "commit_sha": "54aba963de2fe7c2fecf5ddd39e279966d89b402",
     "depends_on": [
       "ENNEA-RP-28"
     ],
@@ -15144,6 +15144,12 @@
         "at": "2026-07-03T10:44:48.676Z",
         "status": "local_validation_passed",
         "notes": "Required local checks passed and changed files remained within ENNEA-RP-29 scope."
+      },
+      {
+        "at": "2026-07-03T10:45:11.657Z",
+        "status": "committed",
+        "commit_sha": "54aba963de2fe7c2fecf5ddd39e279966d89b402",
+        "notes": "Implementation commit created after local validation."
       }
     ],
     "failure_reason": null,
@@ -15168,7 +15174,7 @@
       ],
       "evidence": "Changed files are confined to arrow placeholder copy in theory_hint_registry plus train ledger reconciliation/status for ENNEA-RP-28/29."
     },
-    "status": "local_validation_passed",
+    "status": "committed",
     "title": "ENNEA-RP-29: fix(enneagram): repair arrow placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15015,7 +15015,7 @@
         "evidence": "All GitHub PR checks passed on PR #2695: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-v2, and verify-mbti-legacy."
       }
     },
-    "commit_sha": "8014580b1fafd535fe2b34fd1b22e1a5c50de8ce",
+    "commit_sha": "e9bc21cfacc594f03ebf406d44cc4a23517522aa",
     "depends_on": [
       "ENNEA-RP-27"
     ],
@@ -15049,14 +15049,19 @@
         "at": "2026-07-03T10:33:36.311Z",
         "status": "ready_to_merge",
         "notes": "Required local checks, scope validation, and GitHub PR checks passed; PR #2695 is clean and ready for squash merge."
+      },
+      {
+        "at": "2026-07-03T10:41:11.838Z",
+        "status": "merged",
+        "notes": "Reconciled after PR #2695 squash merge; origin/main contains merge commit e9bc21cfacc594f03ebf406d44cc4a23517522aa, local main was synced, and local/remote task branches were cleaned before ENNEA-RP-29 execution."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-28",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-03T10:39:34Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2695",
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "allowed_files": [
@@ -15075,7 +15080,7 @@
       ],
       "evidence": "Changed files are confined to state spectrum content in state/type registries plus train ledger reconciliation."
     },
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "ENNEA-RP-28: fix(enneagram): repair state spectrum",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },
@@ -15086,6 +15091,38 @@
       "authorization": {
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
         "status": "pass"
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-28 merged as PR #2695 and merge commit e9bc21cfacc594f03ebf406d44cc4a23517522aa is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json"
+      },
+      "enneagram_type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "notes": "Passed with existing PHPUnit warnings."
+      },
+      "enneagram_registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "notes": "Passed with existing PHPUnit warnings."
+      },
+      "enneagram_report_composer_v2": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "notes": "Passed with existing PHPUnit warnings."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "notes": "Passed with existing PHPUnit warnings; 83641 assertions."
+      },
+      "git_diff_check": {
+        "status": "pass",
+        "command": "git diff --check"
       }
     },
     "commit_sha": null,
@@ -15097,6 +15134,16 @@
         "at": "2026-07-02T16:10:24Z",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
         "status": "pending_dependency"
+      },
+      {
+        "at": "2026-07-03T10:41:11.838Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-29-arrow-growth-reference-placeholder after ENNEA-RP-28 merge and cleanup; scope is arrow placeholder content in theory hint registry plus train ledger only."
+      },
+      {
+        "at": "2026-07-03T10:44:48.676Z",
+        "status": "local_validation_passed",
+        "notes": "Required local checks passed and changed files remained within ENNEA-RP-29 scope."
       }
     ],
     "failure_reason": null,
@@ -15113,9 +15160,15 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [],
+      "status": "pass",
+      "changed_files": [
+        "backend/content_packs/ENNEAGRAM/v2/registry/theory_hint_registry.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "evidence": "Changed files are confined to arrow placeholder copy in theory_hint_registry plus train ledger reconciliation/status for ENNEA-RP-28/29."
     },
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "title": "ENNEA-RP-29: fix(enneagram): repair arrow placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },


### PR DESCRIPTION
## What changed
- Repaired the Enneagram result-page `arrow_growth_reference_placeholder` registry copy so arrow references remain future-module placeholders.
- Removed hard pressure/growth/path interpretation from the current runtime-facing boundary text.
- Reconciled ENNEA-RP-28 post-merge ledger state and recorded ENNEA-RP-29 local validation.

## Why
- ENNEA-RP-29 is scoped to keeping arrow references scientifically bounded until a future module implements explicit interpretation logic.
- The copy now states that current result pages do not infer pressure direction, growth direction, or fixed paths from arrow theory.

## Validation
- `cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json`
- `cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest`
- `cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest`
- `cd backend && php artisan test --filter=EnneagramReportComposerV2Test`
- `cd backend && php artisan test --filter=Enneagram`
- `git diff --check`

## Scope validation
- Changed files are limited to `backend/content_packs/ENNEAGRAM/v2/registry/theory_hint_registry.json` and `docs/codex/pr-train-state.json`.

## Intentionally deferred
- No frontend changes.
- No validator/test changes.
- No CMS writes, registry release activation, staging wait, manual deploy, production deploy, or online smoke.
