### PR TITLE
ENNEA-RP-36: fix(enneagram): repair method boundary

### DIFF
--- a/backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json
@@ -19,7 +19,7 @@
             "method_key": "e105_standard_methodology",
             "form_variant": "e105",
             "display_context": "result_page",
-            "copy": "E105 标准版使用 Likert 强度作答，适合先建立一次全谱轮廓、Top3、Dominance Gap 与 close-call 阅读框架。它呈现的是同一题型内部的相对信号，不是九型人格的临床量表、能力测量或稳定人格定论。",
+            "copy": "E105 标准版使用 Likert 强度作答，用来形成同一题型内的九型线索轮廓、Top3、Dominance Gap 与 close-call 阅读入口。它适合做自我观察的起点，但不是临床诊断、心理健康筛查、能力测量、招聘筛选或稳定人格定论；分数只能在 E105 自身的题型和计分语境内阅读。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -27,7 +27,7 @@
             "method_key": "fc144_forced_choice_methodology",
             "form_variant": "fc144",
             "display_context": "result_page",
-            "copy": "FC144 使用 forced-choice 配对选择，更适合在 close-call 后观察你在两难取舍中反复选择的线索。它不是比 E105 更“准确”的版本，也不与 E105 共享同一分数来源；两者结果应按各自题型边界阅读。",
+            "copy": "FC144 使用 forced-choice 配对选择，用来观察你在两难取舍中反复偏向的动机线索，尤其适合作为 close-call 后的补充观察。它不是比 E105 更准确的版本，也不与 E105 共享同一分数来源；结果应按 FC144 自身题型边界阅读，不能把跨 form 差异解释为人格变化或测评优劣。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -35,7 +35,7 @@
             "method_key": "same_model_not_same_score_space",
             "form_variant": "all",
             "display_context": "technical_note",
-            "copy": "E105 与 FC144 属于同一 ENNEAGRAM 模型和解释框架，但题型、作答任务与计分来源不同，不处在同一 score space。它们可以共用结果页结构与安全边界，但不默认直接比较数值高低，也不把跨 form 差异解释为人格变化。",
+            "copy": "E105 与 FC144 属于同一 ENNEAGRAM 模型和解释框架，但题型、作答任务、计分来源和误差结构不同，不处在同一 score space。系统可以复用结果页结构、模块顺序和安全边界，但不会默认直接比较两套数值高低，也不会把跨 form 的 Top3 差异解读成个体状态变化、人格发展或谁更真实。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -43,7 +43,7 @@
             "method_key": "cross_form_compare_blocked",
             "form_variant": "all",
             "display_context": "history",
-            "copy": "跨 form 对比默认关闭。只要没有等值映射，系统就不会把 E105 与 FC144 放进同一数值比较语义里。",
+            "copy": "跨 form 对比默认关闭。除非未来存在经过验证的等值映射，系统不会把 E105 与 FC144 放入同一分数比较语义，也不会生成“提升/下降”“更健康/更不健康”这类跨题型结论。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -51,7 +51,7 @@
             "method_key": "non_diagnostic_boundary",
             "form_variant": "all",
             "display_context": "technical_note",
-            "copy": "本结果只用于人格模式理解、自我观察与反思对话。它不用于临床诊断、心理治疗建议、心理健康判断、招聘筛选、岗位匹配、能力评价或对个体做绝对定性；高分、主候选、close-call 与低质量提示都应被看作解释假设，而不是事实判决。若某个工作、团队或关系情境模块显示未启用，也只表示当前产品没有开放该情境化解释，不表示系统隐藏了更确定的岗位、团队适配或关系风险判断。",
+            "copy": "本结果只用于人格模式理解、自我观察和反思对话。九型人格在证据基础上应被当作解释工具，而不是已充分验证的临床量表、心理健康判断、治疗建议、招聘筛选、岗位匹配、能力评价或个体风险评估。高分、主候选、Top3、close-call、diffuse 与低质量提示都只能作为解释假设；如果某个工作、团队或关系情境模块未启用，也只表示当前产品没有开放该情境化解释，不表示系统隐藏了更确定的适配、风险或诊断结论。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -59,7 +59,7 @@
             "method_key": "user_confirmed_type_boundary",
             "form_variant": "all",
             "display_context": "observation",
-            "copy": "user_confirmed_type 是自我观察证据，不是系统改判。它会进入历史记录，但不会覆盖 primary_candidate、Top3 或 scorer 输出。",
+            "copy": "user_confirmed_type 是用户在观察后记录的自我共鸣证据，不是系统改判，也不是更高权威的类型确认。它会进入历史记录，帮助后续阅读时标注用户视角，但不会覆盖 primary_candidate、Top3、scorer 输出或原始 attempt 的计分事实。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -67,7 +67,7 @@
             "method_key": "low_quality_boundary",
             "form_variant": "all",
             "display_context": "result_page",
-            "copy": "当低质量信号触发时，结果仍可阅读，但解释边界会收窄。优先建议在状态更稳定时重测同一题型，而不是立刻切到另一 form。",
+            "copy": "当低质量信号触发时，结果仍可阅读，但解释边界会明显收窄。页面只保留轻量观察建议，避免把单次低稳定度作答扩展成确定性类型判断；优先建议在状态更稳定、时间更充足时重测同一题型，而不是立刻切换 form 来寻找“更好答案”。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -75,7 +75,7 @@
             "method_key": "diffuse_boundary",
             "form_variant": "all",
             "display_context": "result_page",
-            "copy": "当结果呈现 diffuse 结构时，它表示九个类型线索较分散，或 Top3 之间还没有形成足够清晰的主次关系；这不是作答失败，也不是系统无效。页面会降低单一号码的确定语气，优先引导你并排阅读 Top3、三中心分布、近期反例和 7 天观察任务，再决定哪些解释真正贴近日常动机。",
+            "copy": "diffuse 表示九个类型线索较分散，或 Top3 尚未形成足够清晰的主次关系。它不是作答失败，也不是系统无效，更不是人格混乱或心理健康信号。页面会降低单一号码的确定语气，优先引导并排阅读 Top3、三中心分布、近期反例和 7 天观察任务，再判断哪些解释在日常动机中更贴近。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -83,7 +83,7 @@
             "method_key": "close_call_boundary",
             "form_variant": "all",
             "display_context": "result_page",
-            "copy": "close-call 表示 Top1 与 Top2 接近。系统不会假装自己比数据更确定，而会把分歧转换成 pair 辨析与 7 天观察问题。",
+            "copy": "close-call 表示 Top1 与 Top2 接近，系统不会假装比数据更确定。页面会把差异转成 pair 辨析、反例检查和 7 天观察问题；它不是双重人格、类型不稳定或需要被强行二选一的证明。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15972,13 +15972,19 @@
         "status": "committed",
         "commit_sha": "1ac27175ac50d6ea3865f3e834fad86e057f26ec",
         "notes": "Implementation commit created after local validation."
+      },
+      {
+        "at": "2026-07-03T12:57:28.830Z",
+        "status": "pr_opened_github_checks_pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2703",
+        "notes": "PR opened; waiting for required GitHub checks."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-36",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2703",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
@@ -15996,7 +16002,7 @@
       ],
       "evidence": "Changed files are confined to method_registry boundary copy and train ledger reconciliation/state."
     },
-    "status": "committed",
+    "status": "pr_opened_github_checks_pending",
     "title": "ENNEA-RP-36: fix(enneagram): repair method boundary",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15824,9 +15824,13 @@
         "status": "pass",
         "command": "gh pr checks 2702 --repo fermatmind/fap-api --watch --interval 15",
         "evidence": "All reported GitHub checks passed for PR #2702 before ready_to_merge ledger update."
+      },
+      "post_merge_cleanup": {
+        "status": "pass",
+        "evidence": "PR #2702 merged as 3171b7f60093288fc2ed979fe1634bb6df6c60ef; origin/main contained the merge commit, local main was synced to origin/main, worktree was clean, and local/remote task branches were removed before ENNEA-RP-36."
       }
     },
-    "commit_sha": "62269bf70354fd71147a10d4f283738a3c0d98cc",
+    "commit_sha": "3171b7f60093288fc2ed979fe1634bb6df6c60ef",
     "depends_on": [
       "ENNEA-RP-34"
     ],
@@ -15862,14 +15866,21 @@
         "at": "2026-07-03T12:46:02.328Z",
         "status": "ready_to_merge",
         "notes": "GitHub checks passed; PR is ready to merge after final head-check confirmation."
+      },
+      {
+        "at": "2026-07-03T12:53:11.142Z",
+        "status": "merged",
+        "commit_sha": "3171b7f60093288fc2ed979fe1634bb6df6c60ef",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2702",
+        "notes": "Reconciled post-merge facts: GitHub reports merged, origin/main contains merge commit, local main synced, worktree clean, and task branch cleanup completed."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-35",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-03T12:51:25Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2702",
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "allowed_files": [
@@ -15886,7 +15897,7 @@
       ],
       "evidence": "Changed files are confined to relationship_pack.relationship_traps and train ledger reconciliation/state."
     },
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "ENNEA-RP-35: fix(enneagram): repair relationship blind spot",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },
@@ -15897,6 +15908,43 @@
       "authorization": {
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
         "status": "pass"
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-35 merged as PR #2702 and merge commit 3171b7f60093288fc2ed979fe1634bb6df6c60ef is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json"
+      },
+      "enneagram_type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "notes": "Passed with existing PHPUnit warnings."
+      },
+      "enneagram_registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "notes": "Passed with existing PHPUnit warnings."
+      },
+      "enneagram_report_composer_v2": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "notes": "Passed with existing PHPUnit warnings."
+      },
+      "enneagram_method_registry_boundary": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramMethodRegistryBoundaryTest",
+        "notes": "Current-scope failure was inspected and fixed by preserving required boundary phrases."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "notes": "Passed with existing PHPUnit warnings; 83641 assertions."
+      },
+      "git_diff_check": {
+        "status": "pass",
+        "command": "git diff --check"
       }
     },
     "commit_sha": null,
@@ -15908,6 +15956,16 @@
         "at": "2026-07-02T16:10:24Z",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
         "status": "pending_dependency"
+      },
+      {
+        "at": "2026-07-03T12:53:11.142Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-36-method-boundary; scope is method_registry boundary copy plus train ledger only."
+      },
+      {
+        "at": "2026-07-03T12:56:29.932Z",
+        "status": "local_validation_passed",
+        "notes": "Required local checks passed after fixing current-scope method boundary phrase regression; changed files remained within ENNEA-RP-36 scope."
       }
     ],
     "failure_reason": null,
@@ -15924,9 +15982,15 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [],
+      "status": "pass",
+      "changed_files": [
+        "backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "evidence": "Changed files are confined to method_registry boundary copy and train ledger reconciliation/state."
     },
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "title": "ENNEA-RP-36: fix(enneagram): repair method boundary",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15945,6 +15945,11 @@
       "git_diff_check": {
         "status": "pass",
         "command": "git diff --check"
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2703 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All reported GitHub checks passed for PR #2703 before ready_to_merge ledger update."
       }
     },
     "commit_sha": "1ac27175ac50d6ea3865f3e834fad86e057f26ec",
@@ -15978,6 +15983,11 @@
         "status": "pr_opened_github_checks_pending",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2703",
         "notes": "PR opened; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-07-03T13:03:22.352Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub checks passed; PR is ready to merge after final head-check confirmation."
       }
     ],
     "failure_reason": null,
@@ -16002,7 +16012,7 @@
       ],
       "evidence": "Changed files are confined to method_registry boundary copy and train ledger reconciliation/state."
     },
-    "status": "pr_opened_github_checks_pending",
+    "status": "ready_to_merge",
     "title": "ENNEA-RP-36: fix(enneagram): repair method boundary",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -15947,7 +15947,7 @@
         "command": "git diff --check"
       }
     },
-    "commit_sha": null,
+    "commit_sha": "1ac27175ac50d6ea3865f3e834fad86e057f26ec",
     "depends_on": [
       "ENNEA-RP-35"
     ],
@@ -15966,6 +15966,12 @@
         "at": "2026-07-03T12:56:29.932Z",
         "status": "local_validation_passed",
         "notes": "Required local checks passed after fixing current-scope method boundary phrase regression; changed files remained within ENNEA-RP-36 scope."
+      },
+      {
+        "at": "2026-07-03T12:56:45.595Z",
+        "status": "committed",
+        "commit_sha": "1ac27175ac50d6ea3865f3e834fad86e057f26ec",
+        "notes": "Implementation commit created after local validation."
       }
     ],
     "failure_reason": null,
@@ -15990,7 +15996,7 @@
       ],
       "evidence": "Changed files are confined to method_registry boundary copy and train ledger reconciliation/state."
     },
-    "status": "local_validation_passed",
+    "status": "committed",
     "title": "ENNEA-RP-36: fix(enneagram): repair method boundary",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },


### PR DESCRIPTION
## What changed
- Repaired Enneagram method registry boundary copy.
- Consolidated non-diagnostic, non-hiring/screening, score-space, low-quality, diffuse, close-call, and user-confirmed-type boundaries.
- Reconciled ENNEA-RP-35 post-merge cleanup in the PR train ledger and recorded ENNEA-RP-36 local validation.

## Why
- The method boundary needs to keep E105/FC144 form semantics clear and prevent unsupported clinical, hiring, ability, health, or cross-form certainty claims.

## Validation
- `cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json`
- `cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest`
- `cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest`
- `cd backend && php artisan test --filter=EnneagramReportComposerV2Test`
- `cd backend && php artisan test --filter=EnneagramMethodRegistryBoundaryTest`
- `cd backend && php artisan test --filter=Enneagram`
- `git diff --check`

## Scope validation
Changed files are confined to:
- `backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json`
- `docs/codex/pr-train-state.json`

## Intentionally deferred
- No fap-web/frontend changes.
- No validator/test changes.
- No seven-day observation, resonance feedback, or future ENNEA-RP scopes.
- No CMS write, registry activation, staging wait, server verification, manual deploy, or production deploy.