### PR TITLE
ENNEA-RP-38: fix(enneagram): repair resonance feedback placeholder

### DIFF
--- a/backend/content_packs/ENNEAGRAM/v2/registry/observation_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/observation_registry.json
@@ -98,8 +98,8 @@
             "day": 3,
             "phase": "day3_feedback",
             "title": "Day 3｜轻量回看前三天",
-            "prompt": "不用给自己定型。只回看前三天：哪一类动机在线索里出现得稍多一点？如果不清楚，就选不清楚，并写下最有代表性的一个场景。",
-            "example": "如果你是 close-call，把 Top1 和 Top2 当作两个候选假设并排观察，不用强行二选一。",
+            "prompt": "不用给自己定型。只回看前三天：哪一类动机在线索里出现得稍多一点？如果不清楚，就选不清楚，并写下一个可回看的真实场景。",
+            "example": "如果你是 close-call，把 Top1 和 Top2 当作两个候选假设并排观察；这次反馈只记录证据，不要求强行二选一。",
             "user_input_schema": {
                 "type": "object",
                 "fields": {
@@ -135,7 +135,7 @@
             },
             "analytics_event_key": "enneagram_day3_feedback_submitted",
             "suggested_next_action": "read_top3",
-            "boundary_copy": "Day3 反馈只进入自我观察记录，不会静默改写本次测量结果。",
+            "boundary_copy": "Day3 反馈只进入自我观察记录，不会改写本次测量分数、主型候选或结果页解释。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -255,8 +255,8 @@
             "day": 7,
             "phase": "day7_resonance",
             "title": "Day 7｜深度共鸣投票",
-            "prompt": "回看这一周，不问哪个号码更好，只问哪些解释更贴近日常动机。可以选择 Top1、Top2、Top3、其他或仍不确定，并写一句证据。",
-            "example": "如果仍然摇摆，这不是失败。你可以继续阅读 Top3、保留不确定，或在需要时选择同题型重测或 FC144 补充观察。",
+            "prompt": "回看这一周，不问哪个号码更好，只问哪些解释更贴近日常动机。可以选择 Top1、Top2、Top3、其他或仍不确定，并写一句可回看的证据。",
+            "example": "如果仍然摇摆，这不是失败。你可以保留不确定、继续阅读 Top3，或在需要时选择同题型重测或 FC144 补充观察。",
             "user_input_schema": {
                 "type": "object",
                 "fields": {
@@ -299,7 +299,7 @@
             },
             "analytics_event_key": "enneagram_day7_feedback_submitted",
             "suggested_next_action": "observe_7_days",
-            "boundary_copy": "自我观察确认会被记录进历史，但不会把本次测量结果静默改写成系统改判。",
+            "boundary_copy": "Day7 共鸣反馈只记录你的自我观察证据，不触发系统重判，也不会把本次结果静默改写成新主型。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         }

--- a/backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json
@@ -61,7 +61,7 @@
             "label": "Day7 共鸣反馈"
         },
         "observation.self_confirmation_boundary": {
-            "label": "这不会静默改写本次测量结果。它会作为你的自我观察证据记录在历史中。"
+            "label": "反馈只记录你的自我观察证据，不会改写本次测量分数、主型候选或历史结果。"
         }
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16208,6 +16208,11 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to resonance feedback UI/observation copy and train ledger reconciliation/state."
+      },
+      "pr_created": {
+        "status": "pass",
+        "command": "gh pr create --repo fermatmind/fap-api --base main --head codex/ennea-rp-38-resonance-feedback-placeholder",
+        "evidence": "Opened PR #2705 for ENNEA-RP-38."
       }
     },
     "commit_sha": "8cfc53635e49567d15a061575834ac95b9897dd4",
@@ -16235,13 +16240,19 @@
         "status": "committed",
         "commit_sha": "8cfc53635e49567d15a061575834ac95b9897dd4",
         "notes": "Committed ENNEA-RP-38 resonance feedback placeholder copy repair and local validation ledger."
+      },
+      {
+        "at": "2026-07-03T13:31:43.540Z",
+        "status": "pr_open",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2705",
+        "notes": "Opened PR #2705 for ENNEA-RP-38."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-38",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2705",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
@@ -16260,7 +16271,7 @@
       ],
       "evidence": "Changed files are confined to resonance feedback UI/observation copy and train ledger reconciliation/state."
     },
-    "status": "committed",
+    "status": "pr_open",
     "title": "ENNEA-RP-38: fix(enneagram): repair resonance feedback placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16087,9 +16087,13 @@
         "status": "pass",
         "command": "gh pr checks 2704 --repo fermatmind/fap-api --watch --interval 15",
         "evidence": "All reported GitHub checks passed for PR #2704 before ready_to_merge ledger update."
+      },
+      "post_merge_cleanup": {
+        "status": "pass",
+        "evidence": "PR #2704 merged as e1ad1aa03e05e95e76efd68060ea30b6bbb2f42b; origin/main contained the merge commit, local main was synced to origin/main, worktree was clean, and local/remote task branches were removed before ENNEA-RP-38."
       }
     },
-    "commit_sha": "876c4e77ec3d43a02041f908af1cb89e549488a5",
+    "commit_sha": "e1ad1aa03e05e95e76efd68060ea30b6bbb2f42b",
     "depends_on": [
       "ENNEA-RP-36"
     ],
@@ -16125,14 +16129,21 @@
         "at": "2026-07-03T13:21:43.595Z",
         "status": "ready_to_merge",
         "notes": "GitHub checks passed; PR is ready to merge after final head-check confirmation."
+      },
+      {
+        "at": "2026-07-03T13:29:39.021Z",
+        "status": "merged",
+        "commit_sha": "e1ad1aa03e05e95e76efd68060ea30b6bbb2f42b",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2704",
+        "notes": "Reconciled post-merge facts: GitHub reports merged, origin/main contains merge commit, local main synced, worktree clean, and task branch cleanup completed."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-37",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-03T13:27:23Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2704",
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "allowed_files": [
@@ -16148,7 +16159,7 @@
       ],
       "evidence": "Changed files are confined to observation_registry seven-day observation copy and train ledger reconciliation/state."
     },
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "ENNEA-RP-37: fix(enneagram): repair seven-day observation",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },
@@ -16159,6 +16170,44 @@
       "authorization": {
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
         "status": "pass"
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-37 merged as PR #2704 and merge commit e1ad1aa03e05e95e76efd68060ea30b6bbb2f42b is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All Enneagram v2 registry JSON files parsed successfully."
+      },
+      "enneagram_type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed locally during ENNEA-RP-38 validation."
+      },
+      "enneagram_registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Passed locally during ENNEA-RP-38 validation."
+      },
+      "enneagram_report_composer_v2": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Passed locally during ENNEA-RP-38 validation."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed locally during ENNEA-RP-38 validation."
+      },
+      "git_diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors reported."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to resonance feedback UI/observation copy and train ledger reconciliation/state."
       }
     },
     "commit_sha": null,
@@ -16170,6 +16219,16 @@
         "at": "2026-07-02T16:10:24Z",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
         "status": "pending_dependency"
+      },
+      {
+        "at": "2026-07-03T13:29:39.021Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-38-resonance-feedback-placeholder; scope is resonance feedback placeholder and observation boundary copy plus train ledger only."
+      },
+      {
+        "at": "2026-07-03T13:30:42.396Z",
+        "status": "local_validation_passed",
+        "notes": "Required local validation and scope validation passed for resonance feedback placeholder boundary repair."
       }
     ],
     "failure_reason": null,
@@ -16187,9 +16246,15 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [],
+      "changed_files": [
+        "backend/content_packs/ENNEAGRAM/v2/registry/observation_registry.json",
+        "backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json",
+        "docs/codex/pr-train-state.json"
+      ],
+      "evidence": "Changed files are confined to resonance feedback UI/observation copy and train ledger reconciliation/state."
     },
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "title": "ENNEA-RP-38: fix(enneagram): repair resonance feedback placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16213,6 +16213,11 @@
         "status": "pass",
         "command": "gh pr create --repo fermatmind/fap-api --base main --head codex/ennea-rp-38-resonance-feedback-placeholder",
         "evidence": "Opened PR #2705 for ENNEA-RP-38."
+      },
+      "github_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2705 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All reported GitHub checks passed for PR #2705 before ready_to_merge ledger update."
       }
     },
     "commit_sha": "8cfc53635e49567d15a061575834ac95b9897dd4",
@@ -16246,6 +16251,11 @@
         "status": "pr_open",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2705",
         "notes": "Opened PR #2705 for ENNEA-RP-38."
+      },
+      {
+        "at": "2026-07-03T13:37:28.348Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub checks passed; PR is ready to merge after final head-check confirmation."
       }
     ],
     "failure_reason": null,
@@ -16271,7 +16281,7 @@
       ],
       "evidence": "Changed files are confined to resonance feedback UI/observation copy and train ledger reconciliation/state."
     },
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "ENNEA-RP-38: fix(enneagram): repair resonance feedback placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16210,7 +16210,7 @@
         "evidence": "Changed files are confined to resonance feedback UI/observation copy and train ledger reconciliation/state."
       }
     },
-    "commit_sha": null,
+    "commit_sha": "8cfc53635e49567d15a061575834ac95b9897dd4",
     "depends_on": [
       "ENNEA-RP-37"
     ],
@@ -16229,6 +16229,12 @@
         "at": "2026-07-03T13:30:42.396Z",
         "status": "local_validation_passed",
         "notes": "Required local validation and scope validation passed for resonance feedback placeholder boundary repair."
+      },
+      {
+        "at": "2026-07-03T13:30:57.925Z",
+        "status": "committed",
+        "commit_sha": "8cfc53635e49567d15a061575834ac95b9897dd4",
+        "notes": "Committed ENNEA-RP-38 resonance feedback placeholder copy repair and local validation ledger."
       }
     ],
     "failure_reason": null,
@@ -16254,7 +16260,7 @@
       ],
       "evidence": "Changed files are confined to resonance feedback UI/observation copy and train ledger reconciliation/state."
     },
-    "status": "local_validation_passed",
+    "status": "committed",
     "title": "ENNEA-RP-38: fix(enneagram): repair resonance feedback placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },


### PR DESCRIPTION
## What changed
- Clarified Day3 and Day7 observation feedback copy so user feedback is framed as self-observation evidence only.
- Updated the shared observation confirmation boundary copy to state that feedback does not rewrite scores, primary candidates, historical results, or result-page interpretation.
- Reconciled ENNEA-RP-37 post-merge facts and recorded ENNEA-RP-38 local validation in the PR train ledger.

## Why
The resonance feedback placeholder should not imply that a user vote or self-confirmation changes the measured result. It should clearly separate self-observation evidence from scoring, primary-candidate selection, history, and system adjudication.

## Validation
- `cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json`
- `cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest`
- `cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest`
- `cd backend && php artisan test --filter=EnneagramReportComposerV2Test`
- `cd backend && php artisan test --filter=Enneagram`
- `git diff --check`

## Scope validation
Changed files are confined to:
- `backend/content_packs/ENNEAGRAM/v2/registry/observation_registry.json`
- `backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json`
- `docs/codex/pr-train-state.json`

## Intentionally deferred
- No frontend/fap-web changes.
- No validator/test changes.
- No history/share/retake, form recommendation, sample report, technical note, or future ENNEA-RP scope changes.
- No CMS writes, registry activation, backend deploy, production deploy, or online smoke.
