### PR TITLE
ENNEA-RP-40: fix(enneagram): repair form recommendation

### DIFF
--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -1423,6 +1423,15 @@ final class EnneagramReportComposer
             $scope === 'diffuse' => 'observe_before_retake',
             default => 'stay_with_current_form',
         };
+        $methodKey = match ($recommendation) {
+            'retake_same_form_after_quality_check' => 'low_quality_boundary',
+            'consider_fc144_followup' => 'fc144_forced_choice_methodology',
+            'observe_before_retake' => 'diffuse_boundary',
+            default => 'same_model_not_same_score_space',
+        };
+        $recommendationMethod = is_array($indexes['method_entries'][$methodKey] ?? null)
+            ? $indexes['method_entries'][$methodKey]
+            : [];
 
         return $this->module(
             'form_recommendation',
@@ -1435,11 +1444,14 @@ final class EnneagramReportComposer
                 'form_code' => data_get($projectionV2, 'form.form_code'),
                 'methodology_variant' => data_get($projectionV2, 'form.methodology_variant'),
                 'recommended_first_action' => data_get($projectionV2, 'render_hints.recommended_first_action'),
+                'recommendation_copy' => $recommendationMethod['copy'] ?? null,
+                'boundary_kind' => 'form_specific_observation_not_cross_form_verdict',
+                'not_for' => ['cross_form_score_comparison', 'accuracy_ranking', 'replacement_result', 'personality_change_claim'],
             ],
             ['classification.interpretation_scope', 'form.form_code', 'form.methodology_variant'],
-            ['enneagram_method_registry'],
+            ['enneagram_method_registry:'.$methodKey],
             [],
-            $this->registryMeta($indexes, 'enneagram_method_registry')
+            $recommendationMethod !== [] ? $this->entryMeta($recommendationMethod, $this->registryMeta($indexes, 'enneagram_method_registry')) : $this->registryMeta($indexes, 'enneagram_method_registry')
         );
     }
 

--- a/backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json
+++ b/backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json
@@ -27,7 +27,7 @@
             "method_key": "fc144_forced_choice_methodology",
             "form_variant": "fc144",
             "display_context": "result_page",
-            "copy": "FC144 使用 forced-choice 配对选择，用来观察你在两难取舍中反复偏向的动机线索，尤其适合作为 close-call 后的补充观察。它不是比 E105 更准确的版本，也不与 E105 共享同一分数来源；结果应按 FC144 自身题型边界阅读，不能把跨 form 差异解释为人格变化或测评优劣。",
+            "copy": "FC144 使用 forced-choice 配对选择，用来观察你在两难取舍中反复偏向的动机线索，尤其适合作为 close-call 后的补充观察。它不是比 E105 更准确的版本，也不会替代 E105 的 primary_candidate、Top3 或原始计分事实；结果应按 FC144 自身题型边界阅读，不能把跨 form 差异解释为人格变化或测评优劣。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -67,7 +67,7 @@
             "method_key": "low_quality_boundary",
             "form_variant": "all",
             "display_context": "result_page",
-            "copy": "当低质量信号触发时，结果仍可阅读，但解释边界会明显收窄。页面只保留轻量观察建议，避免把单次低稳定度作答扩展成确定性类型判断；优先建议在状态更稳定、时间更充足时重测同一题型。切换 form 可以作为另一次观察，但不能用来寻找“更好答案”，也不能把两次 form 差异做成分数升降、人格变化或可靠性证明。",
+            "copy": "当低质量信号触发时，结果仍可阅读，但解释边界会明显收窄。页面只保留轻量观察建议，避免把单次低稳定度作答扩展成确定性类型判断；优先建议在状态更稳定、时间更充足时重测同一题型。切换 form 可以作为另一次观察，但不能被当成规避质量边界、寻找更好答案、证明人格变化或比较分数升降的方法。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },
@@ -75,7 +75,7 @@
             "method_key": "diffuse_boundary",
             "form_variant": "all",
             "display_context": "result_page",
-            "copy": "diffuse 表示九个类型线索较分散，或 Top3 尚未形成足够清晰的主次关系。它不是作答失败，也不是系统无效，更不是人格混乱或心理健康信号。页面会降低单一号码的确定语气，优先引导并排阅读 Top3、三中心分布、近期反例和 7 天观察任务，再判断哪些解释在日常动机中更贴近。",
+            "copy": "diffuse 表示九个类型线索较分散，或 Top3 尚未形成足够清晰的主次关系。它不是作答失败，也不是系统无效，更不是人格混乱或心理健康信号。页面会降低单一号码的确定语气，优先引导并排阅读 Top3、三中心分布、近期反例和 7 天观察任务；重测只能提供另一份作答样本，不能自动修正成更稳定或更真实的类型。",
             "content_maturity": "p0_ready",
             "evidence_level": "descriptive"
         },

--- a/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
+++ b/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
@@ -329,6 +329,35 @@ final class EnneagramReportComposerV2Test extends TestCase
         $this->assertStringContainsString('不是在责备作答者', (string) data_get($summary, 'content.body'));
     }
 
+    public function test_form_recommendation_uses_safe_registry_boundary_copy(): void
+    {
+        $payload = $this->composeReportV2(
+            $this->syntheticProjectionInput('enneagram_forced_choice_144', [
+                'T5' => 84.0,
+                'T6' => 68.0,
+                'T4' => 52.0,
+                'T1' => 35.0,
+                'T2' => 28.0,
+                'T3' => 21.0,
+                'T7' => 18.0,
+                'T8' => 16.0,
+                'T9' => 12.0,
+            ], [], [
+                'level' => 'P2',
+                'flags' => ['speed_too_fast'],
+            ])
+        );
+
+        $module = $this->module($payload, 'form_recommendation');
+
+        $this->assertSame('retake_same_form_after_quality_check', data_get($module, 'content.recommendation_key'));
+        $this->assertSame('form_specific_observation_not_cross_form_verdict', data_get($module, 'content.boundary_kind'));
+        $this->assertStringContainsString('重测同一题型', (string) data_get($module, 'content.recommendation_copy'));
+        $this->assertStringContainsString('不能被当成规避质量边界', (string) data_get($module, 'content.recommendation_copy'));
+        $this->assertContains('accuracy_ranking', (array) data_get($module, 'content.not_for'));
+        $this->assertContains('enneagram_method_registry:low_quality_boundary', (array) data_get($module, 'registry_refs'));
+    }
+
     public function test_v2_modules_expose_p0_ready_registry_provenance(): void
     {
         $payload = $this->composeReportV2(

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16481,7 +16481,7 @@
         "evidence": "Changed files are confined to form recommendation method copy, composer output, Enneagram test coverage, and train ledger reconciliation/state."
       }
     },
-    "commit_sha": null,
+    "commit_sha": "f01b3abd944e5c171824469176633280138f1bff",
     "depends_on": [
       "ENNEA-RP-39"
     ],
@@ -16500,6 +16500,12 @@
         "at": "2026-07-03T14:04:32.156Z",
         "status": "local_validation_passed",
         "notes": "Required local validation and scope validation passed for form recommendation repair."
+      },
+      {
+        "at": "2026-07-03T14:04:47.358Z",
+        "status": "committed",
+        "commit_sha": "f01b3abd944e5c171824469176633280138f1bff",
+        "notes": "Committed ENNEA-RP-40 form recommendation repair and local validation ledger."
       }
     ],
     "failure_reason": null,
@@ -16527,7 +16533,7 @@
       ],
       "evidence": "Changed files are confined to form recommendation method copy, composer output, Enneagram test coverage, and train ledger reconciliation/state."
     },
-    "status": "local_validation_passed",
+    "status": "committed",
     "title": "ENNEA-RP-40: fix(enneagram): repair form recommendation",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16356,9 +16356,13 @@
         "status": "pass",
         "command": "gh pr checks 2706 --repo fermatmind/fap-api --watch --interval 15",
         "evidence": "All reported GitHub checks passed for PR #2706 before ready_to_merge ledger update."
+      },
+      "post_merge_cleanup": {
+        "status": "pass",
+        "evidence": "PR #2706 merged as 50bc742960ef29d3dbc30bad8a68d0924852cb7e; origin/main contained the merge commit, local main was synced to origin/main, worktree was clean, and local/remote task branches were removed before ENNEA-RP-40."
       }
     },
-    "commit_sha": "6c2d31106d7ce9b1674189f85c577f7c0a8a52e3",
+    "commit_sha": "50bc742960ef29d3dbc30bad8a68d0924852cb7e",
     "depends_on": [
       "ENNEA-RP-38"
     ],
@@ -16394,14 +16398,21 @@
         "at": "2026-07-03T13:53:49.259Z",
         "status": "ready_to_merge",
         "notes": "GitHub checks passed; PR is ready to merge after final head-check confirmation."
+      },
+      {
+        "at": "2026-07-03T14:02:03.487Z",
+        "status": "merged",
+        "commit_sha": "50bc742960ef29d3dbc30bad8a68d0924852cb7e",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2706",
+        "notes": "Reconciled post-merge facts: GitHub reports merged, origin/main contains merge commit, local main synced, worktree clean, and task branch cleanup completed."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-39",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-03T13:59:24Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2706",
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "allowed_files": [
@@ -16419,7 +16430,7 @@
       ],
       "evidence": "Changed files are confined to history/share/retake placeholder UI/method copy and train ledger reconciliation/state."
     },
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "ENNEA-RP-39: fix(enneagram): repair history share retake placeholder",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },
@@ -16430,6 +16441,44 @@
       "authorization": {
         "evidence": "User-provided /goal explicitly authorized ENNEA-RP-01 through ENNEA-RP-43 manifest/state registration and sequential execution.",
         "status": "pass"
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ENNEA-RP-39 merged as PR #2706 and merge commit 50bc742960ef29d3dbc30bad8a68d0924852cb7e is present in origin/main."
+      },
+      "jq_registry_json": {
+        "status": "pass",
+        "command": "cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json",
+        "evidence": "All Enneagram v2 registry JSON files parsed successfully."
+      },
+      "enneagram_type_registry_coverage": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest",
+        "evidence": "Passed locally during ENNEA-RP-40 validation."
+      },
+      "enneagram_registry_pack_load": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest",
+        "evidence": "Initial run exposed current-scope method registry key expansion invalid under existing validator; fixed by reusing existing method keys, then passed locally."
+      },
+      "enneagram_report_composer_v2": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramReportComposerV2Test",
+        "evidence": "Initial run exposed a current-scope test assertion typo for retake/retake key spelling; fixed in test, then passed locally."
+      },
+      "enneagram_filter": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Enneagram",
+        "evidence": "Passed locally after current-scope fixes."
+      },
+      "git_diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors reported."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to form recommendation method copy, composer output, Enneagram test coverage, and train ledger reconciliation/state."
       }
     },
     "commit_sha": null,
@@ -16441,6 +16490,16 @@
         "at": "2026-07-02T16:10:24Z",
         "notes": "Registered as user-authorized sequential Enneagram result-page content asset PR; execution waits for dependency merge.",
         "status": "pending_dependency"
+      },
+      {
+        "at": "2026-07-03T14:02:03.487Z",
+        "status": "in_progress",
+        "notes": "Started from latest origin/main on branch codex/ennea-rp-40-form-recommendation; scope is form recommendation method copy, composer output, Enneagram tests, and train ledger only."
+      },
+      {
+        "at": "2026-07-03T14:04:32.156Z",
+        "status": "local_validation_passed",
+        "notes": "Required local validation and scope validation passed for form recommendation repair."
       }
     ],
     "failure_reason": null,
@@ -16459,9 +16518,16 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [],
+      "changed_files": [
+        "backend/app/Services/Report/EnneagramReportComposer.php",
+        "backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json",
+        "backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php",
+        "docs/codex/pr-train-state.json"
+      ],
+      "evidence": "Changed files are confined to form recommendation method copy, composer output, Enneagram test coverage, and train ledger reconciliation/state."
     },
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "title": "ENNEA-RP-40: fix(enneagram): repair form recommendation",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16479,6 +16479,11 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to form recommendation method copy, composer output, Enneagram test coverage, and train ledger reconciliation/state."
+      },
+      "pr_created": {
+        "status": "pass",
+        "command": "gh pr create --repo fermatmind/fap-api --base main --head codex/ennea-rp-40-form-recommendation",
+        "evidence": "Opened PR #2707 for ENNEA-RP-40."
       }
     },
     "commit_sha": "f01b3abd944e5c171824469176633280138f1bff",
@@ -16506,13 +16511,19 @@
         "status": "committed",
         "commit_sha": "f01b3abd944e5c171824469176633280138f1bff",
         "notes": "Committed ENNEA-RP-40 form recommendation repair and local validation ledger."
+      },
+      {
+        "at": "2026-07-03T14:05:26.934Z",
+        "status": "pr_open",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2707",
+        "notes": "Opened PR #2707 for ENNEA-RP-40."
       }
     ],
     "failure_reason": null,
     "id": "ENNEA-RP-40",
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2707",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "scope_validation": {
@@ -16533,7 +16544,7 @@
       ],
       "evidence": "Changed files are confined to form recommendation method copy, composer output, Enneagram test coverage, and train ledger reconciliation/state."
     },
-    "status": "committed",
+    "status": "pr_open",
     "title": "ENNEA-RP-40: fix(enneagram): repair form recommendation",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -16484,6 +16484,11 @@
         "status": "pass",
         "command": "gh pr create --repo fermatmind/fap-api --base main --head codex/ennea-rp-40-form-recommendation",
         "evidence": "Opened PR #2707 for ENNEA-RP-40."
+      },
+      "github_checks": {
+        "status": "pass",
+        "command": "gh pr checks 2707 --repo fermatmind/fap-api --watch --interval 15",
+        "evidence": "All reported GitHub checks passed for PR #2707 before ready_to_merge ledger update."
       }
     },
     "commit_sha": "f01b3abd944e5c171824469176633280138f1bff",
@@ -16517,6 +16522,11 @@
         "status": "pr_open",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2707",
         "notes": "Opened PR #2707 for ENNEA-RP-40."
+      },
+      {
+        "at": "2026-07-03T14:11:06.167Z",
+        "status": "ready_to_merge",
+        "notes": "GitHub checks passed; PR is ready to merge after final head-check confirmation."
       }
     ],
     "failure_reason": null,
@@ -16544,7 +16554,7 @@
       ],
       "evidence": "Changed files are confined to form recommendation method copy, composer output, Enneagram test coverage, and train ledger reconciliation/state."
     },
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "ENNEA-RP-40: fix(enneagram): repair form recommendation",
     "train_scope": "enneagram_result_page_content_asset_repair"
   },


### PR DESCRIPTION
## What changed
- Added safe form recommendation copy to the result-page module by reusing existing method registry boundary entries.
- Strengthened FC144, diffuse, and low-quality method copy around follow-up/retest boundaries.
- Added Enneagram report composer coverage for recommendation copy, registry refs, and explicit `not_for` boundaries.
- Reconciled ENNEA-RP-39 post-merge facts and recorded ENNEA-RP-40 local validation in the PR train ledger.

## Why
The form recommendation module should not imply FC144 is more accurate, a replacement result, a cross-form score comparison, or evidence of personality change. It should state whether to stay with the current form, observe first, consider FC144 only as a supplemental lens, or retake the same form after quality concerns.

## Validation
- `cd backend && jq empty content_packs/ENNEAGRAM/v2/registry/*.json`
- `cd backend && php artisan test --filter=EnneagramTypeRegistryCoverageTest`
- `cd backend && php artisan test --filter=EnneagramRegistryPackLoadTest`
- `cd backend && php artisan test --filter=EnneagramReportComposerV2Test`
- `cd backend && php artisan test --filter=Enneagram`
- `git diff --check`

## Scope validation
Changed files are confined to:
- `backend/app/Services/Report/EnneagramReportComposer.php`
- `backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json`
- `backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php`
- `docs/codex/pr-train-state.json`

## Intentionally deferred
- No frontend/fap-web changes.
- No validator changes.
- No sample report, technical note, or future ENNEA-RP scope changes.
- No CMS writes, registry activation, backend deploy, production deploy, or online smoke.
