### PR TITLE
docs(seo): clarify llms-full stabilization ownership

### DIFF
--- a/docs/runbooks/seo-daily-media-release-runner.md
+++ b/docs/runbooks/seo-daily-media-release-runner.md
@@ -56,6 +56,20 @@ php artisan media-assets:import-seo-image-bundle \
 
 4. Continue only after the resolved package contains canonical `https://assets.fermatmind.com/...` image URLs. Then proceed to CMS draft import, preview QA, controlled publish, URL Truth, Search Channel, GSC Request Indexing, and D1/D7/D14 observation.
 
+## Discoverability Boundary
+
+The Media Library runner is responsible only for source image validation, CDN
+availability, variant generation, and CMS image metadata readiness.
+
+`/llms-full.txt` complete/degraded state is a fap-web public runtime
+artifact/cache concern, not a Media Library or backend importer concern. After
+article publish, `llms-full` parity and stabilization must be handled by the
+fap-web public verifier plus the content-release revalidation / llms-full warm
+gate when needed.
+
+Do not try to repair `/llms-full.txt` degraded mode through the Media Library
+importer, CMS image backfill, or the SEO content package draft importer.
+
 ## Half-Failed Asset Recovery
 
 When an earlier run created MediaAsset rows but CDN/object truth was not ready, audit first:


### PR DESCRIPTION
## What changed
- Added a Discoverability Boundary section to the SEO Daily Media Release Runner runbook.
- Clarified that the Media Library runner owns source image validation, CDN availability, variants, and CMS image metadata readiness only.
- Clarified that `/llms-full.txt` complete/degraded state belongs to fap-web public runtime artifact/cache stabilization, handled by public verifier plus content-release revalidation / llms-full warm when needed.

## Why
The media runbook previously flowed from Media Library import into the broader daily SEO release chain without naming the ownership boundary. This could make future llms-full degraded incidents look like Media Library/importer failures even when backend authority is already correct.

## Validation
- `rg -n "Discoverability Boundary|llms-full|Media Library runner|content-release revalidation" docs/runbooks/seo-daily-media-release-runner.md`
- `git diff --check`

## Intentionally deferred
- No backend code changes.
- No importer changes.
- No CMS writes.
- No fap-web runtime changes.
- No deploy.
