### PR TITLE
IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01: remove unsafe IQ V1 result artifact claims

### DIFF
--- a/backend/app/Services/Report/IqReportBuilder.php
+++ b/backend/app/Services/Report/IqReportBuilder.php
@@ -60,28 +60,6 @@ final class IqReportBuilder
                 ],
             ],
         ],
-        'iq_pro' => [
-            'pdf_payload' => [
-                'labels' => [
-                    'zh-CN' => 'IQ 报告 PDF',
-                    'en' => 'IQ report PDF',
-                ],
-                'description' => [
-                    'zh-CN' => '在线 IQ 估测报告 PDF；当前仅定义合同，尚未生成正式文件。',
-                    'en' => 'Online IQ estimate report PDF; contract-defined only until formal file generation is implemented.',
-                ],
-            ],
-            'certificate_payload' => [
-                'labels' => [
-                    'zh-CN' => 'IQ 结果凭证',
-                    'en' => 'IQ result certificate',
-                ],
-                'description' => [
-                    'zh-CN' => '在线 IQ 估测结果凭证；当前仅定义合同，尚未生成正式文件。',
-                    'en' => 'Online IQ estimate result certificate; contract-defined only until formal file generation is implemented.',
-                ],
-            ],
-        ],
     ];
 
     /**
@@ -165,22 +143,6 @@ final class IqReportBuilder
             'access' => [
                 'report_access_level' => $reportAccessLevel,
                 'variant' => $normalizedVariant,
-            ],
-            'iq_pro' => [
-                'pdf_payload' => [
-                    'status' => 'contract_defined_not_implemented',
-                    'label' => $this->iqProLabel('pdf_payload', $locale),
-                    'description' => $this->iqProDescription('pdf_payload', $locale),
-                    'scale_code' => self::CANONICAL_SCALE_CODE,
-                    'attempt_id' => (string) ($attempt->id ?? ''),
-                ],
-                'certificate_payload' => [
-                    'status' => 'contract_defined_not_implemented',
-                    'label' => $this->iqProLabel('certificate_payload', $locale),
-                    'description' => $this->iqProDescription('certificate_payload', $locale),
-                    'scale_code' => self::CANONICAL_SCALE_CODE,
-                    'attempt_id' => (string) ($attempt->id ?? ''),
-                ],
             ],
             'sections' => [
                 'dimensions' => $dimensions,
@@ -415,16 +377,6 @@ final class IqReportBuilder
     private function dimensionLabel(string $dimensionKey, string $locale): ?string
     {
         return $this->localizedLabel("dimensions.{$dimensionKey}.labels", $locale);
-    }
-
-    private function iqProLabel(string $payloadKey, string $locale): ?string
-    {
-        return $this->localizedLabel("iq_pro.{$payloadKey}.labels", $locale);
-    }
-
-    private function iqProDescription(string $payloadKey, string $locale): ?string
-    {
-        return $this->localizedLabel("iq_pro.{$payloadKey}.description", $locale);
     }
 
     private function localizedLabel(string $basePath, string $locale): ?string

--- a/backend/docs/seo/generated/result-en-parity-03-iq-locale-safe-labels.v1.json
+++ b/backend/docs/seo/generated/result-en-parity-03-iq-locale-safe-labels.v1.json
@@ -23,9 +23,7 @@
     "iq.dimensions.visual_spatial_insight.en",
     "iq.dimensions.visual_spatial_pattern_reasoning.en",
     "iq.dimensions.numeric_pattern_reasoning.en",
-    "iq.dimensions.numerical_pattern_reasoning.en",
-    "iq_pro.pdf_payload.en",
-    "iq_pro.certificate_payload.en"
+    "iq.dimensions.numerical_pattern_reasoning.en"
   ],
   "asset_matrix": [
     {
@@ -52,29 +50,12 @@
       "has_en": true,
       "missing_en": false,
       "fallback_to_zh_allowed": false
-    },
-    {
-      "asset_key": "iq_pro.pdf_payload",
-      "has_zh": true,
-      "has_en": true,
-      "missing_en": false,
-      "fallback_to_zh_allowed": false,
-      "status": "contract_defined_not_implemented"
-    },
-    {
-      "asset_key": "iq_pro.certificate_payload",
-      "has_zh": true,
-      "has_en": true,
-      "missing_en": false,
-      "fallback_to_zh_allowed": false,
-      "status": "contract_defined_not_implemented"
     }
   ],
   "claim_boundary": {
     "allowed": [
-      "online IQ estimate",
-      "confidence-bound result",
-      "contract-defined PDF/certificate payload",
+      "raw IQ-style reasoning score",
+      "beta standard score when backend authority provides it",
       "not a clinical diagnosis"
     ],
     "forbidden": [

--- a/backend/tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php
+++ b/backend/tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php
@@ -33,8 +33,7 @@ final class ResultEnParity03IqLocaleSafeLabelsTest extends TestCase
         $this->assertSame('Visual-spatial insight', data_get($report, 'dimensions.visual_spatial_insight.dimension_name'));
         $this->assertSame('Visual-spatial pattern reasoning', data_get($report, 'dimensions.visual_spatial_pattern_reasoning.dimension_name'));
         $this->assertSame('Numeric pattern reasoning', data_get($report, 'dimensions.numerical_pattern_reasoning.dimension_name'));
-        $this->assertSame('IQ report PDF', data_get($report, 'iq_pro.pdf_payload.label'));
-        $this->assertSame('IQ result certificate', data_get($report, 'iq_pro.certificate_payload.label'));
+        $this->assertNull(data_get($report, 'iq_pro'));
 
         $serialized = json_encode($report, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         $this->assertDoesNotMatchRegularExpression('/[\x{4e00}-\x{9fff}]/u', $serialized);
@@ -60,7 +59,7 @@ final class ResultEnParity03IqLocaleSafeLabelsTest extends TestCase
         $this->assertSame('数字规律推理', data_get($report, 'dimensions.numerical_pattern_reasoning.dimension_name'));
     }
 
-    public function test_iq_label_catalog_keeps_online_estimate_claim_boundary(): void
+    public function test_iq_label_catalog_keeps_artifact_claim_boundary(): void
     {
         $payload = app(IqReportBuilder::class)->composeVariant(
             $this->attempt('en-US'),
@@ -72,10 +71,7 @@ final class ResultEnParity03IqLocaleSafeLabelsTest extends TestCase
             ]
         );
 
-        $visibleEnglish = implode(' ', [
-            data_get($payload, 'report.iq_pro.pdf_payload.description'),
-            data_get($payload, 'report.iq_pro.certificate_payload.description'),
-        ]);
+        $visibleEnglish = json_encode(data_get($payload, 'report'), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
 
         foreach ([
             'clinical diagnosis',
@@ -83,11 +79,15 @@ final class ResultEnParity03IqLocaleSafeLabelsTest extends TestCase
             'certified IQ',
             'globally most accurate',
             'treatment',
+            'IQ report PDF',
+            'IQ result certificate',
+            'Online IQ estimate report PDF',
+            'Online IQ estimate result certificate',
+            'pdf_payload',
+            'certificate_payload',
         ] as $claim) {
             $this->assertStringNotContainsString(strtolower($claim), strtolower($visibleEnglish), $claim);
         }
-
-        $this->assertStringContainsString('Online IQ estimate', $visibleEnglish);
     }
 
     public function test_generated_iq_inventory_json_parses(): void
@@ -100,7 +100,8 @@ final class ResultEnParity03IqLocaleSafeLabelsTest extends TestCase
         $this->assertSame('RESULT-EN-PARITY-03', $decoded['pr_id'] ?? null);
         $this->assertSame('iq', $decoded['family'] ?? null);
         $this->assertContains('iq.dimensions.visual_spatial_insight.en', $decoded['fixed_keys'] ?? []);
-        $this->assertContains('iq_pro.pdf_payload.en', $decoded['fixed_keys'] ?? []);
+        $this->assertNotContains('iq_pro.pdf_payload.en', $decoded['fixed_keys'] ?? []);
+        $this->assertNotContains('iq_pro.certificate_payload.en', $decoded['fixed_keys'] ?? []);
         $this->assertSame('fail_closed_no_zh_label_fallback', $decoded['english_runtime_policy'] ?? null);
     }
 

--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -252,13 +252,12 @@ final class IqReportContractTest extends TestCase
         $this->assertIsArray(data_get($payload, 'report.dimensions'));
         $this->assertIsArray(data_get($payload, 'report.quality'));
         $this->assertIsArray(data_get($payload, 'report.scoring'));
-        $this->assertIsArray(data_get($payload, 'report.iq_pro'));
+        $this->assertNull(data_get($payload, 'report.iq_pro'));
         $this->assertNull(data_get($payload, 'report.scoring.answer_key_version'));
         $this->assertEquals(21.0, data_get($payload, 'report.summary.raw_score'));
         $this->assertSame('A', data_get($payload, 'report.quality.level'));
-        $this->assertSame('contract_defined_not_implemented', data_get($payload, 'report.iq_pro.pdf_payload.status'));
-        $this->assertSame('contract_defined_not_implemented', data_get($payload, 'report.iq_pro.certificate_payload.status'));
         $this->assertPayloadHasNoAnswerKeyFields($payload);
+        $this->assertPayloadHasNoIqV1ForbiddenArtifactClaims($payload);
     }
 
     public function test_iq_result_endpoint_redacts_legacy_answer_keys_from_public_payload(): void
@@ -376,6 +375,29 @@ final class IqReportContractTest extends TestCase
         }
     }
 
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertPayloadHasNoIqV1ForbiddenArtifactClaims(array $payload): void
+    {
+        $serialized = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        foreach ([
+            'pdf_payload',
+            'certificate_payload',
+            'IQ report PDF',
+            'IQ result certificate',
+            'Online IQ estimate report PDF',
+            'Online IQ estimate result certificate',
+            'IQ 报告 PDF',
+            'IQ 结果凭证',
+            '在线 IQ 估测报告 PDF',
+            '在线 IQ 估测结果凭证',
+        ] as $forbiddenClaim) {
+            $this->assertStringNotContainsString($forbiddenClaim, $serialized, $forbiddenClaim);
+        }
+    }
+
     public function test_iq_paid_report_entitlement_unlocks_full_payload_for_matching_anon(): void
     {
         $this->seedScales();
@@ -402,7 +424,7 @@ final class IqReportContractTest extends TestCase
         $this->assertSame('iq.report.v1', data_get($payload, 'report.schema_version'));
         $this->assertIsArray(data_get($payload, 'report.dimensions'));
         $this->assertIsArray(data_get($payload, 'report.scoring'));
-        $this->assertIsArray(data_get($payload, 'report.iq_pro'));
+        $this->assertNull(data_get($payload, 'report.iq_pro'));
         $this->assertArrayHasKey('raw_score', data_get($payload, 'report.summary', []));
         $this->assertNull(data_get($payload, 'report.summary.iq_estimate'));
         $this->assertNull(data_get($payload, 'report.summary.percentile'));
@@ -414,6 +436,7 @@ final class IqReportContractTest extends TestCase
         $this->assertFalse((bool) data_get($payload, 'report.summary.claim_policy.claim_eligible'));
         $this->assertNull(data_get($payload, 'report.answer_key'));
         $this->assertNull(data_get($payload, 'report.correct_answers'));
+        $this->assertPayloadHasNoIqV1ForbiddenArtifactClaims($payload);
     }
 
     public function test_iq_paid_report_entitlement_does_not_unlock_for_wrong_anon(): void

--- a/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
@@ -95,8 +95,9 @@ final class IqReportBuilderTest extends TestCase
         $this->assertSame(75.0, data_get($payload, 'report.dimensions.visual_spatial_insight.percent_correct'));
         $this->assertSame(4.0, data_get($payload, 'report.dimensions.visual_spatial_pattern_reasoning.raw_score'));
         $this->assertSame(2.0, data_get($payload, 'report.dimensions.numerical_pattern_reasoning.raw_score'));
-        $this->assertSame('contract_defined_not_implemented', data_get($payload, 'report.iq_pro.pdf_payload.status'));
+        $this->assertNull(data_get($payload, 'report.iq_pro'));
         $this->assertSame('full', data_get($payload, 'report.access.report_access_level'));
+        $this->assertNoIqV1ForbiddenArtifactClaims($payload);
     }
 
     public function test_builder_emits_iq_claim_fields_only_when_norm_claim_policy_is_eligible(): void
@@ -224,5 +225,28 @@ final class IqReportBuilderTest extends TestCase
                 'NPR' => ['raw_score' => 0.0, 'percent_correct' => 0.0, 'item_count' => 6, 'answered_count' => 6, 'correct_count' => 0],
             ],
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertNoIqV1ForbiddenArtifactClaims(array $payload): void
+    {
+        $serialized = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        foreach ([
+            'pdf_payload',
+            'certificate_payload',
+            'IQ report PDF',
+            'IQ result certificate',
+            'Online IQ estimate report PDF',
+            'Online IQ estimate result certificate',
+            'IQ 报告 PDF',
+            'IQ 结果凭证',
+            '在线 IQ 估测报告 PDF',
+            '在线 IQ 估测结果凭证',
+        ] as $forbiddenClaim) {
+            $this->assertStringNotContainsString($forbiddenClaim, $serialized, $forbiddenClaim);
+        }
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24646,7 +24646,7 @@
       }
     },
     "cms_mutation": false,
-    "commit_sha": "da237bbc468774611075f3ad7543ac67691982d2",
+    "commit_sha": "cce6c9f0a21260647e57f41e98bbef744efc1deb",
     "content_authority": "backend",
     "database_mutation": false,
     "depends_on": [
@@ -24683,14 +24683,21 @@
     "failure_reason": null,
     "id": "IQ-BETA-STANDARD-SCORE-1",
     "local_cleanup_executed": false,
-    "merged_at": null,
+    "merged_at": "2026-06-29T03:29:16Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2542",
     "production_write_execution": false,
     "publish_allowed": false,
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
-    "status": "ci_fix_local_checks_passed",
-    "title": "feat(iq): add random-baseline beta standard score"
+    "status": "merged",
+    "title": "feat(iq): add random-baseline beta standard score",
+    "transitions": [
+      {
+        "at": "2026-07-04T13:29:35Z",
+        "status": "merged",
+        "note": "Reconciled while starting IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01: GitHub shows PR #2542 MERGED at 2026-06-29T03:29:16Z with squash commit cce6c9f0a21260647e57f41e98bbef744efc1deb; origin/main contains the merge commit."
+      }
+    ]
   },
   "IQ-OWNER-30-BACKEND-ASSETS-01": {
     "base": "main",
@@ -48820,6 +48827,258 @@
     },
     "status": "merged",
     "title": "TAKE-EN-QUESTION-LOCALE-SCAN-00 take flow EN/ZH question locale scan"
+  },
+  "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01": {
+    "id": "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-v1-result-page-safe-scoring-qa-fix-01",
+    "title": "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01: remove unsafe IQ V1 result artifact claims",
+    "depends_on": [
+      "IQ-BETA-STANDARD-SCORE-1"
+    ],
+    "status": "committed",
+    "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+    "checks": {
+      "iq_report_builder_unit": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/IqReportBuilderTest.php --no-ansi",
+        "status": "passed",
+        "evidence": "PASS: 3 tests, 51 assertions."
+      },
+      "iq_report_contract_feature": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi",
+        "status": "passed",
+        "evidence": "PASS: 8 tests, 778 assertions."
+      },
+      "iq_locale_safe_labels": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php --no-ansi",
+        "status": "passed",
+        "evidence": "PASS: 4 tests, 32 assertions."
+      },
+      "route_list_api_v03": {
+        "command": "cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt",
+        "status": "passed"
+      },
+      "json_yaml_diff": {
+        "command": "python3 -m json.tool backend/docs/seo/generated/result-en-parity-03-iq-locale-safe-labels.v1.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "status": "passed"
+      },
+      "scoped_pint": {
+        "command": "cd backend && ./vendor/bin/pint --test app/Services/Report/IqReportBuilder.php tests/Unit/Services/Report/IqReportBuilderTest.php tests/Feature/V0_3/IqReportContractTest.php tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php --no-interaction",
+        "status": "passed"
+      },
+      "php_lint": {
+        "command": "php -l backend/app/Services/Report/IqReportBuilder.php && php -l backend/tests/Unit/Services/Report/IqReportBuilderTest.php && php -l backend/tests/Feature/V0_3/IqReportContractTest.php && php -l backend/tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php",
+        "status": "passed"
+      },
+      "scope_validation": {
+        "command": "git diff --name-status && git status --short --untracked-files=all",
+        "status": "passed",
+        "evidence": "Changed files are limited to IqReportBuilder, focused IQ report/SeoIntel tests, one generated SeoIntel JSON artifact, and authorized docs/codex PR-train metadata. No fap-web, payment, CMS, DB migration, item bank answer key, search, deploy, or production command changes."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": "2c86ec4fa",
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "backend",
+    "transitions": [
+      {
+        "at": "2026-07-04T13:29:35Z",
+        "status": "in_progress",
+        "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+      },
+      {
+        "at": "2026-07-04T13:30:41Z",
+        "status": "local_validation_passed",
+        "summary": "Removed IQ V1 report artifact placeholders, updated focused contract/parity tests and generated audit JSON, reconciled beta score dependency ledger, and passed local manifest validation. No production deploy, production DB mutation, CMS write, fap-web change, payment change, or item bank answer-key change performed."
+      },
+      {
+        "at": "2026-07-04T13:31:21Z",
+        "status": "committed",
+        "summary": "Committed scoped IQ V1 safe scoring/report artifact claim fix at 2c86ec4fa."
+      }
+    ]
+  },
+  "IQ-V1-POSITIONING-LOCK-01": {
+    "id": "IQ-V1-POSITIONING-LOCK-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-v1-positioning-lock-01",
+    "title": "IQ-V1-POSITIONING-LOCK-01: lock IQ V1 public positioning boundaries",
+    "depends_on": [
+      "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01"
+    ],
+    "status": "pending",
+    "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+    "checks": {},
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "backend",
+    "transitions": [
+      {
+        "at": "2026-07-04T13:29:35Z",
+        "status": "pending",
+        "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+      }
+    ]
+  },
+  "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01": {
+    "id": "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-v1-free-full-result-controlled-smoke-01",
+    "title": "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01: add controlled IQ free full result smoke",
+    "depends_on": [
+      "IQ-V1-POSITIONING-LOCK-01"
+    ],
+    "status": "pending",
+    "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+    "checks": {},
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "backend",
+    "transitions": [
+      {
+        "at": "2026-07-04T13:29:35Z",
+        "status": "pending",
+        "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+      }
+    ]
+  },
+  "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01": {
+    "id": "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-v1-landing-copy-cms-dry-run-01",
+    "title": "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01: prepare IQ landing copy CMS dry run",
+    "depends_on": [
+      "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01"
+    ],
+    "status": "pending",
+    "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+    "checks": {},
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "backend",
+    "transitions": [
+      {
+        "at": "2026-07-04T13:29:35Z",
+        "status": "pending",
+        "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+      }
+    ]
+  },
+  "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01": {
+    "id": "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-v1-item-dimension-tagging-implementation-01",
+    "title": "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01: implement IQ V1 item dimension tagging",
+    "depends_on": [
+      "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01"
+    ],
+    "status": "pending",
+    "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+    "checks": {},
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "backend",
+    "transitions": [
+      {
+        "at": "2026-07-04T13:29:35Z",
+        "status": "pending",
+        "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+      }
+    ]
   },
   "items": {
     "2786-CN-PROXY-PUBLIC-OWNER-PR-TRAIN-1": {
@@ -73256,6 +73515,258 @@
       "repo": "fap-api",
       "status": "planned",
       "title": "chore(iq): freeze legacy SVG assets and add provenance verification"
+    },
+    "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01": {
+      "id": "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01",
+      "repo": "fap-api",
+      "base": "main",
+      "branch": "codex/iq-v1-result-page-safe-scoring-qa-fix-01",
+      "title": "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01: remove unsafe IQ V1 result artifact claims",
+      "depends_on": [
+        "IQ-BETA-STANDARD-SCORE-1"
+      ],
+      "status": "committed",
+      "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+      "checks": {
+        "iq_report_builder_unit": {
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/IqReportBuilderTest.php --no-ansi",
+          "status": "passed",
+          "evidence": "PASS: 3 tests, 51 assertions."
+        },
+        "iq_report_contract_feature": {
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi",
+          "status": "passed",
+          "evidence": "PASS: 8 tests, 778 assertions."
+        },
+        "iq_locale_safe_labels": {
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php --no-ansi",
+          "status": "passed",
+          "evidence": "PASS: 4 tests, 32 assertions."
+        },
+        "route_list_api_v03": {
+          "command": "cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt",
+          "status": "passed"
+        },
+        "json_yaml_diff": {
+          "command": "python3 -m json.tool backend/docs/seo/generated/result-en-parity-03-iq-locale-safe-labels.v1.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+          "status": "passed"
+        },
+        "scoped_pint": {
+          "command": "cd backend && ./vendor/bin/pint --test app/Services/Report/IqReportBuilder.php tests/Unit/Services/Report/IqReportBuilderTest.php tests/Feature/V0_3/IqReportContractTest.php tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php --no-interaction",
+          "status": "passed"
+        },
+        "php_lint": {
+          "command": "php -l backend/app/Services/Report/IqReportBuilder.php && php -l backend/tests/Unit/Services/Report/IqReportBuilderTest.php && php -l backend/tests/Feature/V0_3/IqReportContractTest.php && php -l backend/tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php",
+          "status": "passed"
+        },
+        "scope_validation": {
+          "command": "git diff --name-status && git status --short --untracked-files=all",
+          "status": "passed",
+          "evidence": "Changed files are limited to IqReportBuilder, focused IQ report/SeoIntel tests, one generated SeoIntel JSON artifact, and authorized docs/codex PR-train metadata. No fap-web, payment, CMS, DB migration, item bank answer key, search, deploy, or production command changes."
+        }
+      },
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "commit_sha": "2c86ec4fa",
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_write_execution": false,
+      "production_migration_execution_allowed": false,
+      "database_mutation": false,
+      "cms_mutation": false,
+      "api_runtime_change": true,
+      "publish_allowed": false,
+      "deploy_allowed": false,
+      "scheduler_activation": false,
+      "content_authority": "backend",
+      "transitions": [
+        {
+          "at": "2026-07-04T13:29:35Z",
+          "status": "in_progress",
+          "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+        },
+        {
+          "at": "2026-07-04T13:30:41Z",
+          "status": "local_validation_passed",
+          "summary": "Removed IQ V1 report artifact placeholders, updated focused contract/parity tests and generated audit JSON, reconciled beta score dependency ledger, and passed local manifest validation. No production deploy, production DB mutation, CMS write, fap-web change, payment change, or item bank answer-key change performed."
+        },
+        {
+          "at": "2026-07-04T13:31:21Z",
+          "status": "committed",
+          "summary": "Committed scoped IQ V1 safe scoring/report artifact claim fix at 2c86ec4fa."
+        }
+      ]
+    },
+    "IQ-V1-POSITIONING-LOCK-01": {
+      "id": "IQ-V1-POSITIONING-LOCK-01",
+      "repo": "fap-api",
+      "base": "main",
+      "branch": "codex/iq-v1-positioning-lock-01",
+      "title": "IQ-V1-POSITIONING-LOCK-01: lock IQ V1 public positioning boundaries",
+      "depends_on": [
+        "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01"
+      ],
+      "status": "pending",
+      "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+      "checks": {},
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_write_execution": false,
+      "production_migration_execution_allowed": false,
+      "database_mutation": false,
+      "cms_mutation": false,
+      "api_runtime_change": false,
+      "publish_allowed": false,
+      "deploy_allowed": false,
+      "scheduler_activation": false,
+      "content_authority": "backend",
+      "transitions": [
+        {
+          "at": "2026-07-04T13:29:35Z",
+          "status": "pending",
+          "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+        }
+      ]
+    },
+    "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01": {
+      "id": "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01",
+      "repo": "fap-api",
+      "base": "main",
+      "branch": "codex/iq-v1-free-full-result-controlled-smoke-01",
+      "title": "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01: add controlled IQ free full result smoke",
+      "depends_on": [
+        "IQ-V1-POSITIONING-LOCK-01"
+      ],
+      "status": "pending",
+      "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+      "checks": {},
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_write_execution": false,
+      "production_migration_execution_allowed": false,
+      "database_mutation": false,
+      "cms_mutation": false,
+      "api_runtime_change": false,
+      "publish_allowed": false,
+      "deploy_allowed": false,
+      "scheduler_activation": false,
+      "content_authority": "backend",
+      "transitions": [
+        {
+          "at": "2026-07-04T13:29:35Z",
+          "status": "pending",
+          "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+        }
+      ]
+    },
+    "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01": {
+      "id": "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01",
+      "repo": "fap-api",
+      "base": "main",
+      "branch": "codex/iq-v1-landing-copy-cms-dry-run-01",
+      "title": "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01: prepare IQ landing copy CMS dry run",
+      "depends_on": [
+        "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01"
+      ],
+      "status": "pending",
+      "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+      "checks": {},
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_write_execution": false,
+      "production_migration_execution_allowed": false,
+      "database_mutation": false,
+      "cms_mutation": false,
+      "api_runtime_change": false,
+      "publish_allowed": false,
+      "deploy_allowed": false,
+      "scheduler_activation": false,
+      "content_authority": "backend",
+      "transitions": [
+        {
+          "at": "2026-07-04T13:29:35Z",
+          "status": "pending",
+          "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+        }
+      ]
+    },
+    "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01": {
+      "id": "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01",
+      "repo": "fap-api",
+      "base": "main",
+      "branch": "codex/iq-v1-item-dimension-tagging-implementation-01",
+      "title": "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01: implement IQ V1 item dimension tagging",
+      "depends_on": [
+        "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01"
+      ],
+      "status": "pending",
+      "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
+      "checks": {},
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "commit_sha": null,
+      "pr_url": null,
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "production_write_execution": false,
+      "production_migration_execution_allowed": false,
+      "database_mutation": false,
+      "cms_mutation": false,
+      "api_runtime_change": true,
+      "publish_allowed": false,
+      "deploy_allowed": false,
+      "scheduler_activation": false,
+      "content_authority": "backend",
+      "transitions": [
+        {
+          "at": "2026-07-04T13:29:35Z",
+          "status": "pending",
+          "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+        }
+      ]
     }
   },
   "prs": {
@@ -78305,5 +78816,5 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-03T09:03:53Z"
+  "updated_at": "2026-07-04T13:31:21Z"
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48837,7 +48837,7 @@
     "depends_on": [
       "IQ-BETA-STANDARD-SCORE-1"
     ],
-    "status": "committed",
+    "status": "pr_open",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
     "checks": {
       "iq_report_builder_unit": {
@@ -48883,8 +48883,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": "2c86ec4fa",
-    "pr_url": null,
+    "commit_sha": "40f3a6f18e8949a5f6df2f13cee440d1a2777668",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2714",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -48913,6 +48913,11 @@
         "at": "2026-07-04T13:31:21Z",
         "status": "committed",
         "summary": "Committed scoped IQ V1 safe scoring/report artifact claim fix at 2c86ec4fa."
+      },
+      {
+        "at": "2026-07-04T13:32:25Z",
+        "status": "pr_open",
+        "summary": "Opened PR #2714 after local validation passed and pushed branch codex/iq-v1-result-page-safe-scoring-qa-fix-01."
       }
     ]
   },
@@ -73525,7 +73530,7 @@
       "depends_on": [
         "IQ-BETA-STANDARD-SCORE-1"
       ],
-      "status": "committed",
+      "status": "pr_open",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
       "checks": {
         "iq_report_builder_unit": {
@@ -73571,8 +73576,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "commit_sha": "2c86ec4fa",
-      "pr_url": null,
+      "commit_sha": "40f3a6f18e8949a5f6df2f13cee440d1a2777668",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/2714",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -73601,6 +73606,11 @@
           "at": "2026-07-04T13:31:21Z",
           "status": "committed",
           "summary": "Committed scoped IQ V1 safe scoring/report artifact claim fix at 2c86ec4fa."
+        },
+        {
+          "at": "2026-07-04T13:32:25Z",
+          "status": "pr_open",
+          "summary": "Opened PR #2714 after local validation passed and pushed branch codex/iq-v1-result-page-safe-scoring-qa-fix-01."
         }
       ]
     },
@@ -78816,5 +78826,5 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-04T13:31:21Z"
+  "updated_at": "2026-07-04T13:32:25Z"
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -36450,3 +36450,199 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01
+    repo: fap-api
+    depends_on:
+      - IQ-BETA-STANDARD-SCORE-1
+    branch: codex/iq-v1-result-page-safe-scoring-qa-fix-01
+    title: "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01: remove unsafe IQ V1 result artifact claims"
+    train_scope: iq_v1_public_launch_readiness
+    status: user_authorized
+    scope:
+      - Remove IQ V1 public report payload placeholders that imply PDF, certificate, or true IQ estimate artifacts.
+      - Keep beta_standard_score, raw-score-only claim policy, answer-key redaction, and existing report access behavior intact.
+      - Add focused backend contract tests proving public IQ report payloads do not expose PDF/certificate artifact fields or copy.
+      - Reconcile stale IQ-BETA-STANDARD-SCORE-1 ledger facts only as dependency bookkeeping.
+    allowed_paths:
+      - backend/app/Services/Report/IqReportBuilder.php
+      - backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+      - backend/tests/Feature/V0_3/IqReportContractTest.php
+      - backend/tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php
+      - backend/docs/seo/generated/result-en-parity-03-iq-locale-safe-labels.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, frontend fallback content, payment, checkout, orders, webhooks, entitlement grants, item banks, questions, answer keys, scoring formula, database migrations, production commands, production DB, CMS, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, staging deploy, or production deploy.
+      - Add official/certified/diagnostic/Mensa IQ claims, production IQ estimates, population percentiles, PDF/certificate claims, or paid-report public SEO claims.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/IqReportBuilderTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php --no-ansi
+      - cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt
+      - python3 -m json.tool backend/docs/seo/generated/result-en-parity-03-iq-locale-safe-labels.v1.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: IQ-V1-POSITIONING-LOCK-01
+    repo: fap-api
+    depends_on:
+      - IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01
+    branch: codex/iq-v1-positioning-lock-01
+    title: "IQ-V1-POSITIONING-LOCK-01: lock IQ V1 public positioning boundaries"
+    train_scope: iq_v1_public_launch_readiness
+    status: user_authorized
+    scope:
+      - Add backend-owned policy/test coverage that locks IQ V1 public positioning away from official IQ, certification, diagnostic, admission, hiring, salary, and fixed intelligence claims.
+      - Keep runtime content authority in backend/CMS; do not add frontend editorial fallback copy.
+      - Record any existing non-current-scope copy concerns as sidecar issues when they do not block this PR's scope validation or required checks.
+    allowed_paths:
+      - backend/app/**
+      - backend/tests/**Iq**
+      - backend/tests/**IQ**
+      - backend/tests/Feature/SeoIntel/**Iq**
+      - backend/docs/seo/iq-v1/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, frontend fallback content, payment, checkout, item banks, scoring formula, database migrations, production commands, production DB, CMS writes, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, staging deploy, or production deploy.
+      - Add public paid-report, official IQ, certification, diagnostic, Mensa, admission, hiring, salary, or career guarantee claims.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi
+      - cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01
+    repo: fap-api
+    depends_on:
+      - IQ-V1-POSITIONING-LOCK-01
+    branch: codex/iq-v1-free-full-result-controlled-smoke-01
+    title: "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01: add controlled IQ free full result smoke"
+    train_scope: iq_v1_public_launch_readiness
+    status: user_authorized
+    scope:
+      - Add non-production controlled smoke coverage for IQ V1 free complete-result behavior.
+      - Verify raw score, beta_standard_score, no production IQ estimate, no population percentile, no paywall offer leakage, and no answer-key leakage in the controlled path.
+      - Keep the smoke local/test-only and do not execute production attempts or production DB mutations.
+    allowed_paths:
+      - backend/tests/**Iq**
+      - backend/tests/**IQ**
+      - backend/app/**
+      - backend/docs/seo/iq-v1/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, frontend fallback content, payment, checkout, orders, webhooks, item banks, scoring formula, production commands, production DB, CMS writes, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, staging deploy, or production deploy.
+      - Run live production smoke, production imports, or manual deploys.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi
+      - cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: IQ-V1-LANDING-COPY-CMS-DRY-RUN-01
+    repo: fap-api
+    depends_on:
+      - IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01
+    branch: codex/iq-v1-landing-copy-cms-dry-run-01
+    title: "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01: prepare IQ landing copy CMS dry run"
+    train_scope: iq_v1_public_launch_readiness
+    status: user_authorized
+    scope:
+      - Prepare dry-run-only backend CMS import/validation artifacts for IQ V1 landing copy.
+      - Validate claim-safe copy boundaries without writing CMS, publishing, revalidating, submitting search, or changing frontend fallback content.
+      - Keep output ready for owner review, not production activation.
+    allowed_paths:
+      - backend/docs/seo/iq-v1/**
+      - backend/scripts/**iq**
+      - backend/tests/**Iq**
+      - backend/tests/**IQ**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, frontend fallback content, payment, checkout, item banks, scoring formula, database migrations, production commands, production DB, CMS writes/publish, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, search submission, staging deploy, or production deploy.
+      - Add public paid-report, official IQ, certification, diagnostic, Mensa, admission, hiring, salary, or career guarantee claims.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01
+    repo: fap-api
+    depends_on:
+      - IQ-V1-LANDING-COPY-CMS-DRY-RUN-01
+    branch: codex/iq-v1-item-dimension-tagging-implementation-01
+    title: "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01: implement IQ V1 item dimension tagging"
+    train_scope: iq_v1_public_launch_readiness
+    status: user_authorized
+    scope:
+      - Implement backend-authoritative IQ_OWNER_ORIGINAL_30 item dimension tagging without changing answer keys, item text, images, scoring correctness, or production data.
+      - Add focused validation proving dimension tags are present and report dimension aggregation remains answer-key safe.
+      - Keep item-bank mutations scoped to metadata tagging only.
+    allowed_paths:
+      - backend/content_packages/**IQ_OWNER_ORIGINAL_30/**
+      - content_packages/**IQ_OWNER_ORIGINAL_30/**
+      - backend/app/Services/Assessment/**
+      - backend/app/Services/Report/**
+      - backend/tests/**Iq**
+      - backend/tests/**IQ**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, frontend fallback content, payment, checkout, orders, webhooks, answer keys, correct answers, scoring formula, production commands, production DB, CMS writes, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, staging deploy, or production deploy.
+      - Add public paid-report, official IQ, certification, diagnostic, Mensa, admission, hiring, salary, or career guarantee claims.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Removed IQ V1 `iq_pro.pdf_payload` and `iq_pro.certificate_payload` placeholders from `IqReportBuilder` full report payloads.
- Removed the associated backend label-catalog copy that implied IQ report PDF / IQ result certificate artifacts.
- Updated IQ report unit/API contract/English parity tests to assert full report access still exposes scoring and dimensions but does not expose PDF/certificate artifact fields or copy.
- Registered the operator-authorized five-PR IQ V1 train entries and reconciled the already-merged IQ beta standard score dependency ledger fact for PR #2542.

## Why
IQ V1 public result/report surfaces must remain raw-score/beta-standard-score safe and must not imply official IQ, certified artifacts, PDF/certificate entitlement, or true IQ-estimate authority unless backend authority explicitly enables those claims later.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Report/IqReportBuilderTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php --no-ansi`
- `cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt`
- `python3 -m json.tool backend/docs/seo/generated/result-en-parity-03-iq-locale-safe-labels.v1.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `cd backend && ./vendor/bin/pint --test app/Services/Report/IqReportBuilder.php tests/Unit/Services/Report/IqReportBuilderTest.php tests/Feature/V0_3/IqReportContractTest.php tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php --no-interaction`
- `php -l backend/app/Services/Report/IqReportBuilder.php && php -l backend/tests/Unit/Services/Report/IqReportBuilderTest.php && php -l backend/tests/Feature/V0_3/IqReportContractTest.php && php -l backend/tests/Feature/SeoIntel/ResultEnParity03IqLocaleSafeLabelsTest.php`

## Intentionally deferred
- No fap-web changes.
- No payment, checkout, orders, webhooks, or entitlement changes.
- No item bank, question, answer key, or scoring formula changes.
- No CMS writes, production DB commands, search submission, sitemap/llms/canonical/noindex/JSON-LD changes, staging deploy, or production deploy.
- Later IQ V1 train scopes remain separate PRs.
