### PR TITLE
IQ-V1-POSITIONING-LOCK-01: lock IQ V1 public positioning boundaries

### DIFF
--- a/backend/docs/seo/iq-v1/iq-v1-positioning-lock.v1.json
+++ b/backend/docs/seo/iq-v1/iq-v1-positioning-lock.v1.json
@@ -1,0 +1,120 @@
+{
+  "schema": "iq.v1.positioning_lock.v1",
+  "pr_id": "IQ-V1-POSITIONING-LOCK-01",
+  "surface": "iq_v1_public_positioning",
+  "authority": {
+    "owner": "backend_policy_artifact",
+    "runtime_copy_authority": "backend_cms_or_public_api",
+    "frontend_fallback_copy_authority": false,
+    "cms_write_allowed_in_this_pr": false,
+    "production_deploy_allowed_in_this_pr": false
+  },
+  "result_authority": {
+    "backend_report_required": true,
+    "beta_standard_score_source": "backend_owned_random_baseline",
+    "iq_estimate_public_copy_enabled": false,
+    "percentile_public_copy_enabled": false,
+    "production_norm_required_for_iq_estimate": true
+  },
+  "media_authority": {
+    "source": "backend_cms_media_library",
+    "frontend_fallback_media_authority": false
+  },
+  "allowed_positioning": [
+    "IQ-style reasoning practice",
+    "matrix reasoning and pattern-recognition practice",
+    "raw score and completion-detail interpretation",
+    "backend-owned beta standard score when present",
+    "educational self-understanding context"
+  ],
+  "allowed_public_copy_examples": [
+    "Explore IQ-style reasoning questions and review your raw score details.",
+    "FermatMind V1 shows a backend-owned beta standard score for this reasoning test when available.",
+    "Use the result as a practice-oriented reasoning reference, not as an official credential."
+  ],
+  "required_public_boundaries": [
+    "not official IQ certification",
+    "not clinical or diagnostic assessment",
+    "not admission, hiring, salary, or career-outcome evidence",
+    "not a fixed conclusion about intelligence"
+  ],
+  "forbidden_claim_classes": [
+    {
+      "id": "official_iq_certification",
+      "blocked": true
+    },
+    {
+      "id": "clinical_or_diagnostic_iq",
+      "blocked": true
+    },
+    {
+      "id": "mensa_or_official_affiliation",
+      "blocked": true
+    },
+    {
+      "id": "admission_hiring_salary_or_career_guarantee",
+      "blocked": true
+    },
+    {
+      "id": "fixed_intelligence_conclusion",
+      "blocked": true
+    },
+    {
+      "id": "public_iq_estimate_without_norm_authority",
+      "blocked": true
+    },
+    {
+      "id": "population_percentile_without_norm_authority",
+      "blocked": true
+    },
+    {
+      "id": "pdf_or_certificate_public_claim",
+      "blocked": true
+    },
+    {
+      "id": "paid_report_public_seo_claim",
+      "blocked": true
+    }
+  ],
+  "public_copy_switches": {
+    "official_iq_claims_enabled": false,
+    "certification_claims_enabled": false,
+    "diagnostic_claims_enabled": false,
+    "mensa_claims_enabled": false,
+    "admission_claims_enabled": false,
+    "hiring_claims_enabled": false,
+    "salary_claims_enabled": false,
+    "career_guarantee_claims_enabled": false,
+    "fixed_intelligence_claims_enabled": false,
+    "paid_report_seo_claims_enabled": false,
+    "pdf_or_certificate_claims_enabled": false
+  },
+  "forbidden_public_copy_terms": [
+    "official IQ",
+    "certified IQ",
+    "diagnostic IQ",
+    "clinical IQ",
+    "Mensa",
+    "admission proof",
+    "hiring fit",
+    "salary prediction",
+    "career guarantee",
+    "fixed intelligence",
+    "IQ certificate",
+    "IQ report PDF",
+    "official certification",
+    "官方智商",
+    "智商认证",
+    "临床诊断",
+    "门萨",
+    "录取证明",
+    "招聘筛选",
+    "薪资预测",
+    "职业保证"
+  ],
+  "review": {
+    "status": "locked_for_v1_public_launch",
+    "requires_owner_approval_to_relax": true,
+    "last_reviewed": "2026-07-04"
+  }
+}

--- a/backend/tests/Feature/SeoIntel/IqV1PositioningLockTest.php
+++ b/backend/tests/Feature/SeoIntel/IqV1PositioningLockTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class IqV1PositioningLockTest extends TestCase
+{
+    public function test_iq_v1_positioning_lock_blocks_high_risk_claim_classes(): void
+    {
+        $policy = $this->positioningLockPolicy();
+
+        $this->assertSame('iq.v1.positioning_lock.v1', data_get($policy, 'schema'));
+        $this->assertSame('IQ-V1-POSITIONING-LOCK-01', data_get($policy, 'pr_id'));
+        $this->assertSame('backend_policy_artifact', data_get($policy, 'authority.owner'));
+        $this->assertSame('backend_cms_or_public_api', data_get($policy, 'authority.runtime_copy_authority'));
+        $this->assertFalse((bool) data_get($policy, 'authority.frontend_fallback_copy_authority'));
+        $this->assertFalse((bool) data_get($policy, 'authority.cms_write_allowed_in_this_pr'));
+        $this->assertFalse((bool) data_get($policy, 'authority.production_deploy_allowed_in_this_pr'));
+
+        $this->assertTrue((bool) data_get($policy, 'result_authority.backend_report_required'));
+        $this->assertSame('backend_owned_random_baseline', data_get($policy, 'result_authority.beta_standard_score_source'));
+        $this->assertFalse((bool) data_get($policy, 'result_authority.iq_estimate_public_copy_enabled'));
+        $this->assertFalse((bool) data_get($policy, 'result_authority.percentile_public_copy_enabled'));
+        $this->assertTrue((bool) data_get($policy, 'result_authority.production_norm_required_for_iq_estimate'));
+        $this->assertSame('backend_cms_media_library', data_get($policy, 'media_authority.source'));
+        $this->assertFalse((bool) data_get($policy, 'media_authority.frontend_fallback_media_authority'));
+
+        $forbiddenClasses = collect(data_get($policy, 'forbidden_claim_classes', []))
+            ->mapWithKeys(fn (array $row): array => [(string) ($row['id'] ?? '') => (bool) ($row['blocked'] ?? false)]);
+
+        foreach ([
+            'official_iq_certification',
+            'clinical_or_diagnostic_iq',
+            'mensa_or_official_affiliation',
+            'admission_hiring_salary_or_career_guarantee',
+            'fixed_intelligence_conclusion',
+            'public_iq_estimate_without_norm_authority',
+            'population_percentile_without_norm_authority',
+            'pdf_or_certificate_public_claim',
+            'paid_report_public_seo_claim',
+        ] as $classId) {
+            $this->assertTrue((bool) $forbiddenClasses->get($classId), $classId);
+        }
+    }
+
+    public function test_iq_v1_allowed_public_examples_do_not_cross_positioning_boundaries(): void
+    {
+        $policy = $this->positioningLockPolicy();
+
+        foreach (data_get($policy, 'public_copy_switches', []) as $switch => $enabled) {
+            $this->assertFalse((bool) $enabled, (string) $switch);
+        }
+
+        $safePublicCopy = strtolower(implode(' ', [
+            implode(' ', data_get($policy, 'allowed_positioning', [])),
+            implode(' ', data_get($policy, 'allowed_public_copy_examples', [])),
+        ]));
+
+        foreach (data_get($policy, 'forbidden_public_copy_terms', []) as $forbiddenTerm) {
+            $this->assertStringNotContainsString(strtolower((string) $forbiddenTerm), $safePublicCopy, (string) $forbiddenTerm);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function positioningLockPolicy(): array
+    {
+        $path = base_path('docs/seo/iq-v1/iq-v1-positioning-lock.v1.json');
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48935,7 +48935,7 @@
     "depends_on": [
       "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01"
     ],
-    "status": "local_validation_passed",
+    "status": "pr_open",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
     "checks": {
       "focused_positioning_lock": {
@@ -48976,8 +48976,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "711404a81",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2715",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49006,6 +49006,11 @@
         "at": "2026-07-04T13:42:16Z",
         "status": "local_validation_passed",
         "summary": "Added backend-owned IQ V1 positioning lock policy artifact and SeoIntel test coverage. Focused test, IQ filter suite, route list, JSON/YAML/diff, scoped Pint, and PHP lint passed. No runtime copy, CMS write, production deploy, payment, item bank, SEO runtime, sitemap, llms, canonical, noindex, or JSON-LD changes."
+      },
+      {
+        "at": "2026-07-04T13:43:07Z",
+        "status": "pr_open",
+        "summary": "Opened PR #2715 after local validation passed and pushed branch codex/iq-v1-positioning-lock-01."
       }
     ]
   },
@@ -73675,7 +73680,7 @@
       "depends_on": [
         "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01"
       ],
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
       "checks": {
         "focused_positioning_lock": {
@@ -73716,8 +73721,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "711404a81",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/2715",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -73746,6 +73751,11 @@
           "at": "2026-07-04T13:42:16Z",
           "status": "local_validation_passed",
           "summary": "Added backend-owned IQ V1 positioning lock policy artifact and SeoIntel test coverage. Focused test, IQ filter suite, route list, JSON/YAML/diff, scoped Pint, and PHP lint passed. No runtime copy, CMS write, production deploy, payment, item bank, SEO runtime, sitemap, llms, canonical, noindex, or JSON-LD changes."
+        },
+        {
+          "at": "2026-07-04T13:43:07Z",
+          "status": "pr_open",
+          "summary": "Opened PR #2715 after local validation passed and pushed branch codex/iq-v1-positioning-lock-01."
         }
       ]
     },
@@ -78920,5 +78930,5 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-04T13:42:16Z"
+  "updated_at": "2026-07-04T13:43:07Z"
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48837,7 +48837,7 @@
     "depends_on": [
       "IQ-BETA-STANDARD-SCORE-1"
     ],
-    "status": "pr_open",
+    "status": "merged",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
     "checks": {
       "iq_report_builder_unit": {
@@ -48880,14 +48880,14 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
-    "commit_sha": "40f3a6f18e8949a5f6df2f13cee440d1a2777668",
+    "commit_sha": "847088d0f5ac250812abcb39f27949ad5f6c6533",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2714",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-07-04T13:38:36Z",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
@@ -48918,6 +48918,11 @@
         "at": "2026-07-04T13:32:25Z",
         "status": "pr_open",
         "summary": "Opened PR #2714 after local validation passed and pushed branch codex/iq-v1-result-page-safe-scoring-qa-fix-01."
+      },
+      {
+        "at": "2026-07-04T13:41:11Z",
+        "status": "merged",
+        "summary": "Reconciled by IQ-V1-POSITIONING-LOCK-01 preflight: PR #2714 is MERGED with squash commit 847088d0f5ac250812abcb39f27949ad5f6c6533, origin/main contains the merge, the remote task branch is deleted, local main is synced, and worktree was clean. scripts/post_merge_cleanup.sh was unavailable, so script-based local cleanup was not executed."
       }
     ]
   },
@@ -48930,12 +48935,44 @@
     "depends_on": [
       "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01"
     ],
-    "status": "pending",
+    "status": "local_validation_passed",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
-    "checks": {},
+    "checks": {
+      "focused_positioning_lock": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/IqV1PositioningLockTest.php --no-ansi",
+        "status": "passed",
+        "evidence": "PASS: 2 tests, 57 assertions."
+      },
+      "iq_filter_suite": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi",
+        "status": "passed",
+        "evidence": "PASS: 116 tests, 10821 assertions."
+      },
+      "route_list_api_v03": {
+        "command": "cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt",
+        "status": "passed"
+      },
+      "json_yaml_diff": {
+        "command": "python3 -m json.tool backend/docs/seo/iq-v1/iq-v1-positioning-lock.v1.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "status": "passed"
+      },
+      "scoped_pint": {
+        "command": "cd backend && ./vendor/bin/pint --test tests/Feature/SeoIntel/IqV1PositioningLockTest.php --no-interaction",
+        "status": "passed"
+      },
+      "php_lint": {
+        "command": "php -l backend/tests/Feature/SeoIntel/IqV1PositioningLockTest.php",
+        "status": "passed"
+      },
+      "scope_validation": {
+        "command": "git diff --name-status && git status --short --untracked-files=all",
+        "status": "passed",
+        "evidence": "Changed files are limited to IQ V1 positioning lock policy/test artifacts and authorized docs/codex state reconciliation. No fap-web, CMS write, production deploy, payment, item bank, SEO runtime, sitemap, llms, canonical, noindex, or JSON-LD changes."
+      }
+    },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -48959,6 +48996,16 @@
         "at": "2026-07-04T13:29:35Z",
         "status": "pending",
         "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+      },
+      {
+        "at": "2026-07-04T13:41:11Z",
+        "status": "in_progress",
+        "summary": "Started scoped IQ V1 positioning lock implementation from latest main. Scope is backend docs/SeoIntel policy/test coverage only; no fap-web, CMS write, production deploy, payment, item bank, SEO runtime, sitemap, llms, canonical, noindex, or JSON-LD changes."
+      },
+      {
+        "at": "2026-07-04T13:42:16Z",
+        "status": "local_validation_passed",
+        "summary": "Added backend-owned IQ V1 positioning lock policy artifact and SeoIntel test coverage. Focused test, IQ filter suite, route list, JSON/YAML/diff, scoped Pint, and PHP lint passed. No runtime copy, CMS write, production deploy, payment, item bank, SEO runtime, sitemap, llms, canonical, noindex, or JSON-LD changes."
       }
     ]
   },
@@ -73530,7 +73577,7 @@
       "depends_on": [
         "IQ-BETA-STANDARD-SCORE-1"
       ],
-      "status": "pr_open",
+      "status": "merged",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
       "checks": {
         "iq_report_builder_unit": {
@@ -73573,14 +73620,14 @@
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
-        "post_merge_revalidated": null
+        "github_checks_green": true,
+        "post_merge_revalidated": true
       },
-      "commit_sha": "40f3a6f18e8949a5f6df2f13cee440d1a2777668",
+      "commit_sha": "847088d0f5ac250812abcb39f27949ad5f6c6533",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2714",
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-07-04T13:38:36Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_write_execution": false,
       "production_migration_execution_allowed": false,
@@ -73611,6 +73658,11 @@
           "at": "2026-07-04T13:32:25Z",
           "status": "pr_open",
           "summary": "Opened PR #2714 after local validation passed and pushed branch codex/iq-v1-result-page-safe-scoring-qa-fix-01."
+        },
+        {
+          "at": "2026-07-04T13:41:11Z",
+          "status": "merged",
+          "summary": "Reconciled by IQ-V1-POSITIONING-LOCK-01 preflight: PR #2714 is MERGED with squash commit 847088d0f5ac250812abcb39f27949ad5f6c6533, origin/main contains the merge, the remote task branch is deleted, local main is synced, and worktree was clean. scripts/post_merge_cleanup.sh was unavailable, so script-based local cleanup was not executed."
         }
       ]
     },
@@ -73623,12 +73675,44 @@
       "depends_on": [
         "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01"
       ],
-      "status": "pending",
+      "status": "local_validation_passed",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
-      "checks": {},
+      "checks": {
+        "focused_positioning_lock": {
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/IqV1PositioningLockTest.php --no-ansi",
+          "status": "passed",
+          "evidence": "PASS: 2 tests, 57 assertions."
+        },
+        "iq_filter_suite": {
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi",
+          "status": "passed",
+          "evidence": "PASS: 116 tests, 10821 assertions."
+        },
+        "route_list_api_v03": {
+          "command": "cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt",
+          "status": "passed"
+        },
+        "json_yaml_diff": {
+          "command": "python3 -m json.tool backend/docs/seo/iq-v1/iq-v1-positioning-lock.v1.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+          "status": "passed"
+        },
+        "scoped_pint": {
+          "command": "cd backend && ./vendor/bin/pint --test tests/Feature/SeoIntel/IqV1PositioningLockTest.php --no-interaction",
+          "status": "passed"
+        },
+        "php_lint": {
+          "command": "php -l backend/tests/Feature/SeoIntel/IqV1PositioningLockTest.php",
+          "status": "passed"
+        },
+        "scope_validation": {
+          "command": "git diff --name-status && git status --short --untracked-files=all",
+          "status": "passed",
+          "evidence": "Changed files are limited to IQ V1 positioning lock policy/test artifacts and authorized docs/codex state reconciliation. No fap-web, CMS write, production deploy, payment, item bank, SEO runtime, sitemap, llms, canonical, noindex, or JSON-LD changes."
+        }
+      },
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
@@ -73652,6 +73736,16 @@
           "at": "2026-07-04T13:29:35Z",
           "status": "pending",
           "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+        },
+        {
+          "at": "2026-07-04T13:41:11Z",
+          "status": "in_progress",
+          "summary": "Started scoped IQ V1 positioning lock implementation from latest main. Scope is backend docs/SeoIntel policy/test coverage only; no fap-web, CMS write, production deploy, payment, item bank, SEO runtime, sitemap, llms, canonical, noindex, or JSON-LD changes."
+        },
+        {
+          "at": "2026-07-04T13:42:16Z",
+          "status": "local_validation_passed",
+          "summary": "Added backend-owned IQ V1 positioning lock policy artifact and SeoIntel test coverage. Focused test, IQ filter suite, route list, JSON/YAML/diff, scoped Pint, and PHP lint passed. No runtime copy, CMS write, production deploy, payment, item bank, SEO runtime, sitemap, llms, canonical, noindex, or JSON-LD changes."
         }
       ]
     },
@@ -78826,5 +78920,5 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-04T13:32:25Z"
+  "updated_at": "2026-07-04T13:42:16Z"
 }


### PR DESCRIPTION
## What changed
- Added backend-owned IQ V1 positioning lock policy artifact at `backend/docs/seo/iq-v1/iq-v1-positioning-lock.v1.json`.
- Added SeoIntel test coverage proving high-risk IQ claim classes stay blocked and allowed public examples do not cross positioning boundaries.
- Reconciled prior PR #2714 merge facts in the PR-train state ledger.

## Why
IQ V1 public surfaces need an explicit backend-owned safety lock before launch content work continues. The lock keeps public positioning away from official IQ certification, clinical/diagnostic IQ, Mensa/official affiliation, admission/hiring/salary/career guarantees, fixed intelligence conclusions, unsupported public IQ estimates/percentiles, PDF/certificate claims, and paid-report public SEO claims.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/IqV1PositioningLockTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi`
- `cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt`
- `python3 -m json.tool backend/docs/seo/iq-v1/iq-v1-positioning-lock.v1.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `cd backend && ./vendor/bin/pint --test tests/Feature/SeoIntel/IqV1PositioningLockTest.php --no-interaction`
- `php -l backend/tests/Feature/SeoIntel/IqV1PositioningLockTest.php`

## Intentionally deferred
- No fap-web changes or frontend fallback content.
- No CMS writes, publishing, revalidation, search submission, sitemap, llms, canonical, noindex, or JSON-LD changes.
- No payment, checkout, item bank, scoring formula, production DB, staging deploy, or production deploy changes.
- Later IQ V1 train scopes remain separate PRs.
