### PR TITLE
IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01: add controlled IQ free full result smoke

### DIFF
--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Assessment\IqBetaStandardScore;
 use App\Services\Attempts\AttemptSubmitService;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -64,13 +65,13 @@ final class IqReportContractTest extends TestCase
         ]);
     }
 
-    private function createScoredResult(string $attemptId): Result
+    private function createScoredResult(string $attemptId, bool $withOwnerBetaStandardScore = false): Result
     {
         $score = [
             'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
             'status' => 'scored',
             'scoring_mode' => 'scored',
-            'bank_id' => 'IQ_SHOWCASE_12_BETA',
+            'bank_id' => $withOwnerBetaStandardScore ? 'IQ_OWNER_ORIGINAL_30' : 'IQ_SHOWCASE_12_BETA',
             'answer_key_version' => 'showcase12.v1',
             'norm_table_version' => 'unavailable',
             'scoring_engine_version' => 'iq_scoring_v2',
@@ -142,6 +143,9 @@ final class IqReportContractTest extends TestCase
                 ],
             ],
         ];
+        if ($withOwnerBetaStandardScore) {
+            $score = array_merge($score, app(IqBetaStandardScore::class)->fromRawScore((int) $score['raw_score']));
+        }
 
         return Result::create([
             'id' => (string) Str::uuid(),
@@ -227,7 +231,7 @@ final class IqReportContractTest extends TestCase
         $anonId = 'anon_iq_report_free_full_mode';
         $token = $this->issueAnonToken($anonId);
         $this->createAttempt($attemptId, $anonId);
-        $this->createScoredResult($attemptId);
+        $this->createScoredResult($attemptId, withOwnerBetaStandardScore: true);
 
         $response = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -255,9 +259,21 @@ final class IqReportContractTest extends TestCase
         $this->assertNull(data_get($payload, 'report.iq_pro'));
         $this->assertNull(data_get($payload, 'report.scoring.answer_key_version'));
         $this->assertEquals(21.0, data_get($payload, 'report.summary.raw_score'));
+        $this->assertSame(145, data_get($payload, 'report.summary.beta_standard_score'));
+        $this->assertSame(145, data_get($payload, 'report.scoring.beta_standard_score'));
+        $this->assertSame(IqBetaStandardScore::STATUS_SIMULATION_CALIBRATED_BETA, data_get($payload, 'report.summary.beta_standard_score_status'));
+        $this->assertSame(IqBetaStandardScore::SOURCE, data_get($payload, 'report.summary.beta_standard_score_source'));
+        $this->assertFalse((bool) data_get($payload, 'report.summary.production_normed'));
+        $this->assertFalse((bool) data_get($payload, 'report.summary.claim_eligible'));
+        $this->assertFalse((bool) data_get($payload, 'report.summary.population_percentile_eligible'));
+        $this->assertNull(data_get($payload, 'report.summary.iq_estimate'));
+        $this->assertNull(data_get($payload, 'report.summary.percentile'));
+        $this->assertNull(data_get($payload, 'report.summary.confidence_interval'));
+        $this->assertSame('raw_score_only', data_get($payload, 'report.summary.score_claim_level'));
         $this->assertSame('A', data_get($payload, 'report.quality.level'));
         $this->assertPayloadHasNoAnswerKeyFields($payload);
         $this->assertPayloadHasNoIqV1ForbiddenArtifactClaims($payload);
+        $this->assertPayloadHasNoIqV1ForbiddenPositioningClaims($payload);
     }
 
     public function test_iq_result_endpoint_redacts_legacy_answer_keys_from_public_payload(): void
@@ -393,6 +409,36 @@ final class IqReportContractTest extends TestCase
             'IQ 结果凭证',
             '在线 IQ 估测报告 PDF',
             '在线 IQ 估测结果凭证',
+        ] as $forbiddenClaim) {
+            $this->assertStringNotContainsString($forbiddenClaim, $serialized, $forbiddenClaim);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertPayloadHasNoIqV1ForbiddenPositioningClaims(array $payload): void
+    {
+        $serialized = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        foreach ([
+            '¥1.99',
+            '¥5',
+            'official IQ',
+            'certified IQ',
+            'diagnostic IQ',
+            'Mensa',
+            'admission proof',
+            'hiring fit',
+            'salary prediction',
+            'career guarantee',
+            '官方智商',
+            '智商认证',
+            '临床诊断',
+            '门萨',
+            '录取证明',
+            '招聘筛选',
+            '薪资预测',
         ] as $forbiddenClaim) {
             $this->assertStringNotContainsString($forbiddenClaim, $serialized, $forbiddenClaim);
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48935,7 +48935,7 @@
     "depends_on": [
       "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01"
     ],
-    "status": "pr_open",
+    "status": "merged",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
     "checks": {
       "focused_positioning_lock": {
@@ -48973,14 +48973,14 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
-    "commit_sha": "711404a81",
+    "commit_sha": "59d467cb43946770a5a729ca2a3ea800bf8b67b1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2715",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-07-04T13:48:54Z",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
@@ -49011,6 +49011,11 @@
         "at": "2026-07-04T13:43:07Z",
         "status": "pr_open",
         "summary": "Opened PR #2715 after local validation passed and pushed branch codex/iq-v1-positioning-lock-01."
+      },
+      {
+        "at": "2026-07-04T13:50:30Z",
+        "status": "merged",
+        "summary": "Reconciled by IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01 preflight: PR #2715 is MERGED with squash commit 59d467cb43946770a5a729ca2a3ea800bf8b67b1, origin/main contains the merge, remote branch is deleted, local main is synced, and worktree was clean."
       }
     ]
   },
@@ -49023,12 +49028,44 @@
     "depends_on": [
       "IQ-V1-POSITIONING-LOCK-01"
     ],
-    "status": "pending",
+    "status": "local_validation_passed",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
-    "checks": {},
+    "checks": {
+      "iq_report_contract_feature": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi",
+        "status": "passed",
+        "evidence": "PASS: 8 tests, 806 assertions."
+      },
+      "iq_filter_suite": {
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi",
+        "status": "passed",
+        "evidence": "PASS: 116 tests, 10849 assertions."
+      },
+      "route_list_api_v03": {
+        "command": "cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt",
+        "status": "passed"
+      },
+      "json_yaml_diff": {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && git diff --check",
+        "status": "passed"
+      },
+      "scoped_pint": {
+        "command": "cd backend && ./vendor/bin/pint --test tests/Feature/V0_3/IqReportContractTest.php --no-interaction",
+        "status": "passed"
+      },
+      "php_lint": {
+        "command": "php -l backend/tests/Feature/V0_3/IqReportContractTest.php",
+        "status": "passed"
+      },
+      "scope_validation": {
+        "command": "git diff --name-status && git status --short --untracked-files=all",
+        "status": "passed",
+        "evidence": "Changed files are limited to IqReportContractTest and authorized docs/codex state reconciliation. No live production smoke, fap-web, payment, CMS, item bank, production DB, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, or deploy changes."
+      }
+    },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -49052,6 +49089,16 @@
         "at": "2026-07-04T13:29:35Z",
         "status": "pending",
         "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+      },
+      {
+        "at": "2026-07-04T13:50:30Z",
+        "status": "in_progress",
+        "summary": "Started controlled IQ V1 free full result smoke coverage from latest main. Scope is focused backend test/state only; no live production smoke, production DB, fap-web, payment, CMS, item bank, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, or deploy changes."
+      },
+      {
+        "at": "2026-07-04T13:51:24Z",
+        "status": "local_validation_passed",
+        "summary": "Extended controlled free full IQ report smoke to use Owner Original 30 beta_standard_score and assert raw score, beta score, no IQ estimate, no percentile, no production norm claim, no paywall/offers, no answer key leak, and no forbidden positioning claims. Local validation passed."
       }
     ]
   },
@@ -73680,7 +73727,7 @@
       "depends_on": [
         "IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01"
       ],
-      "status": "pr_open",
+      "status": "merged",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
       "checks": {
         "focused_positioning_lock": {
@@ -73718,14 +73765,14 @@
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
-        "post_merge_revalidated": null
+        "github_checks_green": true,
+        "post_merge_revalidated": true
       },
-      "commit_sha": "711404a81",
+      "commit_sha": "59d467cb43946770a5a729ca2a3ea800bf8b67b1",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2715",
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-07-04T13:48:54Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "production_write_execution": false,
       "production_migration_execution_allowed": false,
@@ -73756,6 +73803,11 @@
           "at": "2026-07-04T13:43:07Z",
           "status": "pr_open",
           "summary": "Opened PR #2715 after local validation passed and pushed branch codex/iq-v1-positioning-lock-01."
+        },
+        {
+          "at": "2026-07-04T13:50:30Z",
+          "status": "merged",
+          "summary": "Reconciled by IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01 preflight: PR #2715 is MERGED with squash commit 59d467cb43946770a5a729ca2a3ea800bf8b67b1, origin/main contains the merge, remote branch is deleted, local main is synced, and worktree was clean."
         }
       ]
     },
@@ -73768,12 +73820,44 @@
       "depends_on": [
         "IQ-V1-POSITIONING-LOCK-01"
       ],
-      "status": "pending",
+      "status": "local_validation_passed",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
-      "checks": {},
+      "checks": {
+        "iq_report_contract_feature": {
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi",
+          "status": "passed",
+          "evidence": "PASS: 8 tests, 806 assertions."
+        },
+        "iq_filter_suite": {
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi",
+          "status": "passed",
+          "evidence": "PASS: 116 tests, 10849 assertions."
+        },
+        "route_list_api_v03": {
+          "command": "cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt",
+          "status": "passed"
+        },
+        "json_yaml_diff": {
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && git diff --check",
+          "status": "passed"
+        },
+        "scoped_pint": {
+          "command": "cd backend && ./vendor/bin/pint --test tests/Feature/V0_3/IqReportContractTest.php --no-interaction",
+          "status": "passed"
+        },
+        "php_lint": {
+          "command": "php -l backend/tests/Feature/V0_3/IqReportContractTest.php",
+          "status": "passed"
+        },
+        "scope_validation": {
+          "command": "git diff --name-status && git status --short --untracked-files=all",
+          "status": "passed",
+          "evidence": "Changed files are limited to IqReportContractTest and authorized docs/codex state reconciliation. No live production smoke, fap-web, payment, CMS, item bank, production DB, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, or deploy changes."
+        }
+      },
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
@@ -73797,6 +73881,16 @@
           "at": "2026-07-04T13:29:35Z",
           "status": "pending",
           "summary": "Registered from the operator-provided IQ V1 five-PR train execution goal. No production deploy, production DB mutation, CMS write, search submission, fap-web fallback content, payment change, or item-bank answer-key change is authorized."
+        },
+        {
+          "at": "2026-07-04T13:50:30Z",
+          "status": "in_progress",
+          "summary": "Started controlled IQ V1 free full result smoke coverage from latest main. Scope is focused backend test/state only; no live production smoke, production DB, fap-web, payment, CMS, item bank, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, or deploy changes."
+        },
+        {
+          "at": "2026-07-04T13:51:24Z",
+          "status": "local_validation_passed",
+          "summary": "Extended controlled free full IQ report smoke to use Owner Original 30 beta_standard_score and assert raw score, beta score, no IQ estimate, no percentile, no production norm claim, no paywall/offers, no answer key leak, and no forbidden positioning claims. Local validation passed."
         }
       ]
     },
@@ -78930,5 +79024,5 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-04T13:43:07Z"
+  "updated_at": "2026-07-04T13:51:24Z"
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49028,7 +49028,7 @@
     "depends_on": [
       "IQ-V1-POSITIONING-LOCK-01"
     ],
-    "status": "local_validation_passed",
+    "status": "pr_open",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
     "checks": {
       "iq_report_contract_feature": {
@@ -49069,8 +49069,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "65204d554",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2716",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49099,6 +49099,11 @@
         "at": "2026-07-04T13:51:24Z",
         "status": "local_validation_passed",
         "summary": "Extended controlled free full IQ report smoke to use Owner Original 30 beta_standard_score and assert raw score, beta score, no IQ estimate, no percentile, no production norm claim, no paywall/offers, no answer key leak, and no forbidden positioning claims. Local validation passed."
+      },
+      {
+        "at": "2026-07-04T13:52:09Z",
+        "status": "pr_open",
+        "summary": "Opened PR #2716 after local validation passed and pushed branch codex/iq-v1-free-full-result-controlled-smoke-01."
       }
     ]
   },
@@ -73820,7 +73825,7 @@
       "depends_on": [
         "IQ-V1-POSITIONING-LOCK-01"
       ],
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
       "checks": {
         "iq_report_contract_feature": {
@@ -73861,8 +73866,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "65204d554",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/2716",
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -73891,6 +73896,11 @@
           "at": "2026-07-04T13:51:24Z",
           "status": "local_validation_passed",
           "summary": "Extended controlled free full IQ report smoke to use Owner Original 30 beta_standard_score and assert raw score, beta score, no IQ estimate, no percentile, no production norm claim, no paywall/offers, no answer key leak, and no forbidden positioning claims. Local validation passed."
+        },
+        {
+          "at": "2026-07-04T13:52:09Z",
+          "status": "pr_open",
+          "summary": "Opened PR #2716 after local validation passed and pushed branch codex/iq-v1-free-full-result-controlled-smoke-01."
         }
       ]
     },
@@ -79024,5 +79034,5 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-04T13:51:24Z"
+  "updated_at": "2026-07-04T13:52:09Z"
 }


### PR DESCRIPTION
## What changed
- Extended the IQ report contract free-full-mode smoke to use `IQ_OWNER_ORIGINAL_30` with backend-owned `beta_standard_score`.
- Added assertions for raw score, beta standard score, beta source/status, raw-score-only claim policy, no IQ estimate, no percentile, no production norm claim, no paywall/offers, no answer-key leak, and no forbidden IQ positioning claims.
- Reconciled prior PR #2715 merge facts in the PR-train state ledger.

## Why
IQ V1 needs controlled backend smoke coverage proving the free complete-result path is true and safe before CMS/content launch work continues.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/IqReportContractTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Iq --no-ansi`
- `cd backend && php artisan route:list --path=api/v0.3 --no-ansi >/tmp/fap-api-route-list-v03.txt`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- `cd backend && ./vendor/bin/pint --test tests/Feature/V0_3/IqReportContractTest.php --no-interaction`
- `php -l backend/tests/Feature/V0_3/IqReportContractTest.php`

## Intentionally deferred
- No live production smoke and no production DB commands.
- No fap-web changes, CMS writes, publishing, search submission, sitemap, llms, canonical, noindex, or JSON-LD changes.
- No payment, checkout, item bank, scoring formula, staging deploy, or production deploy changes.
- Later IQ V1 train scopes remain separate PRs.
