### PR TITLE
IQ-V1-LANDING-COPY-CMS-DRY-RUN-01: add IQ V1 landing copy dry-run package

### DIFF
--- a/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/BLOCKED_OR_UNVERIFIED_ASSUMPTIONS.md
+++ b/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/BLOCKED_OR_UNVERIFIED_ASSUMPTIONS.md
@@ -1,0 +1,22 @@
+# Blocked or Unverified Assumptions
+
+## Blockers
+
+No blocker for creating the next scoped implementation PRs under the documented boundaries.
+
+## Unverified Assumptions
+
+- No production smoke was run.
+- No CMS runtime state was queried or mutated.
+- No search channel, revalidation, deploy, DB write, or production command was run.
+- `fap-web` was observed only and had unrelated existing dirty files. No frontend edits were made.
+- Live deployment state was not checked in this scan.
+- The separate seven IQ method-page CMS dry-run was not inspected or touched.
+- Item-level safe alias plan is based on backend private dimension authority and current V1-safe alias taxonomy; it is not a psychometric validation or norming approval.
+
+## Required Owner Approval Later
+
+- Any CMS write, draft creation, publish, or import.
+- Any production deploy, production smoke, revalidation, or search submission.
+- Any norm import or public IQ estimate/percentile enablement.
+- Any formal intelligence credential, downloadable credential, clinical judgment, admission, hiring, salary, career outcome, or external affiliation claim.

--- a/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_FOUR_TASK_DEPENDENCY_ORDER.md
+++ b/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_FOUR_TASK_DEPENDENCY_ORDER.md
@@ -1,0 +1,46 @@
+# IQ V1 Four-Task Dependency Order
+
+## Which Task Should Run First?
+
+1. `IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01`
+
+Reason: result-page forbidden output safety must be fixed before smoke or launch. In current main this appears already effective after PR #2714 and #2716, so a follow-up PR is not required unless new tests prove a regression.
+
+## Recommended Order
+
+1. Result-page safe scoring QA fix or confirm-no-op coverage.
+2. Positioning lock.
+3. Landing-copy CMS dry-run.
+4. Item dimension tagging.
+
+Given current main:
+
+1. Positioning and landing dry-run may proceed because result safety is effective and positioning lock exists.
+2. Item dimension tagging can run after or parallel to landing dry-run if it remains metadata-only and does not change scoring.
+
+## Parallelizable Tasks
+
+- `IQ-V1-LANDING-COPY-CMS-DRY-RUN-01` and `IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01` can run in parallel after confirming result safety and positioning lock.
+- Do not run a production smoke in this four-task scan.
+
+## Tasks Depending on Result-Page Forbidden Output Being Fixed
+
+- Landing-copy CMS dry-run, because public copy must not promise outputs that result/report safety cannot support.
+- Any live smoke or launch validation, though live smoke is out of scope here.
+
+## Tasks Requiring GPT 5.5 Pro Review
+
+- Landing-copy CMS dry-run before CMS write or public copy promotion.
+- Any future relaxation of positioning lock or claim boundary.
+- Optional for item dimension tagging if owner wants psychometric language review, but not required for metadata-only safe aliases.
+
+## Tasks Requiring Human Approval
+
+- CMS write, CMS draft creation, CMS publish, production deploy, revalidation, search submission, production smoke with real user attempts, norm import, IQ estimate/percentile enablement, PDF/certificate claims, and any relaxation of forbidden claim boundaries.
+
+## Tasks Not Suitable for Automatic PR Train
+
+- Any task that writes CMS or publishes copy.
+- Any task that imports norm tables or enables IQ estimate/percentile claims.
+- Any task that changes answer keys, correct answers, scoring formulas, item order, assets, or images.
+- Any task that triggers production deploy, production smoke, revalidation, cache purge, or search submission.

--- a/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_FOUR_TASK_SCAN_CONTROL_PACKET.md
+++ b/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_FOUR_TASK_SCAN_CONTROL_PACKET.md
@@ -1,0 +1,35 @@
+# IQ V1 Four-Task Execution Readiness Scan Control Packet
+
+Date: 2026-07-04
+Mode: scan-only
+Primary repo: `/Users/rainie/Desktop/GitHub/fap-api`
+Observed repo: `/Users/rainie/Desktop/GitHub/fap-web`
+
+## Boundaries
+
+- No implementation.
+- No PR creation.
+- No commit or push.
+- No CMS write, CMS draft creation, CMS publish, DB write, production smoke, deploy, revalidation, search submission, item-bank answer changes, scoring formula changes, correct-answer changes, item order changes, SVG/image mutation, frontend fallback content, or private URL exposure.
+- The separate seven IQ method-page CMS dry-run is out of scope.
+
+## Preflight
+
+- `fap-api`: `main...origin/main`, clean at preflight.
+- `fap-web`: observed only; branch had unrelated existing modifications. No files were edited there.
+- PR #2714: `MERGED`, merge commit `847088d0f5ac250812abcb39f27949ad5f6c6533`.
+- PR #2715: `MERGED`, merge commit `59d467cb43946770a5a729ca2a3ea800bf8b67b1`.
+- PR #2716: `MERGED`, merge commit `ce7a6e1bc210a336a6cf2a31b218d630dc4a8a58`.
+
+## Evidence Summary
+
+- Result/report safety is mostly effective in backend main after #2714 and #2716.
+- Positioning lock is present as backend policy artifact after #2715.
+- Landing copy dry-run is ready after positioning lock, but must remain draft-review-only and CMS-write-free.
+- Item dimension tagging is implementable as metadata-only, but current public `items.json` does not yet expose safe dimension aliases.
+
+## Overall Verdict
+
+`READY_FOR_FOUR_TASK_EXECUTION`
+
+Execution should still preserve the dependency order in `IQ_V1_FOUR_TASK_DEPENDENCY_ORDER.md`.

--- a/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_ITEM_DIMENSION_TAGGING_EXECUTION_READINESS.md
+++ b/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_ITEM_DIMENSION_TAGGING_EXECUTION_READINESS.md
@@ -1,0 +1,81 @@
+# IQ V1 Item Dimension Tagging Execution Readiness
+
+## Classification
+
+`READY_FOR_ITEM_TAGGING_PR`
+
+## Current State
+
+- Public `IQ_OWNER_ORIGINAL_30/items.json` has 30 items but no public safe dimension aliases.
+- Current top-level public item fields include sequence, title, stem/options media, provenance, answer-key status, and asset hashes.
+- The runtime scoring service obtains private dimensions from backend-only answer-key authority and exposes scored dimension summaries through backend report payloads.
+- `scoring_spec.json` records private scoring dimension counts: VSPR 14, VSI 13, NPR 3.
+
+## Safe Tag Plan
+
+Allowed tags only:
+
+- `matrix_reasoning`
+- `visual_reasoning`
+- `pattern_recognition`
+- `spatial_reasoning`
+
+Unsupported/forbidden tags for V1:
+
+- `working_memory`
+- `processing_speed`
+- `quantitative_reasoning`
+- `verbal_comprehension`
+
+Safe per-item aliases:
+
+| Item | Safe public aliases | Confidence |
+| --- | --- | --- |
+| Q01 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q02 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q03 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q04 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q05 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q06 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q07 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q08 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q09 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q10 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q11 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q12 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q13 | `pattern_recognition` | medium |
+| Q14 | `pattern_recognition` | medium |
+| Q15 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q16 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q17 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q18 | `pattern_recognition` | medium |
+| Q19 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q20 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q21 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q22 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q23 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q24 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q25 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q26 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q27 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q28 | `spatial_reasoning`, `visual_reasoning`, `pattern_recognition` | high |
+| Q29 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+| Q30 | `matrix_reasoning`, `pattern_recognition`, `visual_reasoning` | high |
+
+## Implementation Constraints
+
+- Metadata-only.
+- Do not change answers, correct answers, scoring formula, item order, assets, hashes, SVG/images, or option payloads.
+- Do not output private answer keys, solution rules, distractor logic, asset hashes, generator metadata, raw attempt IDs, URLs, tokens, cookies, credentials, or private payloads.
+- Public payload redaction must continue to strip private scoring fields.
+
+## Tests Required
+
+- `cd backend && php artisan test --filter=IqOwnerOriginal30PrivateScoringTest`
+- Add/extend a focused content test that asserts safe aliases exist for all 30 public items and forbidden V1 tags do not appear.
+- Add/extend a public question payload test to assert safe aliases may be emitted but private answer/scoring fields do not leak.
+- `git diff --check`
+
+## Exact Implementation Prompt
+
+Run `IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01` as a metadata-only backend PR in `/Users/rainie/Desktop/GitHub/fap-api`. Start from latest main. Add safe public dimension aliases for `IQ_OWNER_ORIGINAL_30` using only `matrix_reasoning`, `visual_reasoning`, `pattern_recognition`, and `spatial_reasoning`. Do not change answer keys, correct answers, scoring formulas, item order, image/SVG assets, asset hashes, or option content. Add focused tests proving all 30 items have safe aliases, forbidden V1 tags are absent, public question payloads do not leak answer/scoring private fields, and runtime scoring behavior remains unchanged. Run focused tests and `git diff --check`; then commit, push, and open one scoped PR.

--- a/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_LANDING_COPY_CMS_DRY_RUN_EXECUTION_READINESS.md
+++ b/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_LANDING_COPY_CMS_DRY_RUN_EXECUTION_READINESS.md
@@ -1,0 +1,56 @@
+# IQ V1 Landing Copy CMS Dry-Run Execution Readiness
+
+## Classification
+
+`READY_FOR_CMS_DRY_RUN_PR`
+
+## Reasoning
+
+Positioning lock is already present, result/report safety is effective, and landing-surface authority is backend/CMS-owned. A dry-run package can be generated safely if it remains docs/generated artifact only and labels all copy `draft_review_only`.
+
+## Proposed Artifact Names
+
+- `backend/docs/seo/iq-v1/landing-copy-cms-dry-run/iq-v1-landing-copy-cms-dry-run.v1.json`
+- `backend/docs/seo/iq-v1/landing-copy-cms-dry-run/IQ_V1_LANDING_COPY_CMS_DRY_RUN.md`
+- Optional validator output: `backend/docs/seo/iq-v1/landing-copy-cms-dry-run/IQ_V1_LANDING_COPY_CLAIM_SAFETY_CHECK.md`
+
+## Exact Fields
+
+For each locale (`zh-CN`, `en`):
+
+- `surface_key`
+- `locale`
+- `test_slug`
+- `canonical_path`
+- `draft_status`
+- `title`
+- `seo_title`
+- `meta_description`
+- `h1`
+- `hero_title`
+- `hero_subhead`
+- `primary_cta`
+- `secondary_cta`
+- `questions_label`
+- `duration_label`
+- `result_scope`
+- `free_complete_result_copy`
+- `boundary_copy`
+- `faq`
+- `internal_links`
+- `method_page_links_draft_review_only`
+- `claim_policy`
+- `forbidden_claim_scan`
+- `cms_write_allowed=false`
+
+## Acceptance Checks
+
+- All copy is labeled `draft_review_only`.
+- No CMS write, draft creation, import, publish, revalidation, search submission, or production smoke.
+- No claim of formal intelligence credentials, clinical interpretation, external high-IQ society affiliation, population ranking, admission/hiring/salary/career guarantees, downloadable credentials, or paid report SEO unlock.
+- Explicitly states: free IQ-style reasoning test, 30 original items, about 20 minutes, raw score/correct rate/completion time/dimension performance, free complete result, and non-official/non-diagnostic boundary.
+- Seven IQ method-page CMS dry-run links may be referenced as dependency candidates only; do not import or write those pages in this task.
+
+## Exact Implementation Prompt
+
+Run `IQ-V1-LANDING-COPY-CMS-DRY-RUN-01` as a docs/generated-artifact-only PR in `/Users/rainie/Desktop/GitHub/fap-api`. Start from latest main, do not write CMS, do not create drafts, do not publish, do not deploy, do not revalidate, do not submit to search channels, and do not touch the separate seven IQ method-page CMS dry-run. Generate the zh-CN/en landing-copy dry-run package with every copy field marked `draft_review_only`, enforce the IQ V1 positioning lock, run focused claim-safety grep plus `git diff --check`, commit, push, open one PR, and stop after PR creation/check status per repo policy.

--- a/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_NEXT_EXACT_CODEX_EXECUTION_PROMPTS.md
+++ b/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_NEXT_EXACT_CODEX_EXECUTION_PROMPTS.md
@@ -1,0 +1,37 @@
+# IQ V1 Next Exact Codex Execution Prompts
+
+## 1. Result Page Safe Scoring QA
+
+```text
+/goal Run IQ-V1-RESULT-PAGE-SAFE-SCORING-QA-FIX-01 in /Users/rainie/Desktop/GitHub/fap-api.
+
+Mode: implementation only if current main has a scoped regression; otherwise add/confirm focused tests and report FIX_ALREADY_EFFECTIVE.
+
+Start from latest main. Do not touch CMS, DB, payment, deploy, production smoke, search submission, item-bank answers, scoring formulas, correct answers, item order, or images. Verify backend IQ result/report payloads do not expose formal intelligence credentials, norm-backed public score claims without authority, population ranking, downloadable credential claims, payment CTA/unlock copy, or answer-key/private scoring fields. Run focused tests only: IqReportContractTest, IqReportBuilderTest, IqOwnerOriginal30PrivateScoringTest, plus git diff --check. Open one scoped PR only if code or tests change.
+```
+
+## 2. Positioning Lock
+
+```text
+/goal Run IQ-V1-POSITIONING-LOCK-01 in /Users/rainie/Desktop/GitHub/fap-api.
+
+Mode: implementation only if current main has a scoped regression; otherwise confirm POSITIONING_LOCKED and stop with evidence.
+
+Start from latest main. Keep IQ V1 positioned as a free IQ-style reasoning test with 30 original items, about 20 minutes, raw score/correct rate/completion time/dimension performance, and free complete result. Block formal intelligence credentials, population ranking, clinical judgment, external high-IQ society affiliation, admission/hiring/salary/career claims, downloadable credential claims, and paid-report SEO claims. Do not write CMS, deploy, revalidate, submit to search, touch payment, or modify fap-web fallback copy. Run IqV1PositioningLockTest, LandingSurfacePublicApiTest focused IQ assertions, IqSeoRampAuthorityTest, and git diff --check. Open one scoped PR only if artifacts/tests change.
+```
+
+## 3. Landing Copy CMS Dry-Run
+
+```text
+/goal Run IQ-V1-LANDING-COPY-CMS-DRY-RUN-01 in /Users/rainie/Desktop/GitHub/fap-api.
+
+Create a docs/generated-artifact-only PR for zh-CN and en IQ landing copy dry-run. Do not write CMS, create CMS drafts, publish, deploy, revalidate, submit to search, or touch the separate seven IQ method-page CMS dry-run. Every copy field must be draft_review_only. Cover title, meta, H1, hero, CTA, FAQ, boundary copy, free complete result copy, and internal links. Enforce the IQ V1 positioning lock and forbidden claim list. Mention seven method pages only as draft dependency links, not imports. Run focused claim-safety grep and git diff --check. Open one scoped PR.
+```
+
+## 4. Item Dimension Tagging
+
+```text
+/goal Run IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01 in /Users/rainie/Desktop/GitHub/fap-api.
+
+Implement backend-owned metadata-only safe item dimension aliases for IQ_OWNER_ORIGINAL_30. Allowed aliases: matrix_reasoning, visual_reasoning, pattern_recognition, spatial_reasoning. Forbidden V1 aliases: working_memory, processing_speed, quantitative_reasoning, verbal_comprehension. Do not change answer keys, correct answers, scoring formulas, item order, images/SVGs, asset hashes, options, or runtime scoring outcomes. Add focused tests that all 30 public items have safe aliases, forbidden aliases are absent, public question payloads do not leak private scoring fields, and runtime scoring still passes. Run IqOwnerOriginal30PrivateScoringTest, the new focused tests, and git diff --check. Open one scoped PR.
+```

--- a/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_POSITIONING_LOCK_EXECUTION_READINESS.md
+++ b/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_POSITIONING_LOCK_EXECUTION_READINESS.md
@@ -1,0 +1,37 @@
+# IQ V1 Positioning Lock Execution Readiness
+
+## Classification
+
+`POSITIONING_LOCKED`
+
+## Evidence
+
+- `backend/docs/seo/iq-v1/iq-v1-positioning-lock.v1.json` exists and declares backend policy authority.
+- It allows IQ-style reasoning practice, matrix/pattern-recognition practice, raw score and completion-detail interpretation, backend-owned beta standard score when present, and educational self-understanding context.
+- It blocks formal intelligence credentials, clinical interpretation, external high-IQ society affiliation, admission/hiring/salary/career guarantees, fixed intelligence conclusions, public norm-score claims without authority, population ranking without authority, downloadable credential public claims, and paid-report SEO claims.
+- `backend/tests/Feature/SeoIntel/IqV1PositioningLockTest.php` asserts the policy artifact and forbidden claim classes.
+- `backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php` asserts IQ landing card copy is claim-safe and uses `IQ_OWNER_ORIGINAL_30`.
+- `backend/tests/Feature/SeoIntel/IqSeoRampAuthorityTest.php` asserts IQ SEO ramp authority is backend-CMS-owned, claim-safe, indexable where allowed, and not using forbidden copy.
+
+## Weak Copy
+
+- Existing safe baseline still uses concise card-level copy rather than a full landing-copy package. That is acceptable for current launch lock, but the landing-copy dry-run should expand zh/en title, meta, H1, hero, CTA, FAQ, boundary, and internal-link fields as draft-review-only.
+
+## Forbidden Copy
+
+No forbidden IQ V1 public positioning copy was found in the inspected backend authority artifact or tested landing baseline.
+
+## Dry-Run Update Scope
+
+- Create generated/draft-review-only backend docs artifact only.
+- Do not write CMS.
+- Do not update landing runtime data.
+- Do not import or publish.
+
+## CMS Write Required Later
+
+Yes, only after separate operator approval. This scan and the dry-run PR must not perform the CMS write.
+
+## GPT 5.5 Pro Review Required
+
+Recommended before any CMS write or public copy promotion. Not required to create a dry-run-only artifact.

--- a/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_RESULT_PAGE_SAFE_SCORING_EXECUTION_READINESS.md
+++ b/backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan/IQ_V1_RESULT_PAGE_SAFE_SCORING_EXECUTION_READINESS.md
@@ -1,0 +1,42 @@
+# IQ V1 Result Page Safe Scoring Execution Readiness
+
+## Classification
+
+`FIX_ALREADY_EFFECTIVE`
+
+Secondary note: `fap-web` should remain observed only unless a frontend-specific regression appears in tests or live smoke.
+
+## Evidence
+
+- `backend/app/Services/Report/IqReportBuilder.php` emits `iq_estimate`, `percentile`, and confidence interval only when norm authority is claim-eligible.
+- `backend/app/Services/Assessment/Drivers/IqTestDriver.php` defaults IQ norm outputs to `raw_score_only`, `claim_eligible=false`, and null public norm metrics without claim-ready norm authority.
+- `backend/app/Services/Assessment/IqBetaStandardScore.php` marks beta score as random-simulation-baseline, `production_normed=false`, `claim_eligible=false`, and `population_percentile_eligible=false`.
+- `backend/app/Services/Iq/IqResultPayloadRedactor.php` strips answer-key, correct-answer, solution-rule, scoring-spec, item-bank, asset-hash, and generator-metadata families from IQ public payloads.
+- `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php` applies IQ redaction to result, report, and stored submission response payload paths.
+- `backend/tests/Feature/V0_3/IqReportContractTest.php` covers free-full IQ report mode, beta standard score, null public norm fields, no payment offer, and no answer-key leakage.
+- `backend/tests/Unit/Services/Report/IqReportBuilderTest.php` covers no public norm metrics without claim-eligible norm authority.
+
+## Unsafe Strings or Paths Found
+
+- No current backend main path requires a result-page safety fix for the declared V1 policy.
+- `fap-web` result renderer still contains gated branches for formal IQ estimate, percentile display, PDF placeholder, and certificate placeholder. These are controlled by backend payload/claim state and should not be changed in this backend four-task execution unless a scoped frontend regression test proves user-visible leakage.
+
+## Exact Implementation Scope If Reopened
+
+- Backend only:
+  - `backend/tests/Feature/V0_3/IqReportContractTest.php`
+  - `backend/tests/Unit/Services/Report/IqReportBuilderTest.php`
+  - `backend/app/Services/Report/IqReportBuilder.php`
+  - `backend/app/Services/Iq/IqResultPayloadRedactor.php`
+  - `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
+- Do not touch payment, CMS, production smoke, DB, or item-bank answers.
+
+## Focused Tests
+
+- `cd backend && php artisan test --filter=IqReportContractTest`
+- `cd backend && php artisan test --filter=IqReportBuilderTest`
+- `cd backend && php artisan test --filter=IqOwnerOriginal30PrivateScoringTest`
+
+## fap-web Touch Needed
+
+No. Observe only.

--- a/backend/docs/seo/iq-v1/landing-copy-cms-dry-run/IQ_V1_LANDING_COPY_CLAIM_SAFETY_CHECK.md
+++ b/backend/docs/seo/iq-v1/landing-copy-cms-dry-run/IQ_V1_LANDING_COPY_CLAIM_SAFETY_CHECK.md
@@ -1,0 +1,35 @@
+# IQ V1 Landing Copy Claim Safety Check
+
+Status: `draft_review_only`
+PR: `IQ-V1-LANDING-COPY-CMS-DRY-RUN-01`
+
+## Result
+
+`PASS_DRAFT_REVIEW_ONLY`
+
+## Checked Claims
+
+- Free IQ-style reasoning practice: present.
+- 30 original items: present.
+- About 20 minutes: present.
+- Raw score, accuracy, completion time, and dimension performance: present.
+- Free complete V1 result: present.
+- Formal intelligence credential: blocked.
+- Population ranking: blocked.
+- Clinical or diagnostic interpretation: blocked.
+- External high-IQ society affiliation: blocked.
+- School, hiring, salary, or career decision evidence: blocked.
+- Paid report or downloadable credential promise: blocked.
+
+## Authority
+
+The dry-run package is not runtime authority. Runtime copy must come from backend CMS/public API only after separate owner approval and controlled CMS workflow.
+
+## Validation Commands
+
+```bash
+git diff --check
+python3 -m json.tool backend/docs/seo/iq-v1/landing-copy-cms-dry-run/iq-v1-landing-copy-cms-dry-run.v1.json >/tmp/iq-v1-landing-copy-cms-dry-run.pretty.json
+rg -n "draft_review_only" backend/docs/seo/iq-v1/landing-copy-cms-dry-run
+rg -n "cms_write_allowed\": false" backend/docs/seo/iq-v1/landing-copy-cms-dry-run/iq-v1-landing-copy-cms-dry-run.v1.json
+```

--- a/backend/docs/seo/iq-v1/landing-copy-cms-dry-run/IQ_V1_LANDING_COPY_CMS_DRY_RUN.md
+++ b/backend/docs/seo/iq-v1/landing-copy-cms-dry-run/IQ_V1_LANDING_COPY_CMS_DRY_RUN.md
@@ -1,0 +1,65 @@
+# IQ V1 Landing Copy CMS Dry Run
+
+Status: `draft_review_only`
+PR: `IQ-V1-LANDING-COPY-CMS-DRY-RUN-01`
+CMS write allowed: `false`
+
+## Purpose
+
+This package prepares operator-review copy for the IQ V1 landing surface without creating CMS drafts, publishing content, revalidating caches, submitting search channels, or changing runtime behavior.
+
+## Included Surfaces
+
+- `zh-CN`: `/zh/tests/iq-test-intelligence-quotient-assessment`
+- `en`: `/en/tests/iq-test-intelligence-quotient-assessment`
+
+## Covered Fields
+
+- title
+- SEO title
+- meta description
+- H1
+- hero title and subhead
+- primary and secondary CTA
+- question count
+- duration
+- result scope
+- free complete result copy
+- boundary copy
+- FAQ
+- internal links
+- method-page dependency links
+- claim policy
+- claim-safety scan result
+
+## Product Truth
+
+- Free IQ-style reasoning practice.
+- 30 original items.
+- About 20 minutes.
+- Result page shows raw score, accuracy, completion time, and dimension performance.
+- V1 result is free.
+- Beta-stage standard score may appear only when backend report authority supplies it with the proper boundary copy.
+
+## Boundaries
+
+This package does not claim a formal intelligence credential, population ranking, clinical judgment, external high-IQ society affiliation, school or hiring evidence, salary prediction, career outcome guarantee, downloadable credential, or paid report entitlement.
+
+## Deferred Items
+
+- CMS write.
+- CMS draft creation.
+- CMS publish.
+- Production import.
+- Production smoke.
+- Deploy.
+- Cache revalidation.
+- Search channel submission.
+- Seven IQ method-page CMS dry run.
+
+## Acceptance
+
+- Every public copy field is labeled `draft_review_only`.
+- `cms_write_allowed` is `false`.
+- No frontend fallback copy is introduced.
+- Runtime authority remains backend CMS/public API after separate owner approval.

--- a/backend/docs/seo/iq-v1/landing-copy-cms-dry-run/iq-v1-landing-copy-cms-dry-run.v1.json
+++ b/backend/docs/seo/iq-v1/landing-copy-cms-dry-run/iq-v1-landing-copy-cms-dry-run.v1.json
@@ -1,0 +1,274 @@
+{
+  "schema": "iq.v1.landing_copy_cms_dry_run.v1",
+  "pr_id": "IQ-V1-LANDING-COPY-CMS-DRY-RUN-01",
+  "status": "draft_review_only",
+  "cms_write_allowed": false,
+  "cms_draft_creation_allowed": false,
+  "cms_publish_allowed": false,
+  "production_import_allowed": false,
+  "revalidation_allowed": false,
+  "search_submission_allowed": false,
+  "runtime_authority": "backend_cms_or_public_api_after_separate_owner_approval",
+  "source_positioning_lock": "backend/docs/seo/iq-v1/iq-v1-positioning-lock.v1.json",
+  "dependency_notes": [
+    "Result-page safety is expected to remain backend-owned.",
+    "Method-page links are dependency candidates only and are not imported by this dry run."
+  ],
+  "claim_policy": {
+    "result_scope": "raw_score_correct_rate_completion_time_dimension_performance",
+    "free_complete_result": true,
+    "item_count": 30,
+    "duration_copy": "about_20_minutes",
+    "public_norm_claims_enabled": false,
+    "formal_credential_claims_enabled": false,
+    "clinical_claims_enabled": false,
+    "admission_hiring_salary_or_career_decision_claims_enabled": false,
+    "external_affiliation_claims_enabled": false,
+    "paid_report_claims_enabled": false
+  },
+  "forbidden_claim_scan": {
+    "status": "pass_draft_review_only",
+    "blocked_claim_families": [
+      "formal intelligence credential",
+      "population ranking",
+      "clinical or diagnostic interpretation",
+      "external high-IQ society affiliation",
+      "admission, hiring, salary, or career decision",
+      "paid report or downloadable credential promise"
+    ]
+  },
+  "locales": {
+    "zh-CN": {
+      "status": "draft_review_only",
+      "surface_key": "tests",
+      "locale": "zh-CN",
+      "test_slug": "iq-test-intelligence-quotient-assessment",
+      "canonical_path": "/zh/tests/iq-test-intelligence-quotient-assessment",
+      "title": {
+        "status": "draft_review_only",
+        "value": "IQ 推理练习"
+      },
+      "seo_title": {
+        "status": "draft_review_only",
+        "value": "IQ 推理练习：30 题图形与模式识别测试"
+      },
+      "meta_description": {
+        "status": "draft_review_only",
+        "value": "完成 30 题图形、矩阵和模式识别练习，查看原始得分、正确率、用时和维度表现。结果免费展示，适合作为推理练习参考。"
+      },
+      "h1": {
+        "status": "draft_review_only",
+        "value": "IQ 推理练习"
+      },
+      "hero_title": {
+        "status": "draft_review_only",
+        "value": "用 30 题图形推理了解本次表现"
+      },
+      "hero_subhead": {
+        "status": "draft_review_only",
+        "value": "约 20 分钟完成矩阵、空间和模式识别题，结果页展示原始分、正确率、完成时间和维度表现。"
+      },
+      "primary_cta": {
+        "status": "draft_review_only",
+        "label": "开始免费练习",
+        "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
+        "form_code": "IQ_OWNER_ORIGINAL_30"
+      },
+      "secondary_cta": {
+        "status": "draft_review_only",
+        "label": "了解结果边界",
+        "href": "/zh/tests/iq-test-intelligence-quotient-assessment#result-boundary"
+      },
+      "questions_label": {
+        "status": "draft_review_only",
+        "value": "30 题"
+      },
+      "duration_label": {
+        "status": "draft_review_only",
+        "value": "约 20 分钟"
+      },
+      "result_scope": {
+        "status": "draft_review_only",
+        "items": [
+          "原始得分",
+          "正确率",
+          "完成时间",
+          "视觉推理相关维度表现",
+          "Beta 阶段标准分说明"
+        ]
+      },
+      "free_complete_result_copy": {
+        "status": "draft_review_only",
+        "value": "完成后可免费查看完整 V1 结果，包括本次原始分、正确率、用时和维度表现说明。"
+      },
+      "boundary_copy": {
+        "status": "draft_review_only",
+        "value": "FermatMind V1 是推理练习和自我理解参考，不提供正式智力凭证、人群排名、临床判断，也不用于升学、招聘、薪酬或职业结论。"
+      },
+      "faq": [
+        {
+          "status": "draft_review_only",
+          "question": "这个测试适合用来了解什么？",
+          "answer": "它适合用来观察本次图形推理、空间推理和模式识别表现，并帮助你理解原始分、正确率和完成时间。"
+        },
+        {
+          "status": "draft_review_only",
+          "question": "结果是免费的吗？",
+          "answer": "是。完成 30 题后，V1 结果页免费展示本次原始分、正确率、完成时间和维度表现。"
+        },
+        {
+          "status": "draft_review_only",
+          "question": "结果可以当作正式能力凭证吗？",
+          "answer": "不可以。当前版本用于练习和自我理解，不作为正式凭证、临床判断或任何录用、升学、薪酬和职业决策依据。"
+        }
+      ],
+      "internal_links": [
+        {
+          "status": "draft_review_only",
+          "label": "测试中心",
+          "href": "/zh/tests"
+        },
+        {
+          "status": "draft_review_only",
+          "label": "人格测试",
+          "href": "/zh/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "status": "draft_review_only",
+          "label": "职业兴趣测试",
+          "href": "/zh/tests/holland-career-interest-test-riasec"
+        }
+      ],
+      "method_page_links_draft_review_only": [
+        {
+          "status": "draft_review_only",
+          "task_id": "IQ-METHOD-WHAT-IS-IQ-STYLE-TEST-01",
+          "label": "什么是 IQ 风格推理测试",
+          "href": "/zh/iq-method/what-is-iq-style-test"
+        },
+        {
+          "status": "draft_review_only",
+          "task_id": "IQ-METHOD-SCORE-MEANING-BOUNDARY-01",
+          "label": "如何理解原始分、正确率和用时",
+          "href": "/zh/iq-method/score-meaning-boundary"
+        }
+      ]
+    },
+    "en": {
+      "status": "draft_review_only",
+      "surface_key": "tests",
+      "locale": "en",
+      "test_slug": "iq-test-intelligence-quotient-assessment",
+      "canonical_path": "/en/tests/iq-test-intelligence-quotient-assessment",
+      "title": {
+        "status": "draft_review_only",
+        "value": "IQ Reasoning Practice"
+      },
+      "seo_title": {
+        "status": "draft_review_only",
+        "value": "IQ Reasoning Practice: 30 Matrix and Pattern Questions"
+      },
+      "meta_description": {
+        "status": "draft_review_only",
+        "value": "Complete 30 visual, matrix, and pattern-recognition questions, then review raw score, accuracy, time, and dimension performance. The V1 result is free and practice-oriented."
+      },
+      "h1": {
+        "status": "draft_review_only",
+        "value": "IQ Reasoning Practice"
+      },
+      "hero_title": {
+        "status": "draft_review_only",
+        "value": "Review your 30-question reasoning performance"
+      },
+      "hero_subhead": {
+        "status": "draft_review_only",
+        "value": "Spend about 20 minutes on matrix, spatial, and pattern-recognition questions, then review raw score, accuracy, completion time, and dimension performance."
+      },
+      "primary_cta": {
+        "status": "draft_review_only",
+        "label": "Start free practice",
+        "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
+        "form_code": "IQ_OWNER_ORIGINAL_30"
+      },
+      "secondary_cta": {
+        "status": "draft_review_only",
+        "label": "Review result boundaries",
+        "href": "/en/tests/iq-test-intelligence-quotient-assessment#result-boundary"
+      },
+      "questions_label": {
+        "status": "draft_review_only",
+        "value": "30 questions"
+      },
+      "duration_label": {
+        "status": "draft_review_only",
+        "value": "About 20 minutes"
+      },
+      "result_scope": {
+        "status": "draft_review_only",
+        "items": [
+          "Raw score",
+          "Accuracy",
+          "Completion time",
+          "Visual reasoning dimension performance",
+          "Beta-stage standard-score note"
+        ]
+      },
+      "free_complete_result_copy": {
+        "status": "draft_review_only",
+        "value": "After finishing all 30 questions, the V1 result page shows the complete free result: raw score, accuracy, time, and dimension performance notes."
+      },
+      "boundary_copy": {
+        "status": "draft_review_only",
+        "value": "FermatMind V1 is for reasoning practice and self-understanding. It does not provide a formal intelligence credential, population ranking, clinical judgment, or evidence for school, hiring, salary, or career decisions."
+      },
+      "faq": [
+        {
+          "status": "draft_review_only",
+          "question": "What is this test useful for?",
+          "answer": "It helps you review this attempt's visual reasoning, spatial reasoning, and pattern-recognition performance, including raw score, accuracy, and completion time."
+        },
+        {
+          "status": "draft_review_only",
+          "question": "Is the result free?",
+          "answer": "Yes. After 30 questions, the V1 result page shows raw score, accuracy, completion time, and dimension performance for free."
+        },
+        {
+          "status": "draft_review_only",
+          "question": "Can I use the result as a formal credential?",
+          "answer": "No. This version is for practice and self-understanding only, not for clinical judgment or school, hiring, salary, or career decisions."
+        }
+      ],
+      "internal_links": [
+        {
+          "status": "draft_review_only",
+          "label": "Tests",
+          "href": "/en/tests"
+        },
+        {
+          "status": "draft_review_only",
+          "label": "Personality test",
+          "href": "/en/tests/mbti-personality-test-16-personality-types"
+        },
+        {
+          "status": "draft_review_only",
+          "label": "Career interest test",
+          "href": "/en/tests/holland-career-interest-test-riasec"
+        }
+      ],
+      "method_page_links_draft_review_only": [
+        {
+          "status": "draft_review_only",
+          "task_id": "IQ-METHOD-WHAT-IS-IQ-STYLE-TEST-01",
+          "label": "What is an IQ-style reasoning test?",
+          "href": "/en/iq-method/what-is-iq-style-test"
+        },
+        {
+          "status": "draft_review_only",
+          "task_id": "IQ-METHOD-SCORE-MEANING-BOUNDARY-01",
+          "label": "How to understand raw score, accuracy, and time",
+          "href": "/en/iq-method/score-meaning-boundary"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What changed
- Added IQ V1 landing copy CMS dry-run artifacts for zh-CN and en.
- Added draft-review-only copy fields for title, SEO title, meta description, H1, hero, CTA, FAQ, boundaries, free complete result copy, internal links, and method-page dependency links.
- Included the four-task readiness scan artifacts that were generated before this PR and are within the approved IQ SEO docs scope.

## Why
- IQ V1 landing copy is ready for a docs-only CMS dry run after result-page safety and positioning lock readiness were confirmed.
- Runtime copy authority remains backend CMS/public API after separate owner approval; this PR does not publish or import content.

## Validation commands
- `git diff --check`
- `python3 -m json.tool backend/docs/seo/iq-v1/landing-copy-cms-dry-run/iq-v1-landing-copy-cms-dry-run.v1.json >/tmp/iq-v1-landing-copy-cms-dry-run.pretty.json`
- `rg -n "official IQ|certified IQ|diagnostic IQ|Mensa|IQ certificate|IQ report PDF|官方智商|智商认证|临床诊断|门萨|录取证明|招聘筛选|薪资预测|职业保证" backend/docs/seo/iq-v1/2026-07-04/four-task-execution-readiness-scan backend/docs/seo/iq-v1/landing-copy-cms-dry-run || true`
- `rg -n "draft_review_only" backend/docs/seo/iq-v1/landing-copy-cms-dry-run`
- `rg -n ""cms_write_allowed": false" backend/docs/seo/iq-v1/landing-copy-cms-dry-run/iq-v1-landing-copy-cms-dry-run.v1.json`
- `cd backend && php artisan test --filter=IqV1PositioningLockTest`
- `cd backend && php artisan test --filter=IqSeoRampAuthorityTest`
- `cd backend && php artisan test --filter=LandingSurfacePublicApiTest`

## Intentionally deferred
- CMS write, CMS draft creation, CMS publish, production import, production deploy, production smoke, cache revalidation, search channel submission, frontend fallback copy, and the separate seven IQ method-page CMS dry-run.

## Repository rule impact
- Docs-only dry-run package. Runtime content authority remains backend CMS/public API; no frontend fallback or publishable runtime content was introduced.