### PR TITLE
IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01: add safe IQ owner item aliases

### DIFF
--- a/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
+++ b/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
@@ -31,6 +31,16 @@ final class IqOwnerOriginal30BankService
     private const PUBLIC_ASSET_ROUTE_PREFIX = 'iq_owner_original_30/';
 
     /**
+     * @var list<string>
+     */
+    private const SAFE_DIMENSION_ALIASES = [
+        'matrix_reasoning',
+        'visual_reasoning',
+        'pattern_recognition',
+        'spatial_reasoning',
+    ];
+
+    /**
      * @return array<string,mixed>
      */
     public function startMetadata(string $packId, string $dirVersion): array
@@ -382,6 +392,7 @@ final class IqOwnerOriginal30BankService
             'item_id' => (string) ($item['item_id'] ?? ''),
             'sequence' => (int) ($item['sequence'] ?? 0),
             'order' => (int) ($item['sequence'] ?? 0),
+            'safe_dimension_aliases' => $this->safeDimensionAliases($item),
             'title' => (string) ($item['title'] ?? ''),
             'stem' => $this->onlyPublicMediaFields(
                 is_array($item['stem'] ?? null) ? $item['stem'] : [],
@@ -389,6 +400,27 @@ final class IqOwnerOriginal30BankService
             ),
             'options' => $options,
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return list<string>
+     */
+    private function safeDimensionAliases(array $item): array
+    {
+        $aliases = is_array($item['safe_dimension_aliases'] ?? null)
+            ? $item['safe_dimension_aliases']
+            : [];
+
+        $safe = [];
+        foreach ($aliases as $alias) {
+            $alias = strtolower(trim((string) $alias));
+            if (in_array($alias, self::SAFE_DIMENSION_ALIASES, true)) {
+                $safe[] = $alias;
+            }
+        }
+
+        return array_values(array_unique($safe));
     }
 
     /**

--- a/backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
+++ b/backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
@@ -91,6 +91,38 @@ final class IqOwnerOriginal30PrivateScoringTest extends TestCase
     }
 
     #[Test]
+    public function public_items_include_only_v1_safe_dimension_aliases(): void
+    {
+        $items = $this->readJson('items.json')['items'] ?? [];
+        $this->assertCount(30, $items);
+
+        $allowed = [
+            'matrix_reasoning',
+            'visual_reasoning',
+            'pattern_recognition',
+            'spatial_reasoning',
+        ];
+        $forbidden = [
+            implode('_', ['working', 'memory']),
+            implode('_', ['processing', 'speed']),
+            implode('_', ['quantitative', 'reasoning']),
+            implode('_', ['verbal', 'comprehension']),
+        ];
+
+        foreach ($items as $index => $item) {
+            $aliases = $item['safe_dimension_aliases'] ?? null;
+            $this->assertIsArray($aliases, 'missing safe aliases for item '.($index + 1));
+            $this->assertNotEmpty($aliases, 'empty safe aliases for item '.($index + 1));
+            $this->assertSame(array_values(array_unique($aliases)), $aliases);
+
+            foreach ($aliases as $alias) {
+                $this->assertContains($alias, $allowed);
+                $this->assertNotContains($alias, $forbidden);
+            }
+        }
+    }
+
+    #[Test]
     public function redacted_public_payload_contains_no_answer_key_or_solution_fields(): void
     {
         $items = $this->readJson('items.json')['items'] ?? [];

--- a/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+++ b/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
@@ -77,6 +77,10 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         ]);
         $this->assertCount(1, $response->json('questions.items'));
         $this->assertSame('IQOWNER30-Q01', $response->json('questions.items.0.question_id'));
+        $this->assertSame(
+            ['matrix_reasoning', 'pattern_recognition', 'visual_reasoning'],
+            $response->json('questions.items.0.safe_dimension_aliases')
+        );
         $this->assertOwnerOriginalQ1AssetsArePubliclyResolvable($response->json('questions.items.0'));
         $this->assertPayloadHasNoPrivateIqFields($response->json());
     }
@@ -109,6 +113,10 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         $this->assertOwnerOriginalQ1AssetsArePubliclyResolvable(
             $payload['questions']['items'][0],
             'https://api.fermatmind.com'
+        );
+        $this->assertSame(
+            ['matrix_reasoning', 'pattern_recognition', 'visual_reasoning'],
+            data_get($payload, 'questions.items.0.safe_dimension_aliases')
         );
         $this->assertPayloadHasNoPrivateIqFields($payload);
     }
@@ -448,6 +456,8 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
             'solutionRule',
             'source_capture_urls',
             'sourceCaptureUrls',
+            'asset_hashes',
+            'assetHashes',
             'generator_metadata',
             'generatorMetadata',
             'provenance',

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json
@@ -12,6 +12,7 @@
             "question_id": "IQOWNER30-Q01",
             "item_id": "IQ_OWNER_ORIGINAL_30_01",
             "sequence": 1,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -133,6 +134,7 @@
             "question_id": "IQOWNER30-Q02",
             "item_id": "IQ_OWNER_ORIGINAL_30_02",
             "sequence": 2,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -254,6 +256,7 @@
             "question_id": "IQOWNER30-Q03",
             "item_id": "IQ_OWNER_ORIGINAL_30_03",
             "sequence": 3,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -375,6 +378,7 @@
             "question_id": "IQOWNER30-Q04",
             "item_id": "IQ_OWNER_ORIGINAL_30_04",
             "sequence": 4,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -496,6 +500,7 @@
             "question_id": "IQOWNER30-Q05",
             "item_id": "IQ_OWNER_ORIGINAL_30_05",
             "sequence": 5,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -617,6 +622,7 @@
             "question_id": "IQOWNER30-Q06",
             "item_id": "IQ_OWNER_ORIGINAL_30_06",
             "sequence": 6,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -738,6 +744,7 @@
             "question_id": "IQOWNER30-Q07",
             "item_id": "IQ_OWNER_ORIGINAL_30_07",
             "sequence": 7,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -859,6 +866,7 @@
             "question_id": "IQOWNER30-Q08",
             "item_id": "IQ_OWNER_ORIGINAL_30_08",
             "sequence": 8,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -980,6 +988,7 @@
             "question_id": "IQOWNER30-Q09",
             "item_id": "IQ_OWNER_ORIGINAL_30_09",
             "sequence": 9,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -1101,6 +1110,7 @@
             "question_id": "IQOWNER30-Q10",
             "item_id": "IQ_OWNER_ORIGINAL_30_10",
             "sequence": 10,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -1222,6 +1232,7 @@
             "question_id": "IQOWNER30-Q11",
             "item_id": "IQ_OWNER_ORIGINAL_30_11",
             "sequence": 11,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -1343,6 +1354,7 @@
             "question_id": "IQOWNER30-Q12",
             "item_id": "IQ_OWNER_ORIGINAL_30_12",
             "sequence": 12,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -1464,6 +1476,7 @@
             "question_id": "IQOWNER30-Q13",
             "item_id": "IQ_OWNER_ORIGINAL_30_13",
             "sequence": 13,
+            "safe_dimension_aliases": ["pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -1585,6 +1598,7 @@
             "question_id": "IQOWNER30-Q14",
             "item_id": "IQ_OWNER_ORIGINAL_30_14",
             "sequence": 14,
+            "safe_dimension_aliases": ["pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -1706,6 +1720,7 @@
             "question_id": "IQOWNER30-Q15",
             "item_id": "IQ_OWNER_ORIGINAL_30_15",
             "sequence": 15,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -1827,6 +1842,7 @@
             "question_id": "IQOWNER30-Q16",
             "item_id": "IQ_OWNER_ORIGINAL_30_16",
             "sequence": 16,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -1948,6 +1964,7 @@
             "question_id": "IQOWNER30-Q17",
             "item_id": "IQ_OWNER_ORIGINAL_30_17",
             "sequence": 17,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -2069,6 +2086,7 @@
             "question_id": "IQOWNER30-Q18",
             "item_id": "IQ_OWNER_ORIGINAL_30_18",
             "sequence": 18,
+            "safe_dimension_aliases": ["pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -2190,6 +2208,7 @@
             "question_id": "IQOWNER30-Q19",
             "item_id": "IQ_OWNER_ORIGINAL_30_19",
             "sequence": 19,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -2311,6 +2330,7 @@
             "question_id": "IQOWNER30-Q20",
             "item_id": "IQ_OWNER_ORIGINAL_30_20",
             "sequence": 20,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -2432,6 +2452,7 @@
             "question_id": "IQOWNER30-Q21",
             "item_id": "IQ_OWNER_ORIGINAL_30_21",
             "sequence": 21,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -2553,6 +2574,7 @@
             "question_id": "IQOWNER30-Q22",
             "item_id": "IQ_OWNER_ORIGINAL_30_22",
             "sequence": 22,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -2674,6 +2696,7 @@
             "question_id": "IQOWNER30-Q23",
             "item_id": "IQ_OWNER_ORIGINAL_30_23",
             "sequence": 23,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -2795,6 +2818,7 @@
             "question_id": "IQOWNER30-Q24",
             "item_id": "IQ_OWNER_ORIGINAL_30_24",
             "sequence": 24,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -2916,6 +2940,7 @@
             "question_id": "IQOWNER30-Q25",
             "item_id": "IQ_OWNER_ORIGINAL_30_25",
             "sequence": 25,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -3037,6 +3062,7 @@
             "question_id": "IQOWNER30-Q26",
             "item_id": "IQ_OWNER_ORIGINAL_30_26",
             "sequence": 26,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -3158,6 +3184,7 @@
             "question_id": "IQOWNER30-Q27",
             "item_id": "IQ_OWNER_ORIGINAL_30_27",
             "sequence": 27,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -3279,6 +3306,7 @@
             "question_id": "IQOWNER30-Q28",
             "item_id": "IQ_OWNER_ORIGINAL_30_28",
             "sequence": 28,
+            "safe_dimension_aliases": ["spatial_reasoning", "visual_reasoning", "pattern_recognition"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -3400,6 +3428,7 @@
             "question_id": "IQOWNER30-Q29",
             "item_id": "IQ_OWNER_ORIGINAL_30_29",
             "sequence": 29,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",
@@ -3521,6 +3550,7 @@
             "question_id": "IQOWNER30-Q30",
             "item_id": "IQ_OWNER_ORIGINAL_30_30",
             "sequence": 30,
+            "safe_dimension_aliases": ["matrix_reasoning", "pattern_recognition", "visual_reasoning"],
             "title": "选择合适的形状来替换缺失的形状。",
             "stem": {
                 "type": "image",


### PR DESCRIPTION
## What changed
- Added `safe_dimension_aliases` to all 30 `IQ_OWNER_ORIGINAL_30` public item records.
- Exposed only those safe aliases through owner-original current-question delivery.
- Added focused tests for allowed alias coverage, forbidden alias absence, public payload exposure, private field redaction, and unchanged runtime scoring behavior.

## Why
- IQ V1 needs backend-owned item metadata for public-safe reasoning dimensions without changing scoring, answers, item order, option content, or assets.

## Validation commands
- `python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json >/tmp/iq-owner-original-30-items.pretty.json`
- `rg -n "working_memory|processing_speed|quantitative_reasoning|verbal_comprehension" content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json backend/app/Services/Iq/IqOwnerOriginal30BankService.php backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php || true`
- `cd backend && php artisan test --filter=IqOwnerOriginal30PrivateScoringTest`
- `cd backend && php artisan test --filter=IqOwnerOriginal30SessionDeliveryTest`
- `git diff --check`
- `python3` structural comparison confirming `items.json` only adds `safe_dimension_aliases` versus `origin/main`

## Intentionally deferred
- Psychometric norming, public norm-score claims, CMS copy, production deploy, production smoke, scoring changes, answer-key changes, item order changes, image/SVG changes, option-content changes, asset-hash changes, and generator metadata changes.

## Repository rule impact
- Backend/content-package metadata only. Runtime authority remains backend-owned; no CMS write, frontend fallback, payment, search, deploy, or scoring authority change.