### PR TITLE
MBTI-CMS-13: add MBTI comparison CMS import dry-run

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php
+++ b/backend/app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\MbtiComparisonCmsImportDryRunPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityMbtiComparisonCmsImportDryRun extends Command
+{
+    protected $signature = 'personality:mbti-comparison-cms-import-dry-run
+        {--package= : Path to the MBTI comparison asset JSON package}
+        {--dry-run : Required; validate and plan without database writes}
+        {--write : Unsupported in this PR; fails closed}
+        {--json : Emit the full JSON dry-run plan}
+        {--output= : Optional path to write the JSON dry-run plan}';
+
+    protected $description = 'Validate MBTI comparison CMS import mapping as a no-write dry run.';
+
+    public function handle(MbtiComparisonCmsImportDryRunPlanner $planner): int
+    {
+        try {
+            $summary = $this->guardedPlan($planner);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary($exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary($exception->getMessage(), 'unexpected_error');
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function guardedPlan(MbtiComparisonCmsImportDryRunPlanner $planner): array
+    {
+        if ((bool) $this->option('write')) {
+            throw new RuntimeException('--write is intentionally unsupported in MBTI-CMS-13.');
+        }
+
+        if (! (bool) $this->option('dry-run')) {
+            throw new RuntimeException('--dry-run is required so this command cannot be mistaken for a write/import command.');
+        }
+
+        $packagePath = trim((string) $this->option('package'));
+        if ($packagePath === '') {
+            throw new RuntimeException('--package is required.');
+        }
+
+        $resolved = $this->resolvePath($packagePath);
+        $raw = (string) File::get($resolved);
+        $decoded = json_decode($raw, true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+
+        return array_merge($planner->plan($decoded, hash('sha256', $raw)), [
+            'package_path' => $resolved,
+            'command' => 'personality:mbti-comparison-cms-import-dry-run',
+        ]);
+    }
+
+    private function resolvePath(string $path): string
+    {
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException('Package file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run_only='.(($summary['dry_run_only'] ?? false) ? '1' : '0'));
+        $this->line('write_supported_in_this_pr='.(($summary['write_supported_in_this_pr'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('cms_write_attempted='.(($summary['cms_write_attempted'] ?? false) ? '1' : '0'));
+        $this->line('publish_attempted='.(($summary['publish_attempted'] ?? false) ? '1' : '0'));
+        $this->line('index_attempted='.(($summary['index_attempted'] ?? false) ? '1' : '0'));
+        $this->line('search_release_attempted='.(($summary['search_release_attempted'] ?? false) ? '1' : '0'));
+        $this->line('sitemap_llms_release_attempted='.(($summary['sitemap_llms_release_attempted'] ?? false) ? '1' : '0'));
+        $this->line('row_count='.(string) ($summary['row_count'] ?? 0));
+        $this->line('comparison_row_count='.(string) ($summary['comparison_row_count'] ?? 0));
+        $this->line('profile_row_count='.(string) ($summary['profile_row_count'] ?? 0));
+        $this->line('at_comparison_count='.(string) ($summary['at_comparison_count'] ?? 0));
+        $this->line('cross_type_comparison_count='.(string) ($summary['cross_type_comparison_count'] ?? 0));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $message, string $code = 'runtime_error'): array
+    {
+        return [
+            'artifact' => 'MBTI-CMS-13-COMPARISON-IMPORT-DRY-RUN',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run_only' => true,
+            'write_supported_in_this_pr' => false,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'search_release_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php
+++ b/backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php
@@ -1,0 +1,483 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+final class MbtiComparisonCmsImportDryRunPlanner
+{
+    private const FORBIDDEN_PUBLIC_ROUTE_PATTERN =
+        '~(?:^|["\'\s(])/(?:[a-z]{2}/)?(?:result|results|orders|order|share|pay|payment|history|private|account)(?:/|[?#\s)"\']|$)~i';
+
+    private const FORBIDDEN_QUERY_PATTERN =
+        '/(?:[?&]|^)(?:token|session|user|result_id|report_id|order_no)=/i';
+
+    private const REQUIRED_SEO_FIELDS = [
+        'seo_title',
+        'seo_description',
+        'breadcrumb_title',
+        'h1',
+        'quick_answer_summary',
+    ];
+
+    private const REQUIRED_CONTENT_FIELDS = [
+        'quick_answer',
+        'max_difference',
+        'quick_judgment_table',
+        'confusion_reason',
+        'real_scene_differences',
+        'misjudgment_warning',
+    ];
+
+    private const FIRST_CLASS_COMPARISON_FIELDS = [
+        'url',
+        'locale',
+        'page_type',
+        'comparison_kind',
+        'canonical_target',
+        'seo.seo_title',
+        'seo.seo_description',
+        'seo.breadcrumb_title',
+        'seo.h1',
+        'seo.quick_answer_summary',
+        'content.quick_answer',
+        'content.max_difference',
+        'content.quick_judgment_table',
+        'content.confusion_reason',
+        'content.real_scene_differences',
+        'content.misjudgment_warning',
+        'faq',
+        'internal_links',
+    ];
+
+    private const STRUCTURED_METADATA_FIELDS = [
+        'primary_query',
+        'secondary_queries',
+        'gsc_query_evidence',
+        'target_intent',
+        'method_boundary',
+        'trademark_boundary',
+        'claim_risk_notes',
+        'qa_flags_for_codex',
+        'route_safety',
+        'source_document',
+        'status',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, string $sourceSha256 = ''): array
+    {
+        $errors = [];
+        $warnings = [];
+        $rows = $this->rows($package, $errors);
+        $rowPlans = [];
+
+        $this->validateTopLevel($package, $warnings);
+        $this->validateForbiddenRoutes($package, $errors);
+
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                $errors[] = $this->issue('rows.'.(string) $index, 'row_not_object', 'Each package row must be a JSON object.');
+
+                continue;
+            }
+
+            $rowPlans[] = $this->rowPlan($row, $index, $errors, $warnings);
+        }
+
+        $comparisonPlans = array_values(array_filter(
+            $rowPlans,
+            static fn (array $row): bool => ($row['page_type'] ?? null) === 'comparison'
+        ));
+        $profilePlans = array_values(array_filter(
+            $rowPlans,
+            static fn (array $row): bool => in_array(($row['page_type'] ?? null), ['profile', 'variant'], true)
+        ));
+        $atPlans = array_values(array_filter(
+            $comparisonPlans,
+            static fn (array $row): bool => ($row['identity']['comparison_kind'] ?? null) === 'at'
+        ));
+        $crossTypePlans = array_values(array_filter(
+            $comparisonPlans,
+            static fn (array $row): bool => ($row['identity']['comparison_kind'] ?? null) === 'cross_type'
+        ));
+
+        return [
+            'artifact' => 'MBTI-CMS-13-COMPARISON-IMPORT-DRY-RUN',
+            'status' => $errors === [] ? 'pass' : 'fail',
+            'ok' => $errors === [],
+            'dry_run_only' => true,
+            'write_supported_in_this_pr' => false,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'search_release_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'source_sha256' => $sourceSha256,
+            'source_version' => (string) ($package['version'] ?? ''),
+            'source_status' => (string) ($package['status'] ?? ''),
+            'row_count' => count($rows),
+            'comparison_row_count' => count($comparisonPlans),
+            'profile_row_count' => count($profilePlans),
+            'at_comparison_count' => count($atPlans),
+            'cross_type_comparison_count' => count($crossTypePlans),
+            'field_mapping_contract' => $this->fieldMappingContract(),
+            'dry_run_write_guard_contract' => $this->dryRunWriteGuardContract(),
+            'rows' => $rowPlans,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  list<array<string,string>>  $errors
+     * @return list<mixed>
+     */
+    private function rows(array $package, array &$errors): array
+    {
+        $rows = $package['rows'] ?? $package['comparisons'] ?? null;
+        if (! is_array($rows)) {
+            $errors[] = $this->issue('rows', 'rows_missing_or_not_array', 'Comparison package must contain rows or comparisons as an array.');
+
+            return [];
+        }
+
+        return array_values($rows);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  list<array<string,string>>  $warnings
+     */
+    private function validateTopLevel(array $package, array &$warnings): void
+    {
+        $line = trim((string) ($package['content_line'] ?? ''));
+        if ($line !== '' && $line !== 'comparison') {
+            $warnings[] = $this->issue('content_line', 'unexpected_content_line', 'MBTI-CMS-13 expects the comparison content line.');
+        }
+
+        $version = trim((string) ($package['version'] ?? ''));
+        if ($version === '') {
+            $warnings[] = $this->issue('version', 'missing_package_version', 'Package version was not provided.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  list<array<string,string>>  $errors
+     */
+    private function validateForbiddenRoutes(array $package, array &$errors): void
+    {
+        $json = json_encode($package, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($json)) {
+            $errors[] = $this->issue('package', 'json_encode_failed', 'Package could not be normalized for route safety scanning.');
+
+            return;
+        }
+
+        if (preg_match(self::FORBIDDEN_PUBLIC_ROUTE_PATTERN, $json) === 1) {
+            $errors[] = $this->issue('package', 'forbidden_public_route_pattern_present', 'Package active payload must not contain result/order/share/payment/history/private/account routes.');
+        }
+
+        if (preg_match(self::FORBIDDEN_QUERY_PATTERN, $json) === 1) {
+            $errors[] = $this->issue('package', 'forbidden_query_pattern_present', 'Package active payload must not contain sensitive query keys.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @param  list<array<string,string>>  $errors
+     * @param  list<array<string,string>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function rowPlan(array $row, int $index, array &$errors, array &$warnings): array
+    {
+        $url = $this->normalizePath((string) ($row['url'] ?? ''));
+        $locale = (string) ($row['locale'] ?? '');
+        $pageType = (string) ($row['page_type'] ?? '');
+        $comparisonKind = (string) ($row['comparison_kind'] ?? '');
+        $seo = is_array($row['seo'] ?? null) ? $row['seo'] : [];
+        $content = is_array($row['content'] ?? null) ? $row['content'] : [];
+        $identity = $this->parseIdentity($url, $locale, $pageType, $comparisonKind, $errors, $index);
+
+        $this->validateRowShape($row, $seo, $content, $errors, $warnings, $index);
+
+        return [
+            'position' => $index + 1,
+            'url' => $url,
+            'locale' => $locale,
+            'page_type' => $pageType,
+            'comparison_kind' => $comparisonKind,
+            'canonical_target' => $this->normalizePath((string) ($row['canonical_target'] ?? '')),
+            'identity' => $identity,
+            'target' => $this->targetFor($identity),
+            'draft_revision' => $this->draftRevisionFor($identity, $url),
+            'first_class_field_destinations' => $this->firstClassDestinations(),
+            'structured_metadata_snapshot_path' => 'mbti_comparison_dry_run_plan.mbti_cms_13_comparison_import_dry_run_v1.structured_metadata',
+            'content_section_keys' => array_keys($content),
+            'seo_keys' => array_keys($seo),
+            'faq_count' => is_array($row['faq'] ?? null) ? count((array) $row['faq']) : 0,
+            'internal_link_count' => is_array($row['internal_links'] ?? null) ? count((array) $row['internal_links']) : 0,
+            'draft_state_after_import' => [
+                'status' => 'draft',
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'published_at' => null,
+            ],
+            'action' => 'would_stage_comparison_revision',
+            'write_mode_in_this_pr' => 'not_supported',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $seo
+     * @param  array<string,mixed>  $content
+     * @param  list<array<string,string>>  $errors
+     * @param  list<array<string,string>>  $warnings
+     */
+    private function validateRowShape(array $row, array $seo, array $content, array &$errors, array &$warnings, int $index): void
+    {
+        foreach (self::REQUIRED_SEO_FIELDS as $field) {
+            if (trim((string) ($seo[$field] ?? '')) === '') {
+                $errors[] = $this->issue('rows.'.(string) $index.'.seo.'.$field, 'required_seo_field_missing', 'Required SEO field is missing.');
+            }
+        }
+
+        foreach (self::REQUIRED_CONTENT_FIELDS as $field) {
+            if (! array_key_exists($field, $content)) {
+                $errors[] = $this->issue('rows.'.(string) $index.'.content.'.$field, 'required_content_field_missing', 'Required comparison answer block field is missing.');
+            }
+        }
+
+        if (! is_array($content['quick_judgment_table'] ?? null) || count((array) $content['quick_judgment_table']) < 2) {
+            $errors[] = $this->issue('rows.'.(string) $index.'.content.quick_judgment_table', 'quick_judgment_table_minimum_not_met', 'Comparison rows need at least two quick judgment rows.');
+        }
+
+        if (! is_array($row['faq'] ?? null) || count((array) $row['faq']) < 3) {
+            $errors[] = $this->issue('rows.'.(string) $index.'.faq', 'faq_minimum_not_met', 'Comparison dry-run rows need at least three FAQ entries.');
+        }
+
+        if (! is_array($row['internal_links'] ?? null) || count((array) $row['internal_links']) < 3) {
+            $warnings[] = $this->issue('rows.'.(string) $index.'.internal_links', 'internal_link_minimum_not_met', 'Comparison rows should include at least three related public links before promotion.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,string>>  $errors
+     * @return array<string,mixed>
+     */
+    private function parseIdentity(string $url, string $locale, string $pageType, string $comparisonKind, array &$errors, int $index): array
+    {
+        if (! in_array($locale, ['en', 'zh-CN'], true)) {
+            $errors[] = $this->issue('rows.'.(string) $index.'.locale', 'unsupported_locale', 'Only en and zh-CN are supported.');
+        }
+
+        if (in_array($pageType, ['profile', 'variant'], true)) {
+            $errors[] = $this->issue('rows.'.(string) $index.'.page_type', 'profile_rows_out_of_scope', 'MBTI-CMS-13 accepts only comparison rows; profile import dry-run belongs to MBTI-CMS-12.');
+
+            return [];
+        }
+
+        if ($pageType !== 'comparison') {
+            $errors[] = $this->issue('rows.'.(string) $index.'.page_type', 'unsupported_page_type', 'Only comparison rows are supported in MBTI-CMS-13.');
+
+            return [];
+        }
+
+        $atMatch = [];
+        $crossMatch = [];
+        if (preg_match('~^/(?:en|zh)/personality/(?<type>[a-z]{4})-a-vs-\k<type>-t$~', $url, $atMatch) === 1) {
+            if (! in_array($comparisonKind, ['', 'at'], true)) {
+                $errors[] = $this->issue('rows.'.(string) $index.'.comparison_kind', 'comparison_kind_url_mismatch', 'A/T comparison URL must use comparison_kind=at.');
+            }
+
+            $baseType = strtoupper((string) $atMatch['type']);
+
+            return [
+                'comparison_kind' => 'at',
+                'comparison_slug' => strtolower($baseType).'-a-vs-'.strtolower($baseType).'-t',
+                'base_type_code' => $baseType,
+                'left_type_code' => $baseType.'-A',
+                'right_type_code' => $baseType.'-T',
+            ];
+        }
+
+        if (preg_match('~^/(?:en|zh)/personality/(?<left>[a-z]{4})-vs-(?<right>[a-z]{4})$~', $url, $crossMatch) === 1) {
+            if (! in_array($comparisonKind, ['', 'cross_type'], true)) {
+                $errors[] = $this->issue('rows.'.(string) $index.'.comparison_kind', 'comparison_kind_url_mismatch', 'Cross-type comparison URL must use comparison_kind=cross_type.');
+            }
+
+            $left = strtoupper((string) $crossMatch['left']);
+            $right = strtoupper((string) $crossMatch['right']);
+            if ($left === $right) {
+                $errors[] = $this->issue('rows.'.(string) $index.'.url', 'cross_type_pair_must_differ', 'Cross-type comparison URL must compare two different base types.');
+            }
+
+            return [
+                'comparison_kind' => 'cross_type',
+                'comparison_slug' => strtolower($left).'-vs-'.strtolower($right),
+                'left_type_code' => $left,
+                'right_type_code' => $right,
+            ];
+        }
+
+        $errors[] = $this->issue('rows.'.(string) $index.'.url', 'invalid_comparison_url', 'Comparison URL must look like /zh/personality/intj-a-vs-intj-t or /zh/personality/entj-vs-intj.');
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $identity
+     * @return array<string,mixed>
+     */
+    private function targetFor(array $identity): array
+    {
+        if (($identity['comparison_kind'] ?? null) === 'at') {
+            return [
+                'target_model' => 'App\\Models\\PersonalityProfileSection',
+                'target_table' => 'personality_profile_sections',
+                'section_key' => 'mbti64_comparison_a_vs_t',
+                'lookup' => [
+                    'org_id' => 0,
+                    'scale_code' => 'MBTI',
+                    'locale' => 'row.locale',
+                    'base_type_code' => (string) ($identity['base_type_code'] ?? ''),
+                ],
+            ];
+        }
+
+        return [
+            'target_model' => 'backend_authority.mbti64_cross_type_comparison',
+            'target_table' => 'planned_mbti_cross_type_comparison_authority',
+            'lookup' => [
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'locale' => 'row.locale',
+                'comparison_slug' => (string) ($identity['comparison_slug'] ?? ''),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $identity
+     * @return array<string,mixed>
+     */
+    private function draftRevisionFor(array $identity, string $url): array
+    {
+        return [
+            'revision_note' => 'MBTI-CMS-13 comparison import dry-run draft: '.$url,
+            'snapshot_key' => 'mbti_cms_13_comparison_import_dry_run_v1',
+            'snapshot_owner' => (string) ($identity['comparison_kind'] ?? 'comparison').' comparison authority draft',
+            'comparison_slug' => (string) ($identity['comparison_slug'] ?? ''),
+            'publish_visibility' => 'not_public_until_separate_approved_promotion_pr',
+            'search_visibility' => 'not_search_released_until_separate_search_gate',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function firstClassDestinations(): array
+    {
+        return [
+            'identity' => 'A/T rows map to personality_profile_sections by base type; cross-type rows map to a future comparison authority draft by comparison slug',
+            'seo' => 'planned destination: comparison public projection SEO fields after a separate approved promotion/write PR',
+            'sections' => 'planned destination: comparison answer/section projection after a separate approved promotion/write PR',
+            'draft_payload' => 'this dry-run emits the complete importable draft contract only; it does not write DB rows',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fieldMappingContract(): array
+    {
+        return [
+            'target_tables' => [
+                'personality_profile_sections',
+                'planned_mbti_cross_type_comparison_authority',
+                'comparison_public_projection_v1',
+            ],
+            'lookup_contract' => [
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'locale' => 'row.locale',
+                'comparison_kind' => 'row.identity.comparison_kind',
+                'comparison_slug' => 'row.identity.comparison_slug',
+            ],
+            'first_class_fields_for_comparison_promotion' => self::FIRST_CLASS_COMPARISON_FIELDS,
+            'structured_metadata_fields' => self::STRUCTURED_METADATA_FIELDS,
+            'unsupported_field_policy' => [
+                'decision' => 'structured_metadata_not_dropped',
+                'storage' => 'mbti_comparison_dry_run_plan.mbti_cms_13_comparison_import_dry_run_v1.structured_metadata',
+                'first_class_promotion_rule' => 'promote only through a later approved CMS write/promotion PR; do not silently map unsupported fields to unrelated columns',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function dryRunWriteGuardContract(): array
+    {
+        return [
+            'this_command_requires' => '--dry-run',
+            'this_command_refuses' => '--write',
+            'write_mode_available_in_this_pr' => false,
+            'future_write_minimum_required_flags' => [
+                '--write',
+                '--draft-only',
+                '--no-publish',
+                '--no-index',
+                '--no-sitemap',
+                '--no-llms',
+                '--no-search-release',
+                '--operator-approved',
+            ],
+            'hard_guards' => [
+                'writes_committed=false in this PR',
+                'cms_write_attempted=false',
+                'publish_attempted=false',
+                'index_attempted=false',
+                'search_release_attempted=false',
+                'sitemap_llms_release_attempted=false',
+                'no published_at mutation',
+                'no public/indexable/sitemap/llms flags enabled',
+                'profile rows fail closed; MBTI-CMS-12 owns profile assets',
+            ],
+        ];
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $normalized = trim($path);
+        if ($normalized === '') {
+            return '';
+        }
+
+        $parsedPath = (string) (parse_url($normalized, PHP_URL_PATH) ?: $normalized);
+        $parsedPath = '/'.ltrim($parsedPath, '/');
+
+        return $parsedPath !== '/' ? rtrim($parsedPath, '/') : $parsedPath;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityMbtiComparisonCmsImportDryRunCommandTest extends TestCase
+{
+    public function test_comparison_dry_run_plans_at_and_cross_type_rows_without_writes(): void
+    {
+        $packagePath = $this->writePackage($this->validComparisonPackage());
+
+        $exitCode = Artisan::call('personality:mbti-comparison-cms-import-dry-run', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $atRow = $payload['rows'][0] ?? [];
+        $crossTypeRow = $payload['rows'][1] ?? [];
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['dry_run_only']);
+        $this->assertFalse($payload['write_supported_in_this_pr']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertSame(2, $payload['row_count']);
+        $this->assertSame(2, $payload['comparison_row_count']);
+        $this->assertSame(0, $payload['profile_row_count']);
+        $this->assertSame(1, $payload['at_comparison_count']);
+        $this->assertSame(1, $payload['cross_type_comparison_count']);
+
+        $this->assertSame('at', $atRow['identity']['comparison_kind'] ?? null);
+        $this->assertSame('INTJ', $atRow['identity']['base_type_code'] ?? null);
+        $this->assertSame('INTJ-A', $atRow['identity']['left_type_code'] ?? null);
+        $this->assertSame('INTJ-T', $atRow['identity']['right_type_code'] ?? null);
+        $this->assertSame('personality_profile_sections', $atRow['target']['target_table'] ?? null);
+        $this->assertSame('mbti64_comparison_a_vs_t', $atRow['target']['section_key'] ?? null);
+        $this->assertSame('not_supported', $atRow['write_mode_in_this_pr'] ?? null);
+
+        $this->assertSame('cross_type', $crossTypeRow['identity']['comparison_kind'] ?? null);
+        $this->assertSame('ENTJ', $crossTypeRow['identity']['left_type_code'] ?? null);
+        $this->assertSame('INTJ', $crossTypeRow['identity']['right_type_code'] ?? null);
+        $this->assertSame('planned_mbti_cross_type_comparison_authority', $crossTypeRow['target']['target_table'] ?? null);
+        $this->assertSame('entj-vs-intj', $crossTypeRow['target']['lookup']['comparison_slug'] ?? null);
+        $this->assertContains('personality_profile_sections', $payload['field_mapping_contract']['target_tables']);
+        $this->assertContains('planned_mbti_cross_type_comparison_authority', $payload['field_mapping_contract']['target_tables']);
+        $this->assertContains('comparison_public_projection_v1', $payload['field_mapping_contract']['target_tables']);
+    }
+
+    public function test_profile_rows_are_rejected_for_comparison_scope(): void
+    {
+        $package = $this->validComparisonPackage();
+        $package['rows'][] = $this->row('/zh/personality/intp-a', 'zh-CN', 'variant', 'profile');
+        $packagePath = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:mbti-comparison-cms-import-dry-run', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $codes = array_column($payload['errors'], 'code');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame(1, $payload['profile_row_count']);
+        $this->assertContains('profile_rows_out_of_scope', $codes);
+    }
+
+    public function test_forbidden_private_routes_and_sensitive_query_keys_fail_closed(): void
+    {
+        $package = $this->validComparisonPackage();
+        $package['rows'][0]['internal_links'][] = [
+            'href' => '/zh/result/private?token=secret',
+            'anchor_text' => 'private result',
+            'role' => 'forbidden',
+            'safe_public_route' => false,
+        ];
+        $packagePath = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:mbti-comparison-cms-import-dry-run', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $codes = array_column($payload['errors'], 'code');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('forbidden_public_route_pattern_present', $codes);
+        $this->assertContains('forbidden_query_pattern_present', $codes);
+    }
+
+    public function test_command_requires_explicit_dry_run(): void
+    {
+        $packagePath = $this->writePackage($this->validComparisonPackage());
+
+        $exitCode = Artisan::call('personality:mbti-comparison-cms-import-dry-run', [
+            '--package' => $packagePath,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('runtime_error', $payload['errors'][0]['code'] ?? null);
+        $this->assertStringContainsString('--dry-run is required', (string) ($payload['errors'][0]['message'] ?? ''));
+    }
+
+    public function test_command_refuses_write_mode(): void
+    {
+        $packagePath = $this->writePackage($this->validComparisonPackage());
+
+        $exitCode = Artisan::call('personality:mbti-comparison-cms-import-dry-run', [
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['write_supported_in_this_pr']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertStringContainsString('--write is intentionally unsupported', (string) ($payload['errors'][0]['message'] ?? ''));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validComparisonPackage(): array
+    {
+        return [
+            'artifact' => 'mbti-comparison-cms-import-dry-run-fixture',
+            'version' => 'cms13-fixture-v1',
+            'status' => 'ready_for_dry_run',
+            'content_line' => 'comparison',
+            'rows' => [
+                $this->row('/zh/personality/intj-a-vs-intj-t', 'zh-CN', 'comparison', 'at'),
+                $this->row('/en/personality/entj-vs-intj', 'en', 'comparison', 'cross_type'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function row(string $url, string $locale, string $pageType, string $comparisonKind): array
+    {
+        $isZh = str_starts_with($url, '/zh/');
+
+        return [
+            'url' => $url,
+            'locale' => $locale,
+            'page_type' => $pageType,
+            'comparison_kind' => $comparisonKind,
+            'canonical_target' => $url,
+            'primary_query' => $isZh ? 'intj-a vs intj-t' : 'entj vs intj',
+            'secondary_queries' => $isZh ? ['intj-a 和 intj-t 区别', 'intj-a intj-t'] : ['entj and intj difference', 'entj intj comparison'],
+            'gsc_query_evidence' => [
+                ['query' => $isZh ? 'intj-a vs intj-t' : 'entj vs intj', 'clicks' => 1, 'impressions' => 12],
+            ],
+            'target_intent' => 'comparison explanation',
+            'method_boundary' => 'Personality comparisons are educational self-understanding aids, not diagnosis.',
+            'trademark_boundary' => 'MBTI-related terms are used descriptively.',
+            'claim_risk_notes' => ['Avoid deterministic hiring or medical claims.'],
+            'qa_flags_for_codex' => ['Keep answer block direct and non-diagnostic.'],
+            'route_safety' => ['forbidden_route_patterns_absent_from_internal_links' => true],
+            'source_document' => 'fixture',
+            'status' => 'draft_for_cms_dry_run',
+            'seo' => [
+                'seo_title' => $isZh ? 'INTJ-A 和 INTJ-T 的区别' : 'ENTJ vs INTJ: Key Differences',
+                'seo_description' => $isZh ? '快速理解 INTJ-A 与 INTJ-T 的最大区别、判断表、误判原因、真实场景和 FAQ。' : 'Compare ENTJ and INTJ by key difference, quick judgment table, common confusion, real situations, and FAQ.',
+                'breadcrumb_title' => $isZh ? 'INTJ-A vs INTJ-T' : 'ENTJ vs INTJ',
+                'h1' => $isZh ? 'INTJ-A 和 INTJ-T 的区别' : 'ENTJ vs INTJ',
+                'quick_answer_summary' => $isZh ? 'INTJ-A 更稳定自信，INTJ-T 更容易复盘修正。' : 'ENTJ tends to organize outward action; INTJ tends to build internal strategy first.',
+            ],
+            'content' => [
+                'quick_answer' => $isZh ? 'INTJ-A 与 INTJ-T 的核心差异在自我确认和压力复盘方式。' : 'ENTJ and INTJ differ most in how strategy becomes action.',
+                'max_difference' => $isZh ? '最大区别是 A 更稳定确认，T 更敏感复盘。' : 'The biggest difference is outward mobilization versus internal modeling.',
+                'quick_judgment_table' => [
+                    ['signal' => $isZh ? '压力下' : 'under pressure', 'left' => $isZh ? '保持稳定判断' : 'mobilizes others', 'right' => $isZh ? '反复校准' : 'rechecks the model'],
+                    ['signal' => $isZh ? '决策时' : 'when deciding', 'left' => $isZh ? '更少摇摆' : 'moves quickly', 'right' => $isZh ? '更重验证' : 'validates first'],
+                ],
+                'confusion_reason' => $isZh ? '两者都偏长期规划，所以容易只看表面标签。' : 'Both can look strategic, so users often confuse the surface.',
+                'real_scene_differences' => $isZh ? '在团队压力、关系沟通和学习规划里差异更明显。' : 'The gap appears in teams, communication, and planning scenes.',
+                'misjudgment_warning' => $isZh ? '不要把类型差异误判为能力高低。' : 'Do not treat type differences as ability rankings.',
+            ],
+            'faq' => [
+                ['question' => $isZh ? 'INTJ-A 和 INTJ-T 最大区别是什么？' : 'What is the biggest ENTJ vs INTJ difference?', 'answer' => $isZh ? '最大区别是自我确认和压力复盘方式。' : 'The biggest difference is how strategy turns into action.'],
+                ['question' => $isZh ? 'INTJ-A 比 INTJ-T 更好吗？' : 'Is ENTJ better than INTJ?', 'answer' => $isZh ? '不是，它们只是压力与自评风格不同。' : 'No, they are different strategy styles.'],
+                ['question' => $isZh ? '这个对比能用于招聘吗？' : 'Can this comparison be used for hiring?', 'answer' => $isZh ? '不能，它只能作为自我理解参考。' : 'No, it is only for self-understanding.'],
+            ],
+            'internal_links' => [
+                ['href' => $isZh ? '/zh/personality' : '/en/personality', 'anchor_text' => 'MBTI hub', 'role' => 'hub', 'safe_public_route' => true],
+                ['href' => $isZh ? '/zh/tests/mbti-personality-test-16-personality-types' : '/en/tests/mbti-personality-test-16-personality-types', 'anchor_text' => 'MBTI test', 'role' => 'test', 'safe_public_route' => true],
+                ['href' => $isZh ? '/zh/personality/intj-a' : '/en/personality/entj', 'anchor_text' => 'related profile', 'role' => 'profile', 'safe_public_route' => true],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function writePackage(array $package): string
+    {
+        $path = sys_get_temp_dir().'/mbti-cms13-comparison-'.bin2hex(random_bytes(6)).'.json';
+        File::put($path, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -376,6 +376,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_comparison_cms_import_dry_run_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php',
+            'backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti64_cms_revision_draft_files(): void
     {
         $changed = [
@@ -4953,6 +4963,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiComparisonCmsImportDryRunFile($file)) {
+                continue;
+            }
+
             if ($this->isMbti64CmsRevisionDraftFile($file)) {
                 continue;
             }
@@ -6448,6 +6462,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityMbtiProfileCmsImportDryRun.php',
             'backend/app/Services/Cms/MbtiProfileCmsImportDryRunPlanner.php',
+        ], true);
+    }
+
+    private function isMbtiComparisonCmsImportDryRunFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php',
+            'backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -8,9 +8,9 @@
     "depends_on": [
       "MBTI-CMS-12"
     ],
-    "status": "committed",
-    "commit_sha": "f51259f81",
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "a0105445e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2720",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -73,6 +73,12 @@
         "from": "local_checks_passed",
         "to": "committed",
         "note": "Committed MBTI-CMS-13 comparison import dry-run scope at f51259f81."
+      },
+      {
+        "at": "2026-07-04T22:31:00Z",
+        "from": "committed",
+        "to": "pr_open",
+        "note": "Opened PR #2720 for MBTI-CMS-13 and pushed branch codex/mbti-cms-13-comparison-import-dry-run."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,4 +1,75 @@
 {
+  "MBTI-CMS-13": {
+    "id": "MBTI-CMS-13",
+    "repo": "fap-api",
+    "title": "MBTI-CMS-13: add MBTI comparison CMS import dry-run",
+    "base": "main",
+    "branch": "codex/mbti-cms-13-comparison-import-dry-run",
+    "depends_on": [
+      "MBTI-CMS-12"
+    ],
+    "status": "local_checks_passed",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized continuing the MBTI asset PR train; MBTI-CMS-13 is added as the comparison CMS import dry-run line after merged MBTI-CMS-12."
+      },
+      "dependency_reconciliation": {
+        "status": "pass",
+        "evidence": "MBTI-CMS-12 PR #2719 is merged, and origin/main contains merge commit 5c27c98adb8755dfa252443531583d731408e2cc."
+      },
+      "focused_comparison_dry_run_contract": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbtiComparisonCmsImportDryRunCommandTest --no-ansi",
+        "evidence": "PASS: 5 tests, 54 assertions. Covers A/T and cross-type dry-run mapping, no-write flags, profile row rejection, localized private route/sensitive query fail-closed behavior, required --dry-run, and refused --write."
+      },
+      "focused_bigfive_runtime_freeze_classifier": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_comparison_cms_import_dry_run_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
+        "evidence": "PASS: 2 tests, 4 assertions. The current PR dry-run command/planner files are explicitly classified as non-runtime-only, and the runtime path diff check passes locally."
+      },
+      "pint_targeted": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "evidence": "PASS: 4 files."
+      },
+      "manifest_state_diff_validation": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "evidence": "PASS: train YAML parses, state JSON parses, and git diff whitespace check passes."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the MBTI-CMS-13 allowed paths: backend/app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php, backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php, backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php, backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-04T22:12:00Z",
+        "from": "user_authorized",
+        "to": "in_progress",
+        "note": "Started backend-only MBTI comparison CMS import dry-run PR from latest main. Scope excludes profile import behavior, CMS writes, production imports, sitemap/llms/search release, and deploys."
+      },
+      {
+        "at": "2026-07-04T22:24:00Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Implemented comparison dry-run command/planner/test and BigFive classifier exemption. Focused PHPUnit, targeted Pint, train YAML parse, state JSON parse, diff check, and allowed-path scope validation passed."
+      }
+    ]
+  },
   "MBTI-CMS-12": {
     "base": "main",
     "branch": "codex/mbti-cms-12-profile-import-dry-run",
@@ -43,26 +114,30 @@
       "scope_validation": {
         "evidence": "Changed files are limited to the MBTI-CMS-12 allowed paths: backend/app/Console/Commands/PersonalityMbtiProfileCmsImportDryRun.php, backend/app/Services/Cms/MbtiProfileCmsImportDryRunPlanner.php, backend/tests/Feature/Console/PersonalityMbtiProfileCmsImportDryRunCommandTest.php, backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json.",
         "status": "pass"
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "PR #2719 is MERGED; origin/main contains merge commit 5c27c98adb8755dfa252443531583d731408e2cc; local main was synced to origin/main; task branch codex/mbti-cms-12-profile-import-dry-run was deleted locally and remotely; worktree was clean before MBTI-CMS-13 started."
       }
     },
-    "commit_sha": "9b0902d36e96675f6eb2b420a597a3695bdb9afb",
+    "commit_sha": "5c27c98adb8755dfa252443531583d731408e2cc",
     "depends_on": [
       "MBTI-GSC-11"
     ],
     "failure_reason": null,
     "id": "MBTI-CMS-12",
-    "local_cleanup_executed": false,
-    "merged_at": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-04T22:08:32Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2719",
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "allowed_paths_only": true,
       "github_checks_green": true,
       "local_validation_passed": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "MBTI-CMS-12: add MBTI profile CMS import dry-run",
     "transitions": [
       {
@@ -106,6 +181,12 @@
         "from": "ci_fix_local_checks_passed",
         "note": "PR #2719 remote checks passed on head 9b0902d36e96675f6eb2b420a597a3695bdb9afb after the classifier fix. Marked ready to merge under squash merge policy.",
         "to": "ready_to_merge"
+      },
+      {
+        "at": "2026-07-04T22:08:32Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "note": "Reconciled in MBTI-CMS-13: GitHub reports PR #2719 merged with squash commit 5c27c98adb8755dfa252443531583d731408e2cc, origin/main contains the merge commit, local main was synced, and task branches were cleaned."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -8,8 +8,8 @@
     "depends_on": [
       "MBTI-CMS-12"
     ],
-    "status": "local_checks_passed",
-    "commit_sha": null,
+    "status": "committed",
+    "commit_sha": "f51259f81",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -67,6 +67,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Implemented comparison dry-run command/planner/test and BigFive classifier exemption. Focused PHPUnit, targeted Pint, train YAML parse, state JSON parse, diff check, and allowed-path scope validation passed."
+      },
+      {
+        "at": "2026-07-04T22:28:00Z",
+        "from": "local_checks_passed",
+        "to": "committed",
+        "note": "Committed MBTI-CMS-13 comparison import dry-run scope at f51259f81."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -8,8 +8,8 @@
     "depends_on": [
       "MBTI-CMS-12"
     ],
-    "status": "pr_open",
-    "commit_sha": "a0105445e",
+    "status": "ready_to_merge",
+    "commit_sha": "2caacc1ac",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2720",
     "failure_reason": null,
     "merged_at": null,
@@ -47,12 +47,16 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to the MBTI-CMS-13 allowed paths: backend/app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php, backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php, backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php, backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PASS on PR #2720 head 2caacc1ac: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -79,6 +83,12 @@
         "from": "committed",
         "to": "pr_open",
         "note": "Opened PR #2720 for MBTI-CMS-13 and pushed branch codex/mbti-cms-13-comparison-import-dry-run."
+      },
+      {
+        "at": "2026-07-04T22:39:00Z",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "note": "PR #2720 remote checks passed on head 2caacc1ac. Marked ready to merge under squash merge policy."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -54,6 +54,49 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: MBTI-CMS-13
+    repo: fap-api
+    depends_on:
+      - MBTI-CMS-12
+    branch: codex/mbti-cms-13-comparison-import-dry-run
+    title: "MBTI-CMS-13: add MBTI comparison CMS import dry-run"
+    train_scope: mbti_personality_asset_cms_import_readiness
+    status: user_authorized
+    scope:
+      - Add a backend-only MBTI comparison CMS import dry-run planner and Artisan command.
+      - Validate A/T comparison and cross-type comparison asset packages, schema shape, field mapping, target tables, and draft-only safety flags without database writes.
+      - Keep profile/variant rows out of this PR and fail them closed for MBTI-CMS-12.
+      - Keep the command dry-run only; no CMS writes, publishing, indexability, sitemap, llms, search release, staging deploy, or production deploy.
+    allowed_paths:
+      - backend/app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php
+      - backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php
+      - backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Implement profile import/dry-run behavior; MBTI-CMS-12 owns profile assets.
+      - Write CMS, run production imports, run database migrations, publish, enable indexability, release sitemap/llms, submit search, trigger staging deploy, trigger production deploy, or add frontend fallback content.
+      - Change public API routes, runtime personality rendering, content authority, canonical/noindex behavior, JSON-LD runtime, or production scheduler behavior.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbtiComparisonCmsImportDryRunCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_comparison_cms_import_dry_run_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-ASSET-01
     repo: fap-api
     branch: codex/pr-eq-asset-01-content-pack-v16


### PR DESCRIPTION
## What changed
- Added a backend-only MBTI comparison CMS import dry-run Artisan command.
- Added a comparison dry-run planner for A/T and cross-type comparison packages, field mapping, target tables, draft-only flags, route/query safety checks, and profile-row fail-closed behavior.
- Added focused PHPUnit coverage plus a BigFive runtime-freeze classifier exemption for these dry-run-only files.
- Registered MBTI-CMS-13 in the PR train manifest/state and reconciled merged MBTI-CMS-12 dependency facts.

## Why
MBTI-CMS-13 needs a no-write import readiness gate for comparison assets before any future approved CMS promotion/write PR.

## Validation
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbtiComparisonCmsImportDryRunCommandTest --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_comparison_cms_import_dry_run_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
- cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No CMS/database writes or production imports.
- No publishing, indexability changes, sitemap/llms release, search release, staging deploy, manual deploy, or production deploy.
- No fap-web/frontend changes.

## Repository rule impact
Backend remains the authority layer. This PR only adds a dry-run validation/planning tool and tests; it does not change public runtime rendering, content ownership, publishing state, or search discoverability.