### PR TITLE
IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01: import IQ method pages as CMS drafts

### DIFF
--- a/backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php
+++ b/backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\IqMethodPages\IqMethodPagesDraftImporter;
+use Illuminate\Console\Command;
+use RuntimeException;
+use Throwable;
+
+final class ArticleImportIqMethodPagesDraft extends Command
+{
+    protected $signature = 'articles:import-iq-method-pages-draft
+        {--package= : Path to fap-web root, generated/iq-method-pages-zh-cn-v0.2, or its cms-dry-run directory}
+        {--dry-run : Validate and plan without writing to the database}
+        {--json : Emit a JSON summary}';
+
+    protected $description = 'Validate and import the zh-CN IQ method pages CMS dry-run package as draft-only CMS records.';
+
+    public function handle(IqMethodPagesDraftImporter $importer): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        try {
+            $summary = $dryRun
+                ? $importer->planFromDirectory($this->optionsPayload())
+                : $importer->importFromDirectory($this->optionsPayload());
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function optionsPayload(): array
+    {
+        return [
+            'package' => (string) $this->option('package'),
+            'dry_run' => (bool) $this->option('dry-run'),
+            'json' => (bool) $this->option('json'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('would_write='.(($summary['would_write'] ?? false) ? '1' : '0'));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+
+        foreach ((array) ($summary['articles'] ?? []) as $article) {
+            if (! is_array($article)) {
+                continue;
+            }
+
+            $this->line(sprintf(
+                'article=%s:%s:%s:article_id=%s:working_revision_id=%s',
+                (string) ($article['locale'] ?? ''),
+                (string) ($article['slug'] ?? ''),
+                (string) ($article['action'] ?? ''),
+                (string) ($article['article_id'] ?? ''),
+                (string) ($article['working_revision_id'] ?? '')
+            ));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('validation_error='.$this->issueLine($error));
+            }
+        }
+        foreach ((array) ($summary['warnings'] ?? []) as $warning) {
+            if (is_array($warning)) {
+                $this->line('validation_warning='.$this->issueLine($warning));
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'action' => 'will_skip',
+            'would_write' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+            'articles' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return implode(':', [
+            (string) ($issue['field'] ?? 'unknown'),
+            (string) ($issue['code'] ?? 'unknown'),
+            (string) ($issue['message'] ?? ''),
+        ]);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -8,6 +8,7 @@ use App\Console\Commands\ArticleCoverPropagationSmoke;
 use App\Console\Commands\ArticleDiscoverabilityRelease;
 use App\Console\Commands\ArticleEnsureSeoMetaBaseline;
 use App\Console\Commands\ArticleImportEditorialPackage;
+use App\Console\Commands\ArticleImportIqMethodPagesDraft;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
 use App\Console\Commands\ArticleReleaseCloseout;
@@ -182,16 +183,16 @@ use App\Console\Commands\PersonalityAgentPostPromotionSearchGateCommand;
 use App\Console\Commands\PersonalityBigFiveCmsImportDraftDryRun;
 use App\Console\Commands\PersonalityBigFivePublicProfileAgentDraft;
 use App\Console\Commands\PersonalityEnneagramCmsDraft;
+use App\Console\Commands\PersonalityEnneagramCmsPromote;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
-use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
 use App\Console\Commands\PersonalityMbti64BackendImportContract;
 use App\Console\Commands\PersonalityMbti64CmsInternalLinkDraft;
 use App\Console\Commands\PersonalityMbti64CmsProjectionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionPromote;
+use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
 use App\Console\Commands\PersonalityTdkNextBatchApprovalDraftGateCommand;
 use App\Console\Commands\PersonalityTdkRuntimePromotionSearchGateReadinessCommand;
-use App\Console\Commands\PersonalityEnneagramCmsPromote;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\RiasecResultPageAssetAgentAuditCommand;
@@ -229,16 +230,16 @@ use App\Console\Commands\SeoAgentRunCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
 use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
-use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
+use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
+use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\SeoOpsGaokaoV5CmsDraftGateCommand;
 use App\Console\Commands\SeoOpsGaokaoV5PropagationGateReadinessCommand;
 use App\Console\Commands\SeoOpsGaokaoV5PublishGateRepairCommand;
 use App\Console\Commands\SeoOpsGaokaoV5UrlTruthEligibilityGateCommand;
+use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityControlledWriterCommand;
-use App\Console\Commands\SeoOpsZhArticleQualityRepairDryRunCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityReadbackCommand;
-use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
-use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
+use App\Console\Commands\SeoOpsZhArticleQualityRepairDryRunCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
 use App\Console\Commands\StorageMigrateLegacyArtifacts;
@@ -442,6 +443,7 @@ class Kernel extends ConsoleKernel
         EvidencePack::class,
         ExperimentGuardrailsEvaluate::class,
         ArticleImportEditorialPackage::class,
+        ArticleImportIqMethodPagesDraft::class,
         ArticleImportSeoContentPackageDraft::class,
         ArticleEnsureSeoMetaBaseline::class,
         ArticleUpdateExistingSeoContentPackage::class,

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -8,7 +8,6 @@ use App\Console\Commands\ArticleCoverPropagationSmoke;
 use App\Console\Commands\ArticleDiscoverabilityRelease;
 use App\Console\Commands\ArticleEnsureSeoMetaBaseline;
 use App\Console\Commands\ArticleImportEditorialPackage;
-use App\Console\Commands\ArticleImportIqMethodPagesDraft;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
 use App\Console\Commands\ArticleReleaseCloseout;
@@ -183,16 +182,16 @@ use App\Console\Commands\PersonalityAgentPostPromotionSearchGateCommand;
 use App\Console\Commands\PersonalityBigFiveCmsImportDraftDryRun;
 use App\Console\Commands\PersonalityBigFivePublicProfileAgentDraft;
 use App\Console\Commands\PersonalityEnneagramCmsDraft;
-use App\Console\Commands\PersonalityEnneagramCmsPromote;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
+use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
 use App\Console\Commands\PersonalityMbti64BackendImportContract;
 use App\Console\Commands\PersonalityMbti64CmsInternalLinkDraft;
 use App\Console\Commands\PersonalityMbti64CmsProjectionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionPromote;
-use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
 use App\Console\Commands\PersonalityTdkNextBatchApprovalDraftGateCommand;
 use App\Console\Commands\PersonalityTdkRuntimePromotionSearchGateReadinessCommand;
+use App\Console\Commands\PersonalityEnneagramCmsPromote;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\RiasecResultPageAssetAgentAuditCommand;
@@ -230,16 +229,16 @@ use App\Console\Commands\SeoAgentRunCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
 use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
-use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
-use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
+use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
 use App\Console\Commands\SeoOpsGaokaoV5CmsDraftGateCommand;
 use App\Console\Commands\SeoOpsGaokaoV5PropagationGateReadinessCommand;
 use App\Console\Commands\SeoOpsGaokaoV5PublishGateRepairCommand;
 use App\Console\Commands\SeoOpsGaokaoV5UrlTruthEligibilityGateCommand;
-use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityControlledWriterCommand;
-use App\Console\Commands\SeoOpsZhArticleQualityReadbackCommand;
 use App\Console\Commands\SeoOpsZhArticleQualityRepairDryRunCommand;
+use App\Console\Commands\SeoOpsZhArticleQualityReadbackCommand;
+use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
+use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
 use App\Console\Commands\StorageMigrateLegacyArtifacts;
@@ -443,7 +442,6 @@ class Kernel extends ConsoleKernel
         EvidencePack::class,
         ExperimentGuardrailsEvaluate::class,
         ArticleImportEditorialPackage::class,
-        ArticleImportIqMethodPagesDraft::class,
         ArticleImportSeoContentPackageDraft::class,
         ArticleEnsureSeoMetaBaseline::class,
         ArticleUpdateExistingSeoContentPackage::class,

--- a/backend/app/Models/TopicProfileEntry.php
+++ b/backend/app/Models/TopicProfileEntry.php
@@ -22,6 +22,8 @@ class TopicProfileEntry extends Model
     public const GROUP_KEYS = [
         'featured',
         'articles',
+        'iq_articles',
+        'eq_articles',
         'personalities',
         'tests',
         'related',

--- a/backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php
+++ b/backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php
@@ -1,0 +1,1037 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms\IqMethodPages;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleEditorialPackageImport;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
+use App\Models\LandingSurface;
+use App\Models\PageBlock;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Services\Cms\ArticleBodyHeadingGuard;
+use App\Services\Cms\ArticleTranslationRevisionWorkspace;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class IqMethodPagesDraftImporter
+{
+    private const EXPECTED_SCHEMA_VERSION = 'fermatmind.iq_method_pages.cms_dry_run_manifest.v1';
+
+    private const EXPECTED_PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01';
+
+    private const EXPECTED_IMPORT_PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01';
+
+    private const CONTENT_TRACK = 'iq_method_pages_zh_cn_v0_2';
+
+    private const DEFAULT_STATE = [
+        'status' => 'draft_review_only',
+        'is_public' => false,
+        'is_indexable' => false,
+        'robots' => 'noindex,follow',
+        'sitemap_eligible' => false,
+        'llms_eligible' => false,
+    ];
+
+    private const FORBIDDEN_TEXT_PATTERNS = [
+        'answer_key' => '/\banswer_key\b/i',
+        'correct_answer' => '/\bcorrect_answer\b/i',
+        'pdf_certificate' => '/\bPDF\s+certificate\b/i',
+        'private_result_route' => '~(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|recover|restore)(?:/|[?#\s)"\']|$)~i',
+        'sensitive_query_key' => '/(?:[?&]|^)(?:result_id|order_id|payment_id|token|score|user_id|report_id)=/i',
+    ];
+
+    public function __construct(
+        private readonly ArticleTranslationRevisionWorkspace $revisionWorkspace,
+        private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function planFromDirectory(array $options): array
+    {
+        return $this->buildPlan($options);
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function importFromDirectory(array $options): array
+    {
+        $plan = $this->buildPlan($options);
+        if (($plan['ok'] ?? false) !== true) {
+            return $plan;
+        }
+
+        $articles = [];
+        $topic = null;
+        $landing = null;
+        $items = is_array($plan['package_items'] ?? null) ? $plan['package_items'] : [];
+
+        DB::transaction(function () use ($items, $plan, &$articles, &$topic, &$landing): void {
+            foreach ($items as $item) {
+                if (is_array($item)) {
+                    $articles[] = $this->writeArticleDraft($item);
+                }
+            }
+
+            $topic = $this->writeTopicDraftLinks($plan, $articles);
+            $landing = $this->writeLandingDraftBlock($plan);
+        });
+
+        return [
+            ...$plan,
+            'dry_run' => false,
+            'action' => 'imported_draft_only',
+            'would_write' => true,
+            'articles' => $articles,
+            'topic_mapping' => $topic,
+            'landing_page_blocks' => $landing,
+            'package_items' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function buildPlan(array $options): array
+    {
+        $errors = [];
+        $warnings = [];
+        $paths = $this->resolvePackagePaths((string) ($options['package'] ?? ''), $errors);
+        $manifest = [];
+        $topicMapping = [];
+        $landingMapping = [];
+        $seoGate = [];
+        $claimAudit = [];
+        $items = [];
+
+        if ($paths !== null) {
+            $manifest = $this->readJson($paths['dry_run_root'].'/cms_import_manifest.json', 'cms_import_manifest.json', $errors);
+            $topicMapping = $this->readJson($paths['dry_run_root'].'/topic_iq_articles_mapping.json', 'topic_iq_articles_mapping.json', $errors);
+            $landingMapping = $this->readJson($paths['dry_run_root'].'/landing_page_blocks_mapping.json', 'landing_page_blocks_mapping.json', $errors);
+            $seoGate = $this->readJson($paths['dry_run_root'].'/seo_geo_gate.json', 'seo_geo_gate.json', $errors);
+            $claimAudit = $this->readJson($paths['dry_run_root'].'/claim_audit_summary.json', 'claim_audit_summary.json', $errors);
+
+            $this->validateManifestEnvelope($manifest, $seoGate, $claimAudit, $errors);
+            $items = $this->buildItems($paths, $manifest, $seoGate, $claimAudit, $errors, $warnings);
+            $this->validateTopicMapping($topicMapping, $items, $errors);
+            $this->validateLandingMapping($landingMapping, $items, $errors);
+        }
+
+        $ok = $errors === [];
+        $plannedArticles = $ok ? array_map(fn (array $item): array => $this->plannedArticle($item), $items) : [];
+
+        return [
+            'ok' => $ok,
+            'dry_run' => (bool) ($options['dry_run'] ?? true),
+            'action' => $ok ? $this->summaryAction($plannedArticles) : 'will_skip',
+            'would_write' => $ok,
+            'pr_id' => self::EXPECTED_IMPORT_PR_ID,
+            'source_pr_id' => (string) ($manifest['pr_id'] ?? ''),
+            'package_root' => $paths['package_root'] ?? null,
+            'dry_run_root' => $paths['dry_run_root'] ?? null,
+            'source_base' => $paths['source_base'] ?? null,
+            'default_state' => self::DEFAULT_STATE,
+            'articles' => $plannedArticles,
+            'topic_mapping' => $ok ? $this->plannedTopicMapping($topicMapping, $items) : null,
+            'landing_page_blocks' => $ok ? $this->plannedLandingBlock($landingMapping) : null,
+            'topic_mapping_payload' => $topicMapping,
+            'landing_mapping_payload' => $landingMapping,
+            'package_items' => $items,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return array{source_base:string,package_root:string,dry_run_root:string}|null
+     */
+    private function resolvePackagePaths(string $package, array &$errors): ?array
+    {
+        $path = trim($package);
+        if ($path === '') {
+            $errors[] = $this->issue('package', 'missing_package', '--package is required.');
+
+            return null;
+        }
+
+        $root = realpath($path);
+        if (! is_string($root) || ! is_dir($root)) {
+            $errors[] = $this->issue('package', 'package_directory_not_found', 'Package directory not found.');
+
+            return null;
+        }
+
+        $candidates = [
+            [
+                'source_base' => $root,
+                'package_root' => $root.'/generated/iq-method-pages-zh-cn-v0.2',
+                'dry_run_root' => $root.'/generated/iq-method-pages-zh-cn-v0.2/cms-dry-run',
+            ],
+            [
+                'source_base' => dirname(dirname($root)),
+                'package_root' => $root,
+                'dry_run_root' => $root.'/cms-dry-run',
+            ],
+            [
+                'source_base' => dirname(dirname(dirname($root))),
+                'package_root' => dirname($root),
+                'dry_run_root' => $root,
+            ],
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate['dry_run_root'].'/cms_import_manifest.json')) {
+                return $candidate;
+            }
+        }
+
+        $errors[] = $this->issue('cms_import_manifest.json', 'manifest_not_found', 'cms_import_manifest.json must exist under cms-dry-run.');
+
+        return null;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path, string $field, array &$errors): array
+    {
+        if (! is_file($path)) {
+            $errors[] = $this->issue($field, 'json_file_not_found', $field.' was not found.');
+
+            return [];
+        }
+
+        try {
+            $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            $errors[] = $this->issue($field, 'invalid_json', $exception->getMessage());
+
+            return [];
+        }
+
+        if (! is_array($decoded)) {
+            $errors[] = $this->issue($field, 'invalid_json', $field.' must decode to an object.');
+
+            return [];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateManifestEnvelope(array $manifest, array $seoGate, array $claimAudit, array &$errors): void
+    {
+        if ((string) ($manifest['schema_version'] ?? '') !== self::EXPECTED_SCHEMA_VERSION) {
+            $errors[] = $this->issue('manifest.schema_version', 'unexpected_schema_version', 'Unexpected IQ method pages dry-run manifest schema.');
+        }
+        if ((string) ($manifest['pr_id'] ?? '') !== self::EXPECTED_PR_ID) {
+            $errors[] = $this->issue('manifest.pr_id', 'unexpected_source_pr_id', 'Manifest source PR id mismatch.');
+        }
+        if ((string) ($manifest['mode'] ?? '') !== 'cms_dry_run_contract_only') {
+            $errors[] = $this->issue('manifest.mode', 'unexpected_mode', 'Manifest must be a CMS dry-run contract.');
+        }
+        if (count((array) ($manifest['article_imports'] ?? [])) !== 7) {
+            $errors[] = $this->issue('manifest.article_imports', 'article_count_mismatch', 'Exactly seven IQ method article imports are required.');
+        }
+
+        foreach (self::DEFAULT_STATE as $field => $expected) {
+            $actual = data_get($manifest, 'required_default_publish_state.'.$field);
+            if ($actual !== $expected) {
+                $errors[] = $this->issue('manifest.required_default_publish_state.'.$field, 'default_state_mismatch', $field.' must remain draft/noindex.');
+            }
+
+            $seoActual = data_get($seoGate, 'default_gate.'.$field);
+            if ($seoActual !== $expected) {
+                $errors[] = $this->issue('seo_geo_gate.default_gate.'.$field, 'seo_gate_mismatch', $field.' must remain draft/noindex.');
+            }
+        }
+
+        if ((string) ($claimAudit['gate_result'] ?? '') !== 'pass_with_human_review_required') {
+            $errors[] = $this->issue('claim_audit.gate_result', 'claim_gate_not_passed', 'Automated claim gate must pass with human review required.');
+        }
+    }
+
+    /**
+     * @param  array{source_base:string,package_root:string,dry_run_root:string}  $paths
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return list<array<string,mixed>>
+     */
+    private function buildItems(array $paths, array $manifest, array $seoGate, array $claimAudit, array &$errors, array &$warnings): array
+    {
+        $seoBySlug = collect((array) ($seoGate['pages'] ?? []))->keyBy('slug');
+        $claimBySlug = collect((array) ($claimAudit['pages'] ?? []))->keyBy('slug');
+        $items = [];
+
+        foreach ((array) ($manifest['article_imports'] ?? []) as $index => $import) {
+            if (! is_array($import)) {
+                $errors[] = $this->issue('manifest.article_imports.'.$index, 'invalid_article_import', 'Article import must be an object.');
+
+                continue;
+            }
+
+            $slug = trim((string) ($import['slug'] ?? ''));
+            $cmsPath = $this->sourcePath($paths['source_base'], data_get($import, 'source_files.article_cms_json'), $errors);
+            $seoPath = $this->sourcePath($paths['source_base'], data_get($import, 'source_files.seo_json'), $errors);
+            $bodyPath = $this->sourcePath($paths['source_base'], data_get($import, 'source_files.article_md'), $errors);
+            $answerSurfacePath = $this->sourcePath($paths['source_base'], data_get($import, 'source_files.answer_surface_v1_json'), $errors);
+            $internalLinksPath = $this->sourcePath($paths['source_base'], data_get($import, 'source_files.internal_links_json'), $errors);
+            $mediaBriefPath = $this->sourcePath($paths['source_base'], data_get($import, 'source_files.media_brief_json'), $errors);
+
+            $cms = $cmsPath !== null ? $this->readJson($cmsPath, $slug.'.article.cms.json', $errors) : [];
+            $seo = $seoPath !== null ? $this->readJson($seoPath, $slug.'.seo.json', $errors) : [];
+            $answerSurface = $answerSurfacePath !== null ? $this->readJson($answerSurfacePath, $slug.'.answer_surface_v1.json', $errors) : [];
+            $internalLinks = $internalLinksPath !== null ? $this->readJson($internalLinksPath, $slug.'.internal_links.json', $errors) : [];
+            $mediaBrief = $mediaBriefPath !== null ? $this->readJson($mediaBriefPath, $slug.'.media_brief.json', $errors) : [];
+            $body = $bodyPath !== null && is_file($bodyPath) ? trim((string) file_get_contents($bodyPath)) : '';
+            $contentMd = trim((string) ($cms['content_md'] ?? $body));
+
+            $item = [
+                'order' => (int) ($import['order'] ?? ($index + 1)),
+                'locale' => (string) ($cms['locale'] ?? $import['locale'] ?? ''),
+                'slug' => Str::slug((string) ($cms['slug'] ?? $slug)),
+                'title' => trim((string) ($cms['title'] ?? $import['title'] ?? '')),
+                'excerpt' => trim((string) ($cms['excerpt'] ?? '')),
+                'content_md' => $this->articleBodyHeadingGuard->downgradeMarkdownH1ToH2($contentMd),
+                'canonical_url' => trim((string) ($seo['canonical_url'] ?? $cms['canonical_url'] ?? $import['canonical_url'] ?? '')),
+                'seo_title' => trim((string) ($seo['seo_title'] ?? $cms['title'] ?? $import['title'] ?? '')),
+                'seo_description' => trim((string) ($seo['seo_description'] ?? $cms['excerpt'] ?? '')),
+                'robots' => trim((string) ($seo['robots'] ?? $cms['robots'] ?? data_get($import, 'publish_state.robots') ?? '')),
+                'category' => trim((string) (data_get($import, 'required_cms_fields.category') ?? $cms['category_suggestion'] ?? '测评方法与边界')),
+                'tags' => array_values(array_filter(array_map(static fn (mixed $tag): string => trim((string) $tag), (array) ($cms['tags'] ?? data_get($import, 'required_cms_fields.tags') ?? [])))),
+                'related_test_slug' => trim((string) ($cms['related_test_slug'] ?? data_get($import, 'required_cms_fields.related_test_slug') ?? '')),
+                'schema_json' => is_array($cms['schema_json'] ?? null) ? $cms['schema_json'] : [],
+                'answer_surface_v1' => $answerSurface,
+                'internal_links' => $internalLinks,
+                'media_brief' => $mediaBrief,
+                'claim_audit' => $claimBySlug->get($slug, []),
+                'seo_gate' => $seoBySlug->get($slug, []),
+                'source_files' => $import['source_files'] ?? [],
+            ];
+
+            $this->validateItem($item, $errors, $warnings);
+            $items[] = $item;
+        }
+
+        usort($items, static fn (array $a, array $b): int => ((int) $a['order']) <=> ((int) $b['order']));
+
+        return $items;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function sourcePath(string $sourceBase, mixed $relativePath, array &$errors): ?string
+    {
+        $relative = trim((string) $relativePath);
+        if ($relative === '') {
+            $errors[] = $this->issue('source_files', 'missing_source_path', 'Required source file path is missing.');
+
+            return null;
+        }
+
+        $path = realpath($sourceBase.'/'.ltrim($relative, '/'));
+        if (! is_string($path) || ! is_file($path)) {
+            $errors[] = $this->issue($relative, 'source_file_not_found', 'Referenced source file was not found.');
+
+            return null;
+        }
+
+        return $path;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     */
+    private function validateItem(array $item, array &$errors, array &$warnings): void
+    {
+        $slug = (string) ($item['slug'] ?? '');
+        foreach (['locale', 'slug', 'title', 'excerpt', 'content_md', 'canonical_url', 'seo_title', 'seo_description', 'robots', 'category', 'related_test_slug'] as $field) {
+            if (trim((string) ($item[$field] ?? '')) === '') {
+                $errors[] = $this->issue($slug.'.'.$field, 'missing_required_field', $field.' is required.');
+            }
+        }
+        if ((string) ($item['locale'] ?? '') !== 'zh-CN') {
+            $errors[] = $this->issue($slug.'.locale', 'unsupported_locale', 'IQ method pages import is zh-CN only.');
+        }
+        if (! str_starts_with((string) ($item['canonical_url'] ?? ''), 'https://fermatmind.com/zh/articles/'.$slug)) {
+            $errors[] = $this->issue($slug.'.canonical_url', 'canonical_mismatch', 'Canonical URL must match the zh article slug.');
+        }
+        if ((string) ($item['robots'] ?? '') !== self::DEFAULT_STATE['robots']) {
+            $errors[] = $this->issue($slug.'.robots', 'robots_mismatch', 'Robots must remain noindex,follow.');
+        }
+        if ((string) data_get($item, 'seo_gate.robots') !== self::DEFAULT_STATE['robots']) {
+            $errors[] = $this->issue($slug.'.seo_gate.robots', 'robots_mismatch', 'SEO gate robots must remain noindex,follow.');
+        }
+        if (data_get($item, 'claim_audit.human_review_required') !== true) {
+            $errors[] = $this->issue($slug.'.claim_audit.human_review_required', 'human_review_required_missing', 'Human claim review must remain required.');
+        }
+        if ((array) data_get($item, 'claim_audit.forbidden_terms_found', []) !== []) {
+            $errors[] = $this->issue($slug.'.claim_audit.forbidden_terms_found', 'forbidden_terms_found', 'Claim audit must not contain forbidden terms.');
+        }
+
+        $activeText = json_encode([
+            'title' => $item['title'] ?? '',
+            'excerpt' => $item['excerpt'] ?? '',
+            'content_md' => $item['content_md'] ?? '',
+            'answer_surface_v1' => $item['answer_surface_v1'] ?? [],
+            'internal_links' => $this->withoutPolicyKeys($item['internal_links'] ?? []),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+
+        foreach (self::FORBIDDEN_TEXT_PATTERNS as $code => $pattern) {
+            if (preg_match($pattern, $activeText) === 1) {
+                $errors[] = $this->issue($slug.'.private_or_scoring_guard', $code, 'Public import surface contains a forbidden private/scoring/certificate token.');
+            }
+        }
+
+        if (mb_strlen((string) ($item['seo_title'] ?? '')) > 80) {
+            $warnings[] = $this->issue($slug.'.seo_title', 'seo_title_long', 'SEO title is longer than the preferred compact limit.');
+        }
+        if (mb_strlen((string) ($item['seo_description'] ?? '')) > 180) {
+            $warnings[] = $this->issue($slug.'.seo_description', 'seo_description_long', 'SEO description is longer than the preferred compact limit.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateTopicMapping(array $topicMapping, array $items, array &$errors): void
+    {
+        if ((string) data_get($topicMapping, 'target_topic.slug') !== 'iq-eq') {
+            $errors[] = $this->issue('topic_mapping.target_topic.slug', 'topic_slug_mismatch', 'Target topic must be iq-eq.');
+        }
+        if (data_get($topicMapping, 'required_display_policy.split_mixed_group') !== true) {
+            $errors[] = $this->issue('topic_mapping.required_display_policy.split_mixed_group', 'split_group_required', 'IQ/EQ topic mapping must split IQ and EQ groups.');
+        }
+
+        $mapped = collect((array) data_get($topicMapping, 'entry_groups.0.items', []))->pluck('slug')->all();
+        $slugs = array_column($items, 'slug');
+        if ($mapped !== $slugs) {
+            $errors[] = $this->issue('topic_mapping.entry_groups.iq_articles.items', 'topic_items_mismatch', 'Topic IQ article items must match import order.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateLandingMapping(array $landingMapping, array $items, array &$errors): void
+    {
+        if ((string) data_get($landingMapping, 'target_landing_surface.related_test_slug') !== 'iq-test-intelligence-quotient-assessment') {
+            $errors[] = $this->issue('landing_mapping.related_test_slug', 'related_test_slug_mismatch', 'Landing mapping must target the IQ test slug.');
+        }
+        if (data_get($landingMapping, 'guardrails.frontend_hardcode_allowed') !== false) {
+            $errors[] = $this->issue('landing_mapping.guardrails.frontend_hardcode_allowed', 'frontend_hardcode_allowed', 'Frontend hardcode must remain forbidden.');
+        }
+
+        $mapped = collect((array) data_get($landingMapping, 'proposed_page_blocks.0.items', []))->pluck('slug')->all();
+        $slugs = array_column($items, 'slug');
+        if ($mapped !== $slugs) {
+            $errors[] = $this->issue('landing_mapping.proposed_page_blocks.items', 'landing_items_mismatch', 'Landing page block items must match import order.');
+        }
+    }
+
+    private function withoutPolicyKeys(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $filtered = [];
+        foreach ($value as $key => $child) {
+            $normalizedKey = strtolower((string) $key);
+            if (in_array($normalizedKey, [
+                'private_flow_guard',
+                'blocked_prefixes',
+                'forbidden',
+                'forbidden_paths',
+                'forbidden_private_routes',
+                'forbidden_query_keys',
+                'forbidden_sensitive_query_keys',
+                'forbidden_substrings',
+                'sensitive_query_keys',
+            ], true)) {
+                continue;
+            }
+
+            $filtered[$key] = $this->withoutPolicyKeys($child);
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    private function plannedArticle(array $item): array
+    {
+        $existing = $this->existingArticle($item);
+
+        return [
+            'locale' => 'zh-CN',
+            'slug' => (string) $item['slug'],
+            'title' => (string) $item['title'],
+            'action' => $existing instanceof Article ? 'would_update_draft' : 'would_create_draft',
+            'article_id' => $existing instanceof Article ? (int) $existing->id : null,
+            'status' => self::DEFAULT_STATE['status'],
+            'is_public' => false,
+            'is_indexable' => false,
+            'robots' => self::DEFAULT_STATE['robots'],
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'canonical_url' => (string) $item['canonical_url'],
+            'human_review_required' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    private function writeArticleDraft(array $item): array
+    {
+        $existing = $this->existingArticle($item);
+        if ($existing instanceof Article && $this->isPublishedOrPublic($existing)) {
+            throw new RuntimeException('Existing published/public IQ method article cannot be mutated by draft importer.');
+        }
+
+        $category = $this->resolveCategory((string) $item['category']);
+        $metadata = $this->metadata($item);
+
+        $article = $existing instanceof Article ? $existing : new Article;
+        $article->forceFill([
+            'org_id' => 0,
+            'category_id' => (int) $category->id,
+            'author_name' => 'Fermat Institute',
+            'reviewer_name' => null,
+            'reading_minutes' => $this->readingMinutes((string) $item['content_md']),
+            'slug' => (string) $item['slug'],
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'iq-method-pages-zh-cn-v0-2-'.(string) $item['slug'],
+            'title' => (string) $item['title'],
+            'excerpt' => (string) $item['excerpt'],
+            'content_md' => (string) $item['content_md'],
+            'content_html' => null,
+            'cover_image_url' => null,
+            'cover_image_alt' => null,
+            'cover_image_width' => null,
+            'cover_image_height' => null,
+            'cover_image_variants' => $metadata,
+            'related_test_slug' => (string) $item['related_test_slug'],
+            'status' => self::DEFAULT_STATE['status'],
+            'is_public' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'published_revision_id' => null,
+        ])->save();
+
+        $revision = $this->revisionWorkspace->saveWorkingRevision($article, [
+            'title' => (string) $item['title'],
+            'excerpt' => (string) $item['excerpt'],
+            'content_md' => (string) $item['content_md'],
+            'seo_title' => (string) $item['seo_title'],
+            'seo_description' => (string) $item['seo_description'],
+            'working_revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'status' => self::DEFAULT_STATE['status'],
+            'is_public' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'published_at' => null,
+            'published_revision_id' => null,
+        ])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->updateOrCreate(
+            [
+                'org_id' => 0,
+                'article_id' => (int) $article->id,
+                'locale' => 'zh-CN',
+            ],
+            [
+                'seo_title' => (string) $item['seo_title'],
+                'seo_description' => (string) $item['seo_description'],
+                'canonical_url' => (string) $item['canonical_url'],
+                'og_title' => (string) $item['seo_title'],
+                'og_description' => (string) $item['seo_description'],
+                'og_image_url' => null,
+                'robots' => self::DEFAULT_STATE['robots'],
+                'schema_json' => [
+                    'editorial_package_v1' => $metadata['editorial_package_v1'],
+                ],
+                'is_indexable' => false,
+            ],
+        );
+
+        $this->syncTags($article, (array) $item['tags']);
+        $this->persistImportRecord($article, $revision, $item, $metadata);
+
+        return [
+            'locale' => 'zh-CN',
+            'slug' => (string) $item['slug'],
+            'title' => (string) $item['title'],
+            'action' => $existing instanceof Article ? 'updated_draft' : 'created_draft',
+            'article_id' => (int) $article->id,
+            'working_revision_id' => (int) $revision->id,
+            'status' => self::DEFAULT_STATE['status'],
+            'working_revision_status' => (string) $revision->revision_status,
+            'is_public' => false,
+            'is_indexable' => false,
+            'robots' => self::DEFAULT_STATE['robots'],
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'canonical_url' => (string) $item['canonical_url'],
+            'preview_url_candidate' => '/ops/article-preview/'.(int) $article->id,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     */
+    private function existingArticle(array $item): ?Article
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', (string) $item['slug'])
+            ->first();
+    }
+
+    private function isPublishedOrPublic(Article $article): bool
+    {
+        return (string) $article->status === 'published'
+            || (bool) $article->is_public
+            || $article->published_revision_id !== null
+            || $article->published_at !== null;
+    }
+
+    private function resolveCategory(string $name): ArticleCategory
+    {
+        $label = trim($name) !== '' ? trim($name) : '测评方法与边界';
+        $existing = ArticleCategory::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('name', $label)
+            ->first();
+
+        if ($existing instanceof ArticleCategory) {
+            if (! (bool) $existing->is_active) {
+                $existing->forceFill(['is_active' => true])->save();
+            }
+
+            return $existing;
+        }
+
+        return ArticleCategory::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => $this->uniqueCategorySlug($label),
+            'name' => $label,
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+    }
+
+    private function uniqueCategorySlug(string $seed): string
+    {
+        $base = Str::slug($seed);
+        if ($base === '') {
+            $base = 'article-category-'.substr(hash('sha256', $seed), 0, 10);
+        }
+
+        $slug = $base;
+        $suffix = 2;
+        while (ArticleCategory::query()->withoutGlobalScopes()->where('org_id', 0)->where('slug', $slug)->exists()) {
+            $slug = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * @param  list<string>  $tags
+     */
+    private function syncTags(Article $article, array $tags): void
+    {
+        $tagIds = [];
+        foreach ($tags as $tagName) {
+            $name = trim($tagName);
+            if ($name === '') {
+                continue;
+            }
+
+            $tag = ArticleTag::query()->withoutGlobalScopes()->firstOrCreate(
+                ['org_id' => 0, 'name' => $name],
+                ['slug' => $this->uniqueTagSlug($name), 'is_active' => true],
+            );
+            if (! (bool) $tag->is_active) {
+                $tag->forceFill(['is_active' => true])->save();
+            }
+            $tagIds[(int) $tag->id] = ['org_id' => 0];
+        }
+
+        $article->tags()->sync($tagIds);
+    }
+
+    private function uniqueTagSlug(string $seed): string
+    {
+        $base = Str::slug($seed);
+        if ($base === '') {
+            $base = 'article-tag-'.substr(hash('sha256', $seed), 0, 10);
+        }
+
+        $slug = $base;
+        $suffix = 2;
+        while (ArticleTag::query()->withoutGlobalScopes()->where('org_id', 0)->where('slug', $slug)->exists()) {
+            $slug = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    private function metadata(array $item): array
+    {
+        return [
+            'editorial_package_v1' => [
+                'source' => self::CONTENT_TRACK,
+                'source_pr_id' => self::EXPECTED_PR_ID,
+                'import_pr_id' => self::EXPECTED_IMPORT_PR_ID,
+                'status' => self::DEFAULT_STATE['status'],
+                'is_public' => false,
+                'is_indexable' => false,
+                'robots' => self::DEFAULT_STATE['robots'],
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'search_submission_allowed' => false,
+                'publish_allowed' => false,
+                'review_required_before_publish' => true,
+                'answer_surface_v1' => $item['answer_surface_v1'] ?? [],
+                'internal_links' => $item['internal_links'] ?? [],
+                'media_brief' => $item['media_brief'] ?? [],
+                'claim_audit' => $item['claim_audit'] ?? [],
+                'source_files' => $item['source_files'] ?? [],
+                'body_hash' => hash('sha256', preg_replace("/\r\n?/", "\n", trim((string) $item['content_md'])) ?: trim((string) $item['content_md'])),
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $articles
+     * @return array<string,mixed>
+     */
+    private function writeTopicDraftLinks(array $plan, array $articles): array
+    {
+        $profile = TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', 'iq-eq')
+            ->first();
+
+        if (! $profile instanceof TopicProfile) {
+            $profile = TopicProfile::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'topic_code' => 'iq-eq',
+                'slug' => 'iq-eq',
+                'locale' => 'zh-CN',
+                'title' => 'IQ 与 EQ 主题内容聚合',
+                'subtitle' => 'IQ 文章和 EQ 文章分组阅读。',
+                'excerpt' => '认知能力、情绪能力与解释边界。',
+                'status' => TopicProfile::STATUS_DRAFT,
+                'is_public' => false,
+                'is_indexable' => false,
+                'schema_version' => 'v1',
+                'sort_order' => 0,
+            ]);
+        }
+
+        TopicProfileEntry::query()
+            ->where('profile_id', (int) $profile->id)
+            ->where('group_key', 'iq_articles')
+            ->delete();
+
+        foreach ($articles as $index => $article) {
+            TopicProfileEntry::query()->create([
+                'profile_id' => (int) $profile->id,
+                'entry_type' => 'article',
+                'group_key' => 'iq_articles',
+                'target_key' => (string) $article['slug'],
+                'target_locale' => 'zh-CN',
+                'title_override' => (string) $article['title'],
+                'excerpt_override' => null,
+                'badge_label' => 'IQ 文章',
+                'cta_label' => '阅读文章',
+                'target_url_override' => '/zh/articles/'.(string) $article['slug'],
+                'payload_json' => [
+                    'source' => self::CONTENT_TRACK,
+                    'status' => self::DEFAULT_STATE['status'],
+                    'is_public' => false,
+                    'is_indexable' => false,
+                ],
+                'sort_order' => ($index + 1) * 10,
+                'is_featured' => $index === 0,
+                'is_enabled' => true,
+            ]);
+        }
+
+        return [
+            'operation' => 'upserted_iq_topic_draft_links',
+            'topic_profile_id' => (int) $profile->id,
+            'slug' => 'iq-eq',
+            'group_key' => 'iq_articles',
+            'label' => 'IQ 文章',
+            'items_count' => count($articles),
+            'topic_publication_changed' => false,
+            'topic_status' => (string) $profile->status,
+            'topic_is_public' => (bool) $profile->is_public,
+            'topic_is_indexable' => (bool) $profile->is_indexable,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function plannedTopicMapping(array $topicMapping, array $items): array
+    {
+        $profile = TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', 'iq-eq')
+            ->first();
+
+        return [
+            'operation' => $profile instanceof TopicProfile ? 'would_replace_iq_topic_draft_links' : 'would_create_topic_and_iq_draft_links',
+            'target_topic' => data_get($topicMapping, 'target_topic.route', '/zh/topics/iq-eq'),
+            'group_key' => 'iq_articles',
+            'label' => 'IQ 文章',
+            'items_count' => count($items),
+            'topic_publication_changed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function writeLandingDraftBlock(array $plan): array
+    {
+        $landing = $plan['landing_mapping_payload'] ?? [];
+        $surface = LandingSurface::query()->withoutGlobalScopes()->updateOrCreate(
+            [
+                'org_id' => 0,
+                'surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+                'locale' => 'zh-CN',
+            ],
+            [
+                'title' => 'IQ 测试方法与边界',
+                'description' => 'IQ 风格测试 landing 页辅助方法论链接草稿配置。',
+                'schema_version' => 'iq-method-links.v1',
+                'payload_json' => [
+                    'source' => self::CONTENT_TRACK,
+                    'route' => '/zh/tests/iq-test-intelligence-quotient-assessment',
+                    'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                    'status' => self::DEFAULT_STATE['status'],
+                    'frontend_hardcode_allowed' => false,
+                ],
+                'status' => LandingSurface::STATUS_DRAFT,
+                'is_public' => false,
+                'is_indexable' => false,
+                'published_at' => null,
+                'scheduled_at' => null,
+            ],
+        );
+
+        $block = (array) data_get($landing, 'proposed_page_blocks.0', []);
+        PageBlock::query()->updateOrCreate(
+            [
+                'landing_surface_id' => (int) $surface->id,
+                'block_key' => 'iq_methodology_boundary_links',
+            ],
+            [
+                'block_type' => 'article_link_cluster',
+                'title' => 'IQ 测试方法与边界',
+                'payload_json' => [
+                    'source' => self::CONTENT_TRACK,
+                    'placement' => (string) ($block['placement'] ?? 'supporting_methodology_links'),
+                    'label' => (string) ($block['label'] ?? 'IQ 测试方法与边界'),
+                    'items' => (array) ($block['items'] ?? []),
+                    'status' => self::DEFAULT_STATE['status'],
+                    'frontend_hardcode_allowed' => false,
+                    'publish_or_indexing_change_allowed' => false,
+                ],
+                'sort_order' => 700,
+                'is_enabled' => true,
+            ],
+        );
+
+        return [
+            'operation' => 'upserted_landing_draft_block',
+            'surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+            'landing_surface_id' => (int) $surface->id,
+            'block_key' => 'iq_methodology_boundary_links',
+            'status' => LandingSurface::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => false,
+            'items_count' => count((array) ($block['items'] ?? [])),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function plannedLandingBlock(array $landingMapping): array
+    {
+        $surface = LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('surface_key', 'test:iq-test-intelligence-quotient-assessment')
+            ->where('locale', 'zh-CN')
+            ->first();
+
+        return [
+            'operation' => $surface instanceof LandingSurface ? 'would_update_landing_draft_block' : 'would_create_landing_draft_block',
+            'surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+            'block_key' => 'iq_methodology_boundary_links',
+            'status' => LandingSurface::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => false,
+            'items_count' => count((array) data_get($landingMapping, 'proposed_page_blocks.0.items', [])),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  array<string,mixed>  $metadata
+     */
+    private function persistImportRecord(Article $article, ArticleTranslationRevision $revision, array $item, array $metadata): void
+    {
+        ArticleEditorialPackageImport::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'slug' => (string) $item['slug'],
+            'locale' => 'zh-CN',
+            'title' => (string) $item['title'],
+            'content_track' => self::CONTENT_TRACK,
+            'status' => ArticleEditorialPackageImport::STATUS_IMPORTED,
+            'intended_status' => self::DEFAULT_STATE['status'],
+            'validation_summary_json' => [
+                'source' => 'articles:import-iq-method-pages-draft',
+                'source_pr_id' => self::EXPECTED_PR_ID,
+                'import_pr_id' => self::EXPECTED_IMPORT_PR_ID,
+                'working_revision_id' => (int) $revision->id,
+                'preview_url_candidate' => '/ops/article-preview/'.(int) $article->id,
+            ],
+            'claim_result_json' => [
+                'status' => 'pass_with_human_review_required',
+                'human_review_required' => true,
+                'claim_audit' => $item['claim_audit'] ?? [],
+            ],
+            'exactness_json' => [
+                'canonical_url' => (string) $item['canonical_url'],
+                'robots' => self::DEFAULT_STATE['robots'],
+                'status' => self::DEFAULT_STATE['status'],
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ],
+            'references_json' => ['status' => 'method_and_claim_review_required'],
+            'media_json' => [
+                'status' => 'media_library_upload_deferred',
+                'media_brief' => $item['media_brief'] ?? [],
+            ],
+            'graph_json' => [
+                'topic_group' => 'iq_articles',
+                'topic_route' => '/zh/topics/iq-eq',
+                'landing_surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+                'internal_links' => $item['internal_links'] ?? [],
+            ],
+            'answer_surface_json' => $item['answer_surface_v1'] ?? [],
+            'body_hash' => (string) data_get($metadata, 'editorial_package_v1.body_hash'),
+            'heading_sequence_json' => $this->headingSequence((string) $item['content_md']),
+            'references_count' => 0,
+            'missing_fields_json' => [],
+            'blocked_reasons_json' => [
+                'human_method_review_required',
+                'human_claim_review_required',
+                'cms_readback_required',
+                'publish_not_allowed_in_import_pr',
+                'sitemap_llms_activation_not_allowed_in_import_pr',
+            ],
+            'imported_by' => null,
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function headingSequence(string $body): array
+    {
+        $headings = [];
+        foreach (explode("\n", str_replace(["\r\n", "\r"], "\n", $body)) as $line) {
+            if (preg_match('/^(#{2,6})[ \t]+/', $line, $matches) === 1) {
+                $headings[] = strlen((string) $matches[1]).':'.trim(substr($line, strlen((string) $matches[0])));
+            }
+        }
+
+        return $headings;
+    }
+
+    private function readingMinutes(string $body): int
+    {
+        return max(1, (int) ceil(max(1, mb_strlen(strip_tags($body))) / 700));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $articles
+     */
+    private function summaryAction(array $articles): string
+    {
+        $actions = array_values(array_unique(array_map(static fn (array $article): string => (string) ($article['action'] ?? ''), $articles)));
+
+        return count($actions) === 1 ? $actions[0] : 'would_upsert_drafts';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -30,6 +30,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withCommands([
         __DIR__.'/../app/Console/Commands',
+        \App\Console\Commands\ArticleImportIqMethodPagesDraft::class,
         \App\Console\Commands\PersonalityEnneagramCmsPromote::class,
         \App\Console\Commands\FapResolvePack::class,
         \App\Console\Commands\RiasecResultPageAssetAgentAuditCommand::class,

--- a/backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php
@@ -1,0 +1,435 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleEditorialPackageImport;
+use App\Models\ArticleSeoMeta;
+use App\Models\LandingSurface;
+use App\Models\PageBlock;
+use App\Models\TopicProfileEntry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArticleImportIqMethodPagesDraftCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_accepts_iq_method_package_without_database_writes(): void
+    {
+        $package = $this->writeIqMethodPackage();
+
+        $exitCode = Artisan::call('articles:import-iq-method-pages-draft', [
+            '--package' => $package,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertSame('would_create_draft', $payload['action']);
+        $this->assertSame('IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01', $payload['pr_id']);
+        $this->assertSame('IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01', $payload['source_pr_id']);
+        $this->assertCount(7, $payload['articles']);
+        $this->assertSame('iq_articles', $payload['topic_mapping']['group_key']);
+        $this->assertSame('test:iq-test-intelligence-quotient-assessment', $payload['landing_page_blocks']['surface_key']);
+
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, TopicProfileEntry::query()->count());
+        $this->assertSame(0, LandingSurface::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, PageBlock::query()->count());
+    }
+
+    public function test_import_writes_seven_draft_articles_topic_links_and_landing_block(): void
+    {
+        $package = $this->writeIqMethodPackage();
+
+        $exitCode = Artisan::call('articles:import-iq-method-pages-draft', [
+            '--package' => $package,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('imported_draft_only', $payload['action']);
+        $this->assertCount(7, $payload['articles']);
+
+        $articles = Article::query()->withoutGlobalScopes()->orderBy('slug')->get();
+        $this->assertCount(7, $articles);
+        foreach ($articles as $article) {
+            $this->assertSame('zh-CN', $article->locale);
+            $this->assertSame('draft_review_only', $article->status);
+            $this->assertFalse((bool) $article->is_public);
+            $this->assertFalse((bool) $article->is_indexable);
+            $this->assertFalse((bool) $article->sitemap_eligible);
+            $this->assertFalse((bool) $article->llms_eligible);
+            $this->assertNull($article->published_at);
+            $this->assertNull($article->published_revision_id);
+            $this->assertSame('iq-test-intelligence-quotient-assessment', $article->related_test_slug);
+            $this->assertNotNull($article->working_revision_id);
+            $this->assertSame('human_review', $article->workingRevision?->revision_status);
+
+            $seo = ArticleSeoMeta::query()->withoutGlobalScopes()->where('article_id', $article->id)->first();
+            $this->assertInstanceOf(ArticleSeoMeta::class, $seo);
+            $this->assertSame('noindex,follow', $seo->robots);
+            $this->assertFalse((bool) $seo->is_indexable);
+            $this->assertStringStartsWith('https://fermatmind.com/zh/articles/', (string) $seo->canonical_url);
+            $this->assertSame('draft_review_only', data_get($seo->schema_json, 'editorial_package_v1.status'));
+            $this->assertFalse((bool) data_get($seo->schema_json, 'editorial_package_v1.publish_allowed'));
+        }
+
+        $this->assertSame(7, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
+        $this->assertSame(7, TopicProfileEntry::query()->where('group_key', 'iq_articles')->count());
+
+        $surface = LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('surface_key', 'test:iq-test-intelligence-quotient-assessment')
+            ->where('locale', 'zh-CN')
+            ->first();
+        $this->assertInstanceOf(LandingSurface::class, $surface);
+        $this->assertSame('draft', $surface->status);
+        $this->assertFalse((bool) $surface->is_public);
+        $this->assertFalse((bool) $surface->is_indexable);
+
+        $block = PageBlock::query()
+            ->where('landing_surface_id', $surface->id)
+            ->where('block_key', 'iq_methodology_boundary_links')
+            ->first();
+        $this->assertInstanceOf(PageBlock::class, $block);
+        $this->assertSame('article_link_cluster', $block->block_type);
+        $this->assertCount(7, data_get($block->payload_json, 'items'));
+        $this->assertFalse((bool) data_get($block->payload_json, 'frontend_hardcode_allowed'));
+    }
+
+    public function test_import_rejects_scoring_secret_tokens_in_public_surfaces(): void
+    {
+        $package = $this->writeIqMethodPackage(static function (array &$pages): void {
+            $pages[0]['title'] .= ' answer_key';
+        });
+
+        $exitCode = Artisan::call('articles:import-iq-method-pages-draft', [
+            '--package' => $package,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('answer_key', collect($payload['errors'])->pluck('code')->all());
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    /**
+     * @param  null|callable(list<array<string,mixed>>&):void  $mutatePages
+     */
+    private function writeIqMethodPackage(?callable $mutatePages = null): string
+    {
+        $root = sys_get_temp_dir().'/iq-method-pages-'.Str::uuid();
+        $packageRoot = $root.'/generated/iq-method-pages-zh-cn-v0.2';
+        $dryRunRoot = $packageRoot.'/cms-dry-run';
+        mkdir($dryRunRoot, 0777, true);
+
+        $pages = $this->pageDefinitions();
+        if ($mutatePages !== null) {
+            $mutatePages($pages);
+        }
+
+        $articleImports = [];
+        $seoPages = [];
+        $claimPages = [];
+        $topicItems = [];
+        $landingItems = [];
+
+        foreach ($pages as $index => $page) {
+            $pageNumber = str_pad((string) ($index + 1), 2, '0', STR_PAD_LEFT);
+            $pageDir = $packageRoot.'/pages/'.$pageNumber.'-'.$page['slug'];
+            mkdir($pageDir, 0777, true);
+
+            $relativeDir = 'generated/iq-method-pages-zh-cn-v0.2/pages/'.$pageNumber.'-'.$page['slug'];
+            $articleMd = $relativeDir.'/article.md';
+            $articleCms = $relativeDir.'/article.cms.json';
+            $seoJson = $relativeDir.'/seo.json';
+            $answerSurface = $relativeDir.'/answer_surface_v1.json';
+            $internalLinks = $relativeDir.'/internal_links.json';
+            $mediaBrief = $relativeDir.'/media_brief.json';
+            $faq = $relativeDir.'/faq.json';
+            $landingSurface = $relativeDir.'/landing_surface_v1.json';
+            $geoAnswer = $relativeDir.'/geo_answer_block.json';
+            $claimAudit = $relativeDir.'/claim_audit.json';
+            $qaChecklist = $relativeDir.'/qa_checklist.md';
+
+            file_put_contents($pageDir.'/article.md', $page['content_md']);
+            file_put_contents($pageDir.'/article.cms.json', json_encode([
+                'status' => 'draft_review_only',
+                'locale' => 'zh-CN',
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'excerpt' => $page['excerpt'],
+                'content_md' => $page['content_md'],
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'category_suggestion' => $page['category'],
+                'tags' => ['IQ 风格推理测试', '测评方法与边界', '非官方非认证', '推理表现'],
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'reviewer_status' => 'method_and_claim_review_required',
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'schema_json' => [
+                    'editorial_package_v1' => [
+                        'package_version' => 'iq-method-pages-zh-cn-v0.2',
+                        'review_required_before_publish' => true,
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/seo.json', json_encode([
+                'status' => 'draft_review_only',
+                'seo_title' => $page['seo_title'],
+                'seo_description' => $page['seo_description'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/answer_surface_v1.json', json_encode([
+                'version' => 'answer_surface_v1',
+                'status' => 'draft_review_only',
+                'quick_answer' => 'IQ 风格推理测试用于理解本次推理任务表现，非官方、非临床、非认证。',
+                'faq_items' => [
+                    ['question' => '这是正式智力测评吗？', 'answer' => '不是。'],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/internal_links.json', json_encode([
+                'links_out' => [
+                    ['label' => '开始 IQ 风格推理测试', 'href' => '/zh/tests/iq-test-intelligence-quotient-assessment'],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/media_brief.json', json_encode([
+                'status' => 'media_library_upload_deferred',
+                'brief' => 'No public media URL assigned in draft import.',
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/faq.json', '{"items":[]}');
+            file_put_contents($pageDir.'/landing_surface_v1.json', '{"status":"draft_review_only"}');
+            file_put_contents($pageDir.'/geo_answer_block.json', '{"status":"draft_review_only"}');
+            file_put_contents($pageDir.'/claim_audit.json', '{"status":"passed_text_scan"}');
+            file_put_contents($pageDir.'/qa_checklist.md', "- draft only\n");
+
+            $articleImports[] = [
+                'order' => $index + 1,
+                'cms_resource_type' => 'Article',
+                'operation' => 'upsert_draft_only',
+                'locale' => 'zh-CN',
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'route' => '/zh/articles/'.$page['slug'],
+                'source_files' => [
+                    'article_md' => $articleMd,
+                    'article_cms_json' => $articleCms,
+                    'seo_json' => $seoJson,
+                    'faq_json' => $faq,
+                    'internal_links_json' => $internalLinks,
+                    'answer_surface_v1_json' => $answerSurface,
+                    'landing_surface_v1_json' => $landingSurface,
+                    'geo_answer_block_json' => $geoAnswer,
+                    'media_brief_json' => $mediaBrief,
+                    'claim_audit_json' => $claimAudit,
+                    'qa_checklist_md' => $qaChecklist,
+                ],
+                'required_cms_fields' => [
+                    'category' => $page['category'],
+                    'tags' => ['IQ 风格推理测试', '测评方法与边界', '非官方非认证', '推理表现'],
+                    'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                ],
+                'publish_state' => $this->draftState(),
+                'gates' => [
+                    'human_method_review_required' => true,
+                    'human_claim_review_required' => true,
+                    'cms_dry_run_required' => true,
+                    'cms_readback_required' => true,
+                    'private_url_guard_required' => true,
+                    'production_publish_allowed_in_this_pr' => false,
+                    'sitemap_llms_activation_allowed_in_this_pr' => false,
+                ],
+            ];
+            $seoPages[] = [
+                'slug' => $page['slug'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ];
+            $claimPages[] = [
+                'slug' => $page['slug'],
+                'status' => 'draft_review_only',
+                'page_status' => 'draft_review_only_passed_text_scan',
+                'forbidden_terms_found' => [],
+                'human_review_required' => true,
+            ];
+            $topicItems[] = [
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'href' => '/zh/articles/'.$page['slug'],
+                'status' => 'draft_review_only',
+                'is_public' => false,
+                'is_indexable' => false,
+            ];
+            $landingItems[] = [
+                'title' => $page['title'],
+                'href' => '/zh/articles/'.$page['slug'],
+                'slug' => $page['slug'],
+            ];
+        }
+
+        file_put_contents($dryRunRoot.'/cms_import_manifest.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.cms_dry_run_manifest.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'mode' => 'cms_dry_run_contract_only',
+            'source_package' => 'generated/iq-method-pages-zh-cn-v0.2',
+            'required_default_publish_state' => $this->draftState(),
+            'article_imports' => $articleImports,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/seo_geo_gate.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.seo_geo_gate.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'status' => 'hold_noindex_until_human_and_cms_readback_pass',
+            'default_gate' => $this->draftState(),
+            'pages' => $seoPages,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/claim_audit_summary.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.claim_audit_summary.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'status' => 'automated_text_scan_passed_human_review_required',
+            'pages' => $claimPages,
+            'gate_result' => 'pass_with_human_review_required',
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/topic_iq_articles_mapping.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.topic_mapping.v1',
+            'target_topic' => [
+                'locale' => 'zh-CN',
+                'slug' => 'iq-eq',
+                'route' => '/zh/topics/iq-eq',
+            ],
+            'required_display_policy' => [
+                'split_mixed_group' => true,
+                'iq_group_label' => 'IQ 文章',
+                'eq_group_label' => 'EQ 文章',
+                'frontend_hardcode_allowed' => false,
+            ],
+            'entry_groups' => [
+                [
+                    'group_key' => 'iq_articles',
+                    'label' => 'IQ 文章',
+                    'items' => $topicItems,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/landing_page_blocks_mapping.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.landing_page_blocks_mapping.v1',
+            'target_landing_surface' => [
+                'locale' => 'zh-CN',
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'route' => '/zh/tests/iq-test-intelligence-quotient-assessment',
+            ],
+            'proposed_page_blocks' => [
+                [
+                    'block_key' => 'iq_methodology_boundary_links',
+                    'block_type' => 'article_link_cluster',
+                    'label' => 'IQ 测试方法与边界',
+                    'placement' => 'supporting_methodology_links',
+                    'items' => $landingItems,
+                ],
+            ],
+            'guardrails' => [
+                'frontend_hardcode_allowed' => false,
+                'private_flow_links_allowed' => false,
+                'result_or_order_links_allowed' => false,
+                'publish_or_indexing_change_allowed_in_this_pr' => false,
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $root;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function pageDefinitions(): array
+    {
+        $slugs = [
+            'what-is-iq-style-reasoning-test' => '什么是 IQ 风格推理测试？',
+            'online-iq-test-vs-professional-assessment' => '在线 IQ 风格测试和专业智力测评有什么区别？',
+            'iq-test-score-meaning-boundary' => 'IQ 风格测试里的原始分、正确率和完成时间说明什么？',
+            'matrix-reasoning-pattern-recognition-guide' => '矩阵推理和模式识别题在测什么？',
+            'why-fermatmind-iq-v1-not-certification' => '为什么 FermatMind IQ V1 是非认证测试？',
+            'iq-test-privacy-data-boundary' => 'IQ 风格测试的数据和隐私边界是什么？',
+            'iq-expert-review-disclosure' => 'FermatMind 如何审查 IQ 风格测试内容？',
+        ];
+
+        $pages = [];
+        foreach ($slugs as $slug => $title) {
+            $pages[] = [
+                'slug' => $slug,
+                'title' => $title,
+                'excerpt' => '解释 IQ 风格推理测试的方法、边界和信任层，保持非官方、非临床、非认证表达。',
+                'seo_title' => mb_substr($title.' 方法边界说明', 0, 70),
+                'seo_description' => '了解 FermatMind IQ V1 的方法边界：原创 30 题、约 20 分钟，只解释原始分、正确率、完成时间和维度表现。',
+                'category' => $slug === 'matrix-reasoning-pattern-recognition-guide' ? '能力与认知' : '测评方法与边界',
+                'content_md' => implode("\n\n", [
+                    'IQ 风格推理测试是一类用图形、矩阵和规律补全任务观察推理表现的在线测试。FermatMind IQ V1 使用原创 30 题，约 20 分钟，重点解释本次任务中的原始分、正确率、完成时间和维度表现。它不是外部证明，也不是医疗或教育决策工具。',
+                    '## 这是什么 / 这不是什么',
+                    '这是一套在线 IQ 风格推理任务，不是正式智力结论、外部认证或临床测评。',
+                    '## 方法解释',
+                    '页面只解释公开方法与边界，不公开题目 ID、答案、解题步骤、评分表或后端评分规则。',
+                    '## FAQ',
+                    '### 这是正式智力测评吗？',
+                    '不是。它用于理解本次推理任务表现。',
+                ]),
+            ];
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function draftState(): array
+    {
+        return [
+            'status' => 'draft_review_only',
+            'is_public' => false,
+            'is_indexable' => false,
+            'robots' => 'noindex,follow',
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -3163,6 +3163,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_method_pages_cms_draft_importer_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Models/TopicProfileEntry.php',
+            'backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php',
+            'backend/bootstrap/app.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleImportIqMethodPagesDraft;',
+            '+        ArticleImportIqMethodPagesDraft::class,',
+        ];
+        $bootstrapAppChangedLines = [
+            '+        \\App\\Console\\Commands\\ArticleImportIqMethodPagesDraft::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            changed: $changed,
+            repoRoot: '',
+            baseRef: '',
+            kernelChangedLines: $kernelChangedLines,
+            bootstrapAppChangedLines: $bootstrapAppChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_iq_production_observability_guard_changes(): void
     {
         $changed = [
@@ -6019,6 +6045,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isIqMethodPagesCmsDraftImporterFile($file)) {
+                continue;
+            }
+
             if ($this->isIqProductionObservabilityGuardFile($file)) {
                 continue;
             }
@@ -6260,6 +6290,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsIqNormImportDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsIqMethodPagesCmsDraftImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64BackendImportContractOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsInternalLinkDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6340,6 +6371,9 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsTestMetricsSchedulerOnly(
                         $bootstrapAppChangedLines ?? $this->changedLinesForFile($repoRoot, $baseRef, $file)
                     )
+                    || $this->kernelDiffIsIqMethodPagesCmsDraftImporterOnly(
+                        $bootstrapAppChangedLines ?? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                    )
                     || $this->kernelDiffIsRiasecResultPageAssetAgentHarnessOnly(
                         $bootstrapAppChangedLines ?? $this->changedLinesForFile($repoRoot, $baseRef, $file)
                     )
@@ -6354,6 +6388,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 && $baseRef === ''
                 && (
                     $this->kernelDiffIsTestMetricsSchedulerOnly($bootstrapAppChangedLines ?? [])
+                    || $this->kernelDiffIsIqMethodPagesCmsDraftImporterOnly($bootstrapAppChangedLines ?? [])
                     || $this->kernelDiffIsRiasecResultPageAssetAgentHarnessOnly($bootstrapAppChangedLines ?? [])
                 )
             ) {
@@ -7658,6 +7693,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isIqNormImportDryRunCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/NormsIqImport.php';
+    }
+
+    private function isIqMethodPagesCmsDraftImporterFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php',
+            'backend/app/Models/TopicProfileEntry.php',
+        ], true)
+            || str_starts_with($file, 'backend/app/Services/Cms/IqMethodPages/');
     }
 
     private function isIqProductionObservabilityGuardFile(string $file): bool
@@ -10561,6 +10605,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bNormsIqImport\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsIqMethodPagesCmsDraftImporterOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $normalized) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bArticleImportIqMethodPagesDraft\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49538,7 +49538,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01"
     ],
-    "status": "committed",
+    "status": "pr_open",
     "authorized_by_user": "2026-07-05 user explicitly provided IQ 7 pages CMS上线执行计划 with this PR id, repo, scope, and dry-run/import/readback/publish/SEO-GEO split.",
     "checks": {
       "dependency": {
@@ -49579,8 +49579,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": "ab66a60a978c04721b4d45b1db2ea04d6b305403",
-    "pr_url": null,
+    "commit_sha": "e840911382fac0376fc0f9145cea32062a87e88d",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2721",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49624,7 +49624,12 @@
       {
         "at": "2026-07-05T12:45:00+08:00",
         "status": "committed",
-        "summary": "Committed IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01 scoped backend importer changes at ab66a60a978c04721b4d45b1db2ea04d6b305403."
+        "summary": "Committed IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01 scoped backend importer changes at e840911382fac0376fc0f9145cea32062a87e88d."
+      },
+      {
+        "at": "2026-07-05T12:52:00+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #2721 at https://github.com/fermatmind/fap-api/pull/2721 for IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -454,7 +454,7 @@
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
-    "status": "ci_fix_local_checks_passed",
+    "status": "ready_to_merge",
     "title": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01 add controlled analytics funnel refresh write guard",
     "transitions": [
       {
@@ -49446,7 +49446,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "commit_sha": "65204d554",
@@ -49641,6 +49641,11 @@
         "at": "2026-07-05T13:12:00+08:00",
         "status": "ci_fix_local_checks_passed",
         "summary": "Focused BigFive runtime-freeze regression, IQ importer PHPUnit, targeted Pint, command discovery, route list, real fap-web package dry-run, YAML/JSON parsing, and diff check pass locally after the CI fix."
+      },
+      {
+        "at": "2026-07-05T13:22:00+08:00",
+        "status": "ready_to_merge",
+        "summary": "GitHub checks passed on PR #2721 head 91eace541b3b9944346db7f3e9e572d847f20508: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49552,8 +49552,9 @@
           "php -l backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php",
           "php -l backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php",
           "cd backend && php artisan list articles --no-ansi | rg 'iq-method'",
-          "cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportIqMethodPagesDraft.php app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php app/Models/TopicProfileEntry.php app/Console/Kernel.php bootstrap/app.php",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportIqMethodPagesDraft.php app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php app/Models/TopicProfileEntry.php bootstrap/app.php",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportIqMethodPagesDraftCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_iq_method_pages_cms_draft_importer_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
           "cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt",
           "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
@@ -49630,6 +49631,11 @@
         "at": "2026-07-05T12:52:00+08:00",
         "status": "pr_open",
         "summary": "Opened PR #2721 at https://github.com/fermatmind/fap-api/pull/2721 for IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01."
+      },
+      {
+        "at": "2026-07-05T13:05:00+08:00",
+        "status": "ci_fix_in_progress",
+        "summary": "GitHub verify-bigfive failed because BigFiveResultPageV2CoreBodyPreviewTest treated IQ CMS draft importer files as runtime-impacting. Added a scoped runtime-freeze classifier exemption and regression test for the IQ method pages draft importer; removed the unnecessary Console Kernel runtime diff in favor of Laravel 12 bootstrap command registration."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -781,7 +781,7 @@
         "summary": "Full vendor/bin/pint --test reported class_attributes_separation in backend/tests/Feature/V0_3/IqReportContractTest.php. User authorized including the Pint-only formatting fix in the current PR; full Pint now passes."
       }
     ],
-    "status": "pr_open",
+    "status": "ci_fix_local_checks_passed",
     "title": "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01 allow global org0 funnel scope entry",
     "transitions": [
       {
@@ -49636,6 +49636,11 @@
         "at": "2026-07-05T13:05:00+08:00",
         "status": "ci_fix_in_progress",
         "summary": "GitHub verify-bigfive failed because BigFiveResultPageV2CoreBodyPreviewTest treated IQ CMS draft importer files as runtime-impacting. Added a scoped runtime-freeze classifier exemption and regression test for the IQ method pages draft importer; removed the unnecessary Console Kernel runtime diff in favor of Laravel 12 bootstrap command registration."
+      },
+      {
+        "at": "2026-07-05T13:12:00+08:00",
+        "status": "ci_fix_local_checks_passed",
+        "summary": "Focused BigFive runtime-freeze regression, IQ importer PHPUnit, targeted Pint, command discovery, route list, real fap-web package dry-run, YAML/JSON parsing, and diff check pass locally after the CI fix."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49528,6 +49528,106 @@
       }
     ]
   },
+  "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01": {
+    "id": "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-method-pages-cms-import-01",
+    "title": "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01: import IQ method pages as CMS drafts",
+    "train_scope": "iq_method_pages_zh_cn_cms_import",
+    "depends_on": [
+      "IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01"
+    ],
+    "status": "committed",
+    "authorized_by_user": "2026-07-05 user explicitly provided IQ 7 pages CMS上线执行计划 with this PR id, repo, scope, and dry-run/import/readback/publish/SEO-GEO split.",
+    "checks": {
+      "dependency": {
+        "status": "pass",
+        "evidence": "fap-web PR #1606 for IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01 is merged; origin/main in fap-web contains merge commit 297bd9c7809edc257555a57be5ae406d43e8c05f."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php",
+          "php -l backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php",
+          "php -l backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php",
+          "cd backend && php artisan list articles --no-ansi | rg 'iq-method'",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportIqMethodPagesDraft.php app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php app/Models/TopicProfileEntry.php app/Console/Kernel.php bootstrap/app.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportIqMethodPagesDraftCommandTest --no-ansi",
+          "cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --check",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/iq-method-pages.<temp>.sqlite php artisan migrate --force --no-ansi && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/iq-method-pages.<temp>.sqlite php artisan articles:import-iq-method-pages-draft --package=/Users/rainie/Desktop/GitHub/fap-web --dry-run --json"
+        ],
+        "notes": "Syntax, command discovery, targeted Pint, focused PHPUnit, route:list, YAML/JSON parse, diff check, and real fap-web IQ method dry-run package validation passed. Real package dry-run returned ok=true, action=would_create_draft, article_count=7, errors_count=0."
+      },
+      "composer_test_full_suite": {
+        "status": "failed_external_sidecar",
+        "command": "cd backend && composer test",
+        "evidence": "Exited with code 1 after Composer process timeout at 300 seconds. Before timeout, failures were observed in Content, Architecture, Career, and CareerCms tests outside current IQ method importer scope. Sidecar recorded at generated/pr-train-sidecar-issues/sidecar_issues.md and generated/pr-train-sidecar-issues/sidecar_issues.json."
+      },
+      "focused_architecture_rerun": {
+        "status": "failed_external_sidecar",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ServiceLayerBoundaryTest --no-ansi",
+        "evidence": "Failure points to pre-existing HTTP helper calls in backend/app/Services/SeoIntel/CrawlerLog/CrawlerLogFixtureParser.php and backend/app/Services/Iq/IqOwnerOriginal30BankService.php, not the newly added backend/app/Services/Cms/IqMethodPages importer."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": "ab66a60a978c04721b4d45b1db2ea04d6b305403",
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": true,
+    "cms_mutation": true,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "transitions": [
+      {
+        "at": "2026-07-05T12:00:00+08:00",
+        "status": "in_progress",
+        "summary": "Started backend IQ method pages CMS import tooling from explicit user plan. Scope is importer command/service/test plus PR-train metadata. Production CMS/DB mutation, publish, sitemap/llms activation, frontend fallback, scoring changes, and deploy remain forbidden without separate exact authorization."
+      },
+      {
+        "at": "2026-07-05T12:00:00+08:00",
+        "status": "focused_local_validation_passed",
+        "summary": "Added articles:import-iq-method-pages-draft with dry-run and draft-only import support. Focused PHPUnit confirms dry-run has no DB writes; import creates seven draft_review_only/noindex Article records, IQ topic entries, and draft landing block in test DB; forbidden answer_key token is blocked."
+      },
+      {
+        "at": "2026-07-05T12:00:00+08:00",
+        "status": "local_validation_passed",
+        "summary": "PHP syntax, focused PHPUnit, route:list, YAML/JSON parse, git diff check, and real fap-web package dry-run on migrated temp SQLite passed. Production CMS/DB mutation was not executed."
+      },
+      {
+        "at": "2026-07-05T12:25:00+08:00",
+        "status": "local_validation_passed_with_external_sidecar",
+        "summary": "Full composer test timed out at 300 seconds after unrelated Content/Career/Architecture failures. Recorded external failures in generated/pr-train-sidecar-issues and continued under the user-provided sidecar protocol because focused IQ importer validation and scope validation passed."
+      },
+      {
+        "at": "2026-07-05T12:35:00+08:00",
+        "status": "command_registration_fixed",
+        "summary": "Added explicit Laravel 12 withCommands registration in backend/bootstrap/app.php, refreshed autoload locally, and verified articles:import-iq-method-pages-draft appears in artisan list. Targeted Pint and focused PHPUnit pass after the fix."
+      },
+      {
+        "at": "2026-07-05T12:45:00+08:00",
+        "status": "committed",
+        "summary": "Committed IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01 scoped backend importer changes at ab66a60a978c04721b4d45b1db2ea04d6b305403."
+      }
+    ]
+  },
   "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01": {
     "id": "IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01",
     "repo": "fap-api",
@@ -79414,5 +79514,5 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-04T13:52:09Z"
+  "updated_at": "2026-07-05T12:00:00+08:00"
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -36790,6 +36790,53 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01
+    repo: fap-api
+    depends_on:
+      - IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01
+    branch: codex/iq-method-pages-cms-import-01
+    title: "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01: import IQ method pages as CMS drafts"
+    train_scope: iq_method_pages_zh_cn_cms_import
+    status: in_progress
+    scope:
+      - Add a backend-authoritative importer for the fap-web IQ method pages CMS dry-run package.
+      - Support dry-run validation and draft-only import of 7 zh-CN CMS Article records, IQ topic draft entries, and a draft landing page block.
+      - Preserve draft_review_only/noindex state and keep publish, sitemap, llms, production deploy, and frontend fallback out of scope.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php
+      - backend/app/Services/Cms/IqMethodPages/**
+      - backend/app/Models/TopicProfileEntry.php
+      - backend/app/Console/Kernel.php
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Publish articles, flip indexability, activate sitemap/llms, submit search URLs, run production deploy, rewrite content, change IQ scoring, expose answer keys, or add frontend fallback content.
+      - Mutate production CMS or production DB from this PR without separate exact environment authorization.
+    validation:
+      - php -l backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php
+      - php -l backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php
+      - php -l backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php
+      - cd backend && php artisan list articles --no-ansi | rg 'iq-method'
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportIqMethodPagesDraft.php app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php app/Models/TopicProfileEntry.php app/Console/Kernel.php bootstrap/app.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportIqMethodPagesDraftCommandTest --no-ansi
+      - cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: true
+    cms_mutation: true
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01
+
   - id: IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01
     repo: fap-api
     depends_on:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -36809,6 +36809,7 @@ prs:
       - backend/app/Console/Kernel.php
       - backend/bootstrap/app.php
       - backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
       - generated/pr-train-sidecar-issues/**
@@ -36820,8 +36821,9 @@ prs:
       - php -l backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php
       - php -l backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php
       - cd backend && php artisan list articles --no-ansi | rg 'iq-method'
-      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportIqMethodPagesDraft.php app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php app/Models/TopicProfileEntry.php app/Console/Kernel.php bootstrap/app.php
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportIqMethodPagesDraft.php app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php app/Models/TopicProfileEntry.php bootstrap/app.php
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportIqMethodPagesDraftCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_iq_method_pages_cms_draft_importer_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
       - cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt
       - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -8,5 +8,19 @@
     "why_not_current_pr_scope": "git diff --name-only origin/main...HEAD in the isolated PR worktree contains only the Big Five CMS import dry-run command, planner, tests, Kernel registration, and PR train metadata; it does not contain the IQ method files.",
     "required_checks_affected": "Local full-check reproduction was affected. GitHub required checks run in a clean checkout; the current PR fix targets the actual GitHub failure, which was the hardcoded desktop package path in the test.",
     "recommended_follow_up": "Keep IQ method page work isolated in its own branch/PR and avoid sharing dirty local worktree state with PR-train verification worktrees."
+  },
+  {
+    "repo": "fap-api",
+    "pr_id": "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01",
+    "branch": "codex/iq-method-pages-cms-import-01",
+    "blocker_type": "external_full_suite_failure_timeout",
+    "evidence": [
+      "cd backend && composer test exited with code 1 after Composer process timeout at 300 seconds.",
+      "Unrelated failures observed before timeout: Tests\\Unit\\Services\\Content\\CulturalCalibrationLayerServiceTest, Tests\\Feature\\Architecture\\ServiceLayerBoundaryTest, Tests\\Feature\\Career\\CareerCnProxyPublicOwnerApiTest, Tests\\Feature\\Career\\CareerJobDetailApiTest, Tests\\Feature\\CareerCms\\ArticleBaselineImportTest.",
+      "Focused rerun of ServiceLayerBoundaryTest reported existing HTTP helper violations in backend/app/Services/SeoIntel/CrawlerLog/CrawlerLogFixtureParser.php and backend/app/Services/Iq/IqOwnerOriginal30BankService.php."
+    ],
+    "why_not_current_pr_scope": "Current PR scope only adds the IQ method pages CMS draft importer command/service/test, registers the command, extends the topic group whitelist, and updates PR-train metadata. The observed failures are in Content, Architecture, Career, and CareerCms surfaces outside the changed IQ method importer files.",
+    "required_checks_affected": "unknown_until_github_checks; local focused validation passed",
+    "recommended_follow_up": "Track and fix the failing Content/Career/Architecture tests under their owning PR scopes. Do not mix those repairs into the IQ method pages CMS import PR."
   }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -9,3 +9,29 @@
 - why not current PR scope: `git diff --name-only origin/main...HEAD` in the isolated PR worktree contains only the Big Five CMS import dry-run command, planner, tests, Kernel registration, and PR train metadata. It does not contain the IQ method files.
 - whether required checks are affected: local full-check reproduction was affected; GitHub required checks run in a clean checkout and the current PR fix targets the actual GitHub failure, which was the hardcoded desktop package path in the test.
 - recommended follow-up: keep IQ method page work isolated in its own branch/PR and avoid sharing dirty local worktree state with PR-train verification worktrees.
+
+## IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01
+
+- repo: `fap-api`
+- branch: `codex/iq-method-pages-cms-import-01`
+- blocker type: `external_full_suite_failure_timeout`
+- evidence:
+  - `cd backend && composer test` exited with code 1 after Composer process timeout at 300 seconds.
+  - Before timeout, unrelated failures were observed in:
+    - `Tests\Unit\Services\Content\CulturalCalibrationLayerServiceTest`
+    - `Tests\Feature\Architecture\ServiceLayerBoundaryTest`
+    - `Tests\Feature\Career\CareerCnProxyPublicOwnerApiTest`
+    - `Tests\Feature\Career\CareerJobDetailApiTest`
+    - `Tests\Feature\CareerCms\ArticleBaselineImportTest`
+  - Focused rerun of `ServiceLayerBoundaryTest` reported existing HTTP helper violations in:
+    - `backend/app/Services/SeoIntel/CrawlerLog/CrawlerLogFixtureParser.php`
+    - `backend/app/Services/Iq/IqOwnerOriginal30BankService.php`
+- why not current PR scope:
+  - Current PR scope only adds the IQ method pages CMS draft importer command/service/test, registers the command, extends the topic group whitelist, and updates PR-train metadata.
+  - The observed full-suite failures are in Content, Architecture, Career, and CareerCms surfaces outside the changed IQ method importer files.
+- whether required checks are affected:
+  - Local focused validation for this PR passed.
+  - GitHub required checks must still be inspected after PR creation; if a required check fails, inspect the failing job before merge.
+- recommended follow-up:
+  - Track and fix the failing Content/Career/Architecture tests under their owning PR scopes.
+  - Do not mix those repairs into the IQ method pages CMS import PR.


### PR DESCRIPTION
## What changed
- Added `articles:import-iq-method-pages-draft` for the 7 zh-CN IQ method pages CMS package.
- Supports dry-run planning and draft-only CMS writes for 7 Article records, Article SEO meta, working revisions, article tags/categories, `/zh/topics/iq-eq` IQ topic entries, and a draft IQ methodology landing block.
- Registered the command for Laravel 12 command discovery and allowed `iq_articles` / `eq_articles` topic grouping keys.
- Added focused PHPUnit coverage plus PR-train manifest/state and sidecar issue reporting.

## Why
- Moves the IQ 7-page package from fap-web dry-run artifacts into the backend/CMS authority layer without publishing or indexing it.
- Keeps the required first import state as `draft_review_only`, `is_public=false`, `is_indexable=false`, `robots=noindex,follow`, `sitemap_eligible=false`, and `llms_eligible=false`.

## Validation
- `php -l backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php && php -l backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php && php -l backend/tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php`
- `cd backend && php artisan list articles --no-ansi | rg 'iq-method'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportIqMethodPagesDraft.php app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php tests/Feature/Console/ArticleImportIqMethodPagesDraftCommandTest.php app/Models/TopicProfileEntry.php app/Console/Kernel.php bootstrap/app.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleImportIqMethodPagesDraftCommandTest --no-ansi`
- `cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt`
- `tmpdb=$(mktemp /tmp/iq-method-pages.XXXXXX); cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE="$tmpdb" php artisan migrate --force --no-ansi >/tmp/iq-method-migrate.log && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE="$tmpdb" php artisan articles:import-iq-method-pages-draft --package=/Users/rainie/Desktop/GitHub/fap-web --dry-run --json | jq '{ok, dry_run, action, article_count: (.articles|length), errors_count: (.errors|length)}'`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`

## Deferred items
- No production CMS import.
- No article publish state switch.
- No sitemap / llms activation.
- No frontend fallback content.
- No IQ scoring/item-bank/answer-key changes.
- No production deploy.

## Sidecar
- `cd backend && composer test` timed out at 300 seconds after unrelated Content/Career/Architecture failures. Details are recorded in `generated/pr-train-sidecar-issues/` and are intentionally deferred to their owning scopes.

## Repository rule impact
- This PR keeps IQ method pages backend/CMS-authoritative.
- It introduces import tooling only; runtime publication, SEO indexability, sitemap, and llms eligibility remain gated for later PRs.
