### PR TITLE
BIG5-CMS-FAQ-DEDUPE-02: guard Big Five CMS FAQ duplicate rendering

### DIFF
--- a/backend/app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php
+++ b/backend/app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php
@@ -79,6 +79,14 @@ final class BigFiveCmsImportDraftDryRunPlanner
 
         $contentTypeCounts = $this->contentTypeCounts($rowPlans);
         $localeCounts = $this->localeCounts($rowPlans);
+        $faqBodySectionCount = array_sum(array_map(
+            static fn (array $row): int => (int) ($row['faq_body_section_count'] ?? 0),
+            $rowPlans
+        ));
+        $faqBodySectionRowsCount = count(array_filter(
+            $rowPlans,
+            static fn (array $row): bool => (bool) ($row['faq_body_section_present'] ?? false)
+        ));
 
         return [
             'artifact' => 'BIG5-CMS-IMPORT-DRYRUN-01',
@@ -99,6 +107,10 @@ final class BigFiveCmsImportDraftDryRunPlanner
             'content_type_counts' => $contentTypeCounts,
             'locale_counts' => $localeCounts,
             'old_short_big_five_route_residue_count' => $this->oldShortRouteResidueCount($package),
+            'faq_structured_source' => 'faq',
+            'faq_body_section_count' => $faqBodySectionCount,
+            'faq_body_section_rows_count' => $faqBodySectionRowsCount,
+            'faq_deduplication_policy' => 'faq_field_is_the_only_structured_faq_source; faq-like body_sections are excluded from render_preview_sections to prevent duplicate FAQ rendering.',
             'field_mapping_contract' => $this->fieldMappingContract(),
             'dry_run_write_guard_contract' => $this->dryRunWriteGuardContract(),
             'rows' => $rowPlans,
@@ -170,6 +182,12 @@ final class BigFiveCmsImportDraftDryRunPlanner
         $faq = is_array($row['faq'] ?? null) ? array_values((array) $row['faq']) : [];
         $seo = is_array($row['seo'] ?? null) ? (array) $row['seo'] : [];
         $identity = $this->identityFor($canonicalPath, $locale, $contentType, (string) ($row['slug'] ?? ''), $errors, $index);
+        $faqBodySectionIndexes = $this->faqBodySectionIndexes($bodySections);
+        $renderPreviewSections = array_values(array_filter(
+            $bodySections,
+            fn (mixed $section, int $sectionIndex): bool => ! in_array($sectionIndex, $faqBodySectionIndexes, true),
+            ARRAY_FILTER_USE_BOTH
+        ));
 
         $this->validateRequiredFields($row, $errors, $fieldPrefix);
         $this->validateSeo($seo, $errors, $fieldPrefix);
@@ -215,6 +233,19 @@ final class BigFiveCmsImportDraftDryRunPlanner
                 static fn (mixed $section): string => is_array($section) ? trim((string) ($section['heading'] ?? $section['title'] ?? '')) : '',
                 $bodySections
             ))),
+            'faq_structured_source' => 'faq',
+            'faq_body_section_present' => $faqBodySectionIndexes !== [],
+            'faq_body_section_count' => count($faqBodySectionIndexes),
+            'faq_body_section_indexes' => array_map(
+                static fn (int $sectionIndex): int => $sectionIndex + 1,
+                $faqBodySectionIndexes
+            ),
+            'faq_deduplication_policy' => 'faq_field_is_the_only_structured_faq_source; faq-like body_sections are excluded from render_preview_sections to prevent duplicate FAQ rendering.',
+            'render_preview_section_count' => count($renderPreviewSections),
+            'render_preview_body_section_headings' => array_values(array_filter(array_map(
+                static fn (mixed $section): string => is_array($section) ? trim((string) ($section['heading'] ?? $section['title'] ?? '')) : '',
+                $renderPreviewSections
+            ))),
             'draft_state_after_import' => [
                 'is_public' => false,
                 'index_eligible' => false,
@@ -228,6 +259,36 @@ final class BigFiveCmsImportDraftDryRunPlanner
             'action' => 'would_validate_personality_public_content_asset_draft',
             'write_mode_in_this_pr' => 'not_supported',
         ];
+    }
+
+    /**
+     * @param  list<mixed>  $bodySections
+     * @return list<int>
+     */
+    private function faqBodySectionIndexes(array $bodySections): array
+    {
+        $indexes = [];
+        foreach ($bodySections as $index => $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            if ($this->isFaqBodySection($section)) {
+                $indexes[] = $index;
+            }
+        }
+
+        return $indexes;
+    }
+
+    /**
+     * @param  array<mixed>  $section
+     */
+    private function isFaqBodySection(array $section): bool
+    {
+        $heading = trim((string) ($section['heading'] ?? $section['title'] ?? ''));
+
+        return preg_match('/^(faq|常见问题|问答|问题)$/iu', $heading) === 1;
     }
 
     /**

--- a/backend/tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php
@@ -45,6 +45,10 @@ final class PersonalityBigFiveCmsImportDraftDryRunCommandTest extends TestCase
         $this->assertSame(42, $payload['row_count']);
         $this->assertTrue($payload['row_count_matches_expected']);
         $this->assertSame(0, $payload['old_short_big_five_route_residue_count']);
+        $this->assertSame('faq', $payload['faq_structured_source']);
+        $this->assertSame(42, $payload['faq_body_section_count']);
+        $this->assertSame(42, $payload['faq_body_section_rows_count']);
+        $this->assertStringContainsString('faq_field_is_the_only_structured_faq_source', $payload['faq_deduplication_policy']);
         $this->assertSame('App\\Models\\PersonalityPublicContentAsset', $payload['field_mapping_contract']['target_model']);
         $this->assertContains('personality_public_content_assets', $payload['field_mapping_contract']['target_tables']);
         $this->assertSame(15, $payload['content_type_counts']['trait_range_page'] ?? null);
@@ -53,6 +57,16 @@ final class PersonalityBigFiveCmsImportDraftDryRunCommandTest extends TestCase
         $this->assertSame(5, $payload['content_type_counts']['cross_reading_page'] ?? null);
         $this->assertSame(4, $payload['content_type_counts']['result_review_page'] ?? null);
         $this->assertSame(2, $payload['content_type_counts']['hub_page'] ?? null);
+
+        $firstRow = $payload['rows'][0] ?? [];
+        $this->assertSame('faq', $firstRow['faq_structured_source'] ?? null);
+        $this->assertTrue($firstRow['faq_body_section_present'] ?? false);
+        $this->assertSame(1, $firstRow['faq_body_section_count'] ?? null);
+        $this->assertSame([3], $firstRow['faq_body_section_indexes'] ?? null);
+        $this->assertSame(3, $firstRow['section_count'] ?? null);
+        $this->assertSame(2, $firstRow['render_preview_section_count'] ?? null);
+        $this->assertSame(5, $firstRow['faq_count'] ?? null);
+        $this->assertNotContains('FAQ', $firstRow['render_preview_body_section_headings'] ?? []);
     }
 
     public function test_command_requires_explicit_dry_run(): void
@@ -232,6 +246,7 @@ final class PersonalityBigFiveCmsImportDraftDryRunCommandTest extends TestCase
             'body_sections' => [
                 ['heading' => '快速回答', 'body' => '开放性是大五人格的连续维度之一。'],
                 ['heading' => '方法边界', 'body' => '本页不用于诊断或招聘筛选。'],
+                ['heading' => 'FAQ', 'body' => 'FAQ 正文只用于源包兼容；结构化 FAQ 以 faq 字段为准。'],
             ],
             'faq' => [
                 ['question' => '开放性是什么？', 'answer' => '它描述对新经验和抽象概念的偏好。'],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -146,9 +146,9 @@
     "depends_on": [
       "BIG5-CMS-IMPORT-DRYRUN-01"
     ],
-    "status": "local_checks_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "4a88b5bbc594bf3554712803a206e56c7f3ad912",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2723",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -221,6 +221,18 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Implemented dry-run FAQ dedupe planning. Focused syntax, PHPUnit, real desktop v2 package dry-run, targeted Pint, YAML/JSON parse, diff check, and allowed-path scope validation passed. Local full ci_verify_mbti had external IQ branch-diff interference recorded as sidecar."
+      },
+      {
+        "at": "2026-07-05T04:58:45Z",
+        "from": "local_checks_passed",
+        "to": "committed",
+        "note": "Committed BIG5-CMS-FAQ-DEDUPE-02 FAQ dedupe guard scope at 4a88b5bbc594bf3554712803a206e56c7f3ad912."
+      },
+      {
+        "at": "2026-07-05T04:58:45Z",
+        "from": "committed",
+        "to": "pr_open",
+        "note": "Opened PR #2723 for BIG5-CMS-FAQ-DEDUPE-02 and pushed branch codex/big5-cms-faq-dedupe-02."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5,14 +5,16 @@
     "title": "BIG5-CMS-IMPORT-DRYRUN-01: add Big Five cms-import-draft dry-run validator",
     "base": "main",
     "branch": "codex/big5-cms-import-dryrun-01",
-    "depends_on": [],
-    "status": "ready_to_merge",
-    "commit_sha": "79170c68c15d2b5a9dabf5d1ed03a8edcbb4b338",
+    "depends_on": [
+
+    ],
+    "status": "merged",
+    "commit_sha": "6c6495625ebec0ff6d042613ca12e8031b0f8f45",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2722",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T04:58:45Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -78,13 +80,17 @@
       "github_checks": {
         "status": "pass",
         "evidence": "PASS on PR #2722 head 79170c68c15d2b5a9dabf5d1ed03a8edcbb4b338: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "PR #2722 is MERGED; origin/main contains merge commit 6c6495625ebec0ff6d042613ca12e8031b0f8f45; local main was synced to origin/main; task branch codex/big5-cms-import-dryrun-01 was deleted locally and remotely; worktree was clean before BIG5-CMS-FAQ-DEDUPE-02 started."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -122,6 +128,12 @@
         "from": "ci_fix_in_progress",
         "to": "ready_to_merge",
         "note": "PR #2722 remote checks passed after the portable fixture fix. Marked ready to merge under squash merge policy."
+      },
+      {
+        "at": "2026-07-05T04:58:45Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "note": "Squash merged PR #2722. Verified origin/main contains merge commit 6c6495625ebec0ff6d042613ca12e8031b0f8f45, local main is synced, worktree is clean, and task branch cleanup is complete."
       }
     ]
   },
@@ -134,7 +146,7 @@
     "depends_on": [
       "BIG5-CMS-IMPORT-DRYRUN-01"
     ],
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "commit_sha": null,
     "pr_url": null,
     "failure_reason": null,
@@ -147,13 +159,47 @@
         "evidence": "User explicitly authorized adding BIG5-CMS-FAQ-DEDUPE-02 to the fap-api PR train from the attached /goal execution request."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "BIG5-CMS-FAQ-DEDUPE-02 depends on BIG5-CMS-IMPORT-DRYRUN-01 being merged into main."
+        "status": "pass",
+        "evidence": "BIG5-CMS-IMPORT-DRYRUN-01 PR #2722 is merged, and origin/main contains merge commit 6c6495625ebec0ff6d042613ca12e8031b0f8f45."
+      },
+      "syntax": {
+        "status": "pass",
+        "command": "php -l backend/app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php && php -l backend/tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php",
+        "evidence": "PASS: planner and focused command test file report no syntax errors."
+      },
+      "focused_command_contract": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityBigFiveCmsImportDraftDryRunCommandTest --no-ansi",
+        "evidence": "PASS: 4 tests, 54 assertions. Covers 42-row draft package planning and FAQ dedupe guard fields while preserving no-write behavior."
+      },
+      "desktop_v2_package_faq_dedupe_dry_run": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:big-five-cms-import-draft-dry-run --package=/Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json --dry-run --json",
+        "evidence": "PASS: real desktop v2 package reports ok=true, row_count=42, faq_body_section_count=42, and faq_body_section_rows_count=42; render preview planning excludes FAQ body sections while keeping faq as the structured source."
+      },
+      "pint_targeted": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "evidence": "PASS: 3 files."
+      },
+      "manifest_state_diff_validation": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "evidence": "PASS: train YAML parses, state JSON parses, and git diff whitespace check passes."
+      },
+      "local_full_verify": {
+        "status": "external_blocker_recorded",
+        "command": "cd backend && bash scripts/ci_verify_mbti.sh",
+        "evidence": "Focused current-scope checks passed, but local full verification was affected by the same IQ method branch-diff interference outside PR2 scope. Recorded sidecar details in generated/pr-train-sidecar-issues/sidecar_issues.md and sidecar_issues.json."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to BIG5-CMS-FAQ-DEDUPE-02 allowed paths: backend/app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php, backend/tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php, docs/codex/pr-train-state.json, and generated/pr-train-sidecar-issues/**."
       }
     },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -163,6 +209,18 @@
         "from": "user_authorized",
         "to": "pending_dependency",
         "note": "Registered dependent FAQ deduplication PR; execution waits for BIG5-CMS-IMPORT-DRYRUN-01 merge."
+      },
+      {
+        "at": "2026-07-05T04:58:45Z",
+        "from": "pending_dependency",
+        "to": "in_progress",
+        "note": "Started FAQ deduplication guard after BIG5-CMS-IMPORT-DRYRUN-01 merged into main."
+      },
+      {
+        "at": "2026-07-05T04:58:45Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Implemented dry-run FAQ dedupe planning. Focused syntax, PHPUnit, real desktop v2 package dry-run, targeted Pint, YAML/JSON parse, diff check, and allowed-path scope validation passed. Local full ci_verify_mbti had external IQ branch-diff interference recorded as sidecar."
       }
     ]
   },
@@ -565,7 +623,9 @@
       }
     ],
     "commit_sha": "265e1dcc58edd5a122627ff0e61594c5e3dbeeab",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01",
     "local_cleanup_executed": false,
@@ -677,7 +737,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_cleanup_complete",
     "title": "ANALYTICS-FUNNEL-GA4-BAIDU-MAPPING-SCAN-01 freeze GA4 Baidu funnel mapping",
     "transitions": [
@@ -1051,7 +1113,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "ci_fix_local_checks_passed",
     "title": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 connect Ops 7-day funnel to unified taxonomy read model",
     "transitions": [
@@ -1144,7 +1208,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03 freeze purchase report truth bridge",
     "transitions": [
@@ -1383,7 +1449,9 @@
       "git_diff_cached_check": null,
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_deployed_reconciled",
     "title": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02 fix share_click SQL compatibility",
     "transitions": [
@@ -2091,7 +2159,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2015",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "ready_to_merge",
     "title": "ARTICLE-H1-04: fix(ops): constrain article editor heading controls",
     "train_scope": "article_h1_single_dom",
@@ -2840,7 +2910,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_and_cleaned",
     "title": "AUDIT-SEC-RESULT-IDENTITY-01 harden result recovery identity boundary",
     "transitions": [
@@ -2918,7 +2990,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -3851,7 +3925,9 @@
       }
     },
     "commit_sha": "d62cbe6317f08d4307bd9488e5cf9059c3bcbf1d",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
@@ -4075,7 +4151,9 @@
       }
     },
     "commit_sha": "79b7931eb59d29b9c778b0333bbcb9ccbcc45cd0",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
@@ -4446,7 +4524,9 @@
       }
     },
     "commit_sha": "595811fa6f8aa2047b5f057aa4d8a96176871e609",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
@@ -4536,7 +4616,9 @@
     "commit_sha": "dcab310011707b7c6174ee3171ccf82a54f5750d",
     "content_authority": "backend",
     "database_mutation": false,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "deploy_allowed": false,
     "events": [
       {
@@ -4609,7 +4691,9 @@
       }
     },
     "commit_sha": "aad0bbd600a8519d2d55d54ba001467edc587c36",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "BIG5-CONTENT-ASSET-SCIENTIFIC-AUDIT-MAPPING-01",
     "local_cleanup_executed": true,
@@ -6288,7 +6372,9 @@
       }
     },
     "commit_sha": "ca9af5079add9914ed8d52fb18fb948585c138bf",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-22T16:34:43Z",
@@ -7270,7 +7356,9 @@
       }
     ],
     "commit_sha": "e30f96f4e068c2a7b62e1fe67950ffab6b061c72",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "CAREER-1046-OPS-SCOPE-RECONCILIATION-01",
     "local_cleanup_executed": true,
@@ -7284,7 +7372,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "completed",
     "title": "CAREER-1046-OPS-SCOPE-RECONCILIATION-01 reconcile public 1046 career runtime with CMS/Ops 378 scope",
     "transitions": [
@@ -7632,7 +7722,9 @@
       }
     },
     "commit_sha": "68f2b2dfc0b3b587a53ad85dc52a4b0f4b2eabcf",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": "Sidecar only: full Pint reports out-of-scope EQ test formatting issues; scoped current PR files and current-scope CI fixes passed locally.",
     "history": [
       {
@@ -8746,7 +8838,9 @@
       }
     },
     "commit_sha": "24288ec8713900f6709cd472b51f2d097ef263af",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; current PR focused test, route:list, scoped Pint, composer validate/audit, JSON/YAML, and diff checks pass.",
     "id": "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01",
     "local_cleanup_executed": true,
@@ -9099,14 +9193,18 @@
       }
     },
     "commit_sha": "af382b46070d1455f6b7e2d9fe9af18ba7cb0e55",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-09T15:28:28Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2020",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity",
     "train_scope": "career_zh_display_parity",
@@ -9572,14 +9670,18 @@
       }
     },
     "commit_sha": "12fab79a192c5f0537f2f61fbdc6614653fea9a9",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-11T02:45:32Z",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2025",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "CAREER-ZH-PARITY-FIX-01: fix(career): compact zh parity workbook readiness",
     "train_scope": "career_zh_parity_fix",
@@ -10426,7 +10528,9 @@
       "git_diff_cached_check": true,
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -11488,7 +11592,9 @@
       }
     ],
     "commit_sha": "6716bf50c3cd22691d4609434f8a2b12442b2c8a",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "DETAIL_READY_1046_DELTA_AUTHORITY_REPAIR-01",
     "local_cleanup_executed": false,
@@ -11502,7 +11608,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1046_DELTA_AUTHORITY_REPAIR-01 clean 1046 delta authority manifest",
     "transitions": [
@@ -11589,7 +11697,9 @@
       }
     ],
     "commit_sha": "67e95aac7a4344a407c5c1b563c4131a27d2d7aa",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": "blocked_backend_deploy_required: production backend REVISION 16c01f81b60bb9a5452a867c6c57a78aa77e57bc does not include required PR #1747 merge commit 6716bf50c3cd22691d4609434f8a2b12442b2c8a",
     "id": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01",
     "local_cleanup_executed": false,
@@ -11603,7 +11713,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01 production preflight for clean 1046 rollout apply",
     "transitions": [
@@ -11675,7 +11787,9 @@
       }
     ],
     "commit_sha": "09ec7f599b05d7d555ad186af81633010f5c47f3",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "DETAIL_READY_1046_ROLLOUT_NO_AUDIT_DRY_RUN-01",
     "local_cleanup_executed": false,
@@ -11689,7 +11803,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1046_ROLLOUT_NO_AUDIT_DRY_RUN-01 no-write career rollout dry-run",
     "transitions": [
@@ -11761,7 +11877,9 @@
       }
     ],
     "commit_sha": "e5cbc6816d70383ad33c9da985bd76d6c00c3b73",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "DETAIL_READY_1047_DELTA_AUTHORITY_REPAIR-01",
     "local_cleanup_executed": false,
@@ -11775,7 +11893,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1047_DELTA_AUTHORITY_REPAIR-01 clean 1047 delta authority manifest",
     "transitions": [
@@ -11847,7 +11967,9 @@
       }
     ],
     "commit_sha": "05f7dda0b1350e523c02ea38daccbbedd91ce7e4",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01",
     "local_cleanup_executed": false,
@@ -11861,7 +11983,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01 replacement index-state runtime projection conflict report",
     "transitions": [
@@ -12054,7 +12178,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01 replacement authority source repair",
     "transitions": [
@@ -12257,7 +12383,9 @@
       }
     },
     "commit_sha": "b20330097483c7283509633656a333d1b6d2007a",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "events": [
       {
         "at": "2026-07-02T16:10:24Z",
@@ -12312,7 +12440,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to ENNEA-RP-01 instant_summary registry copy, focused composer test, and user-authorized PR train metadata.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -12461,7 +12591,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to ENNEA-RP-02 type_registry Top3 card fields and PR train state reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -12569,7 +12701,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files remain confined to ENNEA-RP-03 type_registry deep_dive summary fields and PR train state metadata after rebase.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "ready_to_merge",
@@ -12705,7 +12839,9 @@
         "docs/codex/pr-train.yaml"
       ],
       "evidence": "Changed files are confined to ENNEA-RP-04 all9 profile runtime labels, related Enneagram tests, PR train metadata, and the required BigFive runtime-freeze guard exemption for the two Enneagram result-page runtime contract files.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -12818,7 +12954,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to confidence-band projection labels, confidence_band_card composer content, related Enneagram composer test, and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -12937,7 +13075,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to dominance_gap_card composer content, dominance_gap technical note registry copy, related Enneagram tests, and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -13053,7 +13193,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to close-call UI copy, pair fallback close-call guidance, and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -13167,7 +13309,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to type_registry blind_spot_copy content and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -13305,7 +13449,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "After rebase, changed files remain confined to center summary group registry content, center runtime projection, Enneagram tests, and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -13415,7 +13561,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to stance summary group registry content and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -13525,7 +13673,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to harmonic summary group registry content and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -13640,7 +13790,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to wing hint theory registry content and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -13757,7 +13909,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to methodology boundary method/ui registry content and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -13871,7 +14025,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to diffuse boundary method/technical note/ui registry content and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -13985,7 +14141,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to low-quality boundary UI copy, composer output, Enneagram composer test, and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -14097,7 +14255,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to work-style scenario/type registry content and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -14207,7 +14367,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to collaboration strengths content in type registry and train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_cleanup_complete",
@@ -14317,7 +14479,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to collaboration friction content in type registry plus train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_cleanup_complete",
@@ -14427,7 +14591,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to leadership pattern content in type registry plus train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_cleanup_complete",
@@ -14537,7 +14703,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to managed-by-others content in type registry plus train ledger reconciliation.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -14642,7 +14810,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
@@ -14754,7 +14924,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json",
@@ -14864,7 +15036,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
@@ -14985,7 +15159,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json",
@@ -15102,7 +15278,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/group_registry.json",
@@ -15218,7 +15396,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
@@ -15334,7 +15514,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/state_registry.json",
@@ -15451,7 +15633,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/state_registry.json",
@@ -15568,7 +15752,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/theory_hint_registry.json",
@@ -15685,7 +15871,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/scenario_registry.json",
@@ -15802,7 +15990,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
@@ -15912,7 +16102,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
@@ -16024,7 +16216,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/scenario_registry.json",
@@ -16147,7 +16341,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/scenario_registry.json",
@@ -16269,7 +16465,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/type_registry.json",
@@ -16395,7 +16593,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass",
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json",
@@ -16532,7 +16732,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/observation_registry.json",
         "docs/codex/pr-train-state.json"
@@ -16664,7 +16866,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/observation_registry.json",
         "backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json",
@@ -16802,7 +17006,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "changed_files": [
         "backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json",
         "backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json",
@@ -16925,7 +17131,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "changed_files": [
         "backend/app/Services/Report/EnneagramReportComposer.php",
         "backend/content_packs/ENNEAGRAM/v2/registry/method_registry.json",
@@ -17023,7 +17231,9 @@
         "backend/content_packs/ENNEAGRAM/v2/registry/sample_report_registry.json",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "ready_to_merge",
     "title": "ENNEA-RP-41: fix(enneagram): repair sample report link",
@@ -17116,7 +17326,9 @@
         "backend/content_packs/ENNEAGRAM/v2/registry/ui_copy_registry.json",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "ready_to_merge",
     "title": "ENNEA-RP-42: fix(enneagram): repair technical note link",
@@ -17211,7 +17423,9 @@
         "backend/tests/Unit/Services/Content/EnneagramTypeRegistryCoverageTest.php",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "ready_to_merge",
     "title": "ENNEA-RP-43: test(enneagram): enforce registry scientific and style guards",
@@ -17286,7 +17500,9 @@
           "docs/codex/pr-train.yaml"
         ],
         "evidence": "Changed files are confined to Enneagram forced-choice compiled question pack/manifest, focused Enneagram locale test, Big Five freeze classifier test-only allowance for the Enneagram pack files, and authorized PR-train metadata.",
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "pass"
       }
     },
@@ -17392,7 +17608,9 @@
       }
     },
     "commit_sha": "186ee67162d8ad287c2c6279f51950aca1d73ee2",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-22T11:44:35Z",
@@ -18117,7 +18335,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1684",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01": {
@@ -25117,7 +25337,9 @@
       }
     },
     "commit_sha": "9eeb91f57477072fe472b8269ac30ba83004691b",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-23T08:17:44Z",
@@ -25719,7 +25941,9 @@
       }
     },
     "commit_sha": "2d08bb46555389226adf6dbce80dcc9111e2b82a",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "events": [
       {
         "at": "2026-05-25T12:00:00Z",
@@ -25936,7 +26160,9 @@
           "docs/codex/pr-train.yaml"
         ],
         "evidence": "Final branch diff is confined to MBTI controller projection, MBTI English sidecar pack data, focused test, and PR train metadata; shared QuestionsService is no longer in the branch diff.",
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "pass"
       }
     },
@@ -26173,7 +26399,9 @@
     "commit_sha": "44f569449afa97e5a2e39c6dbf21ebdb87ba2c78",
     "content_authority": "backend",
     "database_mutation": false,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "deploy_allowed": false,
     "events": [
       {
@@ -26246,7 +26474,9 @@
       }
     },
     "commit_sha": "614af7ed2aa38dfa2201cb723f48e0f49de471a8",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-26T13:18:57Z",
@@ -26621,7 +26851,9 @@
       }
     },
     "commit_sha": null,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "events": [
       {
         "at": "2026-07-01T14:30:04.421Z",
@@ -26655,7 +26887,9 @@
         "docs/codex/pr-train-state.json",
         "generated/pr-train-sidecar-issues/**"
       ],
-      "outside_scope_files": []
+      "outside_scope_files": [
+
+      ]
     },
     "status": "pr_open",
     "title": "MBTI-PDF-SNAPSHOT-SYNC-GUARD-H1: add PDF snapshot render-source cache guard",
@@ -26722,7 +26956,9 @@
       }
     ],
     "commit_sha": "93556a55fbcf71aa998566eb4f276218cda48788",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "OPS-API-INTERNAL-RESOLVE-PROOF",
     "local_cleanup_executed": false,
@@ -26845,7 +27081,9 @@
     "base": "main",
     "branch": "codex/ops-ci-codescan-api-01",
     "checks": {
-      "github": [],
+      "github": [
+
+      ],
       "local": {
         "git_diff_check": "passed",
         "json_validation": "passed",
@@ -26854,7 +27092,9 @@
       }
     },
     "commit_sha": "962be45f81044d1eec60088ef34235f8e020032e",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "history": [
       {
@@ -26921,7 +27161,9 @@
       }
     },
     "commit_sha": "a194a0bb1d0cf83e130cce205cb9410cb48d725b",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "history": [
       {
@@ -26947,7 +27189,9 @@
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "github_checks_passed",
     "title": "fix(ci): eliminate CiScaleImpact Semgrep findings"
   },
@@ -27052,7 +27296,9 @@
       "git_diff_cached_check": null,
       "git_diff_check": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -27273,7 +27519,9 @@
         "backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php"
       ]
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -27297,7 +27545,9 @@
     "base": "main",
     "branch": "codex/ops-release-workflow-01",
     "checks": {
-      "github": [],
+      "github": [
+
+      ],
       "local": {
         "git_diff_check": "passed",
         "json_parse": "passed",
@@ -27340,7 +27590,9 @@
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "docs(ops): codify release operator workflow and deploy incident governance"
   },
@@ -27403,7 +27655,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "docs(ops): codify canonical healthz and release-only deploy policy"
   },
@@ -27640,7 +27894,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "github_checks_passed",
     "title": "PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03 classify Alipay owner mismatch paid orders",
     "transitions": [
@@ -27778,7 +28034,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "github_checks_failed_fix_prepared",
     "title": "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01 schedule Alipay pending payment compensation",
     "transitions": [
@@ -28026,7 +28284,9 @@
       "git_diff_cached_check": "passed",
       "git_diff_check": "passed"
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler",
     "transitions": [
@@ -28687,7 +28947,9 @@
       }
     },
     "commit_sha": "ec0ee01f84204e64f9891f33d6126a7de344a97d",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-25T22:19:24+08:00",
@@ -29580,7 +29842,9 @@
         "docs/audits/eq/eq_agent_runtime_acceptance_2026-06-25.md",
         "docs/codex/pr-train-state.json"
       ],
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "passed"
     },
     "status": "pr_open_p0_blocked_report",
@@ -30459,7 +30723,9 @@
       }
     ],
     "commit_sha": "5d47789f391d0c7cf2c68c63ad3edc22bbd10ea4",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "PR-EQ-ASSET-AUDIT-00",
     "local_cleanup_executed": true,
@@ -31387,7 +31653,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-09 allowed_paths.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -31822,7 +32090,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Scope validation passed against PR-EQ-ASSET-SCI-13 allowed_paths.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged_post_merge_revalidated",
@@ -32403,7 +32673,9 @@
       ]
     },
     "commit_sha": "2523eb2b4abb0c7c9aa6a26ab359fbfb6e659a4b",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "events": [
       {
         "at": "2026-06-26T15:21:54.232288+00:00",
@@ -33388,7 +33660,9 @@
       }
     },
     "commit_sha": "322bf0d8f0884c48730fc23c2713710315d19863",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": "Sidecar only: direct macOS curl to api.fermatmind.com still reports LibreSSL SSL_ERROR_SYSCALL; Node HTTPS and apex same-origin public API reads are healthy.",
     "history": [
       {
@@ -34092,7 +34366,9 @@
           "backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -34209,7 +34485,9 @@
           "git diff --check",
           "git diff --cached --check"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -34292,7 +34570,9 @@
           "git diff --check",
           "git diff --cached --check"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -34381,7 +34661,9 @@
           "git diff --check",
           "git diff --cached --check"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -34468,7 +34750,9 @@
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -34630,7 +34914,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1673",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "RESULT-EN-PARITY-06": {
@@ -34703,7 +34989,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1675",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "RIASEC-CONTENT-140CTA-01": {
@@ -36499,7 +36787,9 @@
       }
     },
     "commit_sha": "2ff9a76b669b356232cddb54dbada9452caa7071",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "id": "RIASEC-CONTENT-SCIENCE-00",
     "local_cleanup_executed": true,
@@ -36793,7 +37083,9 @@
           "docs/codex/pr-train.yaml"
         ],
         "evidence": "Changed files are confined to RIASEC compiled question packs/manifests, focused RIASEC locale test, Big Five freeze classifier test-only allowance for the RIASEC pack files, and authorized PR-train metadata.",
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "pass"
       }
     },
@@ -36994,7 +37286,9 @@
     "next_pr": "RIASEC-FULL-CONTENT-PACK-04",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1484",
     "remote_branch_deleted": true,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "RIASEC-FULL-CONTENT-PACK-03-PREFLIGHT": {
@@ -37068,7 +37362,9 @@
     "next_pr": "RIASEC-FULL-CONTENT-PACK-03",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1483",
     "remote_branch_deleted": true,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged"
   },
   "RIASEC-FULL-CONTENT-PACK-04": {
@@ -37149,7 +37445,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-04: Top3 code chain strategy asset import"
   },
@@ -37238,7 +37536,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-05: Import backend-authoritative RIASEC activity/task examples asset"
   },
@@ -37332,7 +37632,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-05-PREFLIGHT: Activity/task examples asset preflight"
   },
@@ -37416,7 +37718,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-06: Import backend-authoritative RIASEC occupation examples boundary asset"
   },
@@ -37504,7 +37808,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-06-PREFLIGHT: Occupation examples asset preflight"
   },
@@ -37598,7 +37904,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-07: 140Q task/environment/role narrative asset import"
   },
@@ -37690,7 +37998,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-08: Low quality / confidence / near-tie copy asset import"
   },
@@ -37769,7 +38079,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-09: Import backend-authoritative aspirations and disagree path assets"
   },
@@ -37859,7 +38171,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-09-PREFLIGHT: Aspirations and disagree path asset preflight"
   },
@@ -38132,7 +38446,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-11-BE: Backend lifecycle copy import for Share/PDF/History/FAQ/Technical Note"
   },
@@ -38225,7 +38541,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "RIASEC-FULL-CONTENT-PACK-11-BE-PREFLIGHT: Share/PDF/History/FAQ/Technical Note lifecycle copy backend preflight"
   },
@@ -38316,7 +38634,9 @@
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "pr_opened_github_checks_pending",
     "title": "RIASEC-FULL-CONTENT-PACK-13-BE: Backend full content fixture matrix and forbidden claim freeze"
   },
@@ -38553,7 +38873,9 @@
       "yaml_parse_pr_train_manifest": "passed"
     },
     "commit_sha": "03ecc9ad1f037e05206d319c0051629a98053664",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merge_commit": "fa0333b68ff4cb261e01be6658c73b4f9a82c7d0",
@@ -38783,7 +39105,9 @@
       }
     },
     "commit_sha": "436c62975f66236c5fca8f42994efde7e78453dd",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-21T14:20:02Z",
@@ -40261,7 +40585,9 @@
     "commit_sha": "56b0035ef9a880dcf1c98f1b2fe8c57b49bc6079",
     "content_authority": "backend",
     "database_mutation": false,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "deploy_allowed": false,
     "events": [
       {
@@ -40968,7 +41294,9 @@
     "commit_sha": "cb375f6b832be73dc3d2dbb96fbbede577646cf7",
     "content_authority": "backend",
     "database_mutation": false,
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "deploy_allowed": false,
     "events": [
       {
@@ -41283,7 +41611,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to API-03 allowed PDF token, Gotenberg URL, locked MBTI PDF access, config, and train state paths.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -41458,7 +41788,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "evidence": "Changed files are confined to API-04 allowed PDF artifact descriptor, DSAR purge, lifecycle residual audit, BigFive runtime-freeze classifier, and train manifest/state paths.",
-      "outside_scope_files": [],
+      "outside_scope_files": [
+
+      ],
       "status": "pass"
     },
     "status": "merged",
@@ -44381,7 +44713,9 @@
       }
     },
     "commit_sha": "89ba8ee1a64d5a7269c55402ceccee4e83198af6",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-05T03:12:58Z",
@@ -44477,7 +44811,9 @@
     "remote_branch_deleted": true,
     "repo": "fap-api",
     "result": {
-      "blockers": [],
+      "blockers": [
+
+      ],
       "cms_draft_created": false,
       "content_blocked": false,
       "content_safe": true,
@@ -44782,7 +45118,9 @@
       }
     },
     "commit_sha": "933d82e204cf01930424b1635258926c9803777a",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-05T00:46:15Z",
@@ -44951,7 +45289,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -45033,7 +45373,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -45291,7 +45633,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -45374,7 +45718,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -45441,7 +45787,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -45627,7 +45975,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -45684,7 +46034,9 @@
       "local_validation_passed": null,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_external_dependency",
     "transitions": [
       {
@@ -45697,7 +46049,9 @@
   },
   "SEO-CMS-CANARY-PREVIEW-01": {
     "branch": "codex/seo-cms-canary-preview-01",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": "11e82c0c7000bc90f2ec550b83d80a9b941465dc",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
@@ -45789,7 +46143,9 @@
       "origin_main_contains_merge_commit": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -45875,7 +46231,9 @@
       "local_validation_passed": true,
       "post_merge_revalidated": true
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "transitions": [
       {
@@ -46094,7 +46452,9 @@
   },
   "SEO-CONTENT-P1-09": {
     "branch": "codex/seo-content-p1-09",
-    "checks": [],
+    "checks": [
+
+    ],
     "commit_sha": "6547f4e08aebd665da98916dd5787a4a23adfed9",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
@@ -46350,7 +46710,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2011",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily",
     "train_scope": "seo_conversion_tracking",
@@ -46475,7 +46837,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2010",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "merged",
     "title": "SEO-CONV-INGEST-02: feat(analytics): accept canonical SEO conversion funnel ingest",
     "train_scope": "seo_conversion_tracking",
@@ -46603,7 +46967,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2012",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "status": "github_checks_passed_ready_to_merge",
     "title": "SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts",
     "train_scope": "seo_conversion_tracking",
@@ -46721,7 +47087,9 @@
       "runtime_code_edit_performed": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "docs(seo): reconcile seo_intel schema and read-only API contract",
     "train_scope": "search_intelligence_schema_api_contract",
@@ -46881,7 +47249,9 @@
       "read_only_api": true,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "feat(seo): add seo_intel read-only dashboard API contract",
     "train_scope": "seo_intel_read_only_dashboard_api",
@@ -46997,7 +47367,9 @@
       "scheduler_enabled": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "docs(seo): define post-migration collector dry-run readiness",
     "train_scope": "seo_intel_collector_dry_run_readiness",
@@ -47105,7 +47477,9 @@
       "scheduler_enabled": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged_cleanup_complete",
     "title": "docs(seo): record collector dry-run smoke evidence",
     "train_scope": "seo_intel_collector_dry_run_smoke_evidence",
@@ -47212,7 +47586,9 @@
       "scheduler_enabled": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "docs(seo): define controlled collector write gate",
     "train_scope": "seo_intel_controlled_collector_write_gate",
@@ -47310,7 +47686,9 @@
       "runtime_route_changed": false,
       "search_submission_performed": false
     },
-    "sidecars": [],
+    "sidecars": [
+
+    ],
     "status": "merged",
     "title": "docs(seo): define seo_intel migration readiness gate",
     "train_scope": "seo_intel_migration_readiness_gate",
@@ -47436,7 +47814,9 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1466",
     "remote_branch_deleted": true,
     "repo": "fap-api",
-    "sidecar_issues": [],
+    "sidecar_issues": [
+
+    ],
     "state": "merged",
     "status": "merged"
   },
@@ -47705,7 +48085,9 @@
       }
     },
     "commit_sha": "42ef31190f68ebda879a9362bad511052d50a7a9",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-25T21:12:00+08:00",
@@ -48781,7 +49163,9 @@
       }
     },
     "commit_sha": "70bce0cbc971fe52f85d49d338bf79b284806862",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": true,
     "merged_at": "2026-06-08T17:03:46Z",
@@ -48990,7 +49374,9 @@
       }
     },
     "commit_sha": "302e4171f9eb5ace6d913f2fdb310b3379e6cbd2",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
@@ -49059,7 +49445,9 @@
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "passed"
       }
     },
@@ -49152,12 +49540,16 @@
           "docs/codex/pr-train.yaml"
         ],
         "evidence": "Changed files are confined to read-only scan artifacts, focused test, and PR train metadata.",
-        "outside_scope": [],
+        "outside_scope": [
+
+        ],
         "status": "pass"
       }
     },
     "commit_sha": "75b26a54aa2e66cb892d58e88b526f7848d6ac4c",
-    "depends_on": [],
+    "depends_on": [
+
+    ],
     "failure_reason": null,
     "history": [
       {
@@ -49498,7 +49890,8 @@
     ],
     "status": "pending",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
-    "checks": {},
+    "checks": {
+    },
     "scope_validation": {
       "allowed_paths_only": null,
       "local_validation_passed": null,
@@ -49539,7 +49932,8 @@
     ],
     "status": "pending",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
-    "checks": {},
+    "checks": {
+    },
     "scope_validation": {
       "allowed_paths_only": null,
       "local_validation_passed": null,
@@ -49644,8 +50038,12 @@
       "scope_type": "cn_proxy_public_owner_reviewed_manifest_gate_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -49835,7 +50233,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1627",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "updated_at": "2026-05-24T02:08:03+08:00"
     },
@@ -49871,7 +50271,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "schema_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "open",
       "title": "feat(api): add career canonical eligibility audit schema"
     },
@@ -49964,7 +50366,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_cohort_readiness_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "draft_pr_open",
       "title": "feat(api): add career 80 cohort readiness plan"
     },
@@ -50051,7 +50455,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "manifest_train_generator_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_local_checks_passed_pending_github_rerun",
       "title": "feat(api): add career canonical expansion manifest train generator"
     },
@@ -50138,7 +50544,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "batch_live_acceptance_v2_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "open",
       "title": "feat(api): add career batch live acceptance v2"
     },
@@ -50221,7 +50629,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "full_audit_artifact_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career 2786 full audit artifact report"
     },
@@ -50262,7 +50672,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "source_resolver_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career public resolution plan resolver"
     },
@@ -50354,7 +50766,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "entity_inventory_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career occupation entity inventory audit"
     },
@@ -50448,8 +50862,12 @@
       "scope_type": "baseline_metadata_inventory_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed after AUDIT-4 allowlist fix in unrelated BigFive norm/content tests with SQLSTATE[HY000]: General error: 5 database is locked against /tmp/fap-ci.sqlite.",
             "Scoped AUDIT-4 tests, AUDIT-1/2/3 regressions, pint, git diff --check, and BigFive runtime freeze path gate passed."
@@ -50554,7 +50972,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "index_state_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career index-state authority audit"
     },
@@ -50645,7 +51065,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "runtime_projection_truth_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career runtime projection truth eligibility audit"
     },
@@ -50740,7 +51162,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "seo_geo_readiness_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career seo geo readiness audit"
     },
@@ -50830,7 +51254,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "surface_readiness_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career surface readiness audit"
     },
@@ -50926,7 +51352,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "canonical_eligibility_command_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career canonical eligibility audit command"
     },
@@ -51647,7 +52075,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "high",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_committed",
       "title": "fix(security): redact IQ answer keys and locked report payloads",
       "train_scope": "security_audit_remediation"
@@ -51742,7 +52172,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_pending",
       "title": "fix(security): scope ops release failure audits by org",
       "train_scope": "security_audit_remediation"
@@ -51921,7 +52353,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1633",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "CAREER-1046-FRONTEND-DISCOVERY-UX-01": {
@@ -51952,7 +52386,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "CAREER-1046-FRONTEND-DISCOVERY-UX-01 career discovery UX",
       "transitions": [
@@ -52027,7 +52463,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01 career internal linking authority",
       "transitions": [
@@ -52131,7 +52569,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "CAREER-1046-OBSERVABILITY-SLO-01 career runtime observability SLO",
       "transitions": [
@@ -52238,7 +52678,9 @@
         }
       },
       "commit_sha": "b2713e384d5a6d0b650df56222eac19831df21b8",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "id": "CAREER-1046-OPS-READ-MODEL-REPAIR-01",
       "local_cleanup_executed": true,
@@ -52254,7 +52696,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "CAREER-1046-OPS-READ-MODEL-REPAIR-01 career runtime read model repair",
       "transitions": [
@@ -53014,7 +53458,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_search_channel_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add 360 Sogou Shenma adapter contracts",
       "train_scope": "china_search_domestic_adapter_contracts"
@@ -53121,7 +53567,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_crawler_log_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add Chinese crawler log collector foundation",
       "train_scope": "chinese_crawler_log_collector_foundation"
@@ -53238,7 +53686,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -53290,7 +53740,9 @@
         }
       },
       "commit_sha": null,
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": "Initial GitHub verify-bigfive failed because the first pushed history added a backend/app runtime file. The branch is being rewritten to test-support-only scope and revalidated.",
       "id": "CLINICAL-LAUNCH-01",
       "local_cleanup_executed": false,
@@ -53338,7 +53790,9 @@
     "CLINICAL-LAUNCH-02": {
       "base": "main",
       "branch": "codex/clinical-launch-02",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-01"
@@ -53357,15 +53811,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-02 claim boundary naming and disclaimer gate",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-03": {
       "base": "main",
       "branch": "codex/clinical-launch-03",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-02"
@@ -53384,15 +53844,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-03 SDS source and suitability audit",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-04": {
       "base": "main",
       "branch": "codex/clinical-launch-04",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-03"
@@ -53411,15 +53877,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-04 crisis sentinel gate",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-05": {
       "base": "main",
       "branch": "codex/clinical-launch-05",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-04"
@@ -53438,15 +53910,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-05 locale-aware crisis resources",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-06": {
       "base": "main",
       "branch": "codex/clinical-launch-06",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-05"
@@ -53465,15 +53943,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-06 sensitive health data consent and retention gate",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-07": {
       "base": "main",
       "branch": "codex/clinical-launch-07",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-06"
@@ -53492,15 +53976,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-07 free safety and paid report boundary",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-08": {
       "base": "main",
       "branch": "codex/clinical-launch-08",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-07"
@@ -53519,15 +54009,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-08 clinical related article authority plan",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-09": {
       "base": "main",
       "branch": "codex/clinical-launch-09",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-08"
@@ -53546,15 +54042,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-09 robots contract and launch-state SEO gate",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-10": {
       "base": "main",
       "branch": "codex/clinical-launch-10",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-09"
@@ -53573,15 +54075,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-10 SDS canary and Clinical staged noindex enforcement",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-11": {
       "base": "main",
       "branch": "codex/clinical-launch-11",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-10"
@@ -53600,15 +54108,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-11 SDS commercial launch content authority",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-12": {
       "base": "main",
       "branch": "codex/clinical-launch-12",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-11"
@@ -53627,15 +54141,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-12 SDS report personalization authority",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-13": {
       "base": "main",
       "branch": "codex/clinical-launch-13",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-12"
@@ -53654,15 +54174,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-13 Clinical Combo staged content authority",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-14": {
       "base": "main",
       "branch": "codex/clinical-launch-14",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-13"
@@ -53681,15 +54207,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-14 Clinical Combo report personalization authority",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-15": {
       "base": "main",
       "branch": "codex/clinical-launch-15",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-14"
@@ -53708,15 +54240,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-15 clinical media and article import package",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-16": {
       "base": "main",
       "branch": "codex/clinical-launch-16",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-15"
@@ -53735,15 +54273,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-16 Ops clinical launch governance surfaces",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-17": {
       "base": "main",
       "branch": "codex/clinical-launch-17",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-16"
@@ -53762,15 +54306,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-17 frontend clinical UX polish handoff",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-18": {
       "base": "main",
       "branch": "codex/clinical-launch-18",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-17"
@@ -53789,15 +54339,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-18 clinical commerce and recovery validation",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-19": {
       "base": "main",
       "branch": "codex/clinical-launch-19",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-18"
@@ -53816,15 +54372,21 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-19 SDS Search Channel production preflight",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CLINICAL-LAUNCH-20": {
       "base": "main",
       "branch": "codex/clinical-launch-20",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": null,
       "depends_on": [
         "CLINICAL-LAUNCH-19"
@@ -53843,10 +54405,14 @@
         "local_validation_passed": null,
         "post_merge_revalidated": null
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "pending",
       "title": "CLINICAL-LAUNCH-20 SDS canary submission and review",
-      "transitions": []
+      "transitions": [
+
+      ]
     },
     "CMD-FIX-1": {
       "branch": "fix/career-audit-command-layer-orchestration",
@@ -53872,7 +54438,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_command_orchestration_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): wire career eligibility audit command to layer services"
     },
@@ -54053,7 +54621,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1628",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "updated_at": "2026-05-24T02:40:27+08:00"
     },
@@ -54175,7 +54745,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -54324,7 +54896,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -55526,7 +56100,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_context_consumer_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_passed",
       "title": "fix(api): add career audit entity index context inputs"
     },
@@ -55580,7 +56156,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_context_producer_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged_reconciled",
       "title": "feat(api): add career audit db context exporters"
     },
@@ -55636,7 +56214,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "surface_context_producer_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career surface context export producer"
     },
@@ -55671,7 +56251,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1629",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01": {
@@ -55741,7 +56323,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1741",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "local_validation_passed",
       "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01 controlled replacement authority import path",
       "transitions": [
@@ -56067,7 +56651,9 @@
         }
       },
       "commit_sha": "32fb9a3a",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "history": [
         {
@@ -56097,7 +56683,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "low",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "chore(security): add docs shell safety guard",
       "train_scope": "storage_runtime_hygiene"
@@ -56142,7 +56730,9 @@
         }
       },
       "commit_sha": "a95de5c9ff047851336ee1f7c35b2255ac8ba683",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-25T04:07:01.632393+00:00",
@@ -56359,7 +56949,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1667",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "EN-PARITY-03": {
@@ -56448,7 +57040,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1672",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "EN-PARITY-04": {
@@ -56523,7 +57117,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1674",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "local_validation_passed"
     },
     "EN-PARITY-05": {
@@ -56602,7 +57198,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1676",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "EN-PARITY-06": {
@@ -57119,7 +57717,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02 article English counterpart draft package"
     },
@@ -57238,7 +57838,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-CAREER-CONTENT-BATCH-05 career content English draft package"
     },
@@ -57400,7 +58002,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-CONTENT-PAGES-TRANSLATION-BATCH-01 human-reviewed content/help/policy English translation batch"
     },
@@ -57462,7 +58066,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1690",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "GLOBAL-EN-ZH-GLOBAL-UI-I18N-BATCH-08": {
@@ -57513,7 +58119,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "manifest_registered",
       "title": "GLOBAL-EN-ZH-GLOBAL-UI-I18N-BATCH-08 global UI i18n parity review and frontend consumer follow-up"
     },
@@ -57668,7 +58276,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_local_validation_passed",
       "title": "GLOBAL-EN-ZH-MEDIA-ALT-VISUAL-REVIEW-BATCH-07 media alt and visual review package"
     },
@@ -57744,7 +58354,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1681",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_pending"
     },
     "GLOBAL-EN-ZH-PARITY-SCAN-00": {
@@ -57785,7 +58397,9 @@
         }
       },
       "commit_sha": "87345d16c4b7b22a23ead480925bb1f4c58d2721",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-25T11:36:50.288480+00:00",
@@ -57946,7 +58560,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-RESEARCH-CLAIM-REVIEW-BATCH-04 research English translation and claim review package"
     },
@@ -58053,7 +58669,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-RESULT-REPORT-ASSET-BATCH-06 result report English asset draft package"
     },
@@ -58168,7 +58786,9 @@
         "search_channel_action": false,
         "url_submission": false
       },
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "GLOBAL-EN-ZH-TOPIC-TEST-LANDING-BATCH-03 topic test landing English parity draft package"
     },
@@ -58241,7 +58861,9 @@
     "IQ-CMS-MEDIA-02": {
       "base": "main",
       "branch": "codex/iq-cms-media-02-rendering-guard",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "IQ-CMS-MEDIA-01"
       ],
@@ -58355,7 +58977,9 @@
         }
       },
       "commit_sha": "f305f93a",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "id": "IQ-NORM-01",
       "local_cleanup_executed": true,
@@ -58832,7 +59456,9 @@
     "IQ-PAID-REPORT-01": {
       "base": "main",
       "branch": "codex/iq-paid-report-01-entitlement-contract",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": "60eabe326f7e24e71a1bef555493dc9a1d6e6f13",
       "depends_on": [
         "IQ-NORM-03"
@@ -58870,7 +59496,9 @@
     "IQ-PAID-REPORT-02": {
       "base": "main",
       "branch": "codex/iq-paid-report-02-render-entitlement-states",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "IQ-PAID-REPORT-01"
       ],
@@ -58900,7 +59528,9 @@
     "IQ-RELEASE-01": {
       "base": "main",
       "branch": "codex/iq-release-01-launch-readiness-ledger",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "IQ-OBS-01"
       ],
@@ -59022,7 +59652,9 @@
     "IQ-SEO-RAMP-02": {
       "base": "main",
       "branch": "codex/iq-seo-ramp-02-indexation-gate",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "IQ-SEO-RAMP-01"
       ],
@@ -59331,7 +59963,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add Metabase ops access runbook"
     },
@@ -59460,7 +60094,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add Ops Portal SEO auth audit contract"
     },
@@ -59517,7 +60153,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(ops): add SEO dashboard access shell"
     },
@@ -59574,7 +60212,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add private Metabase access bridge contract"
     },
@@ -59638,7 +60278,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add Ops Portal SEO access verification contract"
     },
@@ -59680,7 +60322,9 @@
       "remote_branch_deleted": null,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "verified",
       "title": "/ops/seo production access verification"
     },
@@ -59790,7 +60434,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1626",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "OPS-SECURITY-STORAGE-PATH-SAFETY-01": {
@@ -59852,7 +60498,9 @@
         }
       },
       "commit_sha": "c5d45863c786b8825e1514db97a7db28fa2a9808",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-24T01:05:00+08:00",
@@ -59877,7 +60525,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1625",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "PERSONALITY-ENNEAGRAM-COMPAT-01": {
@@ -59973,7 +60623,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1640",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "local_validated"
     },
     "PR-2": {
@@ -60450,7 +61102,9 @@
       "branch": "codex/pr-audit-be-01-ci-supply-chain",
       "checks": {
         "github_required_checks": {
-          "failed": [],
+          "failed": [
+
+          ],
           "passed": [
             "hygiene",
             "supply-chain",
@@ -60463,7 +61117,9 @@
           "status": "passed"
         },
         "local": {
-          "failed": [],
+          "failed": [
+
+          ],
           "passed": [
             "cd backend && composer validate --strict",
             "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
@@ -60479,7 +61135,9 @@
         }
       },
       "commit_sha": "c87d9bc11f4e1cf90e60c06660b472e8afeb10a0",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-24T07:16:21.665+00:00",
@@ -60518,7 +61176,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1644",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "updated_at": "2026-05-24T07:40:49.781Z"
     },
@@ -60527,7 +61187,9 @@
       "checks": {
         "github_required_checks": {
           "evidence": "PR #1645 passed required GitHub checks and was squash-merged as 0338122739bbe4fd9645943d4f08372a3881f560.",
-          "failed": [],
+          "failed": [
+
+          ],
           "head_sha": "1051d5a87f12f518eb0a6cff7270ebb7be5dbcc2",
           "passed": [
             "hygiene",
@@ -60659,7 +61321,9 @@
         },
         "github": {
           "evidence": "GitHub required checks passed on PR #1648 after adding the scoped runtime-freeze classifier evidence for the attempt_quality retirement migration.",
-          "failed": [],
+          "failed": [
+
+          ],
           "head_sha": "4aa43fd17a91dfca4f4b4035e3c77f9862f211dc",
           "passed": [
             "hygiene",
@@ -60675,7 +61339,9 @@
         },
         "github_required_checks": {
           "evidence": "GitHub PR #1648 is MERGED and origin/main contains merge commit d18c0cc36a84ce50b823c995e4226b188551b0d0.",
-          "failed": [],
+          "failed": [
+
+          ],
           "head_sha": "ac79f977b060252b0f4c0bde711643b2069c7380",
           "passed": [
             "hygiene",
@@ -60749,7 +61415,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1648",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "updated_at": "2026-05-24T10:46:53.618Z"
     },
@@ -61023,7 +61691,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "controlled_codex_assisted_cms_publish_sop",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "PR-CMS-04｜Controlled Codex-Assisted CMS Publish SOP"
     },
@@ -61111,7 +61781,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "semantic_content_gate_architecture",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "PR-CMS-FIX-MASTER｜Scalable Semantic Content Gate Architecture"
     },
@@ -61656,7 +62328,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "article_multi_test_graph_edges",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_local_checks_passed",
       "title": "PR-GRAPH-01｜Article Multi-Test Graph Edges"
     },
@@ -61728,7 +62402,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "PR-HIRING-01 hiring content authority package",
       "transitions": [
@@ -61836,7 +62512,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1418",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "PR-MEDIA-01｜CMS Media Library OSS/CDN Upload Automation"
     },
@@ -61952,7 +62630,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -62057,7 +62737,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(cms): add Research Asset backend MVP"
     },
@@ -62131,7 +62813,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(research): add SEO GEO search channel contract"
     },
@@ -62254,7 +62938,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "article_authority_import_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): import six SEO articles with SVG covers"
     },
@@ -62335,7 +63021,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "article_graph_authority_closure_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): close six-article graph recommendation authority"
     },
@@ -62416,7 +63104,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "article_baseline_republish_projection_convergence_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "open",
       "title": "fix(api): republish article baseline and complete public projection"
     },
@@ -62508,7 +63198,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "chore(cms): add article publish smoke for cover image propagation",
       "train_scope": "publishing_reliability"
@@ -62564,7 +63256,9 @@
         }
       },
       "commit_sha": "5a609e81aaeaaecf0577f7b68fec99f28588f0f8",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "history": [
         {
@@ -62594,7 +63288,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(cms-media): enforce public article media origin and variant readiness",
       "train_scope": "publishing_reliability"
@@ -62791,8 +63487,12 @@
       "scope_type": "final_2786_public_resolution_partition_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -62893,8 +63593,12 @@
       "scope_type": "final_2786_public_owner_partition_authority_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -62994,7 +63698,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "final_2786_software_manual_hold_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): account software manual hold in 2786 readiness"
     },
@@ -63047,7 +63753,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "delta_rollout_manifest_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career 51-delta rollout manifest"
     },
@@ -63100,7 +63808,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_80_candidate_selector_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career 80 candidate readiness selector"
     },
@@ -63154,7 +63864,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_runtime_candidate_pool_planner_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "committed",
       "title": "feat(api): add career 80 runtime candidate pool planner"
     },
@@ -63212,7 +63924,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "career_80_live_surface_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): align career 80 live surface with runtime authority"
     },
@@ -63265,7 +63979,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_manifest_train_command_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "feat(api): add career 80 manifest train command"
     },
@@ -63318,7 +64034,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_readiness_command_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(api): add career 80 cohort readiness command"
     },
@@ -63371,7 +64089,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "80_readiness_selection_gate_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): tighten career 80 readiness candidate selection"
     },
@@ -63425,7 +64145,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "80_target_delta_decomposition_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career 80 target delta decomposition"
     },
@@ -63479,7 +64201,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "career_80_total_live_acceptance_report_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): add career 80 total live acceptance report"
     },
@@ -63580,7 +64304,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_baseline_metadata_mapping_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): map career workbook baseline metadata for audit"
     },
@@ -63631,7 +64357,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "candidate_aware_audit_policy_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "github_checks_passed_human_review_pending",
       "title": "fix(api): accept candidate-aware runtime states for delta planning"
     },
@@ -63702,7 +64430,9 @@
       "failure_reason": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1431",
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): add guarded CN proxy noindex public-owner surface"
     },
@@ -63790,7 +64520,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium_publication_authority",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "committed",
       "title": "fix(api): add CN proxy visible detail policy authority",
       "train_scope": "cn_proxy_visible_detail_policy_authority"
@@ -63871,7 +64603,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "delta_rollout_apply_batch_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): repair career delta rollout apply batch authority"
     },
@@ -63924,7 +64658,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "delta_rollout_gate_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career delta rollout gate semantics"
     },
@@ -64005,7 +64741,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): promote display-backed directory draft jobs in list authority",
       "train_scope": "career_directory_detail_pending_authority"
@@ -64097,7 +64835,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): align directory list with runtime detail authority",
       "train_scope": "career_directory_list_detail_api_authority"
@@ -64151,7 +64891,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_occupation_entity_remediation_planning_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "committed",
       "title": "fix(api): add career occupation entity remediation planning"
     },
@@ -64227,8 +64969,12 @@
       "scope_type": "explicit_rollout_batch_ledger_authority_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed BigFiveResultPageV2CoreBodyPreviewTest::runtime_paths_have_no_uncommitted_diff while reporting CMS test-edge files from the parent worktree, not the current PR files.",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at compiled directory assertions.",
@@ -64343,7 +65089,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_index_state_remediation_planning_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ci_fix_local_checks_passed",
       "title": "fix(api): add career index-state remediation planning"
     },
@@ -64400,7 +65148,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "readiness_policy_classification_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): classify career readiness policy blockers"
     },
@@ -64456,7 +65206,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "index_state_remediation_gate_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): add guarded career index state remediation command"
     },
@@ -64515,7 +65267,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "post_rollout_runtime_projection_authority_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): include verified rollout batches in career runtime projection"
     },
@@ -64552,7 +65306,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): align career 2786 product claim authority",
       "train_scope": "career_product_claim_authority"
@@ -64615,8 +65371,12 @@
       "scope_type": "progressive_closeout_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive closeout command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -64632,8 +65392,12 @@
           "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure"
         },
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
             "Current PR does not modify backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
@@ -64706,8 +65470,12 @@
       "scope_type": "progressive_cohort_target_delta_planning_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed only Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive audit/command/test/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -64783,8 +65551,12 @@
       "scope_type": "progressive_live_acceptance_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive live acceptance command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -64800,8 +65572,12 @@
           "title": "ci_verify_mbti content pack publish/rollback target compiled directory failure"
         },
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
             "Current PR does not modify backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
@@ -64877,8 +65653,12 @@
       "scope_type": "progressive_live_verification_scaling_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at tests/Feature/Content/PacksPublishBig5Test.php:94 asserting File::isDirectory($target.'/compiled').",
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at tests/Feature/Content/PacksRollbackBig5Test.php:97 asserting File::isDirectory($target.'/compiled').",
@@ -64966,7 +65746,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "progressive_readiness_cn_proxy_exclusion_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): exclude CN proxy rows from progressive readiness"
     },
@@ -65024,7 +65806,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "progressive_readiness_occupation_aware_selection_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): make progressive readiness selection occupation-aware"
     },
@@ -65080,7 +65864,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "progressive_readiness_selection_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "committed",
       "title": "fix(api): add progressive career readiness selection"
     },
@@ -65157,8 +65943,12 @@
       "scope_type": "progressive_readiness_software_manual_hold_exclusion_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksPublishBig5Test at the target compiled directory assertion.",
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksRollbackBig5Test at the target compiled directory assertion.",
@@ -65233,8 +66023,12 @@
       "scope_type": "progressive_rollout_manifest_gate_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive rollout manifest/gate command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -65310,8 +66104,12 @@
       "scope_type": "progressive_runtime_artifact_refresh_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career runtime artifact refresh command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -65383,7 +66181,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "progressive_runtime_candidate_pool_selection_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): consume progressive delta slugs in runtime candidate pool"
     },
@@ -65444,8 +66244,12 @@
       "scope_type": "progressive_runtime_candidate_preparation_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career runtime candidate prep command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -65532,7 +66336,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "rollout_command_candidate_aware_artifact_normalization_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(api): normalize candidate-aware rollout projection artifacts"
     },
@@ -65564,7 +66370,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_run_context_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): make career audit run context explicit"
     },
@@ -65669,7 +66477,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_runtime_authority_classification_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): classify career runtime authority gaps for audit"
     },
@@ -65722,7 +66532,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "runtime_artifact_refresh_plan_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career runtime artifact refresh plan"
     },
@@ -65780,7 +66592,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "candidate_aware_runtime_artifact_refresh_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "github_checks_failed_scoped_fix_local_passed",
       "title": "fix(api): add candidate-aware runtime artifact refresh"
     },
@@ -65833,7 +66647,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "runtime_candidate_prep_planner_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career runtime candidate preparation planner"
     },
@@ -65888,7 +66704,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "runtime_candidate_prep_apply_gate_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add guarded runtime candidate preparation command"
     },
@@ -65956,8 +66774,12 @@
       "scope_type": "runtime_projection_lookup_latest_selection_only",
       "sidecar_issues": [
         {
-          "affected_locales": [],
-          "affected_slugs": [],
+          "affected_locales": [
+
+          ],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksPublishBig5Test at compiled directory assertion.",
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksRollbackBig5Test at compiled directory assertion.",
@@ -66076,7 +66898,9 @@
             "en",
             "zh"
           ],
-          "affected_slugs": [],
+          "affected_slugs": [
+
+          ],
           "evidence": [
             "SCAN-3 counts_by_reason_layer maps required_display_field_missing to baseline, not seo_geo.",
             "REPAIR-BASELINE-1 is the next train item and explicitly owns baseline/display metadata mapping."
@@ -66145,7 +66969,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "audit_surface_context_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): add career surface context artifact support"
     },
@@ -66251,7 +67077,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "audit_title_source_mapping_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "fix(api): use workbook english titles in career audit"
     },
@@ -66310,7 +67138,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add Research report URL Truth observation"
     },
@@ -66363,7 +67193,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "github_checks_passed_pending_merge",
       "title": "docs(research): add first Research publish readiness checklist"
     },
@@ -66521,7 +67353,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1668",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_pending"
     },
     "RESULT-EN-PARITY-02": {
@@ -66596,7 +67430,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1669",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "RESULT-EN-PARITY-03": {
@@ -66676,7 +67512,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1670",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "RESULT-EN-PARITY-04": {
@@ -66771,7 +67609,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1671",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_rebased_github_checks_pending"
     },
     "RIASEC-AH-04": {
@@ -66941,7 +67781,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1632",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "RIASEC-DEEP-COPY-01": {
@@ -67007,7 +67849,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_deep_copy_slot_schema_contract_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): harden deep copy slot schema contract"
     },
@@ -67071,7 +67915,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_dimension_deep_copy_slots_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add dimension deep copy runtime slots"
     },
@@ -67512,7 +68358,9 @@
         }
       },
       "commit_sha": "7207f737cd469883370ccae25c6d175ff75c951d",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "local_cleanup_executed": true,
       "merged_at": "2026-05-13T07:06:00Z",
@@ -67520,7 +68368,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "train_registration_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(codex): register RIASEC personalization train"
     },
@@ -67573,7 +68423,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_interpretation_contract_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add interpretation rule spec v2 contract"
     },
@@ -67622,7 +68474,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_quality_contract_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add quality rule spec v2 contract"
     },
@@ -67667,7 +68521,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_projection_extension_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): extend projection v2 with interpretation state"
     },
@@ -67714,7 +68570,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "scope_type": "backend_module_selector_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add report module selector contract"
     },
@@ -67759,7 +68617,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "scope_type": "backend_content_registry_readiness_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): add content registry readiness contract"
     },
@@ -67771,7 +68631,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "branch": "codex/riasec-personalization-06-frontend-fail-closed",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": "bb01c378674b28857b98ddbdf3d657144ef3b83e",
       "depends_on": [
         "RIASEC-PERSONALIZATION-03",
@@ -67784,7 +68646,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-web",
       "scope_type": "frontend_fail_closed_consumer_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(riasec): consume backend personalization state fail-closed"
     },
@@ -67795,7 +68659,9 @@
         "docs/codex/pr-train-state.json"
       ],
       "branch": "codex/riasec-personalization-07-fixture-matrix",
-      "checks": [],
+      "checks": [
+
+      ],
       "commit_sha": "7740b1b09ce6dddb693ac5dbcf8a1d027b0db08b",
       "depends_on": [
         "RIASEC-PERSONALIZATION-01",
@@ -67812,14 +68678,18 @@
       "remote_branch_deleted": false,
       "repo": "fap-web",
       "scope_type": "fixture_matrix_contracts_only",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pending",
       "title": "test(riasec): add personalization fixture matrix contracts"
     },
     "SEARCH-CHANNEL-LIVE-MBTI-01": {
       "branch": "codex/search-channel-live-mbti-01-preflight",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_live_preflight_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveMbti01Preflight --no-ansi (1 test, 25 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -67877,7 +68747,9 @@
     "SEARCH-CHANNEL-LIVE-MBTI-02": {
       "branch": "codex/search-channel-live-mbti-02",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_live_submission_test": "passed: php artisan test --filter=SeoIntelSearchChannelLiveMbti02 --no-ansi (1 test, 14 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -67947,7 +68819,9 @@
     "SEARCH-CHANNEL-LIVE-MBTI-02-24H-REVIEW": {
       "branch": "codex/search-channel-live-mbti-02-24h-review",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_twenty_four_hour_review_test": "passed_with_warnings: php artisan test --filter=SeoIntelSearchChannelLiveMbti02TwentyFourHourReview --no-ansi exited 0 with 1 warning and 14 assertions",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -68368,7 +69242,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -68431,7 +69307,9 @@
         }
       },
       "commit_sha": "dc96157c0c226ed39c2036a27670c092bc54013f",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "local_cleanup_executed": true,
       "merged_at": "2026-06-02T11:46:03Z",
@@ -68445,7 +69323,9 @@
         "local_validation_passed": true,
         "post_merge_revalidated": true
       },
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "transitions": [
         {
@@ -69061,7 +69941,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_collector",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open_github_checks_passed",
       "title": "feat(seo-intel): add drift collector and crawler log foundation",
       "train_scope": "search_intelligence_drift_collector_crawler_log_foundation"
@@ -69187,7 +70069,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_aggregate_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add attribution and revenue builders",
       "train_scope": "search_intelligence_backend_attribution_revenue_builders"
@@ -69311,7 +70195,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_search_channel_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add disabled GSC collector",
       "train_scope": "search_intelligence_gsc_disabled_collector"
@@ -69411,7 +70297,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium_disabled_search_channel_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add Baidu and IndexNow collector foundations",
       "train_scope": "search_intelligence_baidu_indexnow_disabled_collectors"
@@ -69521,7 +70409,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "low_docs_contract_no_deploy",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): add Metabase MVP dashboard spec",
       "train_scope": "metabase_mvp_dashboard_policy_sanitized_views"
@@ -69644,7 +70534,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_disabled_issue_queue_schema",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "github_checks_passed",
       "title": "feat(seo-intel): add CMS issue queue summary",
       "train_scope": "cms_issue_queue_summary_foundation"
@@ -69696,7 +70588,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "docs(seo-intel): finalize SEO Dash MVP online closeout"
     },
@@ -69993,7 +70887,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "medium_migration_scope_no_production_execution",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "fix(seo-intel): isolate seo_intel migrations",
       "train_scope": "seo_intel_migration_isolation"
@@ -70117,7 +71013,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "low_docs_contract_no_execution",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "title": "docs(seo-intel): add controlled write enablement plan",
@@ -70245,7 +71143,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "risk_level": "medium_runtime_guard_no_production_execution",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "title": "feat(seo-intel): add bounded URL truth inventory canary",
@@ -70469,7 +71369,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -70587,7 +71489,9 @@
       "research_publish": false,
       "scheduler_activation": false,
       "sidecar_allowed": true,
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "state": "merged",
       "status": "merged",
       "stop_on_safety_violation": true,
@@ -71299,7 +72203,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B": {
       "branch": "codex/seo-growth-mbti-action-01b-enqueue",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_enqueue_report_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bSearchChannelEnqueue --no-ansi (5 tests, 31 assertions)",
           "git_diff_check": "passed: git diff --check",
@@ -71355,7 +72261,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-01": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-01",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "command_help": "passed: php artisan seo-intel:search-channel-queue --help exposes --canonical-url and --enqueue",
           "focused_single_url_command_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommand --no-ansi (9 tests, 64 assertions)",
@@ -71408,7 +72316,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_url_truth_alignment_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignment --no-ansi (1 test, 34 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -71533,7 +72443,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-PROD-PREFLIGHT": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-prod-preflight",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_prod_preflight_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02ProdPreflight --no-ansi (5 tests, 29 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -71843,7 +72755,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-FIX-02-WWW-CANONICAL-CLEANUP-PLAN": {
       "branch": "codex/seo-growth-mbti-action-01b-fix-02-www-cleanup-plan",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_www_cleanup_plan_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bFix02WwwCanonicalCleanupPlan --no-ansi (4 tests, 30 assertions)",
           "git_diff_cached_check": "passed: git diff --cached --check",
@@ -72094,7 +73008,9 @@
     "SEO-GROWTH-MBTI-ACTION-01B-R2": {
       "branch": "codex/seo-growth-mbti-action-01b-r2-enqueue",
       "checks": {
-        "github": [],
+        "github": [
+
+        ],
         "local": {
           "focused_enqueue_report_test": "passed: php artisan test --filter=SeoIntelGrowthMbtiAction01bR2SearchChannelEnqueue --no-ansi (1 test, 17 assertions)",
           "git_diff_check": "passed: git diff --check",
@@ -72316,7 +73232,9 @@
         }
       },
       "commit_sha": "8208e69422a7487d272df57107a5b5e1cacf6b68",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "events": [
         {
           "at": "2026-05-25T02:53:27.627612+00:00",
@@ -72689,7 +73607,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1631",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged"
     },
     "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00": {
@@ -72781,7 +73701,9 @@
       "remote_branch_deleted": true,
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "merged",
       "title": "feat(seo-intel): add two-stage URL Truth handoff"
     },
@@ -72820,7 +73742,9 @@
       },
       "commit_sha": "9d0b26e4ca234354963d9747f0f27438588856bc",
       "crawler_log_read": false,
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "deploy": false,
       "env_edit": false,
       "external_api_live_activation": false,
@@ -73383,7 +74307,9 @@
         }
       },
       "commit_sha": "59b2bf59703a02efa3d640593355b6d9c288475f",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "history": [
         {
@@ -73413,7 +74339,9 @@
       "remote_branch_deleted": false,
       "repo": "fap-api",
       "risk_level": "low",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pr_open",
       "title": "chore(storage): add read-only release roots audit",
       "train_scope": "storage_runtime_hygiene"
@@ -73714,7 +74642,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1284",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "ready_to_merge"
     },
     "career-runtime-publish-projection": {
@@ -73886,7 +74816,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1356",
       "remote_branch_deleted": false,
       "repo": "fap-web",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pending_dependency"
     },
     "frontend-result-email-gate": {
@@ -73912,12 +74844,16 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1451",
       "remote_branch_deleted": false,
       "repo": "fap-web",
-      "sidecar_issues": [],
+      "sidecar_issues": [
+
+      ],
       "status": "pending_dependency"
     },
     "iq-commerce-unlock-199-500": {
       "branch": "codex/iq-commerce-unlock-199-500",
-      "checks": [],
+      "checks": [
+
+      ],
       "depends_on": [
         "iq-report-builder-three-dimension-result-schema"
       ],
@@ -74295,7 +75231,8 @@
       ],
       "status": "pending",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
-      "checks": {},
+      "checks": {
+      },
       "scope_validation": {
         "allowed_paths_only": null,
         "local_validation_passed": null,
@@ -74336,7 +75273,8 @@
       ],
       "status": "pending",
       "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
-      "checks": {},
+      "checks": {
+      },
       "scope_validation": {
         "allowed_paths_only": null,
         "local_validation_passed": null,
@@ -75126,7 +76064,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1742",
       "remote_branch_deleted": false,
       "repo": "fap-api",
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "local_validation_passed",
       "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01 replacement authority candidate reselect",
       "transitions": [
@@ -75251,7 +76191,9 @@
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1750",
       "remote_branch_deleted": true,
       "repo": "fap-api",
-      "sidecars": [],
+      "sidecars": [
+
+      ],
       "status": "merged",
       "title": "EMAIL-DIRECTMAIL-SMTP-READINESS-01 DirectMail SMTP readiness docs env and outbox test",
       "transitions": [
@@ -75692,7 +76634,9 @@
         }
       },
       "commit_sha": "e934e8a5617ec669f6f326e1177e0c6044f9cb22",
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "failure_reason": null,
       "history": [
         {
@@ -77266,7 +78210,9 @@
         }
       },
       "commit_sha": null,
-      "depends_on": [],
+      "depends_on": [
+
+      ],
       "external_api_credentials_required": false,
       "failure_reason": null,
       "history": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -146,8 +146,8 @@
     "depends_on": [
       "BIG5-CMS-IMPORT-DRYRUN-01"
     ],
-    "status": "pr_open",
-    "commit_sha": "4a88b5bbc594bf3554712803a206e56c7f3ad912",
+    "status": "ready_to_merge",
+    "commit_sha": "e4c48e414cc8ae1735396b52aac4795c605b9b1d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2723",
     "failure_reason": null,
     "merged_at": null,
@@ -195,12 +195,16 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to BIG5-CMS-FAQ-DEDUPE-02 allowed paths: backend/app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php, backend/tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php, docs/codex/pr-train-state.json, and generated/pr-train-sidecar-issues/**."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PASS on PR #2723 head e4c48e414cc8ae1735396b52aac4795c605b9b1d: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -233,6 +237,12 @@
         "from": "committed",
         "to": "pr_open",
         "note": "Opened PR #2723 for BIG5-CMS-FAQ-DEDUPE-02 and pushed branch codex/big5-cms-faq-dedupe-02."
+      },
+      {
+        "at": "2026-07-05T04:58:45Z",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "note": "PR #2723 remote checks passed. Marked ready to merge under squash merge policy."
       }
     ]
   },

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -8,5 +8,15 @@
     "why_not_current_pr_scope": "git diff --name-only origin/main...HEAD in the isolated PR worktree contains only the Big Five CMS import dry-run command, planner, tests, Kernel registration, and PR train metadata; it does not contain the IQ method files.",
     "required_checks_affected": "Local full-check reproduction was affected. GitHub required checks run in a clean checkout; the current PR fix targets the actual GitHub failure, which was the hardcoded desktop package path in the test.",
     "recommended_follow_up": "Keep IQ method page work isolated in its own branch/PR and avoid sharing dirty local worktree state with PR-train verification worktrees."
+  },
+  {
+    "repo": "fap-api",
+    "pr_id": "BIG5-CMS-FAQ-DEDUPE-02",
+    "branch": "codex/big5-cms-faq-dedupe-02",
+    "blocker_type": "local_worktree_branch_diff_interference",
+    "evidence": "PR2 focused syntax, PHPUnit, desktop package dry-run, Pint, YAML/JSON parse, and diff checks passed, but local full scripts/ci_verify_mbti.sh failed in BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with IQ method files: backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php, backend/app/Models/TopicProfileEntry.php, backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php.",
+    "why_not_current_pr_scope": "PR2 only changes BigFiveCmsImportDraftDryRunPlanner.php, PersonalityBigFiveCmsImportDraftDryRunCommandTest.php, PR train metadata, and this sidecar record. It does not add or modify the IQ method files.",
+    "required_checks_affected": "Local full-check reproduction was affected. GitHub required checks run in a clean checkout and should validate the actual PR2 scope without the local IQ branch-diff interference.",
+    "recommended_follow_up": "Isolate or merge/close the IQ method branch separately; do not use that local branch state as a blocker for Big Five CMS import readiness PRs."
   }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -9,3 +9,13 @@
 - why not current PR scope: `git diff --name-only origin/main...HEAD` in the isolated PR worktree contains only the Big Five CMS import dry-run command, planner, tests, Kernel registration, and PR train metadata. It does not contain the IQ method files.
 - whether required checks are affected: local full-check reproduction was affected; GitHub required checks run in a clean checkout and the current PR fix targets the actual GitHub failure, which was the hardcoded desktop package path in the test.
 - recommended follow-up: keep IQ method page work isolated in its own branch/PR and avoid sharing dirty local worktree state with PR-train verification worktrees.
+
+## BIG5-CMS-FAQ-DEDUPE-02 local worktree freeze-test interference
+
+- repo: fap-api
+- PR id / branch: BIG5-CMS-FAQ-DEDUPE-02 / codex/big5-cms-faq-dedupe-02
+- blocker type: local worktree / branch-diff interference during full local `scripts/ci_verify_mbti.sh`
+- evidence: PR2 focused syntax, PHPUnit, desktop package dry-run, Pint, YAML/JSON parse, and diff checks passed, but local full `cd backend && bash scripts/ci_verify_mbti.sh` failed in `BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff` with the same IQ method files: `backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php`, `backend/app/Models/TopicProfileEntry.php`, and `backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php`.
+- why not current PR scope: PR2 only changes `BigFiveCmsImportDraftDryRunPlanner.php`, `PersonalityBigFiveCmsImportDraftDryRunCommandTest.php`, PR train metadata, and this sidecar record. It does not add or modify the IQ method files.
+- whether required checks are affected: local full-check reproduction was affected. GitHub required checks run in a clean checkout and should validate the actual PR2 scope without the local IQ branch-diff interference.
+- recommended follow-up: isolate or merge/close the IQ method branch separately; do not use that local branch state as a blocker for Big Five CMS import readiness PRs.


### PR DESCRIPTION
## What changed
- Added FAQ deduplication planning to the Big Five `cms-import-draft` dry-run planner.
- Treats the top-level `faq` field as the only structured FAQ source.
- Detects FAQ-like `body_sections` by heading (`FAQ`, `常见问题`, `问答`, `问题`) and excludes them from `render_preview_body_section_headings` / `render_preview_section_count`.
- Reports package-level and row-level dedupe fields: `faq_structured_source`, `faq_body_section_count`, `faq_body_section_rows_count`, `faq_body_section_indexes`, and `faq_deduplication_policy`.
- Extended focused tests to cover 42/42 pages with FAQ body sections and confirm preview planning does not render FAQ twice.
- Reconciled PR1 merge facts in the PR train ledger and recorded the repeated local IQ branch-diff interference as a sidecar issue.

## Why
The v2 Big Five package has FAQ content in both `body_sections` and the structured `faq` field. Without an explicit dry-run contract, an importer/preview renderer could render the same FAQ twice.

## Validation
- `php -l backend/app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php` — PASS
- `php -l backend/tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php` — PASS
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityBigFiveCmsImportDraftDryRunCommandTest --no-ansi` — PASS, 4 tests / 54 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:big-five-cms-import-draft-dry-run --package=/Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json --dry-run --json` — PASS, 42 rows / 42 FAQ body sections detected
- `cd backend && vendor/bin/pint --test app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php` — PASS
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"` — PASS
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` — PASS
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null` — PASS
- `git diff --check && git diff --cached --check` — PASS

## Deferred items
- No CMS writes, production imports, publishing, indexing, sitemap/llms release, search submission, staging deploy, or production deploy are included.
- This PR does not implement an actual writer/importer; it only clarifies dry-run planner output for importer/preview consumers.
- Local full `scripts/ci_verify_mbti.sh` was affected by an external IQ method branch-diff interference and is recorded in `generated/pr-train-sidecar-issues/`. GitHub required checks run in clean checkout and remain the merge gate.

## Repository rule impact
Backend-only dry-run/preview contract refinement. Content authority remains backend/CMS; no frontend fallback content, public API runtime change, SEO runtime change, CMS mutation, or deploy behavior is introduced.
