### PR TITLE
IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01: add IQ method CMS readback QA

### DIFF
--- a/backend/app/Console/Commands/ArticleIqMethodPagesReadback.php
+++ b/backend/app/Console/Commands/ArticleIqMethodPagesReadback.php
@@ -1,0 +1,680 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\LandingSurface;
+use App\Models\PageBlock;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Services\Cms\ArticleBodyHeadingGuard;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use JsonException;
+use RuntimeException;
+use Throwable;
+
+final class ArticleIqMethodPagesReadback extends Command
+{
+    private const EXPECTED_SCHEMA_VERSION = 'fermatmind.iq_method_pages.cms_readback.v1';
+
+    private const SOURCE_MANIFEST_SCHEMA_VERSION = 'fermatmind.iq_method_pages.cms_dry_run_manifest.v1';
+
+    private const SOURCE_PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01';
+
+    private const READBACK_PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01';
+
+    private const DEFAULT_STATE = [
+        'status' => 'draft_review_only',
+        'is_public' => false,
+        'is_indexable' => false,
+        'robots' => 'noindex,follow',
+        'sitemap_eligible' => false,
+        'llms_eligible' => false,
+    ];
+
+    private const PRIVATE_ROUTE_PATTERNS = [
+        'attempt_route' => '~/(?:zh/|en/)?attempt(?:/|[?#\s)"\']|$)~i',
+        'result_route' => '~/(?:zh/|en/)?(?:result|results)(?:/|[?#\s)"\']|$)~i',
+        'order_route' => '~/(?:zh/|en/)?(?:orders|order)(?:/|[?#\s)"\']|$)~i',
+        'payment_route' => '~/(?:zh/|en/)?(?:pay|payment)(?:/|[?#\s)"\']|$)~i',
+        'share_route' => '~/(?:zh/|en/)?share(?:/|[?#\s)"\']|$)~i',
+        'history_route' => '~/(?:zh/|en/)?history(?:/|[?#\s)"\']|$)~i',
+        'recovery_route' => '~/(?:zh/|en/)?(?:recover|restore)(?:/|[?#\s)"\']|$)~i',
+        'scoring_secret' => '/\b(?:answer_key|correct_answer|scoring_rule|score_formula)\b/i',
+    ];
+
+    protected $signature = 'articles:iq-method-pages-readback
+        {--package= : Path to fap-web root, generated/iq-method-pages-zh-cn-v0.2, or its cms-dry-run directory}
+        {--artifact-dir= : Optional directory for a readback JSON evidence artifact}
+        {--json : Emit a JSON summary}';
+
+    protected $description = 'Read back the zh-CN IQ method pages CMS draft import and verify it still matches the noindex dry-run manifest.';
+
+    public function __construct(private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $summary = $this->readback();
+            $this->writeArtifactIfRequested($summary);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readback(): array
+    {
+        $issues = [];
+        $paths = $this->resolvePackagePaths((string) $this->option('package'), $issues);
+        $manifest = [];
+        $topicMapping = [];
+        $landingMapping = [];
+        $articles = [];
+        $topicReadback = null;
+        $landingReadback = null;
+
+        if ($paths !== null) {
+            $manifest = $this->readJson($paths['dry_run_root'].'/cms_import_manifest.json', 'cms_import_manifest.json', $issues);
+            $topicMapping = $this->readJson($paths['dry_run_root'].'/topic_iq_articles_mapping.json', 'topic_iq_articles_mapping.json', $issues);
+            $landingMapping = $this->readJson($paths['dry_run_root'].'/landing_page_blocks_mapping.json', 'landing_page_blocks_mapping.json', $issues);
+
+            $this->validateManifestEnvelope($manifest, $issues);
+            $articles = $this->readbackArticles($paths, $manifest, $issues);
+            $topicReadback = $this->readbackTopic($topicMapping, $articles, $issues);
+            $landingReadback = $this->readbackLanding($landingMapping, $articles, $issues);
+        }
+
+        return [
+            'schema_version' => self::EXPECTED_SCHEMA_VERSION,
+            'ok' => $issues === [],
+            'status' => $issues === [] ? 'pass' : 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->toIso8601String(),
+            'pr_id' => self::READBACK_PR_ID,
+            'source_pr_id' => (string) ($manifest['pr_id'] ?? ''),
+            'source_manifest' => [
+                'schema_version' => (string) ($manifest['schema_version'] ?? ''),
+                'package_root' => $paths['package_root'] ?? null,
+                'dry_run_root' => $paths['dry_run_root'] ?? null,
+            ],
+            'expected_article_count' => 7,
+            'article_readbacks' => $articles,
+            'topic_readback' => $topicReadback,
+            'landing_readback' => $landingReadback,
+            'mismatch_count' => count($issues),
+            'issues' => $issues,
+            'side_effects' => [
+                'db_write' => false,
+                'cms_update' => false,
+                'publish' => false,
+                'indexability' => false,
+                'sitemap' => false,
+                'llms' => false,
+                'deploy' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array{source_base:string,package_root:string,dry_run_root:string}|null
+     */
+    private function resolvePackagePaths(string $package, array &$issues): ?array
+    {
+        $path = trim($package);
+        if ($path === '') {
+            $issues[] = $this->issue('package', 'missing_package', '--package is required.');
+
+            return null;
+        }
+
+        $root = realpath($path);
+        if (! is_string($root) || ! is_dir($root)) {
+            $issues[] = $this->issue('package', 'package_directory_not_found', 'Package directory not found.');
+
+            return null;
+        }
+
+        $candidates = [
+            [
+                'source_base' => $root,
+                'package_root' => $root.'/generated/iq-method-pages-zh-cn-v0.2',
+                'dry_run_root' => $root.'/generated/iq-method-pages-zh-cn-v0.2/cms-dry-run',
+            ],
+            [
+                'source_base' => dirname(dirname($root)),
+                'package_root' => $root,
+                'dry_run_root' => $root.'/cms-dry-run',
+            ],
+            [
+                'source_base' => dirname(dirname(dirname($root))),
+                'package_root' => dirname($root),
+                'dry_run_root' => $root,
+            ],
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate['dry_run_root'].'/cms_import_manifest.json')) {
+                return $candidate;
+            }
+        }
+
+        $issues[] = $this->issue('cms_import_manifest.json', 'manifest_not_found', 'cms_import_manifest.json must exist under cms-dry-run.');
+
+        return null;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path, string $field, array &$issues): array
+    {
+        if (! is_file($path)) {
+            $issues[] = $this->issue($field, 'json_file_not_found', $field.' was not found.');
+
+            return [];
+        }
+
+        try {
+            $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            $issues[] = $this->issue($field, 'invalid_json', $exception->getMessage());
+
+            return [];
+        }
+
+        if (! is_array($decoded)) {
+            $issues[] = $this->issue($field, 'invalid_json', $field.' must decode to an object.');
+
+            return [];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function validateManifestEnvelope(array $manifest, array &$issues): void
+    {
+        if ((string) ($manifest['schema_version'] ?? '') !== self::SOURCE_MANIFEST_SCHEMA_VERSION) {
+            $issues[] = $this->issue('manifest.schema_version', 'unexpected_schema_version', 'Unexpected IQ method pages dry-run manifest schema.');
+        }
+        if ((string) ($manifest['pr_id'] ?? '') !== self::SOURCE_PR_ID) {
+            $issues[] = $this->issue('manifest.pr_id', 'unexpected_source_pr_id', 'Manifest source PR id mismatch.');
+        }
+        if (count((array) ($manifest['article_imports'] ?? [])) !== 7) {
+            $issues[] = $this->issue('manifest.article_imports', 'article_count_mismatch', 'Exactly seven IQ method article imports are required.');
+        }
+        foreach (self::DEFAULT_STATE as $field => $expected) {
+            if (data_get($manifest, 'required_default_publish_state.'.$field) !== $expected) {
+                $issues[] = $this->issue('manifest.required_default_publish_state.'.$field, 'default_state_mismatch', $field.' must remain draft/noindex.');
+            }
+        }
+    }
+
+    /**
+     * @param  array{source_base:string,package_root:string,dry_run_root:string}  $paths
+     * @param  list<array<string,mixed>>  $issues
+     * @return list<array<string,mixed>>
+     */
+    private function readbackArticles(array $paths, array $manifest, array &$issues): array
+    {
+        $readbacks = [];
+
+        foreach ((array) ($manifest['article_imports'] ?? []) as $index => $import) {
+            if (! is_array($import)) {
+                $issues[] = $this->issue('manifest.article_imports.'.$index, 'invalid_article_import', 'Article import must be an object.');
+
+                continue;
+            }
+
+            $expected = $this->expectedArticle($paths, $import, $issues);
+            $slug = (string) ($expected['slug'] ?? $import['slug'] ?? '');
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['seoMeta', 'workingRevision'])
+                ->where('org_id', 0)
+                ->where('locale', 'zh-CN')
+                ->where('slug', $slug)
+                ->first();
+
+            if (! $article instanceof Article) {
+                $issues[] = $this->issue($slug, 'article_missing', 'CMS Article draft was not found.');
+                $readbacks[] = [
+                    'slug' => $slug,
+                    'ok' => false,
+                    'status' => 'missing',
+                ];
+
+                continue;
+            }
+
+            $articleIssuesBefore = count($issues);
+            $this->assertSameValue($issues, $slug.'.title', (string) $expected['title'], (string) $article->title);
+            $this->assertSameValue($issues, $slug.'.excerpt', (string) $expected['excerpt'], (string) $article->excerpt);
+            $this->assertSameValue($issues, $slug.'.content_md', (string) $expected['content_md'], (string) $article->content_md);
+            $this->assertSameValue($issues, $slug.'.related_test_slug', 'iq-test-intelligence-quotient-assessment', (string) $article->related_test_slug);
+            $this->assertSameValue($issues, $slug.'.translation_group_id', 'iq-method-pages-zh-cn-v0-2-'.$slug, (string) $article->translation_group_id);
+            $this->assertDraftState($issues, $slug.'.article', [
+                'status' => (string) $article->status,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'sitemap_eligible' => (bool) $article->sitemap_eligible,
+                'llms_eligible' => (bool) $article->llms_eligible,
+            ]);
+            if ($article->published_at !== null || $article->published_revision_id !== null) {
+                $issues[] = $this->issue($slug.'.article.publication', 'published_marker_present', 'Draft readback must not have publication markers.');
+            }
+
+            $revision = $article->workingRevision;
+            if (! $revision instanceof ArticleTranslationRevision) {
+                $issues[] = $this->issue($slug.'.working_revision', 'working_revision_missing', 'Working revision was not found.');
+            } else {
+                $this->assertSameValue($issues, $slug.'.working_revision.status', ArticleTranslationRevision::STATUS_HUMAN_REVIEW, (string) $revision->revision_status);
+                $this->assertSameValue($issues, $slug.'.working_revision.title', (string) $expected['title'], (string) $revision->title);
+                $this->assertSameValue($issues, $slug.'.working_revision.content_md', (string) $expected['content_md'], (string) $revision->content_md);
+                $this->assertSameValue($issues, $slug.'.working_revision.seo_title', (string) $expected['seo_title'], (string) $revision->seo_title);
+                $this->assertSameValue($issues, $slug.'.working_revision.seo_description', (string) $expected['seo_description'], (string) $revision->seo_description);
+            }
+
+            $seo = $article->seoMeta;
+            if (! $seo instanceof ArticleSeoMeta) {
+                $issues[] = $this->issue($slug.'.seo_meta', 'seo_meta_missing', 'Article SEO meta was not found.');
+            } else {
+                $this->assertSameValue($issues, $slug.'.seo_meta.seo_title', (string) $expected['seo_title'], (string) $seo->seo_title);
+                $this->assertSameValue($issues, $slug.'.seo_meta.seo_description', (string) $expected['seo_description'], (string) $seo->seo_description);
+                $this->assertSameValue($issues, $slug.'.seo_meta.canonical_url', (string) $expected['canonical_url'], (string) $seo->canonical_url);
+                $this->assertSameValue($issues, $slug.'.seo_meta.robots', self::DEFAULT_STATE['robots'], (string) $seo->robots);
+                $this->assertSameValue($issues, $slug.'.seo_meta.is_indexable', false, (bool) $seo->is_indexable);
+            }
+
+            $this->assertNoPrivateTokens($issues, $slug.'.public_article_surface', json_encode([
+                'title' => $article->title,
+                'excerpt' => $article->excerpt,
+                'content_md' => $article->content_md,
+                'seo' => $seo instanceof ArticleSeoMeta ? [
+                    'seo_title' => $seo->seo_title,
+                    'seo_description' => $seo->seo_description,
+                    'canonical_url' => $seo->canonical_url,
+                ] : [],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+
+            $readbacks[] = [
+                'slug' => $slug,
+                'article_id' => (int) $article->id,
+                'working_revision_id' => $revision instanceof ArticleTranslationRevision ? (int) $revision->id : null,
+                'ok' => count($issues) === $articleIssuesBefore,
+                'status' => (string) $article->status,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'robots' => $seo instanceof ArticleSeoMeta ? (string) $seo->robots : null,
+                'sitemap_eligible' => (bool) $article->sitemap_eligible,
+                'llms_eligible' => (bool) $article->llms_eligible,
+                'canonical_url' => $seo instanceof ArticleSeoMeta ? (string) $seo->canonical_url : null,
+            ];
+        }
+
+        return $readbacks;
+    }
+
+    /**
+     * @param  array{source_base:string,package_root:string,dry_run_root:string}  $paths
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function expectedArticle(array $paths, array $import, array &$issues): array
+    {
+        $slug = Str::slug((string) ($import['slug'] ?? ''));
+        $cms = $this->readSourceJson($paths['source_base'], data_get($import, 'source_files.article_cms_json'), $slug.'.article.cms.json', $issues);
+        $seo = $this->readSourceJson($paths['source_base'], data_get($import, 'source_files.seo_json'), $slug.'.seo.json', $issues);
+        $articleMd = $this->readSourceText($paths['source_base'], data_get($import, 'source_files.article_md'), $slug.'.article.md', $issues);
+        $contentMd = trim((string) ($cms['content_md'] ?? $articleMd));
+
+        return [
+            'slug' => Str::slug((string) ($cms['slug'] ?? $slug)),
+            'title' => trim((string) ($cms['title'] ?? $import['title'] ?? '')),
+            'excerpt' => trim((string) ($cms['excerpt'] ?? '')),
+            'content_md' => $this->articleBodyHeadingGuard->downgradeMarkdownH1ToH2($contentMd),
+            'canonical_url' => trim((string) ($seo['canonical_url'] ?? $cms['canonical_url'] ?? $import['canonical_url'] ?? '')),
+            'seo_title' => trim((string) ($seo['seo_title'] ?? $cms['title'] ?? $import['title'] ?? '')),
+            'seo_description' => trim((string) ($seo['seo_description'] ?? $cms['excerpt'] ?? '')),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function readSourceJson(string $sourceBase, mixed $relativePath, string $field, array &$issues): array
+    {
+        $path = $this->sourcePath($sourceBase, $relativePath, $field, $issues);
+
+        return $path !== null ? $this->readJson($path, $field, $issues) : [];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function readSourceText(string $sourceBase, mixed $relativePath, string $field, array &$issues): string
+    {
+        $path = $this->sourcePath($sourceBase, $relativePath, $field, $issues);
+
+        return $path !== null ? trim((string) file_get_contents($path)) : '';
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function sourcePath(string $sourceBase, mixed $relativePath, string $field, array &$issues): ?string
+    {
+        $relative = trim((string) $relativePath);
+        if ($relative === '') {
+            $issues[] = $this->issue($field, 'missing_source_path', 'Required source file path is missing.');
+
+            return null;
+        }
+
+        $path = realpath($sourceBase.'/'.ltrim($relative, '/'));
+        if (! is_string($path) || ! is_file($path)) {
+            $issues[] = $this->issue($field, 'source_file_not_found', 'Referenced source file was not found.');
+
+            return null;
+        }
+
+        return $path;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @param  list<array<string,mixed>>  $articles
+     * @return array<string,mixed>
+     */
+    private function readbackTopic(array $topicMapping, array $articles, array &$issues): array
+    {
+        $expectedSlugs = collect($articles)->pluck('slug')->filter()->values()->all();
+        $profile = TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', 'iq-eq')
+            ->first();
+
+        if (! $profile instanceof TopicProfile) {
+            $issues[] = $this->issue('topic.iq-eq', 'topic_missing', 'IQ/EQ topic profile was not found.');
+
+            return [
+                'ok' => false,
+                'slug' => 'iq-eq',
+                'status' => 'missing',
+            ];
+        }
+
+        $this->assertSameValue($issues, 'topic.iq-eq.status', TopicProfile::STATUS_DRAFT, (string) $profile->status);
+        $this->assertSameValue($issues, 'topic.iq-eq.is_public', false, (bool) $profile->is_public);
+        $this->assertSameValue($issues, 'topic.iq-eq.is_indexable', false, (bool) $profile->is_indexable);
+        $this->assertSameValue($issues, 'topic.mapping.group_key', 'iq_articles', (string) data_get($topicMapping, 'entry_groups.0.group_key'));
+        $this->assertSameValue($issues, 'topic.mapping.label', 'IQ 文章', (string) data_get($topicMapping, 'entry_groups.0.label'));
+
+        $entries = TopicProfileEntry::query()
+            ->where('profile_id', (int) $profile->id)
+            ->where('group_key', 'iq_articles')
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
+        $actualSlugs = $entries->pluck('target_key')->values()->all();
+        if ($actualSlugs !== $expectedSlugs) {
+            $issues[] = $this->issue('topic.iq_articles.items', 'topic_items_mismatch', 'Topic IQ article entries do not match the manifest order.');
+        }
+
+        foreach ($entries as $entry) {
+            $this->assertNoPrivateTokens($issues, 'topic.iq_articles.'.$entry->target_key, json_encode([
+                'target_url_override' => $entry->target_url_override,
+                'payload_json' => $entry->payload_json,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+        }
+
+        return [
+            'ok' => $actualSlugs === $expectedSlugs,
+            'topic_profile_id' => (int) $profile->id,
+            'slug' => 'iq-eq',
+            'status' => (string) $profile->status,
+            'is_public' => (bool) $profile->is_public,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'group_key' => 'iq_articles',
+            'expected_items_count' => count($expectedSlugs),
+            'actual_items_count' => $entries->count(),
+            'slugs' => $actualSlugs,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @param  list<array<string,mixed>>  $articles
+     * @return array<string,mixed>
+     */
+    private function readbackLanding(array $landingMapping, array $articles, array &$issues): array
+    {
+        $expectedSlugs = collect($articles)->pluck('slug')->filter()->values()->all();
+        $surface = LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('surface_key', 'test:iq-test-intelligence-quotient-assessment')
+            ->where('locale', 'zh-CN')
+            ->first();
+
+        if (! $surface instanceof LandingSurface) {
+            $issues[] = $this->issue('landing_surface.iq', 'landing_surface_missing', 'IQ landing surface was not found.');
+
+            return [
+                'ok' => false,
+                'surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+                'status' => 'missing',
+            ];
+        }
+
+        $this->assertSameValue($issues, 'landing_surface.iq.status', LandingSurface::STATUS_DRAFT, (string) $surface->status);
+        $this->assertSameValue($issues, 'landing_surface.iq.is_public', false, (bool) $surface->is_public);
+        $this->assertSameValue($issues, 'landing_surface.iq.is_indexable', false, (bool) $surface->is_indexable);
+        $this->assertSameValue($issues, 'landing.mapping.frontend_hardcode_allowed', false, (bool) data_get($landingMapping, 'guardrails.frontend_hardcode_allowed'));
+
+        $block = PageBlock::query()
+            ->where('landing_surface_id', (int) $surface->id)
+            ->where('block_key', 'iq_methodology_boundary_links')
+            ->first();
+
+        if (! $block instanceof PageBlock) {
+            $issues[] = $this->issue('landing_block.iq_methodology_boundary_links', 'landing_block_missing', 'IQ methodology boundary links block was not found.');
+
+            return [
+                'ok' => false,
+                'surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+                'block_key' => 'iq_methodology_boundary_links',
+                'status' => (string) $surface->status,
+            ];
+        }
+
+        $items = collect((array) data_get($block->payload_json, 'items', []));
+        $actualSlugs = $items->pluck('slug')->values()->all();
+        if ($actualSlugs !== $expectedSlugs) {
+            $issues[] = $this->issue('landing_block.iq_methodology_boundary_links.items', 'landing_items_mismatch', 'Landing block article links do not match the manifest order.');
+        }
+        $this->assertSameValue($issues, 'landing_block.frontend_hardcode_allowed', false, (bool) data_get($block->payload_json, 'frontend_hardcode_allowed'));
+        $this->assertSameValue($issues, 'landing_block.publish_or_indexing_change_allowed', false, (bool) data_get($block->payload_json, 'publish_or_indexing_change_allowed'));
+        $this->assertNoPrivateTokens($issues, 'landing_block.iq_methodology_boundary_links.payload', json_encode($block->payload_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+
+        return [
+            'ok' => $actualSlugs === $expectedSlugs,
+            'landing_surface_id' => (int) $surface->id,
+            'block_id' => (int) $block->id,
+            'surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+            'block_key' => 'iq_methodology_boundary_links',
+            'status' => (string) $surface->status,
+            'is_public' => (bool) $surface->is_public,
+            'is_indexable' => (bool) $surface->is_indexable,
+            'expected_items_count' => count($expectedSlugs),
+            'actual_items_count' => $items->count(),
+            'slugs' => $actualSlugs,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @param  array<string,mixed>  $actual
+     */
+    private function assertDraftState(array &$issues, string $field, array $actual): void
+    {
+        foreach (self::DEFAULT_STATE as $stateField => $expected) {
+            if ($stateField === 'robots') {
+                continue;
+            }
+
+            $this->assertSameValue($issues, $field.'.'.$stateField, $expected, $actual[$stateField] ?? null);
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function assertSameValue(array &$issues, string $field, mixed $expected, mixed $actual): void
+    {
+        if ($actual !== $expected) {
+            $issues[] = $this->issue($field, 'value_mismatch', sprintf(
+                'Expected %s but read back %s.',
+                json_encode($expected, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                json_encode($actual, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ));
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function assertNoPrivateTokens(array &$issues, string $field, string $text): void
+    {
+        foreach (self::PRIVATE_ROUTE_PATTERNS as $code => $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                $issues[] = $this->issue($field, $code, 'Public readback surface contains a private route or scoring token.');
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeArtifactIfRequested(array $summary): void
+    {
+        $artifactDir = trim((string) $this->option('artifact-dir'));
+        if ($artifactDir === '') {
+            return;
+        }
+
+        if (! is_dir($artifactDir) && ! mkdir($artifactDir, 0777, true) && ! is_dir($artifactDir)) {
+            throw new RuntimeException('Unable to create artifact directory.');
+        }
+
+        file_put_contents(
+            rtrim($artifactDir, '/').'/iq-method-pages-cms-readback.v1.json',
+            json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'blocked'));
+        $this->line('dry_run=1');
+        $this->line('execute=0');
+        $this->line('expected_article_count='.(string) ($summary['expected_article_count'] ?? 0));
+        $this->line('mismatch_count='.(string) ($summary['mismatch_count'] ?? 0));
+
+        foreach ((array) ($summary['issues'] ?? []) as $issue) {
+            if (is_array($issue)) {
+                $this->line('readback_issue='.$this->issueLine($issue));
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'schema_version' => self::EXPECTED_SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->toIso8601String(),
+            'pr_id' => self::READBACK_PR_ID,
+            'mismatch_count' => 1,
+            'issues' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'side_effects' => [
+                'db_write' => false,
+                'cms_update' => false,
+                'publish' => false,
+                'indexability' => false,
+                'sitemap' => false,
+                'llms' => false,
+                'deploy' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return implode(':', [
+            (string) ($issue['field'] ?? 'unknown'),
+            (string) ($issue['code'] ?? 'unknown'),
+            (string) ($issue['message'] ?? ''),
+        ]);
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -31,6 +31,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withCommands([
         __DIR__.'/../app/Console/Commands',
         \App\Console\Commands\ArticleImportIqMethodPagesDraft::class,
+        \App\Console\Commands\ArticleIqMethodPagesReadback::class,
         \App\Console\Commands\PersonalityEnneagramCmsPromote::class,
         \App\Console\Commands\FapResolvePack::class,
         \App\Console\Commands\RiasecResultPageAssetAgentAuditCommand::class,

--- a/backend/tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php
@@ -1,0 +1,411 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArticleIqMethodPagesReadbackCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_readback_passes_after_iq_method_pages_draft_import(): void
+    {
+        $package = $this->writeIqMethodPackage();
+
+        $importExit = Artisan::call('articles:import-iq-method-pages-draft', [
+            '--package' => $package,
+            '--json' => true,
+        ]);
+        $this->assertSame(0, $importExit);
+
+        $readbackExit = Artisan::call('articles:iq-method-pages-readback', [
+            '--package' => $package,
+            '--json' => true,
+        ]);
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(0, $readbackExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['execute']);
+        $this->assertSame('IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01', $payload['pr_id']);
+        $this->assertSame('IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01', $payload['source_pr_id']);
+        $this->assertSame(7, $payload['expected_article_count']);
+        $this->assertCount(7, $payload['article_readbacks']);
+        $this->assertSame(0, $payload['mismatch_count']);
+        $this->assertSame('iq_articles', $payload['topic_readback']['group_key']);
+        $this->assertSame(7, $payload['topic_readback']['actual_items_count']);
+        $this->assertSame('iq_methodology_boundary_links', $payload['landing_readback']['block_key']);
+        $this->assertSame(7, $payload['landing_readback']['actual_items_count']);
+        $this->assertFalse($payload['side_effects']['db_write']);
+        $this->assertFalse($payload['side_effects']['cms_update']);
+        $this->assertFalse($payload['side_effects']['publish']);
+        $this->assertFalse($payload['side_effects']['indexability']);
+        $this->assertFalse($payload['side_effects']['sitemap']);
+        $this->assertFalse($payload['side_effects']['llms']);
+        $this->assertFalse($payload['side_effects']['deploy']);
+    }
+
+    public function test_readback_fails_closed_when_cms_drafts_are_missing(): void
+    {
+        $package = $this->writeIqMethodPackage();
+
+        $readbackExit = Artisan::call('articles:iq-method-pages-readback', [
+            '--package' => $package,
+            '--json' => true,
+        ]);
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $readbackExit);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertSame(9, $payload['mismatch_count']);
+        $this->assertContains('article_missing', collect($payload['issues'])->pluck('code')->all());
+        $this->assertContains('topic_missing', collect($payload['issues'])->pluck('code')->all());
+        $this->assertContains('landing_surface_missing', collect($payload['issues'])->pluck('code')->all());
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_readback_blocks_if_an_article_has_been_made_public_or_indexable(): void
+    {
+        $package = $this->writeIqMethodPackage();
+
+        $importExit = Artisan::call('articles:import-iq-method-pages-draft', [
+            '--package' => $package,
+            '--json' => true,
+        ]);
+        $this->assertSame(0, $importExit);
+
+        Article::query()
+            ->withoutGlobalScopes()
+            ->where('slug', 'what-is-iq-style-reasoning-test')
+            ->update([
+                'status' => 'published',
+                'is_public' => true,
+                'is_indexable' => true,
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+            ]);
+
+        $readbackExit = Artisan::call('articles:iq-method-pages-readback', [
+            '--package' => $package,
+            '--json' => true,
+        ]);
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $readbackExit);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('value_mismatch', collect($payload['issues'])->pluck('code')->all());
+        $this->assertContains(
+            'what-is-iq-style-reasoning-test.article.status',
+            collect($payload['issues'])->pluck('field')->all(),
+        );
+        $this->assertContains(
+            'what-is-iq-style-reasoning-test.article.is_public',
+            collect($payload['issues'])->pluck('field')->all(),
+        );
+        $this->assertContains(
+            'what-is-iq-style-reasoning-test.article.is_indexable',
+            collect($payload['issues'])->pluck('field')->all(),
+        );
+    }
+
+    private function writeIqMethodPackage(): string
+    {
+        $root = sys_get_temp_dir().'/iq-method-pages-readback-'.Str::uuid();
+        $packageRoot = $root.'/generated/iq-method-pages-zh-cn-v0.2';
+        $dryRunRoot = $packageRoot.'/cms-dry-run';
+        mkdir($dryRunRoot, 0777, true);
+
+        $articleImports = [];
+        $seoPages = [];
+        $claimPages = [];
+        $topicItems = [];
+        $landingItems = [];
+
+        foreach ($this->pageDefinitions() as $index => $page) {
+            $pageNumber = str_pad((string) ($index + 1), 2, '0', STR_PAD_LEFT);
+            $pageDir = $packageRoot.'/pages/'.$pageNumber.'-'.$page['slug'];
+            mkdir($pageDir, 0777, true);
+
+            $relativeDir = 'generated/iq-method-pages-zh-cn-v0.2/pages/'.$pageNumber.'-'.$page['slug'];
+            $articleMd = $relativeDir.'/article.md';
+            $articleCms = $relativeDir.'/article.cms.json';
+            $seoJson = $relativeDir.'/seo.json';
+            $answerSurface = $relativeDir.'/answer_surface_v1.json';
+            $internalLinks = $relativeDir.'/internal_links.json';
+            $mediaBrief = $relativeDir.'/media_brief.json';
+            $faq = $relativeDir.'/faq.json';
+            $landingSurface = $relativeDir.'/landing_surface_v1.json';
+            $geoAnswer = $relativeDir.'/geo_answer_block.json';
+            $claimAudit = $relativeDir.'/claim_audit.json';
+            $qaChecklist = $relativeDir.'/qa_checklist.md';
+
+            file_put_contents($pageDir.'/article.md', $page['content_md']);
+            file_put_contents($pageDir.'/article.cms.json', json_encode([
+                'status' => 'draft_review_only',
+                'locale' => 'zh-CN',
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'excerpt' => $page['excerpt'],
+                'content_md' => $page['content_md'],
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'category_suggestion' => $page['category'],
+                'tags' => ['IQ 风格推理测试', '测评方法与边界', '非官方非认证', '推理表现'],
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'schema_json' => [
+                    'editorial_package_v1' => [
+                        'package_version' => 'iq-method-pages-zh-cn-v0.2',
+                        'review_required_before_publish' => true,
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/seo.json', json_encode([
+                'status' => 'draft_review_only',
+                'seo_title' => $page['seo_title'],
+                'seo_description' => $page['seo_description'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/answer_surface_v1.json', json_encode([
+                'version' => 'answer_surface_v1',
+                'status' => 'draft_review_only',
+                'quick_answer' => 'IQ 风格推理测试用于理解本次推理任务表现，非官方、非临床、非认证。',
+                'faq_items' => [
+                    ['question' => '这是正式智力测评吗？', 'answer' => '不是。'],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/internal_links.json', json_encode([
+                'links_out' => [
+                    ['label' => '开始 IQ 风格推理测试', 'href' => '/zh/tests/iq-test-intelligence-quotient-assessment'],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/media_brief.json', json_encode([
+                'status' => 'media_library_upload_deferred',
+                'brief' => 'No public media URL assigned in draft import.',
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/faq.json', '{"items":[]}');
+            file_put_contents($pageDir.'/landing_surface_v1.json', '{"status":"draft_review_only"}');
+            file_put_contents($pageDir.'/geo_answer_block.json', '{"status":"draft_review_only"}');
+            file_put_contents($pageDir.'/claim_audit.json', '{"status":"passed_text_scan"}');
+            file_put_contents($pageDir.'/qa_checklist.md', "- draft only\n");
+
+            $articleImports[] = [
+                'order' => $index + 1,
+                'cms_resource_type' => 'Article',
+                'operation' => 'upsert_draft_only',
+                'locale' => 'zh-CN',
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'route' => '/zh/articles/'.$page['slug'],
+                'source_files' => [
+                    'article_md' => $articleMd,
+                    'article_cms_json' => $articleCms,
+                    'seo_json' => $seoJson,
+                    'faq_json' => $faq,
+                    'internal_links_json' => $internalLinks,
+                    'answer_surface_v1_json' => $answerSurface,
+                    'landing_surface_v1_json' => $landingSurface,
+                    'geo_answer_block_json' => $geoAnswer,
+                    'media_brief_json' => $mediaBrief,
+                    'claim_audit_json' => $claimAudit,
+                    'qa_checklist_md' => $qaChecklist,
+                ],
+                'required_cms_fields' => [
+                    'category' => $page['category'],
+                    'tags' => ['IQ 风格推理测试', '测评方法与边界', '非官方非认证', '推理表现'],
+                    'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                ],
+                'publish_state' => $this->draftState(),
+                'gates' => [
+                    'human_method_review_required' => true,
+                    'human_claim_review_required' => true,
+                    'cms_dry_run_required' => true,
+                    'cms_readback_required' => true,
+                    'private_url_guard_required' => true,
+                    'production_publish_allowed_in_this_pr' => false,
+                    'sitemap_llms_activation_allowed_in_this_pr' => false,
+                ],
+            ];
+            $seoPages[] = [
+                'slug' => $page['slug'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ];
+            $claimPages[] = [
+                'slug' => $page['slug'],
+                'status' => 'draft_review_only',
+                'page_status' => 'draft_review_only_passed_text_scan',
+                'forbidden_terms_found' => [],
+                'human_review_required' => true,
+            ];
+            $topicItems[] = [
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'href' => '/zh/articles/'.$page['slug'],
+                'status' => 'draft_review_only',
+                'is_public' => false,
+                'is_indexable' => false,
+            ];
+            $landingItems[] = [
+                'title' => $page['title'],
+                'href' => '/zh/articles/'.$page['slug'],
+                'slug' => $page['slug'],
+            ];
+        }
+
+        file_put_contents($dryRunRoot.'/cms_import_manifest.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.cms_dry_run_manifest.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'mode' => 'cms_dry_run_contract_only',
+            'source_package' => 'generated/iq-method-pages-zh-cn-v0.2',
+            'required_default_publish_state' => $this->draftState(),
+            'article_imports' => $articleImports,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/seo_geo_gate.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.seo_geo_gate.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'status' => 'hold_noindex_until_human_and_cms_readback_pass',
+            'default_gate' => $this->draftState(),
+            'pages' => $seoPages,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/claim_audit_summary.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.claim_audit_summary.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'status' => 'automated_text_scan_passed_human_review_required',
+            'pages' => $claimPages,
+            'gate_result' => 'pass_with_human_review_required',
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/topic_iq_articles_mapping.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.topic_mapping.v1',
+            'target_topic' => [
+                'locale' => 'zh-CN',
+                'slug' => 'iq-eq',
+                'route' => '/zh/topics/iq-eq',
+            ],
+            'required_display_policy' => [
+                'split_mixed_group' => true,
+                'iq_group_label' => 'IQ 文章',
+                'eq_group_label' => 'EQ 文章',
+                'frontend_hardcode_allowed' => false,
+            ],
+            'entry_groups' => [
+                [
+                    'group_key' => 'iq_articles',
+                    'label' => 'IQ 文章',
+                    'items' => $topicItems,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/landing_page_blocks_mapping.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.landing_page_blocks_mapping.v1',
+            'target_landing_surface' => [
+                'locale' => 'zh-CN',
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'route' => '/zh/tests/iq-test-intelligence-quotient-assessment',
+            ],
+            'proposed_page_blocks' => [
+                [
+                    'block_key' => 'iq_methodology_boundary_links',
+                    'block_type' => 'article_link_cluster',
+                    'label' => 'IQ 测试方法与边界',
+                    'placement' => 'supporting_methodology_links',
+                    'items' => $landingItems,
+                ],
+            ],
+            'guardrails' => [
+                'frontend_hardcode_allowed' => false,
+                'private_flow_links_allowed' => false,
+                'result_or_order_links_allowed' => false,
+                'publish_or_indexing_change_allowed_in_this_pr' => false,
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $root;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function pageDefinitions(): array
+    {
+        $slugs = [
+            'what-is-iq-style-reasoning-test' => '什么是 IQ 风格推理测试？',
+            'online-iq-test-vs-professional-assessment' => '在线 IQ 风格测试和专业智力测评有什么区别？',
+            'iq-test-score-meaning-boundary' => 'IQ 风格测试里的原始分、正确率和完成时间说明什么？',
+            'matrix-reasoning-pattern-recognition-guide' => '矩阵推理和模式识别题在测什么？',
+            'why-fermatmind-iq-v1-not-certification' => '为什么 FermatMind IQ V1 是非认证测试？',
+            'iq-test-privacy-data-boundary' => 'IQ 风格测试的数据和隐私边界是什么？',
+            'iq-expert-review-disclosure' => 'FermatMind 如何审查 IQ 风格测试内容？',
+        ];
+
+        $pages = [];
+        foreach ($slugs as $slug => $title) {
+            $pages[] = [
+                'slug' => $slug,
+                'title' => $title,
+                'excerpt' => '解释 IQ 风格推理测试的方法、边界和信任层，保持非官方、非临床、非认证表达。',
+                'seo_title' => mb_substr($title.' 方法边界说明', 0, 70),
+                'seo_description' => '了解 FermatMind IQ V1 的方法边界：原创 30 题、约 20 分钟，只解释原始分、正确率、完成时间和维度表现。',
+                'category' => $slug === 'matrix-reasoning-pattern-recognition-guide' ? '能力与认知' : '测评方法与边界',
+                'content_md' => implode("\n\n", [
+                    'IQ 风格推理测试是一类用图形、矩阵和规律补全任务观察推理表现的在线测试。FermatMind IQ V1 使用原创 30 题，约 20 分钟，重点解释本次任务中的原始分、正确率、完成时间和维度表现。它不是外部证明，也不是医疗或教育决策工具。',
+                    '## 这是什么 / 这不是什么',
+                    '这是一套在线 IQ 风格推理任务，不是正式智力结论、外部认证或临床测评。',
+                    '## 方法解释',
+                    '页面只解释公开方法与边界，不公开题目 ID、答案、解题步骤、评分表或后端评分规则。',
+                    '## FAQ',
+                    '### 这是正式智力测评吗？',
+                    '不是。它用于理解本次推理任务表现。',
+                ]),
+            ];
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function draftState(): array
+    {
+        return [
+            'status' => 'draft_review_only',
+            'is_public' => false,
+            'is_indexable' => false,
+            'robots' => 'noindex,follow',
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -401,6 +401,24 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleIqMethodPagesReadback.php',
+            'backend/bootstrap/app.php',
+        ];
+        $bootstrapChangedLines = [
+            '+        \\App\\Console\\Commands\\ArticleIqMethodPagesReadback::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            changed: $changed,
+            repoRoot: '',
+            baseRef: '',
+            bootstrapAppChangedLines: $bootstrapChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti64_cms_revision_draft_files(): void
     {
         $changed = [
@@ -7699,6 +7717,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php',
+            'backend/app/Console/Commands/ArticleIqMethodPagesReadback.php',
             'backend/app/Models/TopicProfileEntry.php',
         ], true)
             || str_starts_with($file, 'backend/app/Services/Cms/IqMethodPages/');
@@ -10627,7 +10646,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\bArticleImportIqMethodPagesDraft\b/u', $normalized) !== 1) {
+            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49538,7 +49538,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01"
     ],
-    "status": "pr_open",
+    "status": "merged",
     "authorized_by_user": "2026-07-05 user explicitly provided IQ 7 pages CMS上线执行计划 with this PR id, repo, scope, and dry-run/import/readback/publish/SEO-GEO split.",
     "checks": {
       "dependency": {
@@ -49572,20 +49572,28 @@
         "status": "failed_external_sidecar",
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ServiceLayerBoundaryTest --no-ansi",
         "evidence": "Failure points to pre-existing HTTP helper calls in backend/app/Services/SeoIntel/CrawlerLog/CrawlerLogFixtureParser.php and backend/app/Services/Iq/IqOwnerOriginal30BankService.php, not the newly added backend/app/Services/Cms/IqMethodPages importer."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PASS on PR #2721 before merge: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "PR #2721 is MERGED; origin/main contains merge commit 83eb4781082f17e574a575b09b92d23acc75021d; local main was synced to origin/main; task branch codex/iq-method-pages-cms-import-01 was removed locally and remotely; worktree was clean after removing generated Big Five compiled test side effects."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
-    "commit_sha": "e840911382fac0376fc0f9145cea32062a87e88d",
+    "commit_sha": "83eb4781082f17e574a575b09b92d23acc75021d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2721",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T05:09:24Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": true,
@@ -49646,6 +49654,11 @@
         "at": "2026-07-05T13:22:00+08:00",
         "status": "ready_to_merge",
         "summary": "GitHub checks passed on PR #2721 head 91eace541b3b9944346db7f3e9e572d847f20508: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      {
+        "at": "2026-07-05T13:09:24+08:00",
+        "status": "merged",
+        "summary": "Reconciled after merge: PR #2721 merged at 2026-07-05T05:09:24Z with merge commit 83eb4781082f17e574a575b09b92d23acc75021d; main synced and local/remote task branches cleaned. Reconciliation is bookkeeping included in the next same-repository PR."
       }
     ]
   },
@@ -79535,5 +79548,115 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-05T12:00:00+08:00"
+  "updated_at": "2026-07-05T12:00:00+08:00",
+  "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01": {
+    "id": "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-method-pages-cms-readback-01",
+    "title": "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01: add IQ method CMS readback QA",
+    "train_scope": "iq_method_pages_zh_cn_cms_readback",
+    "depends_on": [
+      "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01"
+    ],
+    "status": "committed",
+    "authorized_by_user": "2026-07-05 user explicitly provided IQ 7 pages CMS上线执行计划 with readback as PR train step 3, after backend CMS import and before publish.",
+    "checks": {
+      "dependency": {
+        "status": "pass",
+        "evidence": "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01 PR #2721 is merged; origin/main contains merge commit 83eb4781082f17e574a575b09b92d23acc75021d."
+      },
+      "syntax": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/ArticleIqMethodPagesReadback.php",
+          "php -l backend/tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php"
+        ],
+        "evidence": "PASS: readback command and focused command test file report no syntax errors."
+      },
+      "command_discovery": {
+        "status": "pass",
+        "command": "cd backend && composer dump-autoload --no-ansi && php artisan list articles --no-ansi | rg 'iq-method-pages-readback|iq-method-pages|import-iq-method'",
+        "evidence": "PASS: articles:iq-method-pages-readback and articles:import-iq-method-pages-draft are discoverable after autoload refresh."
+      },
+      "pint_targeted": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesReadback.php tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php",
+        "evidence": "PASS: 4 files."
+      },
+      "focused_readback_contract": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesReadbackCommandTest --no-ansi",
+        "evidence": "PASS: 3 tests, 41 assertions. Covers import+readback success, missing CMS draft fail-closed behavior, and early public/indexable state blocking."
+      },
+      "focused_bigfive_runtime_freeze_classifier": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
+        "evidence": "PASS: 2 tests, 4 assertions. The readback command registration is explicitly classified as non-runtime-only, and runtime path diff check passes locally."
+      },
+      "real_package_temp_sqlite_readback": {
+        "status": "pass",
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/iq-method-readback-<temp>.sqlite php artisan migrate --force --no-ansi && php artisan articles:import-iq-method-pages-draft --package=/Users/rainie/Desktop/GitHub/fap-web --json && php artisan articles:iq-method-pages-readback --package=/Users/rainie/Desktop/GitHub/fap-web --json",
+        "evidence": "PASS: real fap-web IQ method dry-run package imported 7 draft articles into temp sqlite and readback returned ok=true, status=pass, article_readbacks=7, mismatch_count=0."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt",
+        "evidence": "PASS: route list generated 222 lines at /tmp/fap-api-route-list-api.txt."
+      },
+      "manifest_state_diff_validation": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "evidence": "PASS: train YAML parses, state JSON parses, and git diff whitespace check passes."
+      },
+      "composer_test_full_suite": {
+        "status": "failed_external_sidecar",
+        "command": "cd backend && composer test",
+        "evidence": "Composer test exceeded 300s and exited 1 after external Career/Content/MBTI/PDF/Architecture/ClinicalCombo/Commerce failures outside current READBACK scope. Recorded sidecar details in generated/pr-train-sidecar-issues/sidecar_issues.md and sidecar_issues.json."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the READBACK allowed paths: backend/app/Console/Commands/ArticleIqMethodPagesReadback.php, backend/bootstrap/app.php, backend/tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php, backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json, and generated/pr-train-sidecar-issues/**."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": "49c3008b77969b0b147fc223aa8c4c9e8792da18",
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "transitions": [
+      {
+        "at": "2026-07-05T13:20:00+08:00",
+        "status": "in_progress",
+        "summary": "Started backend read-only CMS readback QA command for seven zh-CN IQ method pages. Scope excludes CMS writes, production import, publishing, indexability, sitemap/llms activation, frontend fallback, scoring changes, and deploys."
+      },
+      {
+        "at": "2026-07-05T13:45:00+08:00",
+        "status": "local_validation_passed_with_external_sidecar",
+        "summary": "Implemented read-only IQ method pages CMS readback command/test and command registration. Focused local validation and real fap-web package import+readback on temp sqlite passed. Full composer test timed out after external failures outside current scope; sidecar recorded and train may continue subject to GitHub required checks."
+      },
+      {
+        "at": "2026-07-05T13:55:00+08:00",
+        "status": "committed",
+        "summary": "Committed IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01 scoped backend readback QA changes at 49c3008b77969b0b147fc223aa8c4c9e8792da18."
+      }
+    ]
+  }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -79625,7 +79625,7 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": "49c3008b77969b0b147fc223aa8c4c9e8792da18",
+    "commit_sha": "ac72416ce2583c2614c7726404e4d232c908af28",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -79559,7 +79559,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01"
     ],
-    "status": "committed",
+    "status": "pr_open",
     "authorized_by_user": "2026-07-05 user explicitly provided IQ 7 pages CMS上线执行计划 with readback as PR train step 3, after backend CMS import and before publish.",
     "checks": {
       "dependency": {
@@ -79626,7 +79626,7 @@
       "post_merge_revalidated": null
     },
     "commit_sha": "ac72416ce2583c2614c7726404e4d232c908af28",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2724",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -79656,6 +79656,11 @@
         "at": "2026-07-05T13:55:00+08:00",
         "status": "committed",
         "summary": "Committed IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01 scoped backend readback QA changes at 49c3008b77969b0b147fc223aa8c4c9e8792da18."
+      },
+      {
+        "at": "2026-07-05T14:00:00+08:00",
+        "status": "pr_open",
+        "summary": "Opened PR #2724 at https://github.com/fermatmind/fap-api/pull/2724 for IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -36839,6 +36839,52 @@ prs:
     content_authority: CMS/backend
     next_task: IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01
 
+  - id: IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01
+    repo: fap-api
+    depends_on:
+      - IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01
+    branch: codex/iq-method-pages-cms-readback-01
+    title: "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01: add IQ method CMS readback QA"
+    train_scope: iq_method_pages_zh_cn_cms_readback
+    status: in_progress
+    scope:
+      - Add a backend read-only CMS readback command for the 7 zh-CN IQ method pages imported as drafts.
+      - Verify Article rows, working revisions, SEO meta, canonical, robots, topic IQ grouping, landing page block links, and private-route/scoring-token guards against the dry-run manifest.
+      - Fail closed when draft CMS rows are missing, public/indexable state appears early, or topic/landing mappings drift.
+      - Reconcile stale IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01 ledger facts only as same-repository PR-train bookkeeping.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleIqMethodPagesReadback.php
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Publish articles, flip indexability, activate sitemap/llms, submit search URLs, run production deploy, rewrite content, change IQ scoring, expose answer keys, or add frontend fallback content.
+      - Mutate production CMS or production DB from this PR without separate exact environment authorization.
+    validation:
+      - php -l backend/app/Console/Commands/ArticleIqMethodPagesReadback.php
+      - php -l backend/tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php
+      - cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-readback|iq-method-pages'
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesReadback.php tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesReadbackCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
+      - cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01
+
   - id: IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01
     repo: fap-api
     depends_on:

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -22,5 +22,19 @@
     "why_not_current_pr_scope": "Current PR scope only adds the IQ method pages CMS draft importer command/service/test, registers the command, extends the topic group whitelist, and updates PR-train metadata. The observed failures are in Content, Architecture, Career, and CareerCms surfaces outside the changed IQ method importer files.",
     "required_checks_affected": "unknown_until_github_checks; local focused validation passed",
     "recommended_follow_up": "Track and fix the failing Content/Career/Architecture tests under their owning PR scopes. Do not mix those repairs into the IQ method pages CMS import PR."
+  },
+  {
+    "repo": "fap-api",
+    "pr_id": "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01",
+    "branch": "codex/iq-method-pages-cms-readback-01",
+    "blocker_type": "external_full_suite_failure_timeout",
+    "evidence": [
+      "cd backend && composer test exceeded the Composer process timeout of 300 seconds and exited with code 1.",
+      "Failures observed before timeout included Tests\\Unit\\Domain\\Career\\Audit\\CareerFullVisiblePublicationGateTest, Tests\\Unit\\Services\\Content\\CulturalCalibrationLayerServiceTest, Tests\\Unit\\Services\\Mbti\\MbtiResultPersonalizationServiceTest, Tests\\Unit\\Services\\Report\\Pdf\\Mbti\\MbtiPdfPayloadBuilderTest, Tests\\Feature\\Architecture\\ServiceLayerBoundaryTest, Tests\\Feature\\Career\\CareerCnProxyPublicOwnerApiTest, Tests\\Feature\\Career\\CareerJobDetailApiTest, Tests\\Feature\\CareerCms\\ArticleBaselineImportTest, Tests\\Feature\\ClinicalCombo68\\ClinicalComboQuestionsMetaComplianceTest, and Tests\\Feature\\Commerce\\PostPaidAttemptMismatchRepairOpsTenantVisibilityAcceptanceTest.",
+      "Focused READBACK validation passed: ArticleIqMethodPagesReadbackCommandTest, BigFive runtime freeze classifier readback exemption, command discovery, targeted Pint, route:list, real fap-web package import+readback on temp sqlite, YAML/JSON parse, and git diff check."
+    ],
+    "why_not_current_pr_scope": "Current PR scope only adds the read-only IQ method pages CMS readback command/test, registers the command, extends the Big Five runtime-freeze classifier exemption for that command, and updates PR-train metadata. The observed full-suite failures are in Career, Content, MBTI personalization/PDF, Architecture, ClinicalCombo, and Commerce surfaces outside the changed READBACK files.",
+    "required_checks_affected": "unknown_until_github_checks; local focused validation passed and GitHub required checks must still be inspected before merge",
+    "recommended_follow_up": "Track and fix the failing Career/Content/MBTI/PDF/Architecture/ClinicalCombo/Commerce tests under their owning PR scopes. Do not mix those repairs into IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01."
   }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -35,3 +35,32 @@
 - recommended follow-up:
   - Track and fix the failing Content/Career/Architecture tests under their owning PR scopes.
   - Do not mix those repairs into the IQ method pages CMS import PR.
+
+## IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01
+
+- repo: `fap-api`
+- branch: `codex/iq-method-pages-cms-readback-01`
+- blocker type: `external_full_suite_failure_timeout`
+- evidence:
+  - `cd backend && composer test` exceeded the Composer process timeout of 300 seconds and exited with code 1.
+  - Failures observed before timeout included:
+    - `Tests\Unit\Domain\Career\Audit\CareerFullVisiblePublicationGateTest`
+    - `Tests\Unit\Services\Content\CulturalCalibrationLayerServiceTest`
+    - `Tests\Unit\Services\Mbti\MbtiResultPersonalizationServiceTest`
+    - `Tests\Unit\Services\Report\Pdf\Mbti\MbtiPdfPayloadBuilderTest`
+    - `Tests\Feature\Architecture\ServiceLayerBoundaryTest`
+    - `Tests\Feature\Career\CareerCnProxyPublicOwnerApiTest`
+    - `Tests\Feature\Career\CareerJobDetailApiTest`
+    - `Tests\Feature\CareerCms\ArticleBaselineImportTest`
+    - `Tests\Feature\ClinicalCombo68\ClinicalComboQuestionsMetaComplianceTest`
+    - `Tests\Feature\Commerce\PostPaidAttemptMismatchRepairOpsTenantVisibilityAcceptanceTest`
+  - Focused READBACK validation passed: command discovery, targeted Pint, `ArticleIqMethodPagesReadbackCommandTest`, BigFive runtime freeze readback exemption, route:list, real fap-web package import+readback on temp sqlite, YAML/JSON parse, and git diff check.
+- why not current PR scope:
+  - Current PR scope only adds the read-only IQ method pages CMS readback command/test, command registration, Big Five runtime-freeze classifier exemption for that command, and PR-train metadata.
+  - The observed full-suite failures are in Career, Content, MBTI personalization/PDF, Architecture, ClinicalCombo, and Commerce surfaces outside the changed READBACK files.
+- whether required checks are affected:
+  - Unknown until GitHub checks run; local focused validation for current scope passed.
+  - If a required GitHub check fails, inspect the failing job before merge.
+- recommended follow-up:
+  - Track and fix the failing Career/Content/MBTI/PDF/Architecture/ClinicalCombo/Commerce tests under their owning PR scopes.
+  - Do not mix those repairs into the IQ method pages CMS readback PR.


### PR DESCRIPTION
## What changed
- Added `articles:iq-method-pages-readback`, a read-only backend QA command for the seven zh-CN IQ method CMS draft pages.
- The command verifies imported CMS Article rows, working revisions, SEO meta, canonical URLs, `robots=noindex,follow`, topic `iq_articles` grouping, landing page block links, and private-route/scoring-token guards against the dry-run package.
- Added focused PHPUnit coverage for successful import+readback, missing draft fail-closed behavior, and premature public/indexable state blocking.
- Registered the command and extended the Big Five runtime-freeze classifier exemption for this readback tool.
- Added the `IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01` PR train manifest/state entry and reconciled the previous import PR merge facts.
- Recorded external full-suite blockers in sidecar files.

## Why
This is PR train step 3 for the IQ method pages CMS rollout. It proves the backend/CMS draft import can be read back and matched to the dry-run manifest before any publish, indexing, sitemap, llms, or production activation work.

## Validation
- `php -l backend/app/Console/Commands/ArticleIqMethodPagesReadback.php`
- `php -l backend/tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php`
- `cd backend && composer dump-autoload --no-ansi && php artisan list articles --no-ansi | rg 'iq-method-pages-readback|iq-method-pages|import-iq-method'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesReadback.php tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesReadbackCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi`
- Temp sqlite real-package validation against `/Users/rainie/Desktop/GitHub/fap-web`: import returned 7 draft articles; readback returned `ok=true`, `status=pass`, `mismatch_count=0`.
- `cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

`cd backend && composer test` was also attempted. It exceeded the Composer 300s process timeout and showed external failures outside this PR scope; those are recorded in `generated/pr-train-sidecar-issues/`.

## Deferred items
- No CMS production import or production DB mutation.
- No article publish/state flip.
- No sitemap, `llms.txt`, `llms-full.txt`, canonical/runtime SEO activation.
- No frontend fallback content.
- No IQ scoring, item-bank, answer-key, or report behavior changes.
- No staging wait, manual deploy, or production deploy.

## Repository rule impact
This keeps IQ method page content authority in backend CMS. The new command is readback QA only; it does not make frontend content authoritative and does not change publish/indexability/search surfaces.
