### PR TITLE
BIG5-CMS-INDEXABILITY-GATE-03: enforce Big Five public asset noindex and schema runtime gates

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php
@@ -165,6 +165,7 @@ final class PersonalityPublicContentAssetController extends Controller
     {
         $contentSections = is_array($asset->content_sections_json) ? $asset->content_sections_json : [];
         $canonical = is_array($asset->canonical_json) ? $asset->canonical_json : [];
+        $schemaRuntimeEligible = $this->isSchemaRuntimeEligible($asset);
 
         return [
             'id' => (int) $asset->id,
@@ -187,7 +188,8 @@ final class PersonalityPublicContentAssetController extends Controller
             'hreflang' => is_array($asset->hreflang_json) ? $asset->hreflang_json : [],
             'faq' => is_array($asset->faq_json) ? $asset->faq_json : [],
             'media' => is_array($asset->media_json) ? $asset->media_json : [],
-            'schema' => is_array($asset->schema_json) ? $asset->schema_json : [],
+            'schema' => $schemaRuntimeEligible && is_array($asset->schema_json) ? $asset->schema_json : [],
+            'schema_runtime_eligible' => $schemaRuntimeEligible,
             'method_boundary' => is_array($asset->method_boundary_json) ? $asset->method_boundary_json : [],
             'evidence_notes' => is_array($asset->evidence_notes_json) ? $asset->evidence_notes_json : [],
             'internal_links' => is_array($asset->internal_links_json) ? $asset->internal_links_json : [],
@@ -203,6 +205,13 @@ final class PersonalityPublicContentAssetController extends Controller
             'last_reviewed_at' => $asset->last_reviewed_at?->toAtomString(),
             'updated_at' => $asset->updated_at?->toAtomString(),
         ];
+    }
+
+    private function isSchemaRuntimeEligible(PersonalityPublicContentAsset $asset): bool
+    {
+        return (string) $asset->launch_state === PersonalityPublicContentAsset::LAUNCH_PUBLISHED
+            && (bool) $asset->index_eligible
+            && PersonalityPublicContentAsset::normalizeRobots((string) $asset->robots) === PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW;
     }
 
     private function notFoundResponse(): JsonResponse

--- a/backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
@@ -446,6 +446,87 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
         $this->assertStringNotContainsString('/personality/big-five', $sitemapLocs);
     }
 
+    public function test_noindex_content_ready_big_five_asset_suppresses_runtime_schema(): void
+    {
+        PersonalityPublicContentAsset::query()->create($this->assetAttributes([
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            'index_eligible' => false,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'schema_json' => [
+                '@type' => 'WebPage',
+                'name' => 'Draft Big Five page',
+            ],
+        ]));
+
+        $asset = PersonalityPublicContentAsset::query()->firstOrFail();
+        $this->assertFalse((bool) $asset->sitemap_eligible);
+        $this->assertFalse((bool) $asset->llms_eligible);
+
+        $this->getJson('/api/v0.5/personality-content-assets/big_five/big-five?locale=en')
+            ->assertOk()
+            ->assertJsonPath('personality_public_content_asset_v1.launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)
+            ->assertJsonPath('personality_public_content_asset_v1.robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW)
+            ->assertJsonPath('personality_public_content_asset_v1.index_eligible', false)
+            ->assertJsonPath('personality_public_content_asset_v1.sitemap_eligible', false)
+            ->assertJsonPath('personality_public_content_asset_v1.llms_eligible', false)
+            ->assertJsonPath('personality_public_content_asset_v1.schema_runtime_eligible', false)
+            ->assertJsonPath('personality_public_content_asset_v1.schema', []);
+    }
+
+    public function test_published_non_indexable_big_five_asset_suppresses_runtime_schema(): void
+    {
+        PersonalityPublicContentAsset::query()->create($this->assetAttributes([
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_PUBLISHED,
+            'index_eligible' => false,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now()->subMinute(),
+            'schema_json' => [
+                '@type' => 'WebPage',
+                'name' => 'Published but noindex Big Five page',
+            ],
+        ]));
+
+        $asset = PersonalityPublicContentAsset::query()->firstOrFail();
+        $this->assertFalse((bool) $asset->sitemap_eligible);
+        $this->assertFalse((bool) $asset->llms_eligible);
+
+        $this->getJson('/api/v0.5/personality-content-assets/big_five/big-five?locale=en')
+            ->assertOk()
+            ->assertJsonPath('personality_public_content_asset_v1.launch_state', PersonalityPublicContentAsset::LAUNCH_PUBLISHED)
+            ->assertJsonPath('personality_public_content_asset_v1.robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW)
+            ->assertJsonPath('personality_public_content_asset_v1.index_eligible', false)
+            ->assertJsonPath('personality_public_content_asset_v1.sitemap_eligible', false)
+            ->assertJsonPath('personality_public_content_asset_v1.llms_eligible', false)
+            ->assertJsonPath('personality_public_content_asset_v1.schema_runtime_eligible', false)
+            ->assertJsonPath('personality_public_content_asset_v1.schema', []);
+    }
+
+    public function test_published_indexable_big_five_asset_can_emit_runtime_schema(): void
+    {
+        PersonalityPublicContentAsset::query()->create($this->assetAttributes([
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_PUBLISHED,
+            'index_eligible' => true,
+            'published_at' => now()->subMinute(),
+            'schema_json' => [
+                '@type' => 'WebPage',
+                'name' => 'Published indexable Big Five page',
+            ],
+        ]));
+
+        $this->getJson('/api/v0.5/personality-content-assets/big_five/big-five?locale=en')
+            ->assertOk()
+            ->assertJsonPath('personality_public_content_asset_v1.launch_state', PersonalityPublicContentAsset::LAUNCH_PUBLISHED)
+            ->assertJsonPath('personality_public_content_asset_v1.robots', PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW)
+            ->assertJsonPath('personality_public_content_asset_v1.index_eligible', true)
+            ->assertJsonPath('personality_public_content_asset_v1.schema_runtime_eligible', true)
+            ->assertJsonPath('personality_public_content_asset_v1.schema.@type', 'WebPage')
+            ->assertJsonPath('personality_public_content_asset_v1.schema.name', 'Published indexable Big Five page');
+    }
+
     public function test_contract_rejects_disallowed_page_families_and_private_result_modules(): void
     {
         $contract = app(PersonalityPublicContentAssetContract::class);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80651,9 +80651,9 @@
     "depends_on": [
       "BIG5-CMS-FAQ-DEDUPE-02"
     ],
-    "status": "committed",
+    "status": "pr_open",
     "commit_sha": "b7c242a86",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2725",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -80726,6 +80726,12 @@
         "from": "local_checks_passed",
         "to": "committed",
         "note": "Committed BIG5-CMS-INDEXABILITY-GATE-03 schema runtime gate scope at b7c242a86."
+      },
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "committed",
+        "to": "pr_open",
+        "note": "Opened PR #2725 for BIG5-CMS-INDEXABILITY-GATE-03 and pushed branch codex/big5-cms-indexability-gate-03."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -146,13 +146,13 @@
     "depends_on": [
       "BIG5-CMS-IMPORT-DRYRUN-01"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "e4c48e414cc8ae1735396b52aac4795c605b9b1d",
+    "status": "merged",
+    "commit_sha": "d69ec0af6c60045de3201de1191aa109a5aa9e5e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2723",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T05:25:17Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -199,13 +199,17 @@
       "github_checks": {
         "status": "pass",
         "evidence": "PASS on PR #2723 head e4c48e414cc8ae1735396b52aac4795c605b9b1d: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "PR #2723 is MERGED; origin/main contains merge commit d69ec0af6c60045de3201de1191aa109a5aa9e5e; task branch codex/big5-cms-faq-dedupe-02 is absent locally and remotely."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -243,6 +247,12 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "note": "PR #2723 remote checks passed. Marked ready to merge under squash merge policy."
+      },
+      {
+        "at": "2026-07-05T05:25:17Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "note": "Reconciled PR #2723 merge before starting BIG5-CMS-INDEXABILITY-GATE-03. GitHub reports merged, origin/main contains the merge commit, and the task branch is already deleted locally and remotely."
       }
     ]
   },
@@ -80629,6 +80639,169 @@
         "at": "2026-07-05T14:00:00+08:00",
         "status": "pr_open",
         "summary": "Opened PR #2724 at https://github.com/fermatmind/fap-api/pull/2724 for IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01."
+      }
+    ]
+  },
+  "BIG5-CMS-INDEXABILITY-GATE-03": {
+    "id": "BIG5-CMS-INDEXABILITY-GATE-03",
+    "repo": "fap-api",
+    "title": "BIG5-CMS-INDEXABILITY-GATE-03: enforce Big Five public asset noindex and schema runtime gates",
+    "base": "main",
+    "branch": "codex/big5-cms-indexability-gate-03",
+    "depends_on": [
+      "BIG5-CMS-FAQ-DEDUPE-02"
+    ],
+    "status": "local_checks_passed",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized registering BIG5-CMS-INDEXABILITY-GATE-03 in the attached /goal execution request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "BIG5-CMS-FAQ-DEDUPE-02 PR #2723 is merged and origin/main contains merge commit d69ec0af6c60045de3201de1191aa109a5aa9e5e."
+      },
+      "syntax": {
+        "status": "pass",
+        "command": "php -l backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php && php -l backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php",
+        "evidence": "PASS: controller and focused contract test file report no syntax errors."
+      },
+      "focused_schema_runtime_gate": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityPublicContentAssetContractTest::test_noindex_content_ready_big_five_asset_suppresses_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_non_indexable_big_five_asset_suppresses_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_indexable_big_five_asset_can_emit_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_indexable_asset_can_be_read_without_sitemap_or_llms_flags' --no-ansi",
+        "evidence": "PASS: 4 tests, 39 assertions. Covers content_ready/noindex schema suppression, published/non-indexable schema suppression, published/indexable schema emission, and sitemap/llms remain false when flags are false."
+      },
+      "pint_targeted": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php",
+        "evidence": "PASS: 2 files."
+      },
+      "ci_verify_mbti": {
+        "status": "pass",
+        "command": "cd backend && bash scripts/ci_verify_mbti.sh",
+        "evidence": "PASS: full backend verification chain completed successfully, including Big Five gates, MBTI verify flow, migration/security gates, OpenAPI diff gate, and dependency security gate. Generated compiled Big Five artifacts were restored because they were verification byproducts outside current PR scope."
+      },
+      "manifest_state_diff_validation": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check && git diff --cached --check",
+        "evidence": "PASS: train YAML parses, state JSON parses, and diff whitespace checks pass."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to BIG5-CMS-INDEXABILITY-GATE-03 allowed paths: backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php, backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api-big5-03.txt",
+        "evidence": "PASS: route list generated 222 lines at /tmp/fap-api-route-list-api-big5-03.txt; no route path changes were introduced."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "user_authorized",
+        "to": "in_progress",
+        "note": "Started backend-only indexability/schema runtime gate PR from origin/main after BIG5-CMS-FAQ-DEDUPE-02 merge was verified."
+      },
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Implemented public API schema runtime gate and focused Big Five indexability regressions. Syntax, focused PHPUnit, targeted Pint, full ci_verify_mbti, YAML/JSON parse, diff checks, and allowed-path scope validation passed."
+      }
+    ]
+  },
+  "BIG5-CMS-DISCOVERABILITY-SURFACE-04": {
+    "id": "BIG5-CMS-DISCOVERABILITY-SURFACE-04",
+    "repo": "fap-api",
+    "title": "BIG5-CMS-DISCOVERABILITY-SURFACE-04: block Big Five draft assets from sitemap llms and JSON-LD enumeration",
+    "base": "main",
+    "branch": "codex/big5-cms-discoverability-surface-04",
+    "depends_on": [
+      "BIG5-CMS-INDEXABILITY-GATE-03"
+    ],
+    "status": "pending_dependency",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized registering BIG5-CMS-DISCOVERABILITY-SURFACE-04 in the attached /goal execution request."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for BIG5-CMS-INDEXABILITY-GATE-03 to merge."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "user_authorized",
+        "to": "pending_dependency",
+        "note": "Registered dependent PR train item; execution waits for BIG5-CMS-INDEXABILITY-GATE-03 merge."
+      }
+    ]
+  },
+  "BIG5-CONTENT-QUALITY-REVIEW-05": {
+    "id": "BIG5-CONTENT-QUALITY-REVIEW-05",
+    "repo": "fap-api",
+    "title": "BIG5-CONTENT-QUALITY-REVIEW-05: classify Big Five combination and English assets for CMS review",
+    "base": "main",
+    "branch": "codex/big5-content-quality-review-05",
+    "depends_on": [
+      "BIG5-CMS-DISCOVERABILITY-SURFACE-04"
+    ],
+    "status": "pending_dependency",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized registering BIG5-CONTENT-QUALITY-REVIEW-05 in the attached /goal execution request."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for BIG5-CMS-DISCOVERABILITY-SURFACE-04 to merge."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "user_authorized",
+        "to": "pending_dependency",
+        "note": "Registered dependent PR train item; execution waits for BIG5-CMS-DISCOVERABILITY-SURFACE-04 merge."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80651,8 +80651,8 @@
     "depends_on": [
       "BIG5-CMS-FAQ-DEDUPE-02"
     ],
-    "status": "pr_open",
-    "commit_sha": "b7c242a86",
+    "status": "ready_to_merge",
+    "commit_sha": "57ca03963bd0c9cf3383b73a714c43fa78f6ab0e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2725",
     "failure_reason": null,
     "merged_at": null,
@@ -80700,12 +80700,16 @@
         "status": "pass",
         "command": "cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api-big5-03.txt",
         "evidence": "PASS: route list generated 222 lines at /tmp/fap-api-route-list-api-big5-03.txt; no route path changes were introduced."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PASS on PR #2725 head 57ca03963bd0c9cf3383b73a714c43fa78f6ab0e: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -80732,6 +80736,12 @@
         "from": "committed",
         "to": "pr_open",
         "note": "Opened PR #2725 for BIG5-CMS-INDEXABILITY-GATE-03 and pushed branch codex/big5-cms-indexability-gate-03."
+      },
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "note": "PR #2725 remote checks passed. Marked ready to merge under squash merge policy."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80651,8 +80651,8 @@
     "depends_on": [
       "BIG5-CMS-FAQ-DEDUPE-02"
     ],
-    "status": "local_checks_passed",
-    "commit_sha": null,
+    "status": "committed",
+    "commit_sha": "b7c242a86",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -80720,6 +80720,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Implemented public API schema runtime gate and focused Big Five indexability regressions. Syntax, focused PHPUnit, targeted Pint, full ci_verify_mbti, YAML/JSON parse, diff checks, and allowed-path scope validation passed."
+      },
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "local_checks_passed",
+        "to": "committed",
+        "note": "Committed BIG5-CMS-INDEXABILITY-GATE-03 schema runtime gate scope at b7c242a86."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -107,6 +107,132 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: BIG5-CMS-INDEXABILITY-GATE-03
+    repo: fap-api
+    depends_on:
+      - BIG5-CMS-FAQ-DEDUPE-02
+    branch: codex/big5-cms-indexability-gate-03
+    title: "BIG5-CMS-INDEXABILITY-GATE-03: enforce Big Five public asset noindex and schema runtime gates"
+    train_scope: big_five_cms_indexability_readiness
+    status: user_authorized
+    scope:
+      - Enforce Big Five public asset schema runtime gating in the CMS/public API payload.
+      - Ensure noindex, non-index-eligible, or non-published personality public assets do not emit JSON-LD runtime schema.
+      - Preserve fail-closed sitemap_eligible and llms_eligible behavior for Big Five draft/review content.
+      - Add regression coverage for content_ready/noindex, published/non-indexable, and published/indexable asset states.
+      - Keep the change backend-only; no CMS writes, publishing, sitemap/llms release, search release, staging deploy, or production deploy.
+    allowed_paths:
+      - backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php
+      - backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Add frontend content fallback.
+      - Write CMS, run production imports, run database migrations, publish, enable indexability, release sitemap/llms, submit search, trigger staging deploy, trigger production deploy, or add public runtime content.
+      - Change public route paths, permissions, scheduler behavior, secrets, canonical path generation, sitemap runtime inclusion, llms runtime inclusion, or production JSON-LD publishing policy beyond suppressing ineligible schema payloads.
+    validation:
+      - php -l backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php
+      - php -l backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityPublicContentAssetContractTest::test_noindex_content_ready_big_five_asset_suppresses_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_non_indexable_big_five_asset_suppresses_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_indexable_big_five_asset_can_emit_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_indexable_asset_can_be_read_without_sitemap_or_llms_flags' --no-ansi
+      - cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-CMS-DISCOVERABILITY-SURFACE-04
+    repo: fap-api
+    depends_on:
+      - BIG5-CMS-INDEXABILITY-GATE-03
+    branch: codex/big5-cms-discoverability-surface-04
+    title: "BIG5-CMS-DISCOVERABILITY-SURFACE-04: block Big Five draft assets from sitemap llms and JSON-LD enumeration"
+    train_scope: big_five_cms_indexability_readiness
+    status: user_authorized
+    scope:
+      - Audit and regression-test backend SEO/GEO discoverability surfaces for Big Five personality public content assets.
+      - Ensure draft or ineligible Big Five assets do not enter sitemap, llms, or JSON-LD enumeration.
+      - Require sitemap_eligible=true for sitemap surfaces and llms_eligible=true for llms surfaces.
+      - Keep draft JSON-LD and FAQ schema as planning-only unless visible CMS content and indexability gates are approved.
+      - If no runtime enumeration exists for this asset type, add fail-closed contract coverage without adding a release surface.
+    allowed_paths:
+      - backend/app/Http/Controllers/API/V0_5/**
+      - backend/app/Services/SEO/**
+      - backend/tests/Feature/SEO/**
+      - backend/tests/Feature/SeoIntel/**
+      - backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Write CMS, run production imports, run database migrations, publish, enable indexability, release sitemap/llms, submit search, trigger staging deploy, trigger production deploy, or add public runtime content.
+      - Add Big Five assets to sitemap, llms, JSON-LD runtime, canonical release, search submission, or production revalidation.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityPublicContentAssetContractTest|SitemapSourceApiTest|SitemapGeneratorTest' --no-ansi
+      - cd backend && vendor/bin/pint --test tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php tests/Feature/SEO/SitemapSourceApiTest.php tests/Feature/SEO/SitemapGeneratorTest.php
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-CONTENT-QUALITY-REVIEW-05
+    repo: fap-api
+    depends_on:
+      - BIG5-CMS-DISCOVERABILITY-SURFACE-04
+    branch: codex/big5-content-quality-review-05
+    title: "BIG5-CONTENT-QUALITY-REVIEW-05: classify Big Five combination and English assets for CMS review"
+    train_scope: big_five_cms_indexability_readiness
+    status: user_authorized
+    scope:
+      - Generate or update a backend-side Big Five v2 content quality review report for the desktop CMS import draft package.
+      - Classify Chinese combination pages as CMS review candidates with manual polish recommended.
+      - Classify English pages as draft-only and blocked from English SEO expansion.
+      - Verify cms-import-draft.json locale, content_type, status, indexability_gate, FAQ, content length, and canonical path posture.
+      - Keep the output review-only; no content publish, frontend fallback, CMS write, indexability release, sitemap/llms release, search release, or deploy.
+    allowed_paths:
+      - generated/big-five-content-quality-review/**
+      - generated/pr-train-sidecar-issues/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Modify frontend runtime, public API runtime, production CMS content, sitemap/llms runtime, JSON-LD runtime, canonical/noindex behavior, permissions, scheduler behavior, secrets, staging deploy, or production deploy.
+      - Mark English Big Five pages indexable or bypass manual review for combination pages.
+    validation:
+      - python3 -m json.tool /Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: MBTI-CMS-12
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added a backend public API schema runtime gate for `personality_public_content_assets`.
- `schema` now returns an empty array unless the asset is `published`, `index_eligible=true`, and `robots=index,follow`.
- Added `schema_runtime_eligible` to make the runtime decision explicit in the payload.
- Added focused Big Five regression coverage for:
  - `content_ready` + `noindex,follow` suppressing runtime schema
  - `published` + non-indexable suppressing runtime schema
  - `published` + indexable emitting runtime schema
  - sitemap/llms flags staying false when not explicitly eligible
- Registered the next Big Five PR train items and reconciled BIG5-CMS-FAQ-DEDUPE-02 as merged.

## Why
Big Five public CMS assets must remain noindex/draft-safe until CMS review and a separate indexability release. Draft schema planning must not become JSON-LD runtime evidence through the public API payload.

## Validation
- `php -l backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php`
- `php -l backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityPublicContentAssetContractTest::test_noindex_content_ready_big_five_asset_suppresses_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_non_indexable_big_five_asset_suppresses_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_indexable_big_five_asset_can_emit_runtime_schema|PersonalityPublicContentAssetContractTest::test_published_indexable_asset_can_be_read_without_sitemap_or_llms_flags' --no-ansi`
- `cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api-big5-03.txt`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No CMS writes or production imports.
- No publishing or indexability release.
- No sitemap, llms, search submission, canonical release, or JSON-LD publication.
- No staging deploy wait, manual deploy, or production deploy.
- PR 04 owns discoverability surface enumeration tests.
- PR 05 owns content quality review reporting.

## Repository rule impact
This keeps personality public content CMS/backend-authoritative. It does not introduce frontend fallback content or make schema/sitemap/llms a content authority.
