### PR TITLE
IQ-METHOD-PAGES-ZH-CN-PUBLISH-TRAIN-MANIFEST-01: register publish and SEO/GEO train

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80516,7 +80516,7 @@
     }
   },
   "train_id": "email-first-result-access",
-  "updated_at": "2026-07-05T12:00:00+08:00",
+  "updated_at": "2026-07-05T13:55:29+08:00",
   "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01": {
     "id": "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01",
     "repo": "fap-api",
@@ -80527,7 +80527,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01"
     ],
-    "status": "pr_open",
+    "status": "merged",
     "authorized_by_user": "2026-07-05 user explicitly provided IQ 7 pages CMS上线执行计划 with readback as PR train step 3, after backend CMS import and before publish.",
     "checks": {
       "dependency": {
@@ -80585,20 +80585,28 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to the READBACK allowed paths: backend/app/Console/Commands/ArticleIqMethodPagesReadback.php, backend/bootstrap/app.php, backend/tests/Feature/Console/ArticleIqMethodPagesReadbackCommandTest.php, backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json, and generated/pr-train-sidecar-issues/**."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "GitHub reports PR #2724 is MERGED; required checks were green before merge."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "PR #2724 is MERGED at d73366e9467fab5ad3dcf2fb16e3d50520ed38ca; origin/main contains the merge commit; local and remote task branches are absent in this worktree."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
-    "commit_sha": "ac72416ce2583c2614c7726404e4d232c908af28",
+    "commit_sha": "d73366e9467fab5ad3dcf2fb16e3d50520ed38ca",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2724",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T05:40:14Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": false,
@@ -80629,6 +80637,329 @@
         "at": "2026-07-05T14:00:00+08:00",
         "status": "pr_open",
         "summary": "Opened PR #2724 at https://github.com/fermatmind/fap-api/pull/2724 for IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01."
+      },
+      {
+        "at": "2026-07-05T13:55:29+08:00",
+        "status": "merged",
+        "summary": "Reconciled GitHub state: PR #2724 is MERGED at d73366e9467fab5ad3dcf2fb16e3d50520ed38ca, origin/main contains the merge commit, and the task branch is absent locally and remotely."
+      }
+    ]
+  },
+  "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01": {
+    "id": "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-method-pages-publish-gate-01",
+    "title": "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01: add IQ method publish readiness gate",
+    "train_scope": "iq_method_pages_zh_cn_publish_readiness",
+    "depends_on": [
+      "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01"
+    ],
+    "status": "user_authorized",
+    "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01 PR #2724 is merged; origin/main contains merge commit d73366e9467fab5ad3dcf2fb16e3d50520ed38ca."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "next_task": "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01",
+    "transitions": [
+      {
+        "at": "2026-07-05T13:55:29+08:00",
+        "status": "user_authorized",
+        "summary": "Registered read-only publish readiness gate. Scope excludes review approval writes, publish, indexability, sitemap/llms activation, search submission, frontend fallback, production deploy, and production execution without exact SHA authorization."
+      }
+    ]
+  },
+  "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01": {
+    "id": "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-method-pages-review-approval-01",
+    "title": "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01: add IQ method review approval workflow",
+    "train_scope": "iq_method_pages_zh_cn_review_approval",
+    "depends_on": [
+      "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01"
+    ],
+    "status": "pending_dependency",
+    "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01 to merge before starting review approval workflow implementation."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": true,
+    "cms_mutation": true,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "next_task": "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01",
+    "transitions": [
+      {
+        "at": "2026-07-05T13:55:29+08:00",
+        "status": "pending_dependency",
+        "summary": "Registered controlled review approval workflow. Execution waits for publish gate merge and still requires exact deployed SHA authorization before any production review approval write."
+      }
+    ]
+  },
+  "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01": {
+    "id": "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-method-pages-cms-publish-01",
+    "title": "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01: add controlled IQ method article publish workflow",
+    "train_scope": "iq_method_pages_zh_cn_publish",
+    "depends_on": [
+      "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01"
+    ],
+    "status": "pending_dependency",
+    "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01 to merge before starting controlled publish workflow implementation."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": true,
+    "cms_mutation": true,
+    "api_runtime_change": true,
+    "publish_allowed": true,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "next_task": "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01",
+    "transitions": [
+      {
+        "at": "2026-07-05T13:55:29+08:00",
+        "status": "pending_dependency",
+        "summary": "Registered controlled publish workflow. Execution waits for review approval merge and excludes production publish execution without exact deployed SHA and command authorization."
+      }
+    ]
+  },
+  "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01": {
+    "id": "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-method-pages-post-publish-readback-01",
+    "title": "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01: verify published IQ method articles before indexing",
+    "train_scope": "iq_method_pages_zh_cn_post_publish_readback",
+    "depends_on": [
+      "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01"
+    ],
+    "status": "pending_dependency",
+    "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01 to merge before starting post-publish readback implementation."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "next_task": "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01",
+    "transitions": [
+      {
+        "at": "2026-07-05T13:55:29+08:00",
+        "status": "pending_dependency",
+        "summary": "Registered post-publish readback. Execution waits for controlled publish merge and must keep indexability, sitemap, and llms disabled."
+      }
+    ]
+  },
+  "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01": {
+    "id": "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-method-pages-seo-geo-activate-gate-01",
+    "title": "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01: add IQ method SEO/GEO activation gate",
+    "train_scope": "iq_method_pages_zh_cn_seo_geo_activation_readiness",
+    "depends_on": [
+      "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01"
+    ],
+    "status": "pending_dependency",
+    "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01 to merge before starting SEO/GEO activation gate implementation."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "next_task": "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01",
+    "transitions": [
+      {
+        "at": "2026-07-05T13:55:29+08:00",
+        "status": "pending_dependency",
+        "summary": "Registered read-only SEO/GEO activation gate. Execution waits for post-publish readback merge and excludes sitemap/llms/indexability writes."
+      }
+    ]
+  },
+  "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01": {
+    "id": "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01",
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/iq-method-pages-seo-geo-activate-01",
+    "title": "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01: add controlled IQ method sitemap and llms activation",
+    "train_scope": "iq_method_pages_zh_cn_seo_geo_activation",
+    "depends_on": [
+      "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01"
+    ],
+    "status": "pending_dependency",
+    "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01 to merge before starting controlled SEO/GEO activation implementation."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": true,
+    "cms_mutation": true,
+    "api_runtime_change": true,
+    "publish_allowed": false,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "next_task": null,
+    "transitions": [
+      {
+        "at": "2026-07-05T13:55:29+08:00",
+        "status": "pending_dependency",
+        "summary": "Registered controlled SEO/GEO activation workflow. Execution waits for activation gate merge and excludes production activation writes without exact deployed SHA and command authorization."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21084,7 +21084,7 @@ prs:
     base: main
     title: "docs(foundation): validate Daily Giving backend runtime"
     train_scope: foundation_daily_giving_backend_mvp
-    status: in_progress
+    status: merged
     scope:
       - Produce a read-only post-deploy runtime validation report for the Foundation Daily Giving backend MVP.
       - Verify public API route registration, runtime response shape, publication gates, privacy boundary, and known OPS sidecars.
@@ -36883,7 +36883,277 @@ prs:
     search_channel_action: false
     deploy_allowed: false
     content_authority: CMS/backend
+    next_task: IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01
+
+  - id: IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01
+    repo: fap-api
+    depends_on:
+      - IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01
+    branch: codex/iq-method-pages-publish-gate-01
+    title: "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01: add IQ method publish readiness gate"
+    train_scope: iq_method_pages_zh_cn_publish_readiness
+    status: user_authorized
+    scope:
+      - Add a backend read-only publish readiness gate for the 7 zh-CN IQ method CMS Article drafts.
+      - Verify draft/readback state, required method review evidence, claim review evidence, revision approval prerequisites, and controlled publish compatibility.
+      - Fail closed with exact missing review fields or state mismatches before any approval, publish, indexability, sitemap, llms, or production execution.
+      - Reconcile stale IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01 ledger facts as same-repository PR-train bookkeeping.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php
+      - backend/app/Services/Cms/IqMethodPages/**
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/ArticleIqMethodPagesPublishGateCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Approve revisions, publish articles, flip public/indexability state, activate sitemap/llms, submit search URLs, run production deploy, rewrite content, change IQ scoring, expose answer keys, or add frontend fallback content.
+      - Mutate production CMS or production DB from this PR without separate exact environment and SHA authorization.
+    validation:
+      - php -l backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php
+      - php -l backend/tests/Feature/Console/ArticleIqMethodPagesPublishGateCommandTest.php
+      - cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-publish-gate|iq-method-pages'
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesPublishGate.php tests/Feature/Console/ArticleIqMethodPagesPublishGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesPublishGateCommandTest --no-ansi
+      - cd backend && php artisan route:list --path=api --except-vendor --no-ansi >/tmp/fap-api-route-list-api.txt
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01
+
+  - id: IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01
+    repo: fap-api
+    depends_on:
+      - IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01
+    branch: codex/iq-method-pages-review-approval-01
+    title: "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01: add IQ method review approval workflow"
+    train_scope: iq_method_pages_zh_cn_review_approval
+    status: user_authorized
+    scope:
+      - Add a controlled backend workflow that records method review and claim review approval for the 7 zh-CN IQ method CMS Article working revisions.
+      - Require an explicit review packet, exact confirmation phrase, dry-run mode, and article/revision locks before any CMS draft approval write.
+      - Keep the approved articles unpublished, noindex, sitemap-ineligible, and llms-ineligible.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php
+      - backend/app/Services/Cms/IqMethodPages/**
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/ArticleIqMethodPagesReviewApprovalCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Publish articles, flip indexability, activate sitemap/llms, submit search URLs, run production deploy, rewrite content, change IQ scoring, expose answer keys, or add frontend fallback content.
+      - Execute production review approval writes from this PR without separate exact deployed SHA and command authorization.
+    validation:
+      - php -l backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php
+      - php -l backend/tests/Feature/Console/ArticleIqMethodPagesReviewApprovalCommandTest.php
+      - cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-review-approval|iq-method-pages'
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesReviewApproval.php tests/Feature/Console/ArticleIqMethodPagesReviewApprovalCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesReviewApprovalCommandTest --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: true
+    cms_mutation: true
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
     next_task: IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01
+
+  - id: IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01
+    repo: fap-api
+    depends_on:
+      - IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01
+    branch: codex/iq-method-pages-cms-publish-01
+    title: "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01: add controlled IQ method article publish workflow"
+    train_scope: iq_method_pages_zh_cn_publish
+    status: user_authorized
+    scope:
+      - Add or verify a controlled backend batch publish workflow for the 7 approved zh-CN IQ method CMS Articles.
+      - Publish only approved working revisions and keep indexability disabled during publish.
+      - Preserve robots=noindex,follow, sitemap_eligible=false, and llms_eligible=false until the separate SEO/GEO activation train item.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleIqMethodPagesPublish.php
+      - backend/app/Console/Commands/ArticlePublishControlled.php
+      - backend/app/Services/Cms/IqMethodPages/**
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/ArticleIqMethodPagesPublishCommandTest.php
+      - backend/tests/Feature/Console/ArticlePublishControlledCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Flip indexability, activate sitemap/llms, submit search URLs, run production deploy, rewrite content, change IQ scoring, expose answer keys, or add frontend fallback content.
+      - Execute production publish writes from this PR without separate exact deployed SHA and command authorization.
+    validation:
+      - php -l backend/app/Console/Commands/ArticleIqMethodPagesPublish.php
+      - php -l backend/tests/Feature/Console/ArticleIqMethodPagesPublishCommandTest.php
+      - cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-publish|publish-controlled'
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesPublish.php app/Console/Commands/ArticlePublishControlled.php tests/Feature/Console/ArticleIqMethodPagesPublishCommandTest.php tests/Feature/Console/ArticlePublishControlledCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='ArticleIqMethodPagesPublishCommandTest|ArticlePublishControlledCommandTest' --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: true
+    cms_mutation: true
+    api_runtime_change: true
+    publish_allowed: true
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01
+
+  - id: IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01
+    repo: fap-api
+    depends_on:
+      - IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01
+    branch: codex/iq-method-pages-post-publish-readback-01
+    title: "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01: verify published IQ method articles before indexing"
+    train_scope: iq_method_pages_zh_cn_post_publish_readback
+    status: user_authorized
+    scope:
+      - Add a read-only post-publish readback command for the 7 zh-CN IQ method CMS Articles.
+      - Verify public article payloads, approved/published revision consistency, canonical, robots=noindex,follow, topic IQ grouping, landing links, and private-route/scoring-token guards.
+      - Fail closed if any article is missing, unpublished, prematurely indexable, sitemap eligible, llms eligible, or leaking private result/order/answer/scoring fields.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php
+      - backend/app/Services/Cms/IqMethodPages/**
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/ArticleIqMethodPagesPostPublishReadbackCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Flip indexability, activate sitemap/llms, submit search URLs, run production deploy, rewrite content, change IQ scoring, expose answer keys, or add frontend fallback content.
+      - Mutate production CMS or production DB from this PR without separate exact environment authorization.
+    validation:
+      - php -l backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php
+      - php -l backend/tests/Feature/Console/ArticleIqMethodPagesPostPublishReadbackCommandTest.php
+      - cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-post-publish-readback|iq-method-pages'
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php tests/Feature/Console/ArticleIqMethodPagesPostPublishReadbackCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesPostPublishReadbackCommandTest --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01
+
+  - id: IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01
+    repo: fap-api
+    depends_on:
+      - IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01
+    branch: codex/iq-method-pages-seo-geo-activate-gate-01
+    title: "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01: add IQ method SEO/GEO activation gate"
+    train_scope: iq_method_pages_zh_cn_seo_geo_activation_readiness
+    status: user_authorized
+    scope:
+      - Add a read-only SEO/GEO activation gate for the 7 published zh-CN IQ method CMS Articles.
+      - Verify public URL readiness, canonical, visible FAQ/body evidence, claim boundaries, robots transition readiness, sitemap/llms eligibility prerequisites, and private/scoring-token guards.
+      - Output exact article ids/slugs and activation command candidates without changing CMS state.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php
+      - backend/app/Services/Cms/IqMethodPages/**
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivationGateCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Flip indexability, activate sitemap/llms, submit search URLs, run production deploy, rewrite content, change IQ scoring, expose answer keys, or add frontend fallback content.
+      - Mutate production CMS or production DB from this PR without separate exact environment authorization.
+    validation:
+      - php -l backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php
+      - php -l backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivationGateCommandTest.php
+      - cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-seo-geo-activation-gate|iq-method-pages'
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivationGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesSeoGeoActivationGateCommandTest --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01
+
+  - id: IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01
+    repo: fap-api
+    depends_on:
+      - IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01
+    branch: codex/iq-method-pages-seo-geo-activate-01
+    title: "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01: add controlled IQ method sitemap and llms activation"
+    train_scope: iq_method_pages_zh_cn_seo_geo_activation
+    status: user_authorized
+    scope:
+      - Add or verify a controlled backend activation workflow that flips indexability, sitemap eligibility, and llms eligibility for the 7 published zh-CN IQ method CMS Articles.
+      - Preserve backend/CMS authority for metadata, canonical, sitemap, llms.txt, and llms-full.txt enumeration.
+      - Include readback validation that no private result/order/attempt/payment links, answer keys, correct answers, item rules, or scoring logic enter public SEO/GEO surfaces.
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php
+      - backend/app/Console/Commands/ArticleDiscoverabilityRelease.php
+      - backend/app/Services/Cms/IqMethodPages/**
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivateCommandTest.php
+      - backend/tests/Feature/Console/ArticleDiscoverabilityReleaseCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Submit URLs to search engines, trigger Search Channel, run staging deploy waits, trigger production deploy, rewrite content, change IQ scoring, expose answer keys, or add frontend fallback content.
+      - Execute production SEO/GEO activation writes from this PR without separate exact deployed SHA and command authorization.
+    validation:
+      - php -l backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php
+      - php -l backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivateCommandTest.php
+      - cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-seo-geo-activate|discoverability-release'
+      - cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php app/Console/Commands/ArticleDiscoverabilityRelease.php tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivateCommandTest.php tests/Feature/Console/ArticleDiscoverabilityReleaseCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='ArticleIqMethodPagesSeoGeoActivateCommandTest|ArticleDiscoverabilityReleaseCommandTest' --no-ansi
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: true
+    cms_mutation: true
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: null
 
   - id: IQ-V1-ITEM-DIMENSION-TAGGING-IMPLEMENTATION-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Reconciled `IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01` train state as merged after GitHub PR #2724 merged at `d73366e9467fab5ad3dcf2fb16e3d50520ed38ca`.
- Added the missing IQ method page continuation PR-train entries:
  - `IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01`
  - `IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01`
  - `IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01`
  - `IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01`
  - `IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01`
  - `IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01`
- Updated the manifest chain so readback leads to a publish readiness gate instead of direct publish.

## Why
The IQ 7-page CMS workflow cannot safely jump from draft readback directly to publish or sitemap/llms activation. The train now records explicit gates for review evidence, controlled publish, post-publish readback, and SEO/GEO activation.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && echo 'json ok'`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: changed files are limited to `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json`.

## Deferred items
- No CMS write was executed.
- No production import, review approval write, publish, indexability flip, sitemap activation, llms activation, search submission, staging deploy wait, or production deploy was triggered.
- Future production writes still require exact deployed SHA and explicit command authorization.

## Repository rule impact
This is PR-train metadata only. It preserves backend/CMS authority for article content, publishing state, sitemap, and llms enumeration; no frontend fallback or runtime content authority is introduced.
