### PR TITLE
BIG5-CONTENT-QUALITY-REVIEW-05: classify Big Five combination and English assets for CMS review

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81209,8 +81209,8 @@
     "depends_on": [
       "BIG5-CMS-DISCOVERABILITY-SURFACE-04"
     ],
-    "status": "pr_open",
-    "commit_sha": "c713e9aed91d25d72bbe9beaaa31d77afc09d7db",
+    "status": "ready_to_merge",
+    "commit_sha": "92dccd6a02d6f6440b1febbe976018acbef3a924",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2730",
     "failure_reason": null,
     "merged_at": null,
@@ -81247,12 +81247,16 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to BIG5-CONTENT-QUALITY-REVIEW-05 allowed paths: generated/big-five-content-quality-review/** and docs/codex/pr-train-state.json."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PASS on PR #2730 head 92dccd6a02d6f6440b1febbe976018acbef3a924: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -81285,6 +81289,12 @@
         "from": "committed",
         "to": "pr_open",
         "note": "Opened PR #2730 for BIG5-CONTENT-QUALITY-REVIEW-05 and pushed branch codex/big5-content-quality-review-05."
+      },
+      {
+        "at": "2026-07-05T06:48:13Z",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "note": "PR #2730 remote checks passed. Marked ready to merge under squash merge policy."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81209,9 +81209,9 @@
     "depends_on": [
       "BIG5-CMS-DISCOVERABILITY-SURFACE-04"
     ],
-    "status": "committed",
+    "status": "pr_open",
     "commit_sha": "c713e9aed91d25d72bbe9beaaa31d77afc09d7db",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2730",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -81279,6 +81279,12 @@
         "from": "local_checks_passed",
         "to": "committed",
         "note": "Committed BIG5-CONTENT-QUALITY-REVIEW-05 review artifacts at c713e9aed."
+      },
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "committed",
+        "to": "pr_open",
+        "note": "Opened PR #2730 for BIG5-CONTENT-QUALITY-REVIEW-05 and pushed branch codex/big5-content-quality-review-05."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81095,13 +81095,13 @@
     "depends_on": [
       "BIG5-CMS-INDEXABILITY-GATE-03"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "c632eac7bb73e4e8b6899b5599d982e61407cc53",
+    "status": "merged",
+    "commit_sha": "65b4e1b1cbeacaa131a6d7b1de075526ec89095e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2728",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T06:36:29Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -81143,13 +81143,17 @@
       "github_checks": {
         "status": "pass",
         "evidence": "PASS on PR #2728 head c632eac7bb73e4e8b6899b5599d982e61407cc53: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "GitHub reports PR #2728 merged at 2026-07-05T06:36:29Z with merge commit 65b4e1b1cbeacaa131a6d7b1de075526ec89095e. origin/main contains the merge commit, local main was synced to origin/main in the main worktree, worktrees were clean, local branch codex/big5-cms-discoverability-surface-04 was deleted, and the remote branch was absent."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -81187,6 +81191,12 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "note": "PR #2728 remote checks passed. Marked ready to merge under squash merge policy."
+      },
+      {
+        "at": "2026-07-05T06:36:29Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "note": "Reconciled PR #2728 merge before continuing BIG5-CONTENT-QUALITY-REVIEW-05. GitHub reports merged, origin/main contains merge commit 65b4e1b1cbeacaa131a6d7b1de075526ec89095e, local main was synced, and the task branch is deleted locally and remotely."
       }
     ]
   },
@@ -81199,7 +81209,7 @@
     "depends_on": [
       "BIG5-CMS-DISCOVERABILITY-SURFACE-04"
     ],
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "commit_sha": null,
     "pr_url": null,
     "failure_reason": null,
@@ -81212,13 +81222,36 @@
         "evidence": "User explicitly authorized registering BIG5-CONTENT-QUALITY-REVIEW-05 in the attached /goal execution request."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for BIG5-CMS-DISCOVERABILITY-SURFACE-04 to merge."
+        "status": "pass",
+        "evidence": "BIG5-CMS-DISCOVERABILITY-SURFACE-04 PR #2728 is merged and origin/main contains merge commit 65b4e1b1cbeacaa131a6d7b1de075526ec89095e."
+      },
+      "content_quality_scan": {
+        "status": "pass",
+        "evidence": "Generated generated/big-five-content-quality-review/content_quality_review.md and generated/big-five-content-quality-review/content_quality_review.json. The report classifies 6 zh-CN combination pages as CMS review candidates with manual polish recommended and 6 en-US pages as draft-only with English SEO expansion blocked."
+      },
+      "cms_import_draft_json": {
+        "status": "pass",
+        "command": "python3 -m json.tool /Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json >/dev/null",
+        "evidence": "PASS: cms-import-draft.json parses as JSON."
+      },
+      "report_json": {
+        "status": "pass",
+        "command": "python3 -m json.tool generated/big-five-content-quality-review/content_quality_review.json >/dev/null",
+        "evidence": "PASS: generated review report JSON parses."
+      },
+      "manifest_state_diff_validation": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "evidence": "PASS: train YAML parses, state JSON parses, and diff whitespace check passes."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to BIG5-CONTENT-QUALITY-REVIEW-05 allowed paths: generated/big-five-content-quality-review/** and docs/codex/pr-train-state.json."
       }
     },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -81228,6 +81261,18 @@
         "from": "user_authorized",
         "to": "pending_dependency",
         "note": "Registered dependent PR train item; execution waits for BIG5-CMS-DISCOVERABILITY-SURFACE-04 merge."
+      },
+      {
+        "at": "2026-07-05T06:36:29Z",
+        "from": "pending_dependency",
+        "to": "in_progress",
+        "note": "Started content quality review PR after BIG5-CMS-DISCOVERABILITY-SURFACE-04 merge was verified."
+      },
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Generated backend-side Big Five content quality review artifacts. Output is review-only and does not publish, write CMS, or enable SEO/GEO runtime surfaces."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81209,8 +81209,8 @@
     "depends_on": [
       "BIG5-CMS-DISCOVERABILITY-SURFACE-04"
     ],
-    "status": "local_checks_passed",
-    "commit_sha": null,
+    "status": "committed",
+    "commit_sha": "c713e9aed91d25d72bbe9beaaa31d77afc09d7db",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -81273,6 +81273,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Generated backend-side Big Five content quality review artifacts. Output is review-only and does not publish, write CMS, or enable SEO/GEO runtime surfaces."
+      },
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "from": "local_checks_passed",
+        "to": "committed",
+        "note": "Committed BIG5-CONTENT-QUALITY-REVIEW-05 review artifacts at c713e9aed."
       }
     ]
   }

--- a/generated/big-five-content-quality-review/content_quality_review.json
+++ b/generated/big-five-content-quality-review/content_quality_review.json
@@ -1,0 +1,231 @@
+{
+  "generated_at": "2026-07-05T06:40:00Z",
+  "source": "/Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json",
+  "total_rows": 42,
+  "locale_counts": {
+    "zh-CN": 36,
+    "en-US": 6
+  },
+  "content_type_counts": {
+    "combination_page": 6,
+    "cross_reading_page": 5,
+    "hub_page": 2,
+    "trait_range_page": 15,
+    "result_review_page": 4,
+    "trait_page": 10
+  },
+  "status_counts": {
+    "draft_review_required": 42
+  },
+  "indexability_gate_counts": {
+    "manual_review_required": 42
+  },
+  "route_residue": {
+    "short_zh_big_five": 0,
+    "short_en_big_five": 0,
+    "bad_canonical_paths": []
+  },
+  "field_shape": {
+    "missing_required": [],
+    "faq_not_qa": [
+      {
+        "id": "en-US:hub_page:big-five",
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:agreeableness",
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:conscientiousness",
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:extraversion",
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:neuroticism",
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:openness",
+        "faq_count": 3
+      }
+    ],
+    "empty_body_sections": [],
+    "faq_section_duplicates": [
+      "zh-CN:combination_page:high-agreeableness-high-neuroticism",
+      "zh-CN:combination_page:high-openness-high-extraversion",
+      "zh-CN:combination_page:high-openness-low-conscientiousness",
+      "zh-CN:combination_page:low-agreeableness-high-conscientiousness",
+      "zh-CN:combination_page:low-extraversion-high-conscientiousness",
+      "zh-CN:combination_page:low-neuroticism-high-conscientiousness",
+      "zh-CN:cross_reading_page:big-five-learning-style",
+      "zh-CN:cross_reading_page:big-five-relationship-communication",
+      "zh-CN:cross_reading_page:big-five-riasec-career",
+      "zh-CN:cross_reading_page:big-five-stress-management",
+      "zh-CN:cross_reading_page:big-five-vs-mbti",
+      "en-US:hub_page:big-five",
+      "zh-CN:hub_page:big-five",
+      "zh-CN:trait_range_page:agreeableness-high",
+      "zh-CN:trait_range_page:agreeableness-low",
+      "zh-CN:trait_range_page:agreeableness-mid",
+      "zh-CN:trait_range_page:conscientiousness-high",
+      "zh-CN:trait_range_page:conscientiousness-low",
+      "zh-CN:trait_range_page:conscientiousness-mid",
+      "zh-CN:trait_range_page:extraversion-high",
+      "zh-CN:trait_range_page:extraversion-low",
+      "zh-CN:trait_range_page:extraversion-mid",
+      "zh-CN:trait_range_page:neuroticism-high",
+      "zh-CN:trait_range_page:neuroticism-low",
+      "zh-CN:trait_range_page:neuroticism-mid",
+      "zh-CN:trait_range_page:openness-high",
+      "zh-CN:trait_range_page:openness-low",
+      "zh-CN:trait_range_page:openness-mid",
+      "zh-CN:result_review_page:big-five-30-day-review",
+      "zh-CN:result_review_page:big-five-score-ranges",
+      "zh-CN:result_review_page:discuss-results-with-others",
+      "zh-CN:result_review_page:how-to-read-big-five-results",
+      "en-US:trait_page:agreeableness",
+      "zh-CN:trait_page:agreeableness",
+      "en-US:trait_page:conscientiousness",
+      "zh-CN:trait_page:conscientiousness",
+      "en-US:trait_page:extraversion",
+      "zh-CN:trait_page:extraversion",
+      "en-US:trait_page:neuroticism",
+      "zh-CN:trait_page:neuroticism",
+      "en-US:trait_page:openness",
+      "zh-CN:trait_page:openness"
+    ]
+  },
+  "quality": {
+    "combination_pages": [
+      {
+        "id": "zh-CN:combination_page:high-agreeableness-high-neuroticism",
+        "cms_review_classification": "cms_review_candidate_manual_polish_recommended",
+        "publish_now": false,
+        "reason": "Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish.",
+        "repeated_generic_block_count": 3,
+        "cjk_chars": 1018,
+        "faq_count": 5
+      },
+      {
+        "id": "zh-CN:combination_page:high-openness-high-extraversion",
+        "cms_review_classification": "cms_review_candidate_manual_polish_recommended",
+        "publish_now": false,
+        "reason": "Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish.",
+        "repeated_generic_block_count": 3,
+        "cjk_chars": 1019,
+        "faq_count": 5
+      },
+      {
+        "id": "zh-CN:combination_page:high-openness-low-conscientiousness",
+        "cms_review_classification": "cms_review_candidate_manual_polish_recommended",
+        "publish_now": false,
+        "reason": "Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish.",
+        "repeated_generic_block_count": 3,
+        "cjk_chars": 1020,
+        "faq_count": 5
+      },
+      {
+        "id": "zh-CN:combination_page:low-agreeableness-high-conscientiousness",
+        "cms_review_classification": "cms_review_candidate_manual_polish_recommended",
+        "publish_now": false,
+        "reason": "Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish.",
+        "repeated_generic_block_count": 3,
+        "cjk_chars": 1017,
+        "faq_count": 5
+      },
+      {
+        "id": "zh-CN:combination_page:low-extraversion-high-conscientiousness",
+        "cms_review_classification": "cms_review_candidate_manual_polish_recommended",
+        "publish_now": false,
+        "reason": "Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish.",
+        "repeated_generic_block_count": 3,
+        "cjk_chars": 1030,
+        "faq_count": 5
+      },
+      {
+        "id": "zh-CN:combination_page:low-neuroticism-high-conscientiousness",
+        "cms_review_classification": "cms_review_candidate_manual_polish_recommended",
+        "publish_now": false,
+        "reason": "Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish.",
+        "repeated_generic_block_count": 3,
+        "cjk_chars": 1025,
+        "faq_count": 5
+      }
+    ],
+    "english_pages": [
+      {
+        "id": "en-US:hub_page:big-five",
+        "cms_review_classification": "draft_only_block_english_seo_expansion",
+        "publish_now": false,
+        "reason": "English assets should remain draft-only until English editorial depth, parity, and SEO/GEO review are separately approved.",
+        "english_words": 187,
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:agreeableness",
+        "cms_review_classification": "draft_only_block_english_seo_expansion",
+        "publish_now": false,
+        "reason": "English assets should remain draft-only until English editorial depth, parity, and SEO/GEO review are separately approved.",
+        "english_words": 311,
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:conscientiousness",
+        "cms_review_classification": "draft_only_block_english_seo_expansion",
+        "publish_now": false,
+        "reason": "English assets should remain draft-only until English editorial depth, parity, and SEO/GEO review are separately approved.",
+        "english_words": 311,
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:extraversion",
+        "cms_review_classification": "draft_only_block_english_seo_expansion",
+        "publish_now": false,
+        "reason": "English assets should remain draft-only until English editorial depth, parity, and SEO/GEO review are separately approved.",
+        "english_words": 311,
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:neuroticism",
+        "cms_review_classification": "draft_only_block_english_seo_expansion",
+        "publish_now": false,
+        "reason": "English assets should remain draft-only until English editorial depth, parity, and SEO/GEO review are separately approved.",
+        "english_words": 311,
+        "faq_count": 3
+      },
+      {
+        "id": "en-US:trait_page:openness",
+        "cms_review_classification": "draft_only_block_english_seo_expansion",
+        "publish_now": false,
+        "reason": "English assets should remain draft-only until English editorial depth, parity, and SEO/GEO review are separately approved.",
+        "english_words": 311,
+        "faq_count": 3
+      }
+    ],
+    "short_pages": [],
+    "publish_blockers": []
+  },
+  "verdict": "pass_to_cms_review_not_publish",
+  "publish_allowed": false,
+  "seo_expansion_allowed": false,
+  "cms_dry_run_posture": {
+    "can_enter_cms_manual_review": true,
+    "can_enter_backend_importer_dry_run": true,
+    "can_publish": false,
+    "can_enable_sitemap_llms_jsonld": false,
+    "assumptions": [
+      "Importer treats faq as the only structured FAQ source or dedupes FAQ body_sections.",
+      "Backend preserves draft_review_required and manual_review_required gates.",
+      "English locale rows are not selected for SEO expansion or public indexation."
+    ]
+  },
+  "required_followups": [
+    "Editor manually polishes Chinese combination pages before publish approval.",
+    "English pages remain draft-only until separate English editorial parity review.",
+    "Schema/FAQ/llms/sitemap remain planning-only until visible CMS content and claim boundaries are approved."
+  ]
+}

--- a/generated/big-five-content-quality-review/content_quality_review.md
+++ b/generated/big-five-content-quality-review/content_quality_review.md
@@ -1,0 +1,69 @@
+# Big Five Content Quality Review 05
+
+Source: /Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json
+Generated at: 2026-07-05T06:40:00Z
+
+## Verdict
+
+- Status: pass_to_cms_manual_review_and_importer_dry_run
+- Publish: blocked
+- SEO expansion: blocked
+- Reason: the CMS draft has valid draft/import shape and aligned Big Five IA, but combination pages still need manual polish and English rows must remain draft-only.
+
+## Counts
+
+- Total rows: 42
+- Locales: {"zh-CN":36,"en-US":6}
+- Content types: {"combination_page":6,"cross_reading_page":5,"hub_page":2,"trait_range_page":15,"result_review_page":4,"trait_page":10}
+- Statuses: {"draft_review_required":42}
+- Indexability gates: {"manual_review_required":42}
+
+## Contract Checks
+
+- Required field gaps: 0
+- FAQ QA shape issues: 6
+- Empty body section issues: 0
+- FAQ section duplicate-render risk rows: 42
+- Short-path residue /zh/big-five: 0
+- Short-path residue /en/big-five: 0
+- Bad canonical paths: 0
+
+## Chinese Combination Pages
+
+- Classification: CMS review candidates, manual polish recommended.
+- Publish now: no.
+- Main risk: openings are more specific than v1, but several advantage/risk/scenario paragraphs still reuse generic template blocks.
+
+- zh-CN:combination_page:high-agreeableness-high-neuroticism: Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish. cjk_chars=1018, repeated_generic_block_count=3
+- zh-CN:combination_page:high-openness-high-extraversion: Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish. cjk_chars=1019, repeated_generic_block_count=3
+- zh-CN:combination_page:high-openness-low-conscientiousness: Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish. cjk_chars=1020, repeated_generic_block_count=3
+- zh-CN:combination_page:low-agreeableness-high-conscientiousness: Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish. cjk_chars=1017, repeated_generic_block_count=3
+- zh-CN:combination_page:low-extraversion-high-conscientiousness: Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish. cjk_chars=1030, repeated_generic_block_count=3
+- zh-CN:combination_page:low-neuroticism-high-conscientiousness: Specific opening exists, but repeated generic advantage/risk/scenario blocks still need editor polish. cjk_chars=1025, repeated_generic_block_count=3
+
+## English Pages
+
+- Classification: draft-only, block English SEO expansion.
+- Publish now: no.
+- Reason: English parity, editorial depth, and GEO/SEO review require a separate approval track.
+
+- en-US:hub_page:big-five: draft_only_block_english_seo_expansion, english_words=187, faq_count=3
+- en-US:trait_page:agreeableness: draft_only_block_english_seo_expansion, english_words=311, faq_count=3
+- en-US:trait_page:conscientiousness: draft_only_block_english_seo_expansion, english_words=311, faq_count=3
+- en-US:trait_page:extraversion: draft_only_block_english_seo_expansion, english_words=311, faq_count=3
+- en-US:trait_page:neuroticism: draft_only_block_english_seo_expansion, english_words=311, faq_count=3
+- en-US:trait_page:openness: draft_only_block_english_seo_expansion, english_words=311, faq_count=3
+
+## Importer Dry-run Posture
+
+- Can enter CMS manual review: yes.
+- Can enter backend importer dry-run: yes.
+- Can publish: no.
+- Can enter sitemap/llms/JSON-LD runtime: no.
+- Required backend assumption: importer either drops FAQ body_sections or treats the top-level faq field as the single structured FAQ source.
+
+## Required Follow-ups
+
+- Editor manually polishes Chinese combination pages before publish approval.
+- English pages remain draft-only until separate English editorial parity review.
+- Schema/FAQ/llms/sitemap remain planning-only until visible CMS content and claim boundaries are approved.


### PR DESCRIPTION
## What changed
- Added generated Big Five content quality review artifacts for the v2 repaired CMS import draft.
- Classified zh-CN combination pages as CMS review candidates with manual polish recommended.
- Classified en-US Big Five rows as draft-only and blocked from English SEO expansion.
- Reconciled BIG5-CMS-DISCOVERABILITY-SURFACE-04 post-merge state in the PR train ledger.

## Why
The v2 Big Five content package can move into CMS manual review and backend importer dry-run, but it must not be treated as publish-ready or SEO/GEO-ready. This PR records that review posture without modifying CMS content, public runtime, sitemap, llms, JSON-LD, or frontend fallback behavior.

## Validation
- python3 -m json.tool /Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json >/dev/null
- python3 -m json.tool generated/big-five-content-quality-review/content_quality_review.json >/dev/null
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- git diff --check
- git diff --cached --check

## Deferred items
- No CMS write/import, production import, publish approval, indexability release, sitemap, llms, JSON-LD runtime, search submission, staging deploy, or production deploy is included.
- Chinese combination copy still needs human editor polish before publish approval.
- English pages remain draft-only pending a separate English editorial parity and SEO/GEO review.
