### PR TITLE
BIG5-TRAIN-LEDGER-CLOSEOUT-06: reconcile Big Five content quality review train ledger

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81209,13 +81209,13 @@
     "depends_on": [
       "BIG5-CMS-DISCOVERABILITY-SURFACE-04"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "92dccd6a02d6f6440b1febbe976018acbef3a924",
+    "status": "merged",
+    "commit_sha": "075c90211d0ed71b98a9bc903f951f3d3731ca99",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2730",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T06:54:43Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -81251,13 +81251,17 @@
       "github_checks": {
         "status": "pass",
         "evidence": "PASS on PR #2730 head 92dccd6a02d6f6440b1febbe976018acbef3a924: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "PR #2730 is MERGED; origin/main contains merge commit 075c90211d0ed71b98a9bc903f951f3d3731ca99; local main was synced in the train worktree; task branch codex/big5-content-quality-review-05 is absent locally and remotely."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -81295,6 +81299,179 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "note": "PR #2730 remote checks passed. Marked ready to merge under squash merge policy."
+      },
+      {
+        "at": "2026-07-05T07:05:55Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "note": "Reconciled PR #2730 merge before continuing the Big Five CMS asset readiness train. GitHub reports merged, origin/main contains merge commit 075c90211d0ed71b98a9bc903f951f3d3731ca99, and branch cleanup is complete."
+      }
+    ]
+  },
+  "BIG5-TRAIN-LEDGER-CLOSEOUT-06": {
+    "id": "BIG5-TRAIN-LEDGER-CLOSEOUT-06",
+    "repo": "fap-api",
+    "title": "BIG5-TRAIN-LEDGER-CLOSEOUT-06: reconcile Big Five content quality review train ledger",
+    "base": "main",
+    "branch": "codex/big5-train-ledger-closeout-06",
+    "depends_on": [
+      "BIG5-CONTENT-QUALITY-REVIEW-05"
+    ],
+    "status": "local_checks_passed",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized registering BIG5-TRAIN-LEDGER-CLOSEOUT-06 and follow-up Big Five CMS asset readiness PR train items in the attached /goal execution request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "BIG5-CONTENT-QUALITY-REVIEW-05 PR #2730 is merged, and origin/main contains merge commit 075c90211d0ed71b98a9bc903f951f3d3731ca99."
+      },
+      "local_validation": {
+        "status": "pass",
+        "command": "git status --short --branch && gh pr view 2730 --json number,state,mergedAt,mergeCommit,url,headRefName,baseRefName,isDraft && git merge-base --is-ancestor 075c90211d0ed71b98a9bc903f951f3d3731ca99 origin/main && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && rg -n \"BIG5-CONTENT-QUALITY-REVIEW-05|BIG5-TRAIN-LEDGER-CLOSEOUT-06|BIG5-CONTENT-POLISH-06|BIG5-CMS-IMPORT-DRYRUN-07|BIG5-CMS-PREVIEW-READBACK-QA-08\" docs/codex/pr-train.yaml docs/codex/pr-train-state.json && git diff --check",
+        "evidence": "PASS: branch status checked, PR #2730 is MERGED, origin/main contains merge commit 075c90211d0ed71b98a9bc903f951f3d3731ca99, train YAML parses, state JSON parses, requested PR ids are registered, and git diff whitespace check passes."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to BIG5-TRAIN-LEDGER-CLOSEOUT-06 allowed metadata paths: docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-05T07:05:55Z",
+        "from": "user_authorized",
+        "to": "in_progress",
+        "note": "Started metadata-only ledger closeout from latest main. Scope excludes runtime, importer logic, content asset edits, CMS writes, publishing, indexability release, sitemap/llms/JSON-LD runtime, staging deploy, and production deploy."
+      },
+      {
+        "at": "2026-07-05T07:05:55Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Metadata-only ledger closeout validation passed. Scope is limited to train manifest/state registration and PR #2730 merge reconciliation."
+      }
+    ]
+  },
+  "BIG5-CONTENT-POLISH-06": {
+    "id": "BIG5-CONTENT-POLISH-06",
+    "repo": "fap-api",
+    "title": "BIG5-CONTENT-POLISH-06: polish Big Five CMS draft assets before importer dry-run",
+    "base": "main",
+    "branch": "codex/big5-content-polish-06",
+    "depends_on": [
+      "BIG5-TRAIN-LEDGER-CLOSEOUT-06"
+    ],
+    "status": "pending_dependency",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized registering this Big Five CMS asset readiness PR train item in the attached /goal execution request."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-05T07:05:55Z",
+        "from": "user_authorized",
+        "to": "pending_dependency",
+        "note": "Registered dependent content-polish PR; execution waits for BIG5-TRAIN-LEDGER-CLOSEOUT-06 merge."
+      }
+    ]
+  },
+  "BIG5-CMS-IMPORT-DRYRUN-07": {
+    "id": "BIG5-CMS-IMPORT-DRYRUN-07",
+    "repo": "fap-api",
+    "title": "BIG5-CMS-IMPORT-DRYRUN-07: run no-write Big Five CMS import dry-run on polished assets",
+    "base": "main",
+    "branch": "codex/big5-cms-import-dryrun-07",
+    "depends_on": [
+      "BIG5-CONTENT-POLISH-06"
+    ],
+    "status": "pending_dependency",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized registering this Big Five CMS asset readiness PR train item in the attached /goal execution request."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-05T07:05:55Z",
+        "from": "user_authorized",
+        "to": "pending_dependency",
+        "note": "Registered dependent import dry-run PR; execution waits for BIG5-CONTENT-POLISH-06 merge."
+      }
+    ]
+  },
+  "BIG5-CMS-PREVIEW-READBACK-QA-08": {
+    "id": "BIG5-CMS-PREVIEW-READBACK-QA-08",
+    "repo": "fap-api",
+    "title": "BIG5-CMS-PREVIEW-READBACK-QA-08: validate Big Five CMS preview and public API readback payload",
+    "base": "main",
+    "branch": "codex/big5-cms-preview-readback-qa-08",
+    "depends_on": [
+      "BIG5-CMS-IMPORT-DRYRUN-07"
+    ],
+    "status": "pending_dependency",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized registering this Big Five CMS asset readiness PR train item in the attached /goal execution request."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-07-05T07:05:55Z",
+        "from": "user_authorized",
+        "to": "pending_dependency",
+        "note": "Registered dependent preview/readback QA PR; execution waits for BIG5-CMS-IMPORT-DRYRUN-07 merge."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -233,6 +233,172 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+
+  - id: BIG5-TRAIN-LEDGER-CLOSEOUT-06
+    repo: fap-api
+    depends_on:
+      - BIG5-CONTENT-QUALITY-REVIEW-05
+    branch: codex/big5-train-ledger-closeout-06
+    title: "BIG5-TRAIN-LEDGER-CLOSEOUT-06: reconcile Big Five content quality review train ledger"
+    train_scope: big_five_cms_asset_readiness
+    status: user_authorized
+    scope:
+      - Reconcile the Big Five content quality review train ledger after PR #2730 merge.
+      - Verify BIG5-CONTENT-QUALITY-REVIEW-05 is merged and origin/main contains its merge commit.
+      - Record merged, branch cleanup, and post-merge revalidation facts in docs/codex/pr-train-state.json.
+      - Register the user-authorized follow-up Big Five CMS asset readiness train items without implementing their scopes.
+      - Keep this metadata-only; no runtime, importer, content asset, CMS, sitemap, llms, JSON-LD, deploy, or publish changes.
+    allowed_paths:
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Modify backend runtime, importer logic, public API runtime, content assets, production CMS content, sitemap/llms runtime, JSON-LD runtime, canonical/noindex behavior, permissions, scheduler behavior, secrets, staging deploy, or production deploy.
+      - Implement BIG5-CONTENT-POLISH-06, BIG5-CMS-IMPORT-DRYRUN-07, or BIG5-CMS-PREVIEW-READBACK-QA-08 scope in this PR.
+    validation:
+      - git status --short --branch
+      - gh pr view 2730 --json number,state,mergedAt,mergeCommit,url,headRefName,baseRefName,isDraft
+      - git merge-base --is-ancestor 075c90211d0ed71b98a9bc903f951f3d3731ca99 origin/main
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - rg -n "BIG5-CONTENT-QUALITY-REVIEW-05|BIG5-TRAIN-LEDGER-CLOSEOUT-06|BIG5-CONTENT-POLISH-06|BIG5-CMS-IMPORT-DRYRUN-07|BIG5-CMS-PREVIEW-READBACK-QA-08" docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-CONTENT-POLISH-06
+    repo: fap-api
+    depends_on:
+      - BIG5-TRAIN-LEDGER-CLOSEOUT-06
+    branch: codex/big5-content-polish-06
+    title: "BIG5-CONTENT-POLISH-06: polish Big Five CMS draft assets before importer dry-run"
+    train_scope: big_five_cms_asset_readiness
+    status: user_authorized
+    scope:
+      - Polish Chinese Big Five combination draft pages to reduce repeated template language.
+      - Deepen English Big Five hub and trait draft pages.
+      - Expand English FAQs to at least five question/answer entries per page.
+      - Keep every asset draft_review_required, manual_review_required, and CMS/backend authoritative.
+      - Generate or update backend-side review/import-ready assets or reports only; do not write CMS or change runtime SEO surfaces.
+    allowed_paths:
+      - generated/big-five-content-polish/**
+      - generated/big-five-content-quality-review/**
+      - generated/pr-train-sidecar-issues/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Modify frontend runtime, public API runtime, importer runtime, production CMS content, sitemap/llms runtime, JSON-LD runtime, canonical/noindex behavior, permissions, scheduler behavior, secrets, staging deploy, or production deploy.
+      - Write CMS, publish, index, add sitemap/llms/JSON-LD runtime enumeration, or mark English Big Five pages SEO-ready.
+    validation:
+      - python3 -m json.tool generated/big-five-content-polish/cms-import-draft.polished.json >/dev/null
+      - python3 -m json.tool generated/big-five-content-polish/content_polish_report.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-CMS-IMPORT-DRYRUN-07
+    repo: fap-api
+    depends_on:
+      - BIG5-CONTENT-POLISH-06
+    branch: codex/big5-cms-import-dryrun-07
+    title: "BIG5-CMS-IMPORT-DRYRUN-07: run no-write Big Five CMS import dry-run on polished assets"
+    train_scope: big_five_cms_asset_readiness
+    status: user_authorized
+    scope:
+      - Run the backend Big Five CMS import no-write dry-run against the polished draft package.
+      - Validate cms-import-draft.json readability and required field mapping for body_sections, faq, seo, claim_boundaries, and indexability_gate.
+      - Validate FAQ dedupe, claim boundary, indexability gate, canonical path, and short-route residue posture.
+      - Generate a dry-run report only.
+      - Keep this dry-run only; no DB writes, CMS writes, publishing, sitemap/llms/JSON-LD runtime changes, staging deploy, or production deploy.
+    allowed_paths:
+      - generated/big-five-cms-import-dryrun/**
+      - generated/pr-train-sidecar-issues/**
+      - backend/app/Console/Commands/PersonalityBigFiveCmsImportDraftDryRun.php
+      - backend/app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php
+      - backend/tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Write CMS, run production imports, run database migrations, publish, enable indexability, release sitemap/llms, submit search, trigger staging deploy, trigger production deploy, or add public runtime content.
+      - Change public API routes, content authority, canonical/noindex behavior, JSON-LD runtime, permissions, scheduler behavior, or secrets.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:big-five-cms-import-draft-dry-run --package=../generated/big-five-content-polish/cms-import-draft.polished.json --dry-run --json
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityBigFiveCmsImportDraftDryRunCommandTest --no-ansi
+      - python3 -m json.tool generated/big-five-cms-import-dryrun/dryrun_report.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-CMS-PREVIEW-READBACK-QA-08
+    repo: fap-api
+    depends_on:
+      - BIG5-CMS-IMPORT-DRYRUN-07
+    branch: codex/big5-cms-preview-readback-qa-08
+    title: "BIG5-CMS-PREVIEW-READBACK-QA-08: validate Big Five CMS preview and public API readback payload"
+    train_scope: big_five_cms_asset_readiness
+    status: user_authorized
+    scope:
+      - Validate planned CMS preview and public API readback payload structure after the no-write dry-run passes.
+      - Confirm body_sections do not render FAQ twice and faq remains the only structured FAQ source.
+      - Confirm draft/manual review assets remain excluded from public SEO discoverability surfaces.
+      - Confirm preview/readback payloads preserve noindex, manual_review_required, and draft_review_required posture.
+      - Generate a QA report only; no CMS writes, publishing, sitemap/llms/JSON-LD runtime release, staging deploy, or production deploy.
+    allowed_paths:
+      - generated/big-five-cms-preview-readback-qa/**
+      - generated/pr-train-sidecar-issues/**
+      - backend/app/Services/Cms/BigFiveCmsImportDraftDryRunPlanner.php
+      - backend/tests/Feature/Console/PersonalityBigFiveCmsImportDraftDryRunCommandTest.php
+      - backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Write CMS, run production imports, run database migrations, publish, enable indexability, release sitemap/llms, submit search, trigger staging deploy, trigger production deploy, or add public runtime content.
+      - Change public route paths, permissions, scheduler behavior, secrets, canonical path generation, sitemap runtime inclusion, llms runtime inclusion, or production JSON-LD publishing policy.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityBigFiveCmsImportDraftDryRunCommandTest|PersonalityPublicContentAssetContractTest' --no-ansi
+      - python3 -m json.tool generated/big-five-cms-preview-readback-qa/readback_qa_report.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: MBTI-CMS-12
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Reconciled `BIG5-CONTENT-QUALITY-REVIEW-05` in `docs/codex/pr-train-state.json` after PR #2730 merged.
- Registered the user-authorized follow-up Big Five CMS asset readiness PR train items: `BIG5-TRAIN-LEDGER-CLOSEOUT-06`, `BIG5-CONTENT-POLISH-06`, `BIG5-CMS-IMPORT-DRYRUN-07`, and `BIG5-CMS-PREVIEW-READBACK-QA-08`.

## Why
- The previous train item had already merged, but the local train ledger still showed it as `ready_to_merge`.
- The next PRs need explicit manifest/state entries before one-scope-at-a-time execution can continue.

## Validation
- `git status --short --branch`
- `gh pr view 2730 --json number,state,mergedAt,mergeCommit,url,headRefName,baseRefName,isDraft`
- `git merge-base --is-ancestor 075c90211d0ed71b98a9bc903f951f3d3731ca99 origin/main`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `rg -n "BIG5-CONTENT-QUALITY-REVIEW-05|BIG5-TRAIN-LEDGER-CLOSEOUT-06|BIG5-CONTENT-POLISH-06|BIG5-CMS-IMPORT-DRYRUN-07|BIG5-CMS-PREVIEW-READBACK-QA-08" docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --check`
- `git diff --cached --check`

## Deferred items
- No content polishing in this PR.
- No importer dry-run changes in this PR.
- No CMS writes, production imports, publish actions, sitemap/llms/JSON-LD runtime release, staging deploy, or production deploy.

## Repository rule impact
- Metadata-only PR train bookkeeping. No content authority or runtime ownership changes.
