### PR TITLE
BIG5-CONTENT-POLISH-06: polish Big Five CMS draft assets before importer dry-run

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81317,13 +81317,13 @@
     "depends_on": [
       "BIG5-CONTENT-QUALITY-REVIEW-05"
     ],
-    "status": "local_checks_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "merged",
+    "commit_sha": "0387b3c1651a6c35b6825a20da109b3d665c0ca0",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2732",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T07:12:57Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -81341,13 +81341,21 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to BIG5-TRAIN-LEDGER-CLOSEOUT-06 allowed metadata paths: docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PASS on PR #2732: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2 all passed."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "PR #2732 is MERGED; origin/main contains merge commit 0387b3c1651a6c35b6825a20da109b3d665c0ca0; local main was synced; task branch codex/big5-train-ledger-closeout-06 is absent locally and remotely."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -81373,7 +81381,7 @@
     "depends_on": [
       "BIG5-TRAIN-LEDGER-CLOSEOUT-06"
     ],
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "commit_sha": null,
     "pr_url": null,
     "failure_reason": null,
@@ -81384,11 +81392,23 @@
       "manifest_registration": {
         "status": "pass",
         "evidence": "User explicitly authorized registering this Big Five CMS asset readiness PR train item in the attached /goal execution request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "BIG5-TRAIN-LEDGER-CLOSEOUT-06 PR #2732 is merged, and origin/main contains merge commit 0387b3c1651a6c35b6825a20da109b3d665c0ca0."
+      },
+      "content_polish_validation": {
+        "status": "pass",
+        "evidence": "Generated generated/big-five-content-polish/cms-import-draft.polished.json plus JSON/Markdown reports. The polished package keeps 42 rows, all draft_review_required/manual_review_required, zero short-route residue, zero bad canonical paths, zero English FAQ count issues, zero English depth issues under 450 words, zero zh-CN combination pages under 800 CJK chars, and zero mechanical forbidden-claim hits."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to BIG5-CONTENT-POLISH-06 allowed paths: generated/big-five-content-polish/** and docs/codex/pr-train-state.json."
       }
     },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -81398,6 +81418,18 @@
         "from": "user_authorized",
         "to": "pending_dependency",
         "note": "Registered dependent content-polish PR; execution waits for BIG5-TRAIN-LEDGER-CLOSEOUT-06 merge."
+      },
+      {
+        "at": "2026-07-05T07:20:17Z",
+        "from": "pending_dependency",
+        "to": "in_progress",
+        "note": "Started backend-side content polish after BIG5-TRAIN-LEDGER-CLOSEOUT-06 merge was verified. Scope excludes CMS writes, publishing, indexability release, sitemap/llms/JSON-LD runtime, and deploys."
+      },
+      {
+        "at": "2026-07-05T07:20:17Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Generated polished draft package and validation report. Local JSON parse, content count, route, gate, FAQ, depth, forbidden-claim, YAML/JSON, and diff checks passed."
       }
     ]
   },

--- a/generated/big-five-content-polish/cms-import-draft.polished.json
+++ b/generated/big-five-content-polish/cms-import-draft.polished.json
@@ -1,0 +1,4047 @@
+[
+  {
+    "slug": "high-agreeableness-high-neuroticism",
+    "locale": "zh-CN",
+    "content_type": "combination_page",
+    "title": "高宜人 + 高神经质：大五人格组合解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/combinations/high-agreeableness-high-neuroticism",
+    "seo": {
+      "title": "高宜人 + 高神经质是什么意思？大五人格组合复盘指南",
+      "description": "解释大五人格组合：高宜人 + 高神经质。敏感、体谅、容易承担关系压力。用于自我观察和沟通复盘，不作为诊断或职业预测。",
+      "primary_keyword": "高宜人 + 高神经质",
+      "secondary_keywords": [
+        "OCEAN组合",
+        "人格维度组合",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "高宜人 + 高神经质常见张力是“很在意他人，也很容易被关系信号牵动”。用户可能敏感、体贴、愿意配合，但也容易因语气、反馈延迟或冲突迹象产生压力。它不是脆弱或讨好标签，而是关系复盘线索，不能用于诊断焦虑、预测关系质量或评价他人。"
+      },
+      {
+        "heading": "组合解释",
+        "body": "宜人性偏高让用户倾向于照顾他人感受、维持合作和减少冲突；神经质偏高让威胁、否定和不确定更容易被放大。两者叠加时，用户常能提前察觉团队或关系里的细微变化，但也可能把模糊信号解释为自己做错了什么。"
+      },
+      {
+        "heading": "具体优势",
+        "body": "优势是关系雷达细、共情启动快。适合客户支持、团队协调、用户访谈、冲突前置提醒、服务体验优化和需要情绪细节的内容工作。用户往往能发现别人没有说出口的顾虑，并愿意主动修复协作摩擦。"
+      },
+      {
+        "heading": "具体风险",
+        "body": "风险是边界被压力吞掉。常见表现包括过度道歉、把别人的情绪都归因到自己身上、为了避免冲突而答应过多，或在没有证据时反复检查消息和反馈。长期看，关系维护会消耗恢复资源。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "工作学习中，建议把“我感到不安”和“事实证据”分开记录。收到模糊反馈时，先问清任务标准、下一步动作和截止时间，而不是立刻补偿式加班。涉及冲突时，用书面摘要确认共识，减少靠猜测维持合作。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "关系沟通中，可以把请求说具体：“我现在有点担心我们没对齐，能不能告诉我你最在意的一点是什么？”这比反复确认“你是不是生气了”更容易得到有效信息。也要练习允许别人有情绪，而不自动把修复责任全揽到自己身上。"
+      },
+      {
+        "heading": "复盘建议",
+        "body": "复盘建议记录触发点、证据、解释和行动四列。两周后看哪些不安后来被证实，哪些只是压力下的预判。行动上设一个边界句：“我愿意理解你的感受，但我需要先确认这是不是我的责任。”"
+      },
+      {
+        "heading": "人工审稿关注点",
+        "body": "人工审稿时应特别检查两点：一是文本有没有把高神经质写成心理问题，二是有没有把高宜人写成必须牺牲自我的美德。更稳妥的表达，是把它写成关系信号敏感和边界练习之间的平衡。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不是诊断、筛选、预测或分类工具。组合解释不能替代完整测试结果、真实经历和人工审核。它不应进入招聘、人事、升学、金融或法律决策，也不能用来给别人贴固定标签。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。它只是维度组合阅读，不是固定类型库。\n\n没有绝对好坏。要看环境、任务、关系和压力状态。\n\n不能。它只能帮助分析工作方式和协作偏好。\n\n说明组合解释不应机械套用，应回到具体场景复盘。\n\n可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "这个组合是不是一种人格类型？",
+        "answer": "不是。它只是维度组合阅读，不是固定类型库。"
+      },
+      {
+        "question": "这个组合好不好？",
+        "answer": "没有绝对好坏。要看环境、任务、关系和压力状态。"
+      },
+      {
+        "question": "能用它判断适合什么职业吗？",
+        "answer": "不能。它只能帮助分析工作方式和协作偏好。"
+      },
+      {
+        "question": "如果我只符合一部分怎么办？",
+        "answer": "说明组合解释不应机械套用，应回到具体场景复盘。"
+      },
+      {
+        "question": "是否适合分享给别人？",
+        "answer": "可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/big-five-score-ranges",
+      "/zh/personality/big-five/big-five-30-day-review"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "high-openness-high-extraversion",
+    "locale": "zh-CN",
+    "content_type": "combination_page",
+    "title": "高开放 + 高外向：大五人格组合解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/combinations/high-openness-high-extraversion",
+    "seo": {
+      "title": "高开放 + 高外向是什么意思？大五人格组合复盘指南",
+      "description": "解释大五人格组合：高开放 + 高外向。外部探索强、表达活跃、机会捕捉快。用于自我观察和沟通复盘，不作为诊断或职业预测。",
+      "primary_keyword": "高开放 + 高外向",
+      "secondary_keywords": [
+        "OCEAN组合",
+        "人格维度组合",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "高开放 + 高外向常表现为“从交流中生成新想法”：用户喜欢接触人、信息和变化，也容易在讨论中快速扩展方向。这不是社交型人格标签，而是一个信息获取和能量调动模式。它可以帮助复盘创意、协作和表达方式，但不能预测影响力、领导力或职业成就。"
+      },
+      {
+        "heading": "组合解释",
+        "body": "开放性偏高带来好奇、想象和跨界连接；外向性偏高让这些想法更容易通过对话、展示、共创和即时反馈被激活。组合优势在公开表达和早期动员，风险在于讨论过热、承诺过多，或把兴奋感误认为方案已经成熟。"
+      },
+      {
+        "heading": "具体优势",
+        "body": "优势是能让模糊议题快速进入可讨论状态。适合做头脑风暴主持、用户共创、品牌表达、社群活动、课程开场、项目启动会和跨团队对齐。用户往往能把抽象概念说得有感染力，也能让沉默的想法浮出水面。"
+      },
+      {
+        "heading": "具体风险",
+        "body": "风险是能量外放太快，细节验证跟不上。常见成本包括会议中不断扩题、把未验证想法讲得过于确定、听到反馈后马上换方向，或让内向/审慎成员没有足够处理时间。团队可能觉得有激情但不稳定。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "工作学习场景中，应把“发散会”和“决策会”分开。发散会允许白板、类比和快速表达；决策会必须回到证据、资源、负责人和截止时间。每次公开提出新方向时，同时写下“还不知道什么”和“下一步验证什么”，避免把表达力当成证据。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "关系沟通中，这个组合容易用热情推进对话，但对方可能需要安静思考。可以提前约定：重要议题先表达想法，再给对方一段独立消化时间，最后再定行动。这样既保留互动优势，也减少对方被节奏裹挟的感觉。"
+      },
+      {
+        "heading": "复盘建议",
+        "body": "复盘建议关注三件事：哪些想法来自真实需求，哪些来自现场兴奋，哪些承诺后来没有跟进。行动上可以给每次讨论配一个“冷却窗口”：当天只记录，不立刻扩大承诺；第二天再确认是否进入计划。"
+      },
+      {
+        "heading": "人工审稿关注点",
+        "body": "人工审稿时应检查页面是否把表达力等同于影响力。这个组合可以带来启动能量和创意传播，但仍需要证据、倾听和后续兑现。文本要提醒用户给安静成员留出处理时间。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不是诊断、筛选、预测或分类工具。组合解释不能替代完整测试结果、真实经历和人工审核。它不应进入招聘、人事、升学、金融或法律决策，也不能用来给别人贴固定标签。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。它只是维度组合阅读，不是固定类型库。\n\n没有绝对好坏。要看环境、任务、关系和压力状态。\n\n不能。它只能帮助分析工作方式和协作偏好。\n\n说明组合解释不应机械套用，应回到具体场景复盘。\n\n可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "这个组合是不是一种人格类型？",
+        "answer": "不是。它只是维度组合阅读，不是固定类型库。"
+      },
+      {
+        "question": "这个组合好不好？",
+        "answer": "没有绝对好坏。要看环境、任务、关系和压力状态。"
+      },
+      {
+        "question": "能用它判断适合什么职业吗？",
+        "answer": "不能。它只能帮助分析工作方式和协作偏好。"
+      },
+      {
+        "question": "如果我只符合一部分怎么办？",
+        "answer": "说明组合解释不应机械套用，应回到具体场景复盘。"
+      },
+      {
+        "question": "是否适合分享给别人？",
+        "answer": "可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/big-five-score-ranges",
+      "/zh/personality/big-five/big-five-30-day-review"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "high-openness-low-conscientiousness",
+    "locale": "zh-CN",
+    "content_type": "combination_page",
+    "title": "高开放 + 低尽责：大五人格组合解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/combinations/high-openness-low-conscientiousness",
+    "seo": {
+      "title": "高开放 + 低尽责是什么意思？大五人格组合复盘指南",
+      "description": "解释大五人格组合：高开放 + 低尽责。想法多、启动快，但可能收敛不足。用于自我观察和沟通复盘，不作为诊断或职业预测。",
+      "primary_keyword": "高开放 + 低尽责",
+      "secondary_keywords": [
+        "OCEAN组合",
+        "人格维度组合",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "高开放 + 低尽责不是“创意型人格”的标签，而是一个常见张力：脑中同时出现很多可能性，行动启动也快，但后续排序、截止和收尾容易被新的想法打断。这个组合适合用来复盘“为什么我总是先兴奋后分散”，不适合用来判断一个人是否可靠、是否适合某个岗位，或预测项目结果。"
+      },
+      {
+        "heading": "组合解释",
+        "body": "开放性偏高会把注意力带向新概念、新工具、新方案和跨领域连接；尽责性偏低则让默认节奏更依赖兴趣、反馈和外部结构。两者叠加时，用户往往能很快提出原型、方向和替代路径，但对任务拆解、优先级冻结和重复执行的耐受度较低。关键不是压低想象力，而是给探索加上可见边界。"
+      },
+      {
+        "heading": "具体优势",
+        "body": "优势在于早期探索效率高。面对模糊问题时，这类用户更容易提出多个切入点，能把不同信息拼成新框架，也更愿意先做一个粗糙实验。适合承担概念验证、产品探索、内容选题、研究假设、创意脚本、用户访谈提纲等“先打开可能性”的任务。"
+      },
+      {
+        "heading": "具体风险",
+        "body": "主要风险不是“懒”，而是没有足够的收束系统。常见表现是同时开多个坑、在最后 20% 失去耐心、对维护类任务低估时间，或因为方案持续变好而迟迟不交付。如果团队只看到延期，用户只看到灵感，就容易形成互相误读。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "工作和学习中建议把任务分成探索、选择、交付三段：探索阶段允许发散，但选择阶段只能保留一个主方案和一个备选；交付阶段用固定检查清单处理格式、证据、引用、提交物和截止时间。外部日历、同伴检查、公开承诺和小步验收，比单纯要求自己“自律一点”更有效。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "沟通时不要把问题说成“我就是收不了尾”。更可操作的表达是：“我前期会产生很多方案，但需要你和我一起确认本周只推进哪一个，以及完成标准是什么。”在关系里，这个组合也需要提前说明计划变动的边界，避免让别人承担不确定性的成本。"
+      },
+      {
+        "heading": "复盘建议",
+        "body": "复盘时记录三个指标：本周新增了多少想法，真正推进了哪一个，哪一步因为没有外部结构而停住。下次行动可以设为“三个方案内做选择、二十四小时内交一个粗版本、交付前只允许一次大改”。连续两周观察后，再判断这是否是稳定模式。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不是诊断、筛选、预测或分类工具。组合解释不能替代完整测试结果、真实经历和人工审核。它不应进入招聘、人事、升学、金融或法律决策，也不能用来给别人贴固定标签。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。它只是维度组合阅读，不是固定类型库。\n\n没有绝对好坏。要看环境、任务、关系和压力状态。\n\n不能。它只能帮助分析工作方式和协作偏好。\n\n说明组合解释不应机械套用，应回到具体场景复盘。\n\n可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "这个组合是不是一种人格类型？",
+        "answer": "不是。它只是维度组合阅读，不是固定类型库。"
+      },
+      {
+        "question": "这个组合好不好？",
+        "answer": "没有绝对好坏。要看环境、任务、关系和压力状态。"
+      },
+      {
+        "question": "能用它判断适合什么职业吗？",
+        "answer": "不能。它只能帮助分析工作方式和协作偏好。"
+      },
+      {
+        "question": "如果我只符合一部分怎么办？",
+        "answer": "说明组合解释不应机械套用，应回到具体场景复盘。"
+      },
+      {
+        "question": "是否适合分享给别人？",
+        "answer": "可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/big-five-score-ranges",
+      "/zh/personality/big-five/big-five-30-day-review"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "low-agreeableness-high-conscientiousness",
+    "locale": "zh-CN",
+    "content_type": "combination_page",
+    "title": "低宜人 + 高尽责：大五人格组合解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/combinations/low-agreeableness-high-conscientiousness",
+    "seo": {
+      "title": "低宜人 + 高尽责是什么意思？大五人格组合复盘指南",
+      "description": "解释大五人格组合：低宜人 + 高尽责。原则清晰、质量把关强，但沟通可能显得尖锐。用于自我观察和沟通复盘，不作为诊断或职业预测。",
+      "primary_keyword": "低宜人 + 高尽责",
+      "secondary_keywords": [
+        "OCEAN组合",
+        "人格维度组合",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "低宜人 + 高尽责常表现为“标准明确、推进强，但不太愿意用关系润滑换效率”。用户可能重视规则、质量和责任边界，也可能显得直接、挑剔或不够照顾情绪。本页只能帮助复盘协作风格，不能把它说成领导力、绩效或人际结果的预测。"
+      },
+      {
+        "heading": "组合解释",
+        "body": "宜人性偏低让用户更容易坚持判断、提出异议、拒绝模糊妥协；尽责性偏高让这种坚持落到计划、流程、检查和交付标准上。组合优势是守住质量线，风险是把“事的正确”压过“人的可承受”。"
+      },
+      {
+        "heading": "具体优势",
+        "body": "优势在于可靠的标准管理。适合审稿、风控、项目管理、质量验收、流程改造、财务法务协作、数据校验和需要明确责任的场景。用户往往敢指出问题，也愿意承担把事情做完的责任。"
+      },
+      {
+        "heading": "具体风险",
+        "body": "风险是反馈方式让人先防御再理解。常见成本包括会议中快速否定、把不同意见视为不专业、对低质量交付耐心不足，或在关系尚未建立时直接推进规则。团队可能认可结果，但减少主动沟通。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "工作学习中，建议把“标准”和“语气”分开设计。提出问题时先说明共同目标，再给出具体证据和修改建议；重要规则要写成清单，而不是靠临场纠正。对新人或跨部门协作，先解释为什么这个标准重要，再要求执行。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "关系中不要把直接等同于诚实。可以保留清晰边界，但增加一句影响说明：“我指出这个问题是因为它会影响交付，不是评价你这个人。”当对方表达感受时，先复述对方关切，再讨论方案，能减少不必要对抗。"
+      },
+      {
+        "heading": "复盘建议",
+        "body": "复盘时看三类指标：问题是否被解决，关系是否还能继续合作，对方下次是否更愿意提前暴露风险。行动上给每次批评配一个可执行下一步，并限制一次反馈只处理最关键的一到两个点。"
+      },
+      {
+        "heading": "人工审稿关注点",
+        "body": "人工审稿时应避免把这个组合写成“强势管理者”或“高绩效人格”。更准确的重点是标准、责任和反馈方式之间的关系：质量线可以清楚，但表达方式仍需要让协作者能接住。另外，页面应提醒用户区分“必要的质量反馈”和“带有羞辱感的表达”。前者能保护结果，后者会降低信息流动。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不是诊断、筛选、预测或分类工具。组合解释不能替代完整测试结果、真实经历和人工审核。它不应进入招聘、人事、升学、金融或法律决策，也不能用来给别人贴固定标签。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。它只是维度组合阅读，不是固定类型库。\n\n没有绝对好坏。要看环境、任务、关系和压力状态。\n\n不能。它只能帮助分析工作方式和协作偏好。\n\n说明组合解释不应机械套用，应回到具体场景复盘。\n\n可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "这个组合是不是一种人格类型？",
+        "answer": "不是。它只是维度组合阅读，不是固定类型库。"
+      },
+      {
+        "question": "这个组合好不好？",
+        "answer": "没有绝对好坏。要看环境、任务、关系和压力状态。"
+      },
+      {
+        "question": "能用它判断适合什么职业吗？",
+        "answer": "不能。它只能帮助分析工作方式和协作偏好。"
+      },
+      {
+        "question": "如果我只符合一部分怎么办？",
+        "answer": "说明组合解释不应机械套用，应回到具体场景复盘。"
+      },
+      {
+        "question": "是否适合分享给别人？",
+        "answer": "可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/big-five-score-ranges",
+      "/zh/personality/big-five/big-five-30-day-review"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "low-extraversion-high-conscientiousness",
+    "locale": "zh-CN",
+    "content_type": "combination_page",
+    "title": "低外向 + 高尽责：大五人格组合解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/combinations/low-extraversion-high-conscientiousness",
+    "seo": {
+      "title": "低外向 + 高尽责是什么意思？大五人格组合复盘指南",
+      "description": "解释大五人格组合：低外向 + 高尽责。安静、稳定、重交付，适合深度任务。用于自我观察和沟通复盘，不作为诊断或职业预测。",
+      "primary_keyword": "低外向 + 高尽责",
+      "secondary_keywords": [
+        "OCEAN组合",
+        "人格维度组合",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "低外向 + 高尽责常表现为“安静、稳定、靠准备和结构推进”。用户不一定喜欢高频社交或即兴表达，但往往重视质量、可靠性和长期积累。这不是内向型标签，也不能用于判断沟通能力或职业上限；它更适合复盘工作节奏和协作接口。"
+      },
+      {
+        "heading": "组合解释",
+        "body": "外向性偏低让用户更依赖独处处理、深度准备和低噪音环境；尽责性偏高让这种节奏形成计划、清单、复查和持续交付。组合优势是稳定而少噪音，风险是贡献不易被看见，或在高互动环境中恢复不足。"
+      },
+      {
+        "heading": "具体优势",
+        "body": "优势是深度执行和低波动交付。适合研究、写作、数据分析、工程实现、财务整理、长期学习、质量复核和需要独立负责的任务。用户通常能把复杂任务拆开、按步骤推进，并在别人忽略的细节上保持耐心。"
+      },
+      {
+        "heading": "具体风险",
+        "body": "风险是过度依赖“准备好了再说”。常见成本包括会议中不抢话导致观点被遗漏，对临时变化反应慢，长期承担后台工作却缺少可见度，或因为社交消耗而减少必要沟通。别人可能误以为用户没有意见或缺少主动性。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "工作学习中，建议建立可见化输出节奏：每周固定同步进展、风险和下一步；重要观点提前写成一页文档；会议前发出问题清单，会议后确认决策。这样不需要变得外放，也能让贡献被团队读取。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "关系沟通中，可以直接说明自己的处理方式：“我需要一点时间想清楚，但我会在今晚给你答复。”这比沉默更安全。对方需要即时反馈时，可以先给一个临时回应，再约定完整讨论时间。"
+      },
+      {
+        "heading": "复盘建议",
+        "body": "复盘建议记录哪些成果没有被看见，哪些沟通因为等待准备而错过窗口。行动上设置“最低可见度”：每个重要任务至少一次主动同步，每个分歧至少写出自己的判断和证据。"
+      },
+      {
+        "heading": "人工审稿关注点",
+        "body": "人工审稿时应避免把低外向写成社交能力不足。这个组合的关键是低噪音深度工作和可见化同步之间的平衡。文本应鼓励用户设计沟通接口，而不是强迫自己变得外放。另外，页面应提醒团队不要只用发言频率评估参与度。书面输出、稳定交付和风险记录，也应被视为有效协作信号。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不是诊断、筛选、预测或分类工具。组合解释不能替代完整测试结果、真实经历和人工审核。它不应进入招聘、人事、升学、金融或法律决策，也不能用来给别人贴固定标签。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。它只是维度组合阅读，不是固定类型库。\n\n没有绝对好坏。要看环境、任务、关系和压力状态。\n\n不能。它只能帮助分析工作方式和协作偏好。\n\n说明组合解释不应机械套用，应回到具体场景复盘。\n\n可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "这个组合是不是一种人格类型？",
+        "answer": "不是。它只是维度组合阅读，不是固定类型库。"
+      },
+      {
+        "question": "这个组合好不好？",
+        "answer": "没有绝对好坏。要看环境、任务、关系和压力状态。"
+      },
+      {
+        "question": "能用它判断适合什么职业吗？",
+        "answer": "不能。它只能帮助分析工作方式和协作偏好。"
+      },
+      {
+        "question": "如果我只符合一部分怎么办？",
+        "answer": "说明组合解释不应机械套用，应回到具体场景复盘。"
+      },
+      {
+        "question": "是否适合分享给别人？",
+        "answer": "可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/big-five-score-ranges",
+      "/zh/personality/big-five/big-five-30-day-review"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "low-neuroticism-high-conscientiousness",
+    "locale": "zh-CN",
+    "content_type": "combination_page",
+    "title": "低神经质 + 高尽责：大五人格组合解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/combinations/low-neuroticism-high-conscientiousness",
+    "seo": {
+      "title": "低神经质 + 高尽责是什么意思？大五人格组合复盘指南",
+      "description": "解释大五人格组合：低神经质 + 高尽责。稳定、自律、抗压执行强，但可能低估情绪成本。用于自我观察和沟通复盘，不作为诊断或职业预测。",
+      "primary_keyword": "低神经质 + 高尽责",
+      "secondary_keywords": [
+        "OCEAN组合",
+        "人格维度组合",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "低神经质 + 高尽责常表现为“情绪稳定、执行有序、遇事不容易慌”。用户可能在压力下仍能按计划推进，但也可能低估他人的紧张感或忽略早期风险信号。本页用于复盘压力管理和协作节奏，不能预测抗压能力、健康状态或长期职业表现。"
+      },
+      {
+        "heading": "组合解释",
+        "body": "神经质偏低让用户对威胁、否定和波动的反应较平稳；尽责性偏高让这种稳定落到计划、责任和持续执行上。组合优势是可靠推进，风险是把“我不焦虑”误读为“问题不严重”，或用流程覆盖真实情绪需求。"
+      },
+      {
+        "heading": "具体优势",
+        "body": "优势是危机中保持秩序。适合项目收尾、运营保障、考试备考、质量管理、长期训练、流程恢复和需要持续耐心的任务。用户往往能在别人情绪波动时继续拆解问题，稳定完成必要动作。"
+      },
+      {
+        "heading": "具体风险",
+        "body": "风险是对风险和情绪成本的敏感度不足。常见表现包括太晚升级问题，对团队压力反应慢，认为别人“想太多”，或长期压缩休息但没有及时察觉疲劳。稳定不等于没有成本，只是成本不一定以焦虑形式出现。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "工作学习中，建议把风险升级写成客观阈值，而不是等自己感觉紧张。例如延期超过一天、错误重复两次、关键人未响应二十四小时，就触发同步。这样能弥补低警觉带来的晚反应。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "关系沟通中，要避免用“这没什么”结束对方的感受。更好的表达是：“我现在不太慌，但我理解你很担心，我们先确认最坏情况和下一步。”这样既保留稳定性，也让对方感觉被接住。"
+      },
+      {
+        "heading": "复盘建议",
+        "body": "复盘时记录哪些问题因为自己不紧张而延后处理，哪些地方稳定性帮助了团队。行动上建立双轨检查：一轨看任务进度，一轨看人是否还能承受当前节奏。"
+      },
+      {
+        "heading": "人工审稿关注点",
+        "body": "人工审稿时应避免把低神经质写成天然抗压或情绪更健康。更稳妥的重点是稳定推进和风险感知之间的平衡：不慌可以是优势，但仍需要客观阈值来触发升级。另外，页面应提醒用户不要把他人的紧张视为低效率。很多风险正是通过不安信号被提前发现，稳定的人也需要倾听这些信号。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不是诊断、筛选、预测或分类工具。组合解释不能替代完整测试结果、真实经历和人工审核。它不应进入招聘、人事、升学、金融或法律决策，也不能用来给别人贴固定标签。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。它只是维度组合阅读，不是固定类型库。\n\n没有绝对好坏。要看环境、任务、关系和压力状态。\n\n不能。它只能帮助分析工作方式和协作偏好。\n\n说明组合解释不应机械套用，应回到具体场景复盘。\n\n可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "这个组合是不是一种人格类型？",
+        "answer": "不是。它只是维度组合阅读，不是固定类型库。"
+      },
+      {
+        "question": "这个组合好不好？",
+        "answer": "没有绝对好坏。要看环境、任务、关系和压力状态。"
+      },
+      {
+        "question": "能用它判断适合什么职业吗？",
+        "answer": "不能。它只能帮助分析工作方式和协作偏好。"
+      },
+      {
+        "question": "如果我只符合一部分怎么办？",
+        "answer": "说明组合解释不应机械套用，应回到具体场景复盘。"
+      },
+      {
+        "question": "是否适合分享给别人？",
+        "answer": "可以作为沟通素材，但不要用来评价、控制或筛选别人。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/big-five-score-ranges",
+      "/zh/personality/big-five/big-five-30-day-review"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five-learning-style",
+    "locale": "zh-CN",
+    "content_type": "cross_reading_page",
+    "title": "Big Five + 学习方式",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/big-five-learning-style",
+    "seo": {
+      "title": "Big Five + 学习方式｜费马测试大五人格指南",
+      "description": "用五维度观察学习启动、专注、反馈、合作和复盘策略。",
+      "primary_keyword": "Big Five + 学习方式",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "大五人格不能决定一个人适合哪种学习方法，但可以帮助观察学习启动、专注、反馈、合作和复盘策略。学习方式页面的重点不是给用户贴“天生适合某学习法”的标签，而是帮助用户把人格倾向转化成可测试的学习实验。"
+      },
+      {
+        "heading": "五个维度怎么看学习",
+        "body": "高开放者可能喜欢概念、类比和跨学科材料，但需要避免无限扩展；低开放者可能更适合案例、模板和标准答案，但需要预留一点探索空间。高尽责者适合计划和检查清单，但要防止计划替代行动；低尽责者需要更短反馈周期和外部结构。高外向者可能通过讨论吸收信息，低外向者可能需要先独立整理。高宜人者在小组学习中愿意协调，但可能不敢提出真实分歧。高神经质者对考试和反馈敏感，适合建立早期安全练习。"
+      },
+      {
+        "heading": "设计学习实验",
+        "body": "不要直接说“我不适合某方法”。更好的做法是选择一个微实验：同一主题用两种方式学习，各用 30 分钟，然后记录理解程度、启动难度、分心次数和复盘感受。大五维度帮助你解释差异，但不能替代实际测试。"
+      },
+      {
+        "heading": "学习复盘四问",
+        "body": "第一，什么任务让我最容易启动？第二，什么反馈让我最容易坚持？第三，什么环境让我消耗最快？第四，什么恢复动作能让我重新开始？这些问题比“我是不是自律”更有行动价值。"
+      },
+      {
+        "heading": "和 MBTI / RIASEC 的关系",
+        "body": "MBTI 可以帮助用户描述偏好表达，RIASEC 可以提示兴趣活动，大五则帮助拆解执行条件。三者都不应被写成学习能力判断或升学预测。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不评价智力、能力、升学结果或考试表现。大五只提供学习行为复盘框架，不是教育诊断工具。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不能直接判断，但可以帮助设计学习实验。\n\n不是。它提示你可能更需要外部结构、短反馈和清晰启动条件。\n\n不一定。低外向者也可能适合小组，但需要明确角色和恢复时间。\n\n可能影响压力体验，但不能单独预测成绩。\n\n用一周时间记录学习启动、反馈、分心和恢复，再调整一个具体动作。"
+      },
+      {
+        "heading": "内容资产建议",
+        "body": "这类页面适合连接维度页和测试结果页。页面不应宣称某维度决定学习能力，而应提供可记录的学习变量：启动成本、反馈频率、分心来源、复习间隔、合作需求和恢复时间。CMS 中可以把这些变量做成可复用模块，未来再和结果页的行动建议联动。"
+      },
+      {
+        "heading": "复盘示例",
+        "body": "如果用户低尽责但高开放，不应写成“缺乏自律但有创意”，而应写成：更容易被新材料吸引，长期任务需要外部结构。可测试动作是把学习任务切成 25 分钟小块，并在每块结束时写下一个可交付产物。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "大五能判断我适合哪种学习法吗？",
+        "answer": "不能直接判断，但可以帮助设计学习实验。"
+      },
+      {
+        "question": "尽责性低是不是学不好？",
+        "answer": "不是。它提示你可能更需要外部结构、短反馈和清晰启动条件。"
+      },
+      {
+        "question": "外向性低是否不适合小组学习？",
+        "answer": "不一定。低外向者也可能适合小组，但需要明确角色和恢复时间。"
+      },
+      {
+        "question": "神经质高会影响考试吗？",
+        "answer": "可能影响压力体验，但不能单独预测成绩。"
+      },
+      {
+        "question": "最推荐的用法是什么？",
+        "answer": "用一周时间记录学习启动、反馈、分心和恢复，再调整一个具体动作。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five-relationship-communication",
+    "locale": "zh-CN",
+    "content_type": "cross_reading_page",
+    "title": "Big Five + 关系沟通",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/big-five-relationship-communication",
+    "seo": {
+      "title": "Big Five + 关系沟通｜费马测试大五人格指南",
+      "description": "用大五降低沟通误读，把人格评价改写为具体请求。",
+      "primary_keyword": "Big Five + 关系沟通",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "大五人格可以帮助关系沟通，但不应被用来评价、控制或定义别人。它最有价值的用途，是把“你总是这样”改写成更具体、可协商的请求。费马测试（FermatMind）建议把大五当作沟通前的自我整理工具，而不是争论中的证据。"
+      },
+      {
+        "heading": "五个维度如何影响沟通",
+        "body": "开放性影响一个人是否愿意讨论新解释和模糊可能。尽责性影响对承诺、时间和细节的敏感度。外向性影响表达频率、现场反应和恢复方式。宜人性影响冲突中的让步、体谅和边界。神经质/情绪敏感性影响对风险、语气和关系信号的觉察。"
+      },
+      {
+        "heading": "从标签改成请求",
+        "body": "标签化表达会让对方防御，例如“你太敏感”“你太固执”“你不靠谱”。更好的表达是：在什么场景下，我观察到了什么行为，它对我造成什么影响，我希望下次怎么做。例如“在计划频繁变化时，我会焦虑；我希望我们每周固定一次确认优先级”。"
+      },
+      {
+        "heading": "关系中的优势与代价",
+        "body": "高宜人能减少冲突，但也可能压抑需求；低宜人能保护边界，但可能让语气显得尖锐。高外向能推动讨论，但可能抢占空间；低外向能深度整理，但可能延迟反馈。每个维度都不是优劣判断，关键是能否让对方理解你的真实需求。"
+      },
+      {
+        "heading": "不适合的用法",
+        "body": "不要用大五解释所有关系问题，不要把对方的分数当作责备证据，不要把公开页面当作伴侣、朋友或同事的评判标准。关系质量还受到价值观、经历、信任、沟通技能和现实压力影响。"
+      },
+      {
+        "heading": "行动建议",
+        "body": "在重要沟通前写三句话：我观察到的事实、我的感受或成本、我希望下次可执行的动作。沟通后再复盘：我是否把人格标签换成了具体请求？我是否也听到了对方的约束？"
+      },
+      {
+        "heading": "FAQ",
+        "body": "可以作为沟通素材，但不要用来证明对方有问题。\n\n不是。它可能代表边界清晰，但需要注意表达方式。\n\n不应这样标签化。它可能表示更容易觉察风险和关系信号。\n\n不能。它只能帮助理解沟通倾向和误读来源。\n\n把模糊评价改写成具体请求，并在真实对话中验证。"
+      },
+      {
+        "heading": "内容资产建议",
+        "body": "关系沟通页应优先服务“把标签翻译成请求”的任务。每个维度都可以配一个沟通转换例子：开放性对应“请先给我可能性空间”，尽责性对应“请明确截止和责任”，外向性对应“我需要现场讨论或会后整理”，宜人性对应“我需要边界和照顾关系同时存在”，神经质对应“我需要提前知道风险”。"
+      },
+      {
+        "heading": "复盘示例",
+        "body": "一次争执后，不要写“我们性格不合”。可以写：触发场景是计划变化，我的反应是反复确认，对方的成本是被催促。下一次动作是提前约定变更通知方式。这样页面才能帮助用户行动，而不是扩大关系解释。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "可以把页面发给伴侣吗？",
+        "answer": "可以作为沟通素材，但不要用来证明对方有问题。"
+      },
+      {
+        "question": "宜人性低是不是不好相处？",
+        "answer": "不是。它可能代表边界清晰，但需要注意表达方式。"
+      },
+      {
+        "question": "神经质高是不是太敏感？",
+        "answer": "不应这样标签化。它可能表示更容易觉察风险和关系信号。"
+      },
+      {
+        "question": "大五能预测关系结果吗？",
+        "answer": "不能。它只能帮助理解沟通倾向和误读来源。"
+      },
+      {
+        "question": "最适合的使用方式是什么？",
+        "answer": "把模糊评价改写成具体请求，并在真实对话中验证。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five-riasec-career",
+    "locale": "zh-CN",
+    "content_type": "cross_reading_page",
+    "title": "Big Five + RIASEC 职业探索",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/big-five-riasec-career",
+    "seo": {
+      "title": "Big Five + RIASEC 职业探索｜费马测试大五人格指南",
+      "description": "用人格维度理解工作方式，用RIASEC理解兴趣方向，两者不能推断录用结果或收入。",
+      "primary_keyword": "Big Five + RIASEC 职业探索",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "Big Five 和 RIASEC 可以一起用于职业探索，但它们回答的是不同问题。大五更适合描述工作方式、协作节奏、压力反应和自我管理；RIASEC 更适合描述兴趣方向、任务偏好和职业活动类型。两者都不能推断录用结果、收入或职业成功，也不应被用于招聘筛选。"
+      },
+      {
+        "heading": "分工方式",
+        "body": "大五回答“我通常怎样工作”：比如是否喜欢探索新方案，是否依赖计划，是否从社交中获得能量，是否倾向让步，压力下恢复节奏如何。RIASEC 回答“我更容易被什么活动吸引”：比如现实型任务、研究型问题、艺术表达、社会服务、企业推动或常规秩序。把两者放在一起，能得到更具体的职业探索线索。"
+      },
+      {
+        "heading": "一个例子",
+        "body": "高开放的人可能喜欢复杂问题，但如果 RIASEC 的研究型兴趣不高，他未必享受长期数据分析；高外向的人可能喜欢互动，但如果社会型兴趣不高，也未必适合持续照护或咨询服务。反过来，强常规兴趣配合高尽责，可能说明用户在流程、质量和稳定交付中更容易积累优势。"
+      },
+      {
+        "heading": "如何避免误用",
+        "body": "不要把“大五 + RIASEC”写成职业推荐引擎。它只能帮助用户缩小观察范围：哪些任务让我更容易进入状态，哪些环境消耗我，哪些协作方式更稳定。职业选择还需要考虑技能、教育、行业、城市、收入、机会成本和个人约束。"
+      },
+      {
+        "heading": "费马测试页面建议",
+        "body": "交叉页面应从测试结果回到行动：列出一个兴趣方向，再用大五拆解执行条件。例如“我对研究型任务感兴趣”之后，要继续问：我能否承受长期不确定？我是否需要明确结构？我更适合独立研究还是团队讨论？"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不提供录用建议、专业职业规划结论或收入判断。大五解释工作方式，RIASEC解释兴趣方向，两者都只是职业探索中的结构化参考。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不能。它只能帮助理解工作方式和压力来源。\n\n没有固定优先级。兴趣方向和工作方式要一起看。\n\n不应这样使用。公开内容不支持升学、招聘或人事筛选。\n\n把冲突当成复盘线索，回到真实任务和长期行为记录。\n\n选择 3 个职业活动，记录兴趣、能量、压力和完成质量，再比较模式。"
+      },
+      {
+        "heading": "内容资产建议",
+        "body": "这页可以成为职业探索入口，但必须避免职业推荐化。建议 CMS 保留两个字段：personality_work_style 和 interest_activity_direction。前者来自大五的工作方式复盘，后者来自 RIASEC 的活动偏好。前端只负责渲染，不应在本地把两者合成“最适合职业”。"
+      },
+      {
+        "heading": "复盘示例",
+        "body": "如果用户研究型兴趣高、开放性高、尽责性中等，可以建议观察“是否享受长期证据收集”和“是否需要外部 deadline”。这不是推荐某职业，而是指导用户用真实任务验证兴趣和工作方式是否匹配。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "大五能推荐最适合的职业吗？",
+        "answer": "不能。它只能帮助理解工作方式和压力来源。"
+      },
+      {
+        "question": "RIASEC 和大五哪个更重要？",
+        "answer": "没有固定优先级。兴趣方向和工作方式要一起看。"
+      },
+      {
+        "question": "可以给学生或员工做筛选吗？",
+        "answer": "不应这样使用。公开内容不支持升学、招聘或人事筛选。"
+      },
+      {
+        "question": "结果不一致怎么办？",
+        "answer": "把冲突当成复盘线索，回到真实任务和长期行为记录。"
+      },
+      {
+        "question": "下一步怎么做？",
+        "answer": "选择 3 个职业活动，记录兴趣、能量、压力和完成质量，再比较模式。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five-stress-management",
+    "locale": "zh-CN",
+    "content_type": "cross_reading_page",
+    "title": "Big Five + 压力管理",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/big-five-stress-management",
+    "seo": {
+      "title": "Big Five + 压力管理｜费马测试大五人格指南",
+      "description": "把人格倾向转化为压力触发、信号、恢复动作和沟通边界。",
+      "primary_keyword": "Big Five + 压力管理",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "大五人格不能诊断压力问题，但可以帮助用户观察压力触发、反应模式和恢复动作。压力管理页面应避免医疗化表达，也不能承诺改善焦虑或治疗心理问题。费马测试（FermatMind）更适合把大五用于日常复盘：我在什么维度上更容易被触发，什么环境会放大成本，什么恢复方式最可执行。"
+      },
+      {
+        "heading": "五个维度与压力线索",
+        "body": "开放性高的人在不确定环境中可能继续扩展选项，开放性低的人可能更需要明确边界。尽责性高的人容易在失控和未完成中积累压力，尽责性低的人可能在任务堆积后承受追赶压力。外向性高的人可能需要互动恢复，外向性低的人可能需要独处整理。宜人性高的人容易承担关系压力，宜人性低的人可能在冲突后承受关系修复成本。神经质高的人更敏感地捕捉风险，神经质低的人可能低估预警信号。"
+      },
+      {
+        "heading": "复盘方法",
+        "body": "不要问“我为什么这么脆弱”，而要问四件事：触发点是什么，身体信号是什么，我的默认反应是什么，什么动作能让我回到可执行状态。把压力拆成可观察事件，才能避免人格化责备。"
+      },
+      {
+        "heading": "场景化使用",
+        "body": "在工作中，可以记录截止时间、反馈频率、协作对象和任务模糊度。在关系中，可以记录冲突话题、表达方式、边界是否清楚。在学习中，可以记录任务难度、注意力持续时间和恢复质量。大五只是组织这些记录的框架。"
+      },
+      {
+        "heading": "何时不应只靠自我复盘",
+        "body": "如果压力已经持续影响睡眠、饮食、学习、工作或安全感，应优先寻求专业支持。公开人格页面不应提供治疗建议，也不应把神经质或情绪敏感性解释成心理疾病。"
+      },
+      {
+        "heading": "行动建议",
+        "body": "建立一张“压力脚本”：常见触发、早期信号、可做动作、需要求助的人。每次只改一个动作，例如提前确认截止时间、把需求写成文字、安排独处恢复或降低会议密度。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不能。它只能帮助观察压力反应倾向。\n\n不是。它描述压力敏感性，不是临床诊断。\n\n不一定。低敏感可能稳定，也可能忽略风险和他人情绪。\n\n建议先记录两周，观察重复触发，而不是凭一次事件下结论。\n\n不能。如果压力影响日常功能，应寻求专业帮助。"
+      },
+      {
+        "heading": "内容资产建议",
+        "body": "压力管理页尤其需要边界审稿。页面可以写压力触发、恢复脚本和沟通边界，但不能写治疗承诺、症状判断或临床建议。SEO 摘要也应避免“缓解焦虑”“治疗压力”这类医疗化表达，改用“压力复盘”“恢复节奏”“日常观察”。"
+      },
+      {
+        "heading": "复盘示例",
+        "body": "如果用户高尽责且高神经质，页面可以建议建立提前检查点和恢复窗口，而不是说这个人一定焦虑。记录方式是：任务触发、风险想法、身体信号、求助对象、恢复动作。连续记录后再判断是否需要专业支持。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "大五能诊断压力问题吗？",
+        "answer": "不能。它只能帮助观察压力反应倾向。"
+      },
+      {
+        "question": "神经质高是不是心理不健康？",
+        "answer": "不是。它描述压力敏感性，不是临床诊断。"
+      },
+      {
+        "question": "低神经质是不是更好？",
+        "answer": "不一定。低敏感可能稳定，也可能忽略风险和他人情绪。"
+      },
+      {
+        "question": "压力复盘要记录多久？",
+        "answer": "建议先记录两周，观察重复触发，而不是凭一次事件下结论。"
+      },
+      {
+        "question": "这页能替代咨询或治疗吗？",
+        "answer": "不能。如果压力影响日常功能，应寻求专业帮助。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five-vs-mbti",
+    "locale": "zh-CN",
+    "content_type": "cross_reading_page",
+    "title": "大五人格 vs MBTI",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/big-five-vs-mbti",
+    "seo": {
+      "title": "大五人格 vs MBTI｜费马测试大五人格指南",
+      "description": "解释维度模型与类型模型的差异，帮助用户避免把大五硬做成16型标签。",
+      "primary_keyword": "大五人格 vs MBTI",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "大五人格和 MBTI 都能帮助普通用户讨论性格，但它们解决的问题不同。大五是连续维度模型，关注一个人在开放性、尽责性、外向性、宜人性和神经质上的相对倾向；MBTI 更接近类型化语言，适合讨论偏好、表达风格和身份化记忆。费马测试（FermatMind）不建议把大五硬做成 16 型标签，也不建议用 MBTI 替代大五的连续分数阅读。"
+      },
+      {
+        "heading": "两种模型的阅读方式",
+        "body": "读 MBTI 时，用户通常会先看到一个类型代码，再围绕类型特征、沟通风格和常见误读展开。读大五时，重点不是“我是哪一类人”，而是“我在五个维度上分别偏向哪里，这些倾向在什么场景下出现”。一个人可能高开放、低外向、中等尽责，同时在压力期表现出更高情绪敏感性。这样的组合不适合压缩成单一身份标签。"
+      },
+      {
+        "heading": "为什么不能互相替代",
+        "body": "MBTI 类型语言更容易传播，但容易让人忽略程度差异；大五维度更适合复盘强弱和场景变化，但需要用户愿意接受连续分数。两者都不能用于医疗诊断、招聘筛选、录用判断、升学判断或收入预测。更稳妥的做法是：MBTI 用于快速理解偏好表达，大五用于进一步拆解行为倾向、压力反应和成长动作。"
+      },
+      {
+        "heading": "在费马测试里怎么一起使用",
+        "body": "如果用户已经有 MBTI 结果，可以先用 MBTI 找到自己熟悉的表达语言，再用大五追问三个问题：哪些维度解释了我的工作方式？哪些维度解释了我的沟通误读？哪些维度在压力下最容易放大？这样不会把大五变成另一个类型库，也能让 MBTI 不停留在标签层。"
+      },
+      {
+        "heading": "常见误区",
+        "body": "不要把“大五更科学”写成对 MBTI 的简单否定，也不要把 MBTI 写成完全无用。公开页面应保持边界：不同模型有不同用途，任何模型都不是最终身份判断。也不要声称大五能精准推断职业发展结果、关系结果或心理健康状态。"
+      },
+      {
+        "heading": "行动建议",
+        "body": "选一个最近发生的工作或沟通事件，先用 MBTI 语言描述你的偏好，再用大五维度拆解具体行为。例如“我需要独处整理”可以进一步拆成低外向、较高尽责或高神经质下的恢复需求。最后只保留一个下一步动作：提前写议程、会后补充说明、设置反馈节点或预留恢复时间。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页是模型对比说明，不提供个人测评解释，不替代专业判断。任何职业、关系和压力管理建议都只能作为复盘线索，不能作为决策依据。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不能这样简单表达。大五和 MBTI 的模型目标不同，公开页面应说明用途差异，而不是制造权威排名。\n\n不建议。两者不是同一套量尺，强行转换会丢失连续维度的信息。\n\n优先回到真实事件，看哪个解释能帮助你更具体地复盘行为和调整行动。\n\n两者都只能提供工作方式和偏好线索，不能推断录用结果、收入或职业成功。\n\n不建议。大五更适合做维度页、区间页、组合页和结果复盘页。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "大五人格比 MBTI 更准确吗？",
+        "answer": "不能这样简单表达。大五和 MBTI 的模型目标不同，公开页面应说明用途差异，而不是制造权威排名。"
+      },
+      {
+        "question": "可以把大五结果转成 MBTI 类型吗？",
+        "answer": "不建议。两者不是同一套量尺，强行转换会丢失连续维度的信息。"
+      },
+      {
+        "question": "两个结果冲突怎么办？",
+        "answer": "优先回到真实事件，看哪个解释能帮助你更具体地复盘行为和调整行动。"
+      },
+      {
+        "question": "哪个更适合职业探索？",
+        "answer": "两者都只能提供工作方式和偏好线索，不能推断录用结果、收入或职业成功。"
+      },
+      {
+        "question": "费马测试会把大五做成类型库吗？",
+        "answer": "不建议。大五更适合做维度页、区间页、组合页和结果复盘页。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five",
+    "locale": "en-US",
+    "content_type": "hub_page",
+    "title": "Big Five Personality Model: OCEAN Trait Guide",
+    "status": "draft_review_required",
+    "canonical_path": "/en/personality/big-five",
+    "seo": {
+      "title": "Big Five Personality Model: OCEAN Trait Guide",
+      "description": "A FermatMind guide to Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism, with interpretation boundaries.",
+      "primary_keyword": "Big Five personality",
+      "secondary_keywords": [
+        "personality traits",
+        "self-reflection",
+        "trait model"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "What the Big Five is useful for",
+        "body": "The Big Five model describes personality through five continuous dimensions: Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism. FermatMind treats these dimensions as a structured reflection framework, not as a type label. The useful question is not “which box am I in?” but “what pattern tends to appear when the situation calls for exploration, follow-through, interaction, cooperation, or stress recovery?” This makes the model helpful for reviewing work habits, learning strategies, communication defaults, and recurring friction in collaboration."
+      },
+      {
+        "heading": "How to read a result",
+        "body": "A Big Five result should be read as a working hypothesis. A high range suggests that a tendency may appear more often in relevant situations. A mid range usually means context matters strongly: the same person may behave differently when the task, relationship, risk, or energy level changes. A low range is not a defect. It often points to a different default strategy. For example, lower Extraversion may support quieter processing, while higher Extraversion may support faster social feedback. Neither is automatically better."
+      },
+      {
+        "heading": "Practical review workflow",
+        "body": "Use the result with a concrete situation. First, name what happened. Second, describe your first reaction without judging it. Third, ask what the reaction helped you solve. Fourth, ask what it cost. Fifth, choose one small adjustment for the next similar situation. This keeps the model tied to observable behavior rather than turning it into a fixed identity. FermatMind public pages should support this review loop: measure, interpret, act, and review."
+      },
+      {
+        "heading": "Career, learning, and relationships",
+        "body": "For career exploration, Big Five language can clarify working conditions and collaboration preferences, but it should not infer career outcomes, hiring outcomes, income, or admission results. For learning, it can help users notice whether they need novelty, structure, discussion, harmony, or stress-recovery support. For relationships, it can turn vague conflict into negotiable requests, such as asking for clearer deadlines, more processing time, or more explicit emotional context."
+      },
+      {
+        "heading": "What it should not be used for",
+        "body": "FermatMind is a self-understanding, career exploration, and skill-growth system. Big Five content must not be used as medical diagnosis, mental health assessment, hiring or personnel screening, personnel decision support, admissions evaluation, legal or financial advice, or deterministic prediction. Public materials should not claim specific reliability, validity, norm, or percentile values unless those values are separately documented and reviewed."
+      },
+      {
+        "heading": "Draft and indexability boundary",
+        "body": "This English asset remains draft-review content. It is suitable for CMS review and importer dry-run validation, but not for English SEO expansion, sitemap inclusion, llms enumeration, or JSON-LD runtime release until manual editorial review, visible CMS content, and claim boundaries are approved."
+      },
+      {
+        "heading": "FAQ",
+        "body": "No. It is a dimensional model. FermatMind uses it to describe tendencies across five continuous traits, not to assign a fixed personality type.\n\nNo. High and low ranges both have context-dependent strengths and costs. The useful question is whether the tendency fits the situation.\n\nNo. FermatMind does not present Big Five results as medical, clinical, or mental health diagnosis.\n\nNo. They can support reflection about work style and collaboration needs, but they should not be used to infer career outcomes, hiring, income, or admissions outcomes.\n\nThis English page needs separate editorial parity and SEO/GEO review before public indexation or schema runtime release."
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is the Big Five a type system?",
+        "answer": "No. It is a dimensional model. FermatMind uses it to describe tendencies across five continuous traits, not to assign a fixed personality type."
+      },
+      {
+        "question": "Is a high score better than a low score?",
+        "answer": "No. High and low ranges both have context-dependent strengths and costs. The useful question is whether the tendency fits the situation."
+      },
+      {
+        "question": "Can FermatMind diagnose mental health from Big Five results?",
+        "answer": "No. FermatMind does not present Big Five results as medical, clinical, or mental health diagnosis."
+      },
+      {
+        "question": "Can Big Five results infer career outcomes?",
+        "answer": "No. They can support reflection about work style and collaboration needs, but they should not be used to infer career outcomes, hiring, income, or admissions outcomes."
+      },
+      {
+        "question": "Why is this page still draft-only?",
+        "answer": "This English page needs separate editorial parity and SEO/GEO review before public indexation or schema runtime release."
+      }
+    ],
+    "internal_links": [
+      "/en/personality/big-five/openness",
+      "/en/personality/big-five/conscientiousness",
+      "/en/personality/big-five/extraversion",
+      "/en/personality/big-five/agreeableness",
+      "/en/personality/big-five/neuroticism"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "CollectionPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five",
+    "locale": "zh-CN",
+    "content_type": "hub_page",
+    "title": "大五人格模型：OCEAN 五维度自我认知指南",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five",
+    "seo": {
+      "title": "大五人格模型是什么？OCEAN五维度完整解释",
+      "description": "费马测试的大五人格公开指南，解释开放性、尽责性、外向性、宜人性和神经质五个连续维度，以及高/中/低分的使用边界。",
+      "primary_keyword": "大五人格",
+      "secondary_keywords": [
+        "OCEAN人格模型",
+        "五大人格特质",
+        "人格测试"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "五个维度",
+        "body": "- 开放性 Openness：对新经验、抽象概念、审美和变化的偏好。\n- 尽责性 Conscientiousness：计划性、自律、秩序感和目标完成倾向。\n- 外向性 Extraversion：社交能量、表达强度、刺激偏好和行动外显度。\n- 宜人性 Agreeableness：合作、信任、体谅、冲突处理和人际边界。\n- 神经质 Neuroticism：压力反应、情绪敏感性、风险觉察和恢复节奏。"
+      },
+      {
+        "heading": "高/中/低分不是好坏判断",
+        "body": "高分不是优秀，低分不是缺陷。每个维度都存在优势和代价。真正有价值的问题是：这个倾向在什么场景中提高了效率？在什么场景中制造了误解、延迟或压力？中间区间也不是“没有特点”，它通常说明行为更受任务、关系、资源和压力状态影响。"
+      },
+      {
+        "heading": "适合做什么",
+        "body": "大五适合用于自我观察、学习方式调整、关系沟通、职业探索中的工作方式复盘，以及长期成长记录。它可以帮助你把模糊评价拆成可观察行为，例如启动方式、反馈需求、协作节奏、压力信号和恢复动作。"
+      },
+      {
+        "heading": "不适合做什么",
+        "body": "大五不适合作为招聘、人事筛选、升学、医疗、金融或法律决策依据。它也不能推断收入结果、录用、关系结果或人生走向。任何页面、schema、sitemap 或 llms 文本都不能把大五包装成隐藏证据或权威证明。"
+      },
+      {
+        "heading": "推荐阅读路径",
+        "body": "先读五个维度页，再读自己最高和最低维度的区间页。然后阅读“如何读懂大五人格结果”和“大五人格 vs MBTI”。如果你已经有测试结果，优先关注分数极高或极低的维度，并记录它在真实事件中的表现。"
+      },
+      {
+        "heading": "页面资产地图",
+        "body": "第一阶段建议包括：1 个主题中心、5 个维度页、15 个高/中/低区间页、少量高价值组合页、结果复盘页和交叉阅读页。暂不生成 30 facets 页面，除非评分模型、结果 API、CMS schema 和公开证据都支持。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "当前公开内容不提供具体信度、效度、常模或百分位数值。若相关数据未来经公开审核发布，应由 CMS/backend authoritative content 更新，而不是由前端硬编码补充。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "大五强调连续维度，MBTI强调类型化讨论。大五更适合观察强弱程度和场景变化。\n\n不能直接预测职业结果。它只能帮助你分析工作方式、压力来源和协作偏好。\n\n不是。这里的神经质是压力反应和情绪敏感性维度，不是临床诊断。\n\n可能会。人格倾向相对稳定，但表达方式会受环境、年龄、训练和压力影响。\n\n不是。低分代表另一侧倾向，可能在某些环境中更有效。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "大五人格和 MBTI 有什么不同？",
+        "answer": "大五强调连续维度，MBTI强调类型化讨论。大五更适合观察强弱程度和场景变化。"
+      },
+      {
+        "question": "大五结果能说明我适合什么职业吗？",
+        "answer": "不能直接预测职业结果。它只能帮助你分析工作方式、压力来源和协作偏好。"
+      },
+      {
+        "question": "神经质是不是心理疾病？",
+        "answer": "不是。这里的神经质是压力反应和情绪敏感性维度，不是临床诊断。"
+      },
+      {
+        "question": "分数会变化吗？",
+        "answer": "可能会。人格倾向相对稳定，但表达方式会受环境、年龄、训练和压力影响。"
+      },
+      {
+        "question": "低分是不是不好？",
+        "answer": "不是。低分代表另一侧倾向，可能在某些环境中更有效。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness",
+      "/zh/personality/big-five/extraversion",
+      "/zh/personality/big-five/agreeableness",
+      "/zh/personality/big-five/neuroticism"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "CollectionPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "agreeableness-high",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "宜人性高分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/agreeableness-high",
+    "seo": {
+      "title": "宜人性高分怎么理解？大五人格高分倾向复盘指南",
+      "description": "解释大五人格宜人性高分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "宜人性高分",
+      "secondary_keywords": [
+        "合作倾向",
+        "共情",
+        "冲突沟通",
+        "人际边界"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "宜人性高分不是好坏判断，也不是身份标签。它表示你在“合作、信任、体谅、冲突处理和人际边界倾向”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更容易体谅他人、避免冲突、维护关系氛围并提供支持。高宜人在协作、服务和关系修复中很有价值。代价是可能过度让步、承担过多情绪劳动，或难以及时说不。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，宜人性高分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把宜人性高分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，宜人性高分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "记录一次冲突：我保护了什么边界，忽略了什么感受；我维护了什么关系，又牺牲了什么事实。下一次把评价改成具体请求。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分是不是更好？",
+        "answer": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/agreeableness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "agreeableness-low",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "宜人性低分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/agreeableness-low",
+    "seo": {
+      "title": "宜人性低分怎么理解？大五人格低分倾向复盘指南",
+      "description": "解释大五人格宜人性低分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "宜人性低分",
+      "secondary_keywords": [
+        "合作倾向",
+        "共情",
+        "冲突沟通",
+        "人际边界"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "宜人性低分不是好坏判断，也不是身份标签。它表示你在“合作、信任、体谅、冲突处理和人际边界倾向”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更直接、重原则、重事实和边界。低宜人不是不善良，它可能帮助团队识别问题、坚持标准和减少模糊妥协。代价是表达容易显得尖锐，关系维护成本更高。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，宜人性低分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把宜人性低分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，宜人性低分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "记录一次冲突：我保护了什么边界，忽略了什么感受；我维护了什么关系，又牺牲了什么事实。下一次把评价改成具体请求。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "低分是不是更好？",
+        "answer": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/agreeableness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "agreeableness-mid",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "宜人性中间区间：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/agreeableness-mid",
+    "seo": {
+      "title": "宜人性中间区间怎么理解？大五人格中间区间复盘指南",
+      "description": "解释大五人格宜人性中间区间的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "宜人性中间区间",
+      "secondary_keywords": [
+        "合作倾向",
+        "共情",
+        "冲突沟通",
+        "人际边界"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "宜人性中间区间不是好坏判断，也不是身份标签。它表示你在“合作、信任、体谅、冲突处理和人际边界倾向”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "能在合作和边界之间切换。中间区间通常表示你会根据关系重要性、规则清晰度和风险成本调整姿态，而不是一味迁就或一味强硬。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，宜人性中间区间能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把宜人性中间区间放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，宜人性中间区间可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "记录一次冲突：我保护了什么边界，忽略了什么感受；我维护了什么关系，又牺牲了什么事实。下一次把评价改成具体请求。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "中间区间是不是更好？",
+        "answer": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/agreeableness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "conscientiousness-high",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "尽责性高分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/conscientiousness-high",
+    "seo": {
+      "title": "尽责性高分怎么理解？大五人格高分倾向复盘指南",
+      "description": "解释大五人格尽责性高分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "尽责性高分",
+      "secondary_keywords": [
+        "自律",
+        "计划性",
+        "责任感",
+        "执行力"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "尽责性高分不是好坏判断，也不是身份标签。它表示你在“计划性、自律、秩序感、目标推进和收尾倾向”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更容易提前规划、拆解任务、追踪进度并坚持完成。高尽责在长期项目、质量控制和稳定交付中很有价值。代价是可能过度控制、难以容忍混乱，或把临时变化视为威胁。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，尽责性高分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把尽责性高分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，尽责性高分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "选一个拖延或过度控制的任务，记录启动条件、检查节点、收尾动作。复盘重点不是责备，而是找到下一次可复制的外部结构。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分是不是更好？",
+        "answer": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/conscientiousness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "conscientiousness-low",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "尽责性低分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/conscientiousness-low",
+    "seo": {
+      "title": "尽责性低分怎么理解？大五人格低分倾向复盘指南",
+      "description": "解释大五人格尽责性低分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "尽责性低分",
+      "secondary_keywords": [
+        "自律",
+        "计划性",
+        "责任感",
+        "执行力"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "尽责性低分不是好坏判断，也不是身份标签。它表示你在“计划性、自律、秩序感、目标推进和收尾倾向”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更依赖兴趣、环境刺激和短周期反馈启动行动。低尽责不是不可靠，它可能带来灵活、轻装和快速切换。代价是长期任务容易断档，需要外部结构帮助收尾。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，尽责性低分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把尽责性低分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，尽责性低分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "选一个拖延或过度控制的任务，记录启动条件、检查节点、收尾动作。复盘重点不是责备，而是找到下一次可复制的外部结构。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "低分是不是更好？",
+        "answer": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/conscientiousness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "conscientiousness-mid",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "尽责性中间区间：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/conscientiousness-mid",
+    "seo": {
+      "title": "尽责性中间区间怎么理解？大五人格中间区间复盘指南",
+      "description": "解释大五人格尽责性中间区间的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "尽责性中间区间",
+      "secondary_keywords": [
+        "自律",
+        "计划性",
+        "责任感",
+        "执行力"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "尽责性中间区间不是好坏判断，也不是身份标签。它表示你在“计划性、自律、秩序感、目标推进和收尾倾向”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "能在计划和弹性之间折中。中间区间通常表示你会根据任务重要性、外部约束和精力状态调整投入，而不是一直高度自律或一直随性。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，尽责性中间区间能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把尽责性中间区间放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，尽责性中间区间可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "选一个拖延或过度控制的任务，记录启动条件、检查节点、收尾动作。复盘重点不是责备，而是找到下一次可复制的外部结构。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "中间区间是不是更好？",
+        "answer": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/conscientiousness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "extraversion-high",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "外向性高分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/extraversion-high",
+    "seo": {
+      "title": "外向性高分怎么理解？大五人格高分倾向复盘指南",
+      "description": "解释大五人格外向性高分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "外向性高分",
+      "secondary_keywords": [
+        "社交能量",
+        "表达方式",
+        "内向外向",
+        "刺激偏好"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "外向性高分不是好坏判断，也不是身份标签。它表示你在“社交能量、表达强度、行动外显度和刺激偏好”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更容易从互动、表达、现场反馈和外部刺激中获得能量。高外向有助于快速连接、推动气氛和公开表达。代价是可能说得太快、留给他人空间不足，或低估独处整理的重要性。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，外向性高分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把外向性高分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，外向性高分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "复盘一次会议或社交：什么时候能量上升，什么时候消耗过快，哪些表达必须提前准备，哪些场景需要会后补充文字。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分是不是更好？",
+        "answer": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/extraversion",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "extraversion-low",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "外向性低分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/extraversion-low",
+    "seo": {
+      "title": "外向性低分怎么理解？大五人格低分倾向复盘指南",
+      "description": "解释大五人格外向性低分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "外向性低分",
+      "secondary_keywords": [
+        "社交能量",
+        "表达方式",
+        "内向外向",
+        "刺激偏好"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "外向性低分不是好坏判断，也不是身份标签。它表示你在“社交能量、表达强度、行动外显度和刺激偏好”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更偏好低刺激、深度交流和独立整理。低外向不是社交能力差，而是能量来源不同。代价是别人可能误读为冷淡，重要观点也可能因为表达延迟而被忽略。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，外向性低分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把外向性低分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，外向性低分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "复盘一次会议或社交：什么时候能量上升，什么时候消耗过快，哪些表达必须提前准备，哪些场景需要会后补充文字。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "低分是不是更好？",
+        "answer": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/extraversion",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "extraversion-mid",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "外向性中间区间：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/extraversion-mid",
+    "seo": {
+      "title": "外向性中间区间怎么理解？大五人格中间区间复盘指南",
+      "description": "解释大五人格外向性中间区间的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "外向性中间区间",
+      "secondary_keywords": [
+        "社交能量",
+        "表达方式",
+        "内向外向",
+        "刺激偏好"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "外向性中间区间不是好坏判断，也不是身份标签。它表示你在“社交能量、表达强度、行动外显度和刺激偏好”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "在熟悉场景中可以活跃，在高消耗场景中会保留能量。中间区间常体现为社交选择性：不是固定外向或内向，而是受对象、目标和恢复时间影响。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，外向性中间区间能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把外向性中间区间放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，外向性中间区间可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "复盘一次会议或社交：什么时候能量上升，什么时候消耗过快，哪些表达必须提前准备，哪些场景需要会后补充文字。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "中间区间是不是更好？",
+        "answer": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/extraversion",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "neuroticism-high",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "神经质 / 情绪敏感性高分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/neuroticism-high",
+    "seo": {
+      "title": "神经质 / 情绪敏感性高分怎么理解？大五人格高分倾向复盘指南",
+      "description": "解释大五人格神经质 / 情绪敏感性高分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "神经质 / 情绪敏感性高分",
+      "secondary_keywords": [
+        "情绪稳定性",
+        "压力反应",
+        "焦虑倾向",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "神经质 / 情绪敏感性高分不是好坏判断，也不是身份标签。它表示你在“压力反应、情绪敏感性、风险觉察和恢复节奏”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更容易觉察风险、压力和关系信号，也更容易被不确定性牵动。高神经质/情绪敏感性有助于提前发现问题。代价是可能反复预演、恢复较慢，或把暂时压力理解成长期失败。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，神经质 / 情绪敏感性高分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把神经质 / 情绪敏感性高分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，神经质 / 情绪敏感性高分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "复盘一个压力事件：触发点是什么，身体信号是什么，最早的可干预动作是什么，恢复用了多久。目标是建立恢复脚本，不是诊断自己。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分是不是更好？",
+        "answer": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/neuroticism",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "neuroticism-low",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "神经质 / 情绪敏感性低分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/neuroticism-low",
+    "seo": {
+      "title": "神经质 / 情绪敏感性低分怎么理解？大五人格低分倾向复盘指南",
+      "description": "解释大五人格神经质 / 情绪敏感性低分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "神经质 / 情绪敏感性低分",
+      "secondary_keywords": [
+        "情绪稳定性",
+        "压力反应",
+        "焦虑倾向",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "神经质 / 情绪敏感性低分不是好坏判断，也不是身份标签。它表示你在“压力反应、情绪敏感性、风险觉察和恢复节奏”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更不容易被压力信号持续牵动，恢复较快，面对不确定性更稳定。低神经质不是心理更高级，也可能低估情绪成本、忽略早期预警，或让别人觉得不够共情。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，神经质 / 情绪敏感性低分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把神经质 / 情绪敏感性低分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，神经质 / 情绪敏感性低分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "复盘一个压力事件：触发点是什么，身体信号是什么，最早的可干预动作是什么，恢复用了多久。目标是建立恢复脚本，不是诊断自己。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "低分是不是更好？",
+        "answer": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/neuroticism",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "neuroticism-mid",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "神经质 / 情绪敏感性中间区间：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/neuroticism-mid",
+    "seo": {
+      "title": "神经质 / 情绪敏感性中间区间怎么理解？大五人格中间区间复盘指南",
+      "description": "解释大五人格神经质 / 情绪敏感性中间区间的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "神经质 / 情绪敏感性中间区间",
+      "secondary_keywords": [
+        "情绪稳定性",
+        "压力反应",
+        "焦虑倾向",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "神经质 / 情绪敏感性中间区间不是好坏判断，也不是身份标签。它表示你在“压力反应、情绪敏感性、风险觉察和恢复节奏”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "压力反应会随任务、睡眠、关系和控制感变化。中间区间提醒你不要只看人格分数，也要看最近环境负荷：同一个人会在不同阶段表现出不同敏感度。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，神经质 / 情绪敏感性中间区间能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把神经质 / 情绪敏感性中间区间放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，神经质 / 情绪敏感性中间区间可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "复盘一个压力事件：触发点是什么，身体信号是什么，最早的可干预动作是什么，恢复用了多久。目标是建立恢复脚本，不是诊断自己。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "中间区间是不是更好？",
+        "answer": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/neuroticism",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "openness-high",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "开放性高分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/openness-high",
+    "seo": {
+      "title": "开放性高分怎么理解？大五人格高分倾向复盘指南",
+      "description": "解释大五人格开放性高分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "开放性高分",
+      "secondary_keywords": [
+        "OCEAN开放性",
+        "好奇心",
+        "想象力",
+        "审美敏感性"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "开放性高分不是好坏判断，也不是身份标签。它表示你在“对新经验、抽象想法、审美体验和变化的开放程度”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "容易被新概念、复杂问题、跨学科知识和未验证的可能性吸引。高开放者常能提出新角度，也更愿意试错。代价是可能过度发散、低估执行摩擦，或把新鲜感误当成有效性。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，开放性高分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把开放性高分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，开放性高分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "用一个真实任务复盘：先列出三个新方案，再写下证据、成本、最小试验。最后只保留一个可执行动作。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分是不是更好？",
+        "answer": "不是。高分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "openness-low",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "开放性低分：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/openness-low",
+    "seo": {
+      "title": "开放性低分怎么理解？大五人格低分倾向复盘指南",
+      "description": "解释大五人格开放性低分的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "开放性低分",
+      "secondary_keywords": [
+        "OCEAN开放性",
+        "好奇心",
+        "想象力",
+        "审美敏感性"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "开放性低分不是好坏判断，也不是身份标签。它表示你在“对新经验、抽象想法、审美体验和变化的开放程度”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "更偏好明确、熟悉、可验证的路径。低开放不是保守无能，而是更重视稳定性、现实检验和低噪音执行。代价是可能错过早期机会，或对模糊想法过早关闭。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，开放性低分能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把开放性低分放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，开放性低分可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "用一个真实任务复盘：先列出三个新方案，再写下证据、成本、最小试验。最后只保留一个可执行动作。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "低分是不是更好？",
+        "answer": "不是。低分只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "openness-mid",
+    "locale": "zh-CN",
+    "content_type": "trait_range_page",
+    "title": "开放性中间区间：大五人格区间解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/openness-mid",
+    "seo": {
+      "title": "开放性中间区间怎么理解？大五人格中间区间复盘指南",
+      "description": "解释大五人格开放性中间区间的常见表现、优势代价、工作学习、关系沟通和复盘方法。",
+      "primary_keyword": "开放性中间区间",
+      "secondary_keywords": [
+        "OCEAN开放性",
+        "好奇心",
+        "想象力",
+        "审美敏感性"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "开放性中间区间不是好坏判断，也不是身份标签。它表示你在“对新经验、抽象想法、审美体验和变化的开放程度”这一类场景中，某种倾向更容易被观察到。费马测试（FermatMind）建议把它当作复盘线索：看它在什么场景中帮你解决问题，又在什么场景中增加成本。"
+      },
+      {
+        "heading": "这个区间常见表现",
+        "body": "会在探索和落地之间切换。中间区间不是没有特点，而是更看重场景：当风险可控、时间充足时愿意尝试；当任务明确、成本较高时更偏向已验证方案。"
+      },
+      {
+        "heading": "可能的优势",
+        "body": "在匹配环境里，开放性中间区间能形成清楚的默认策略。它可能帮助你更快判断优先级、选择沟通方式、分配注意力，或在压力下保持某种稳定反应。优势不是静态标签，而是倾向与任务要求匹配时产生的效果。"
+      },
+      {
+        "heading": "可能的代价",
+        "body": "同一个倾向换到另一种场景就可能变成成本。过度依赖默认策略时，人会忽略环境变化、他人反馈和长期消耗。阅读这个页面时，不要问“我是不是这样的人”，而要问“这个反应什么时候有效，什么时候开始拖累我”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "把开放性中间区间放进具体任务里看：任务是否清晰，反馈是否及时，协作对象是谁，失败成本多高，恢复时间够不够。只凭一次表现判断人格很容易误读。更可靠的做法是连续记录三到五个相似事件，再找共同模式。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "在关系里，这个区间不应用来评价别人。更好的表达方式是把人格判断翻译成具体请求，例如“我需要更明确的截止时间”“我希望先讨论风险”“我需要会后文字确认”。这样能减少标签化，也更容易让对方知道下一步怎么配合。"
+      },
+      {
+        "heading": "压力信号",
+        "body": "当压力升高时，开放性中间区间可能被放大，也可能被掩盖。请同时记录睡眠、时间压力、关系冲突和身体信号。大五解释的是倾向，不是临床状态；如果压力已经影响日常功能，应优先寻求专业支持。"
+      },
+      {
+        "heading": "复盘动作",
+        "body": "用一个真实任务复盘：先列出三个新方案，再写下证据、成本、最小试验。最后只保留一个可执行动作。 每次复盘只保留一个行动调整：一个提醒、一个边界、一个检查点或一个恢复动作。行动越小，越容易验证。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页只用于自我认知、职业探索和能力成长中的结构化复盘。它不是医疗诊断、心理健康评估、招聘筛选、升学录取、收入预测或法律金融决策工具。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。\n\n很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。\n\n不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。\n\n不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。\n\n不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "中间区间是不是更好？",
+        "answer": "不是。中间区间只表示某种倾向更常出现，是否有效取决于任务、关系和压力状态。"
+      },
+      {
+        "question": "如果我和描述不完全一样怎么办？",
+        "answer": "很正常。人格维度是连续分布，真实表现会受场景、年龄、训练、近期压力和资源影响。"
+      },
+      {
+        "question": "这个页面能替代测试结果吗？",
+        "answer": "不能。它只是帮助你理解结果区间，不能替代完整测评、长期观察和真实反馈。"
+      },
+      {
+        "question": "可以用来评价别人吗？",
+        "answer": "不建议。更适合把它作为自我整理和沟通澄清工具，而不是给别人贴标签。"
+      },
+      {
+        "question": "能判断职业适合度吗？",
+        "answer": "不能预测职业、录用或收入。它只能辅助理解工作方式、压力来源和协作偏好。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five-30-day-review",
+    "locale": "zh-CN",
+    "content_type": "result_review_page",
+    "title": "如何用大五做 30 天自我观察",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/big-five-30-day-review",
+    "seo": {
+      "title": "如何用大五做 30 天自我观察｜费马测试大五人格指南",
+      "description": "把大五结果转化为30天行为记录、压力信号和行动调整。",
+      "primary_keyword": "如何用大五做 30 天自我观察",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "30 天自我观察的目标不是证明人格标签，而是把大五结果转化为可复盘的行为记录。每天只记录一个事件，关注场景、反应、代价和下一步动作。这样能避免把测试结果停留在“像不像我”的讨论里。"
+      },
+      {
+        "heading": "第 1 周：建立观察语言",
+        "body": "第一周只做记录，不急着改变。每天选择一个小事件：一次任务启动、一次沟通、一次压力反应或一次学习中断。写下发生了什么、你怎么反应、结果如何。最后标注可能相关的一个维度，不要一次套用五个维度。"
+      },
+      {
+        "heading": "第 2 周：寻找重复模式",
+        "body": "第二周开始看重复触发。你是否总在任务模糊时拖延？是否在关系冲突中先让步？是否在高刺激环境中恢复慢？如果一个模式至少出现三次，才值得进入行动调整。"
+      },
+      {
+        "heading": "第 3 周：设计小动作",
+        "body": "第三周只改一个动作。高开放可以增加收敛检查，高尽责可以减少过度计划，低外向可以提前准备表达，高宜人可以练习边界句，高神经质可以建立压力恢复脚本。动作要小到当天能完成。"
+      },
+      {
+        "heading": "第 4 周：复盘成本与收益",
+        "body": "第四周比较改变前后：效率是否提高，误解是否减少，压力是否更可管理，恢复是否更快。不要只看成功，也要看新动作有没有引入新成本。"
+      },
+      {
+        "heading": "记录模板",
+        "body": "建议使用四列：场景、默认反应、影响、下次动作。可选第五列是相关维度。不要把记录写成自我批判，也不要让人格解释替代真实原因。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "30 天观察不是心理治疗、诊断工具或职业规划结论。它只是把大五结果转成日常复盘的方法。如果压力或情绪问题持续影响生活，应寻求专业支持。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "5 分钟足够。关键是连续和具体。\n\n不必须。两周也能看到初步模式，30 天更适合稳定复盘。\n\n以真实记录为准，测试结果只是参考。\n\n可以，但要用于互相理解，不要互相评价。\n\n每次只改一个可执行动作，不要试图一次改变人格。"
+      },
+      {
+        "heading": "内容资产建议",
+        "body": "30 天复盘页适合做成可下载或可复制的表格，但表格内容仍应由 CMS 管理。字段建议包括日期、场景、相关维度、默认反应、当时收益、后续成本、下次动作。不要记录私人订单号、报告链接或可识别个人信息。"
+      },
+      {
+        "heading": "审核重点",
+        "body": "这类页面容易被写成“训练人格”或“改变命运”的承诺。审核时要保留低风险表达：观察、复盘、调整、验证。不要承诺用户 30 天后会变得更自律、更外向或关系更好。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "每天要记录多久？",
+        "answer": "5 分钟足够。关键是连续和具体。"
+      },
+      {
+        "question": "必须记录 30 天吗？",
+        "answer": "不必须。两周也能看到初步模式，30 天更适合稳定复盘。"
+      },
+      {
+        "question": "如果记录和结果不一致怎么办？",
+        "answer": "以真实记录为准，测试结果只是参考。"
+      },
+      {
+        "question": "可以和朋友一起做吗？",
+        "answer": "可以，但要用于互相理解，不要互相评价。"
+      },
+      {
+        "question": "最重要的原则是什么？",
+        "answer": "每次只改一个可执行动作，不要试图一次改变人格。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "big-five-score-ranges",
+    "locale": "zh-CN",
+    "content_type": "result_review_page",
+    "title": "大五人格高/中/低分不是好坏判断",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/big-five-score-ranges",
+    "seo": {
+      "title": "大五人格高/中/低分不是好坏判断｜费马测试大五人格指南",
+      "description": "解释高分、中间区间和低分的边界，避免价值化和标签化理解。",
+      "primary_keyword": "大五人格高/中/低分不是好坏判断",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "大五人格的高分、中间区间和低分不是价值等级。它们描述的是倾向强弱和行为方向，不代表能力、品德、心理健康或未来结果。公开页面必须避免把高分写成优越，也不能把低分写成缺陷。"
+      },
+      {
+        "heading": "高分怎么理解",
+        "body": "高分表示某种倾向更容易出现。例如高开放更容易探索新想法，高尽责更容易计划和收尾，高外向更容易通过互动获得能量。高分的优势通常很明显，但代价也会更明显：越强的倾向，越可能在不匹配场景里变成负担。"
+      },
+      {
+        "heading": "低分怎么理解",
+        "body": "低分不是反面评价，而是另一侧策略。例如低开放可能更重视稳定和验证，低外向可能更擅长独立整理，低神经质可能恢复更快。低分也有代价：可能错过探索、延迟表达、低估预警或让他人误读。"
+      },
+      {
+        "heading": "中间区间怎么理解",
+        "body": "中间区间最容易被写得无聊，但它很重要。它通常说明行为更受场景影响：在熟悉任务中一种表现，在高压或陌生任务中另一种表现。中间区间用户需要更多场景记录，而不是更强标签。"
+      },
+      {
+        "heading": "为什么不能价值化",
+        "body": "人格结果一旦被价值化，就容易变成焦虑营销或自我贴标签。费马测试的大五资产应强调“优势与代价并存”：每个维度都要问适配条件，而不是问好坏排名。"
+      },
+      {
+        "heading": "页面设计建议",
+        "body": "每个区间页都应包含常见表现、优势、代价、误读、工作学习、关系沟通、压力信号和复盘动作。这样既能承接 SEO 长尾，也能帮助用户把结果转成行动。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不提供心理诊断、能力判断、职业录用建议或升学判断。当前公开说明中暂不提供具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分只是倾向更明显，也意味着代价可能更明显。\n\n不是。低分代表另一侧倾向，可能在某些任务中更有效。\n\n重点写情境依赖、触发条件和复盘方法。\n\n不建议。大五不应用作人格优劣排名。\n\n只有经过人工审核、内容足够具体且 CMS 权威发布后才建议收录。"
+      },
+      {
+        "heading": "内容资产建议",
+        "body": "区间页应成为维度页和结果页之间的桥。维度页解释概念，区间页解释“我的分数落在某个区域时怎么读”。如果后端未来支持分数 band，CMS 可以把每个 band 对应到具体页面；如果暂不支持，页面仍应保持通用，不显示伪造阈值。"
+      },
+      {
+        "heading": "审核重点",
+        "body": "不要写具体百分位、常模或阈值，除非后端和公开证据明确支持。可以写“高分倾向”“中间区间”“低分倾向”，但不要写“80 分以上”“超过 90% 的人”等未证实数字。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分一定更好吗？",
+        "answer": "不是。高分只是倾向更明显，也意味着代价可能更明显。"
+      },
+      {
+        "question": "低分是不是缺点？",
+        "answer": "不是。低分代表另一侧倾向，可能在某些任务中更有效。"
+      },
+      {
+        "question": "中间分怎么写才有价值？",
+        "answer": "重点写情境依赖、触发条件和复盘方法。"
+      },
+      {
+        "question": "可以比较两个人谁更好吗？",
+        "answer": "不建议。大五不应用作人格优劣排名。"
+      },
+      {
+        "question": "区间页是否应该收录？",
+        "answer": "只有经过人工审核、内容足够具体且 CMS 权威发布后才建议收录。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "discuss-results-with-others",
+    "locale": "zh-CN",
+    "content_type": "result_review_page",
+    "title": "如何和朋友、伴侣、同事讨论大五结果",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/discuss-results-with-others",
+    "seo": {
+      "title": "如何和朋友、伴侣、同事讨论大五结果｜费马测试大五人格指南",
+      "description": "把人格结果用于沟通澄清，而不是指责、控制或贴标签。",
+      "primary_keyword": "如何和朋友、伴侣、同事讨论大五结果",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "讨论大五结果时，目标应该是澄清沟通和协作方式，而不是证明谁对谁错。人格结果越具体，越要避免被用作标签、借口或控制工具。费马测试建议把结果翻译成场景、需求和下一步动作。"
+      },
+      {
+        "heading": "讨论前先做自我整理",
+        "body": "先问自己三个问题：我想让对方理解什么？这个结果对应哪些真实事件？我希望下次有什么具体变化？如果只能说“我就是这样的人”，说明讨论还不够成熟。更好的说法是“在截止时间不明确时，我会反复确认；我希望我们提前约定检查点”。"
+      },
+      {
+        "heading": "朋友关系中的用法",
+        "body": "朋友之间可以用大五解释相处节奏，比如一个人需要更多社交，一个人需要更多独处。重点不是要求对方完全适应自己，而是找到可协商的边界：多久联系一次，哪些话题需要提前说，冲突后如何恢复。"
+      },
+      {
+        "heading": "伴侣关系中的用法",
+        "body": "伴侣讨论时尤其要避免把结果当武器。高宜人不是必须让步，低宜人不是可以冷漠，高神经质不是“太敏感”，低神经质也不是“没心没肺”。把评价改成请求，把分数改成具体场景。"
+      },
+      {
+        "heading": "同事协作中的用法",
+        "body": "同事之间更适合讨论工作方式，而不是人格本身。可以说“我更适合会前收到材料”“我需要明确 owner 和截止时间”“我会后用文字补充观点”。不要把大五结果用于人事筛选、绩效判断或团队标签。"
+      },
+      {
+        "heading": "防止误用的句式",
+        "body": "避免：“你就是高神经质”“你低宜人所以难合作”。推荐：“在临时变化时，我们需要更早同步风险”“我需要你直接指出问题，但也希望给出可执行建议”。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页是沟通辅助，不是关系诊断、伴侣匹配、团队评估或 HR 工具。任何关系建议都需要结合真实互动、边界、信任和具体情境。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "可以，但不要包含私人订单、报告链接或可识别敏感信息。\n\n回到具体事件，而不是争论人格标签。\n\n公开内容不支持招聘、人事筛选或绩效判断。\n\n只能提供一个观察角度，不能替代真实沟通和责任承担。\n\n用“场景 + 感受/成本 + 具体请求”替代人格评价。"
+      },
+      {
+        "heading": "内容资产建议",
+        "body": "这页应和隐私边界一起审核。用户可以分享公开解释页，但不应公开私人测评报告链接、订单信息、attempt id、找回信息或支付信息。页面应鼓励分享“解释框架”和“沟通请求”，而不是分享可识别的个人结果。"
+      },
+      {
+        "heading": "审核重点",
+        "body": "避免把大五用于团队筛选、伴侣匹配或关系诊断。可以写“用于沟通澄清”，不能写“判断对方是否适合你”。如果未来做结果分享功能，也必须经过隐私和索引边界审核。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "可以公开分享结果吗？",
+        "answer": "可以，但不要包含私人订单、报告链接或可识别敏感信息。"
+      },
+      {
+        "question": "对方不同意我的解释怎么办？",
+        "answer": "回到具体事件，而不是争论人格标签。"
+      },
+      {
+        "question": "适合在团队里统一测试吗？",
+        "answer": "公开内容不支持招聘、人事筛选或绩效判断。"
+      },
+      {
+        "question": "结果可以解释关系冲突吗？",
+        "answer": "只能提供一个观察角度，不能替代真实沟通和责任承担。"
+      },
+      {
+        "question": "最安全的讨论方式是什么？",
+        "answer": "用“场景 + 感受/成本 + 具体请求”替代人格评价。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "how-to-read-big-five-results",
+    "locale": "zh-CN",
+    "content_type": "result_review_page",
+    "title": "如何读懂大五人格结果",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/how-to-read-big-five-results",
+    "seo": {
+      "title": "如何读懂大五人格结果｜费马测试大五人格指南",
+      "description": "从五个连续维度、分数区间和真实场景三个层面阅读大五结果。",
+      "primary_keyword": "如何读懂大五人格结果",
+      "secondary_keywords": [
+        "大五人格",
+        "OCEAN",
+        "自我认知"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "快速回答",
+        "body": "读大五人格结果时，不要先问“我是哪种人”，而要看五个连续维度如何共同影响你的行为。每个分数都只是结构化参考，不是身份判决。费马测试（FermatMind）建议按三个层次阅读：维度含义、分数区间、真实场景。"
+      },
+      {
+        "heading": "第一步：先看维度，不急着下结论",
+        "body": "开放性、尽责性、外向性、宜人性和神经质分别描述不同倾向。一个维度不能解释全部行为。例如拖延可能与尽责性有关，也可能与任务模糊、压力过高、反馈太慢或兴趣不足有关。先理解维度，再看它是否真的出现在生活事件里。"
+      },
+      {
+        "heading": "第二步：看高/中/低区间",
+        "body": "高分不是优秀，低分不是缺陷。高分通常表示某种倾向更明显，低分表示另一侧倾向更明显，中间区间常常更依赖场景。不要把中间区间理解成没有特点，也不要把极端分数理解成无法改变。"
+      },
+      {
+        "heading": "第三步：放回真实场景",
+        "body": "结果页最有价值的问题是：这个倾向在什么任务里帮了我？在什么关系里造成误解？在什么压力下被放大？如果分数和真实经验冲突，应优先记录更多事件，而不是强行接受页面描述。"
+      },
+      {
+        "heading": "建议的阅读顺序",
+        "body": "先读总览，再读分数最高和最低的两个维度，之后读对应高/中/低区间页。最后选择一个结果复盘页，例如 30 天自我观察或和他人讨论结果。不要一次读完所有页面后得出固定身份结论。"
+      },
+      {
+        "heading": "常见误读",
+        "body": "不要把大五当成职业预测、伴侣匹配、心理诊断或能力评估。大五能帮助你组织观察，但不能替代长期行为记录、专业判断和具体决策信息。"
+      },
+      {
+        "heading": "行动建议",
+        "body": "选一个最近一周的真实事件，写下：场景、默认反应、结果、成本、下次动作。每次只关联一到两个维度。过度解释会让人格模型变成借口，而不是复盘工具。"
+      },
+      {
+        "heading": "方法边界",
+        "body": "本页不提供诊断、录用建议、升学建议、金融或法律判断。任何职业、关系或压力管理建议都只能作为反思线索，不能替代专业服务或具体决策。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "没有绝对优劣，必须结合场景。\n\n不是。中间区间通常表示情境依赖更强。\n\n人格倾向相对稳定，但表达方式会受环境、年龄、训练和压力影响。\n\n不能推断职业发展结果或收入，只能辅助理解工作方式。\n\n记录真实事件，把一个倾向转化成一个可测试行动。"
+      },
+      {
+        "heading": "内容资产建议",
+        "body": "这页应作为所有大五公开页的阅读总入口。它需要连接测试页、五个维度页、十五个区间页、组合页和结果复盘页。CMS 中建议保留 ordered_reading_path 字段，让前端按审核后的顺序渲染，不要在前端硬编码阅读路径。"
+      },
+      {
+        "heading": "审核重点",
+        "body": "结果阅读页最容易滑向“解释个人命运”。审核时要检查每个段落是否仍停留在结构化参考和工作假设层面。凡是出现“决定、预测、证明、最适合、一定”这类表达，都应改成“可能、倾向、线索、需要结合场景验证”。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "分数高低是否有优劣？",
+        "answer": "没有绝对优劣，必须结合场景。"
+      },
+      {
+        "question": "中间分是不是没特点？",
+        "answer": "不是。中间区间通常表示情境依赖更强。"
+      },
+      {
+        "question": "结果会变化吗？",
+        "answer": "人格倾向相对稳定，但表达方式会受环境、年龄、训练和压力影响。"
+      },
+      {
+        "question": "能用结果判断职业吗？",
+        "answer": "不能推断职业发展结果或收入，只能辅助理解工作方式。"
+      },
+      {
+        "question": "读完结果后最该做什么？",
+        "answer": "记录真实事件，把一个倾向转化成一个可测试行动。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/openness",
+      "/zh/personality/big-five/conscientiousness"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "agreeableness",
+    "locale": "en-US",
+    "content_type": "trait_page",
+    "title": "Agreeableness: Big Five Trait Guide",
+    "status": "draft_review_required",
+    "canonical_path": "/en/personality/big-five/agreeableness",
+    "seo": {
+      "title": "Agreeableness in the Big Five Personality Model",
+      "description": "Understand Agreeableness as a continuous Big Five trait, including high, mid, and low tendencies, practical use cases, and interpretation boundaries.",
+      "primary_keyword": "Big Five Agreeableness",
+      "secondary_keywords": [
+        "OCEAN personality",
+        "personality traits",
+        "self-reflection"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "What this trait describes",
+        "body": "Agreeableness describes cooperation, trust, empathy, conflict style, and concern for interpersonal harmony. FermatMind presents it as a continuous tendency, not as a fixed identity or a clinical label. The point of the page is to help a user notice when this tendency appears, what it helps, what it costs, and what adjustment might be useful in the next real situation."
+      },
+      {
+        "heading": "High, mid, and low ranges",
+        "body": "A high Agreeableness range often means the person defaults toward relationship repair and collaborative signals when the situation makes that trait relevant. A mid range means behavior may shift strongly with context, role, fatigue, incentives, and relationship safety. A low range does not mean a flaw; it often points toward direct boundaries and critical evaluation. Public FermatMind content should avoid treating high as better or low as worse."
+      },
+      {
+        "heading": "Work and learning use cases",
+        "body": "In work and learning, Agreeableness is most useful when connected to a concrete task. Ask what the task demanded, how your default response helped, and where it created friction. For example, the same trait pattern may be helpful in one phase and costly in another: exploration, planning, discussion, delivery, feedback, and recovery each reward different defaults."
+      },
+      {
+        "heading": "Communication and relationship use cases",
+        "body": "In communication, use Agreeableness language as a request-making tool rather than a label. Instead of saying “this is just my trait,” translate the observation into a collaboration rule: what information you need earlier, what pace works better, what kind of feedback helps, or what boundary prevents unnecessary strain."
+      },
+      {
+        "heading": "Common misunderstanding",
+        "body": "The main misunderstanding is to turn a score into a moral ranking or a prediction. Big Five scores should not decide whether someone is capable, trustworthy, hireable, compatible, or likely to succeed. They are better used as structured notes for reflection and discussion."
+      },
+      {
+        "heading": "Review prompts",
+        "body": "For the next two weeks, review situations where Agreeableness felt relevant. Write down the situation, your first reaction, the benefit, the cost, and one small adjustment. If the pattern does not repeat, do not force the trait explanation. If it does repeat, treat it as a working hypothesis to test, not a permanent identity."
+      },
+      {
+        "heading": "Method boundary",
+        "body": "FermatMind uses Big Five results for self-understanding, career exploration, communication review, and skill growth. It is not a medical, hiring, admissions, legal, or financial decision tool. Public materials currently do not provide specific reliability, validity, norm, or percentile values unless separately documented and reviewed."
+      },
+      {
+        "heading": "Draft and indexability boundary",
+        "body": "This English trait page remains draft-review content. It can support CMS manual review and importer dry-run validation, but it should not enter English SEO expansion, sitemap, llms, or JSON-LD runtime until editorial parity and claim boundaries are approved."
+      },
+      {
+        "heading": "FAQ",
+        "body": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response.\n\nNo. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes.\n\nNo. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions.\n\nUse the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit.\n\nIt still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is a high Agreeableness score better?",
+        "answer": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response."
+      },
+      {
+        "question": "Can Agreeableness infer career outcomes?",
+        "answer": "No. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes."
+      },
+      {
+        "question": "Is Agreeableness a diagnosis?",
+        "answer": "No. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions."
+      },
+      {
+        "question": "What should I do if the description only partly fits?",
+        "answer": "Use the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit."
+      },
+      {
+        "question": "Why does this English page remain draft-only?",
+        "answer": "It still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "internal_links": [
+      "/en/personality/big-five",
+      "/en/personality/big-five/how-to-read-big-five-results"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "agreeableness",
+    "locale": "zh-CN",
+    "content_type": "trait_page",
+    "title": "宜人性：大五人格维度解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/agreeableness",
+    "seo": {
+      "title": "宜人性是什么？大五人格宜人性高低分与复盘方法",
+      "description": "理解大五人格宜人性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。",
+      "primary_keyword": "宜人性",
+      "secondary_keywords": [
+        "合作倾向",
+        "共情",
+        "冲突沟通",
+        "人际边界"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "这个维度在描述什么",
+        "body": "宜人性不是身份标签，也不是能力评级。它描述的是人在一类场景中的稳定倾向：更常用什么方式理解信息、安排行动、处理关系或回应压力。费马测试（FermatMind）把大五结果视为结构化参考和工作假设，适合用来复盘行为模式，但不用于医疗诊断、职业录用、升学录取或金融法律决策。"
+      },
+      {
+        "heading": "高分倾向",
+        "body": "更重视关系质量、他人感受、合作氛围和冲突缓和。通常愿意先理解对方立场。"
+      },
+      {
+        "heading": "中间区间",
+        "body": "能在合作与自我保护之间切换。对熟人、陌生人、竞争场景的反应可能差异明显。 中间区间尤其不适合被解释成“没有特点”。更准确的理解是：你的行为表达更依赖场景、对象、目标压力和资源状态。"
+      },
+      {
+        "heading": "低分倾向",
+        "body": "更直接、怀疑、重视原则和利益边界。面对不合理要求时，更容易拒绝或提出质疑。 低分不是缺陷，它只是说明你更常从另一套策略出发。低分在稳定性、边界、现实检验或低刺激环境中可能有明显优势。"
+      },
+      {
+        "heading": "优势与代价并存",
+        "body": "高宜人性有利于信任建立、团队协作、服务沟通和关系修复；低宜人性有利于谈判、质疑、风险识别和原则维护。 但同一个倾向在另一个场景里会产生代价。高分可能过度迁就、难以拒绝或把冲突私人化；低分可能被误读为强硬，也可能忽视情绪成本。 因此，阅读大五结果时不要问“这个分数好不好”，而要问“这个倾向在什么场景中帮了我，在什么场景中增加了成本”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "学习和工作中，高分者适合做协作协调，但要设边界；低分者适合做审查和决策把关，但要避免只输出否定。 如果要把结果用于学习或工作复盘，应记录具体任务：任务是否清晰、反馈是否及时、协作对象是谁、压力持续多久。不要把一次失败直接归因于人格，也不要用一个维度解释所有表现。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "高分者容易先照顾关系，低分者容易先处理问题。有效沟通要同时给出事实、需求和边界。 大五结果在关系中最有价值的用途，不是判断谁对谁错，而是帮助双方把模糊评价翻译成可执行沟通。例如“你总是这样”可以改写为“在截止日前两天，我需要更明确的更新节奏”。"
+      },
+      {
+        "heading": "压力 / 复盘场景",
+        "body": "压力下，高宜人性可能压抑不满，低宜人性可能直接升级冲突。复盘要问：我表达了真实需求吗？我有没有保留对方可回应的空间？ 复盘时建议写下三个问题：当时的触发是什么？我的默认反应是什么？这个反应解决了什么，又制造了什么成本？"
+      },
+      {
+        "heading": "如何使用这个维度做复盘",
+        "body": "练习一句边界表达：我理解你的需要，但我现在能做到的是X，不能做到的是Y。宜人性不是牺牲自己换和平。 建议连续记录七天，每天只记一个微场景：事件、反应、结果、下次调整。不要一次写长篇人格分析，过度解释会削弱行动价值。"
+      },
+      {
+        "heading": "不要这样理解",
+        "body": "宜人性高不是软弱，低也不是坏人。它不是道德标签，而是合作与冲突中的默认策略。 也不要把这个维度用于给朋友、伴侣、同事贴标签。公开页面只能提供解释框架，不能替代当事人的具体经历和真实沟通。"
+      },
+      {
+        "heading": "SEO / GEO 摘要",
+        "body": "- Primary keyword: 宜人性, 大五人格宜人性\n- Secondary keywords: 合作倾向, 共情, 冲突沟通, 人际边界\n- Search intent: informational / self-reflection\n- Suggested URL slug: agreeableness\n- Title tag: 宜人性是什么？大五人格宜人性高低分与复盘方法\n- Meta description: 理解大五人格宜人性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。\n- Structured data recommendation: FAQPage\n- Indexability gate: manual_review_required"
+      },
+      {
+        "heading": "内部链接建议",
+        "body": "- /zh/personality/big-five\n- /zh/personality/big-five/how-to-read-big-five-results\n- /zh/personality/big-five/big-five-score-ranges\n- /zh/personality/big-five/big-five-30-day-review\n- /zh/personality/big-five/big-five-vs-mbti"
+      },
+      {
+        "heading": "方法边界",
+        "body": "费马测试（FermatMind）的大五人格公开内容只用于自我认知、职业探索和能力成长中的结构化复盘。它不是临床诊断，不是心理健康评估，不是招聘、人事筛选、升学录取、收入预测或法律金融决策工具。除非未来公开说明中提供经过审核的证据，否则本页面不声明具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。\n\n不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。\n\n中间区间通常表示情境依赖更强，不应被简单解释为没有特点。\n\n不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。\n\n不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。\n\n把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分一定更好吗？",
+        "answer": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。"
+      },
+      {
+        "question": "低分是不是缺点？",
+        "answer": "不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。"
+      },
+      {
+        "question": "中间区间怎么理解？",
+        "answer": "中间区间通常表示情境依赖更强，不应被简单解释为没有特点。"
+      },
+      {
+        "question": "这个维度能预测职业吗？",
+        "answer": "不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。"
+      },
+      {
+        "question": "这个结果会固定不变吗？",
+        "answer": "不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。"
+      },
+      {
+        "question": "应该怎么用这个页面？",
+        "answer": "把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "conscientiousness",
+    "locale": "en-US",
+    "content_type": "trait_page",
+    "title": "Conscientiousness: Big Five Trait Guide",
+    "status": "draft_review_required",
+    "canonical_path": "/en/personality/big-five/conscientiousness",
+    "seo": {
+      "title": "Conscientiousness in the Big Five Personality Model",
+      "description": "Understand Conscientiousness as a continuous Big Five trait, including high, mid, and low tendencies, practical use cases, and interpretation boundaries.",
+      "primary_keyword": "Big Five Conscientiousness",
+      "secondary_keywords": [
+        "OCEAN personality",
+        "personality traits",
+        "self-reflection"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "What this trait describes",
+        "body": "Conscientiousness describes organization, follow-through, planning, reliability, and preference for clear standards. FermatMind presents it as a continuous tendency, not as a fixed identity or a clinical label. The point of the page is to help a user notice when this tendency appears, what it helps, what it costs, and what adjustment might be useful in the next real situation."
+      },
+      {
+        "heading": "High, mid, and low ranges",
+        "body": "A high Conscientiousness range often means the person defaults toward structure and sustained execution when the situation makes that trait relevant. A mid range means behavior may shift strongly with context, role, fatigue, incentives, and relationship safety. A low range does not mean a flaw; it often points toward flexibility and tolerance for loose plans. Public FermatMind content should avoid treating high as better or low as worse."
+      },
+      {
+        "heading": "Work and learning use cases",
+        "body": "In work and learning, Conscientiousness is most useful when connected to a concrete task. Ask what the task demanded, how your default response helped, and where it created friction. For example, the same trait pattern may be helpful in one phase and costly in another: exploration, planning, discussion, delivery, feedback, and recovery each reward different defaults."
+      },
+      {
+        "heading": "Communication and relationship use cases",
+        "body": "In communication, use Conscientiousness language as a request-making tool rather than a label. Instead of saying “this is just my trait,” translate the observation into a collaboration rule: what information you need earlier, what pace works better, what kind of feedback helps, or what boundary prevents unnecessary strain."
+      },
+      {
+        "heading": "Common misunderstanding",
+        "body": "The main misunderstanding is to turn a score into a moral ranking or a prediction. Big Five scores should not decide whether someone is capable, trustworthy, hireable, compatible, or likely to succeed. They are better used as structured notes for reflection and discussion."
+      },
+      {
+        "heading": "Review prompts",
+        "body": "For the next two weeks, review situations where Conscientiousness felt relevant. Write down the situation, your first reaction, the benefit, the cost, and one small adjustment. If the pattern does not repeat, do not force the trait explanation. If it does repeat, treat it as a working hypothesis to test, not a permanent identity."
+      },
+      {
+        "heading": "Method boundary",
+        "body": "FermatMind uses Big Five results for self-understanding, career exploration, communication review, and skill growth. It is not a medical, hiring, admissions, legal, or financial decision tool. Public materials currently do not provide specific reliability, validity, norm, or percentile values unless separately documented and reviewed."
+      },
+      {
+        "heading": "Draft and indexability boundary",
+        "body": "This English trait page remains draft-review content. It can support CMS manual review and importer dry-run validation, but it should not enter English SEO expansion, sitemap, llms, or JSON-LD runtime until editorial parity and claim boundaries are approved."
+      },
+      {
+        "heading": "FAQ",
+        "body": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response.\n\nNo. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes.\n\nNo. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions.\n\nUse the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit.\n\nIt still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is a high Conscientiousness score better?",
+        "answer": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response."
+      },
+      {
+        "question": "Can Conscientiousness infer career outcomes?",
+        "answer": "No. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes."
+      },
+      {
+        "question": "Is Conscientiousness a diagnosis?",
+        "answer": "No. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions."
+      },
+      {
+        "question": "What should I do if the description only partly fits?",
+        "answer": "Use the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit."
+      },
+      {
+        "question": "Why does this English page remain draft-only?",
+        "answer": "It still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "internal_links": [
+      "/en/personality/big-five",
+      "/en/personality/big-five/how-to-read-big-five-results"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "conscientiousness",
+    "locale": "zh-CN",
+    "content_type": "trait_page",
+    "title": "尽责性：大五人格维度解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/conscientiousness",
+    "seo": {
+      "title": "尽责性是什么？大五人格尽责性高低分与复盘方法",
+      "description": "理解大五人格尽责性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。",
+      "primary_keyword": "尽责性",
+      "secondary_keywords": [
+        "自律",
+        "计划性",
+        "责任感",
+        "执行力"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "这个维度在描述什么",
+        "body": "尽责性不是身份标签，也不是能力评级。它描述的是人在一类场景中的稳定倾向：更常用什么方式理解信息、安排行动、处理关系或回应压力。费马测试（FermatMind）把大五结果视为结构化参考和工作假设，适合用来复盘行为模式，但不用于医疗诊断、职业录用、升学录取或金融法律决策。"
+      },
+      {
+        "heading": "高分倾向",
+        "body": "更重视计划、秩序、承诺和完成度。面对任务时，倾向于拆步骤、设期限、检查细节。"
+      },
+      {
+        "heading": "中间区间",
+        "body": "能在重要任务中保持计划，但在低价值或高不确定任务中可能更随性。执行强度取决于目标清晰度。 中间区间尤其不适合被解释成“没有特点”。更准确的理解是：你的行为表达更依赖场景、对象、目标压力和资源状态。"
+      },
+      {
+        "heading": "低分倾向",
+        "body": "更灵活、即时、抗形式化约束。可能不喜欢过早固定计划，更依赖兴趣、外部提醒或临场反应。 低分不是缺陷，它只是说明你更常从另一套策略出发。低分在稳定性、边界、现实检验或低刺激环境中可能有明显优势。"
+      },
+      {
+        "heading": "优势与代价并存",
+        "body": "高尽责性有利于长期项目、质量控制、备考、交付和复盘。低尽责性在快速变化、临场应对和非标准任务中也可能更轻便。 但同一个倾向在另一个场景里会产生代价。高分可能变成过度控制、完美主义或无法容忍混乱；低分可能出现拖延、遗漏和承诺管理困难。 因此，阅读大五结果时不要问“这个分数好不好”，而要问“这个倾向在什么场景中帮了我，在什么场景中增加了成本”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "学习上，高分适合周期计划和错题复盘；低分更需要外部结构，如番茄钟、任务伙伴、可视化进度和低启动成本。 如果要把结果用于学习或工作复盘，应记录具体任务：任务是否清晰、反馈是否及时、协作对象是谁、压力持续多久。不要把一次失败直接归因于人格，也不要用一个维度解释所有表现。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "高分者可能把“准时、回应、按计划”视为尊重；低分者可能更看重空间和弹性。沟通时要明确最低交付标准。 大五结果在关系中最有价值的用途，不是判断谁对谁错，而是帮助双方把模糊评价翻译成可执行沟通。例如“你总是这样”可以改写为“在截止日前两天，我需要更明确的更新节奏”。"
+      },
+      {
+        "heading": "压力 / 复盘场景",
+        "body": "高尽责压力下容易把所有问题都变成责任问题；低尽责压力下容易回避启动。复盘要区分：我是在修系统，还是在自责？ 复盘时建议写下三个问题：当时的触发是什么？我的默认反应是什么？这个反应解决了什么，又制造了什么成本？"
+      },
+      {
+        "heading": "如何使用这个维度做复盘",
+        "body": "把一个任务拆成“最低可交付版本、理想版本、放弃条件”。尽责性不是把所有事情做满，而是把重要事情做稳。 建议连续记录七天，每天只记一个微场景：事件、反应、结果、下次调整。不要一次写长篇人格分析，过度解释会削弱行动价值。"
+      },
+      {
+        "heading": "不要这样理解",
+        "body": "尽责性高不是道德更好，低也不是不可靠的标签。它是行为组织方式，不是人格优劣。 也不要把这个维度用于给朋友、伴侣、同事贴标签。公开页面只能提供解释框架，不能替代当事人的具体经历和真实沟通。"
+      },
+      {
+        "heading": "SEO / GEO 摘要",
+        "body": "- Primary keyword: 尽责性, 大五人格尽责性\n- Secondary keywords: 自律, 计划性, 责任感, 执行力\n- Search intent: informational / self-reflection\n- Suggested URL slug: conscientiousness\n- Title tag: 尽责性是什么？大五人格尽责性高低分与复盘方法\n- Meta description: 理解大五人格尽责性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。\n- Structured data recommendation: FAQPage\n- Indexability gate: manual_review_required"
+      },
+      {
+        "heading": "内部链接建议",
+        "body": "- /zh/personality/big-five\n- /zh/personality/big-five/how-to-read-big-five-results\n- /zh/personality/big-five/big-five-score-ranges\n- /zh/personality/big-five/big-five-30-day-review\n- /zh/personality/big-five/big-five-vs-mbti"
+      },
+      {
+        "heading": "方法边界",
+        "body": "费马测试（FermatMind）的大五人格公开内容只用于自我认知、职业探索和能力成长中的结构化复盘。它不是临床诊断，不是心理健康评估，不是招聘、人事筛选、升学录取、收入预测或法律金融决策工具。除非未来公开说明中提供经过审核的证据，否则本页面不声明具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。\n\n不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。\n\n中间区间通常表示情境依赖更强，不应被简单解释为没有特点。\n\n不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。\n\n不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。\n\n把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分一定更好吗？",
+        "answer": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。"
+      },
+      {
+        "question": "低分是不是缺点？",
+        "answer": "不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。"
+      },
+      {
+        "question": "中间区间怎么理解？",
+        "answer": "中间区间通常表示情境依赖更强，不应被简单解释为没有特点。"
+      },
+      {
+        "question": "这个维度能预测职业吗？",
+        "answer": "不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。"
+      },
+      {
+        "question": "这个结果会固定不变吗？",
+        "answer": "不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。"
+      },
+      {
+        "question": "应该怎么用这个页面？",
+        "answer": "把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "extraversion",
+    "locale": "en-US",
+    "content_type": "trait_page",
+    "title": "Extraversion: Big Five Trait Guide",
+    "status": "draft_review_required",
+    "canonical_path": "/en/personality/big-five/extraversion",
+    "seo": {
+      "title": "Extraversion in the Big Five Personality Model",
+      "description": "Understand Extraversion as a continuous Big Five trait, including high, mid, and low tendencies, practical use cases, and interpretation boundaries.",
+      "primary_keyword": "Big Five Extraversion",
+      "secondary_keywords": [
+        "OCEAN personality",
+        "personality traits",
+        "self-reflection"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "What this trait describes",
+        "body": "Extraversion describes social energy, assertive expression, pace, stimulation seeking, and comfort with visible interaction. FermatMind presents it as a continuous tendency, not as a fixed identity or a clinical label. The point of the page is to help a user notice when this tendency appears, what it helps, what it costs, and what adjustment might be useful in the next real situation."
+      },
+      {
+        "heading": "High, mid, and low ranges",
+        "body": "A high Extraversion range often means the person defaults toward interaction and external feedback when the situation makes that trait relevant. A mid range means behavior may shift strongly with context, role, fatigue, incentives, and relationship safety. A low range does not mean a flaw; it often points toward quiet processing and lower-stimulation environments. Public FermatMind content should avoid treating high as better or low as worse."
+      },
+      {
+        "heading": "Work and learning use cases",
+        "body": "In work and learning, Extraversion is most useful when connected to a concrete task. Ask what the task demanded, how your default response helped, and where it created friction. For example, the same trait pattern may be helpful in one phase and costly in another: exploration, planning, discussion, delivery, feedback, and recovery each reward different defaults."
+      },
+      {
+        "heading": "Communication and relationship use cases",
+        "body": "In communication, use Extraversion language as a request-making tool rather than a label. Instead of saying “this is just my trait,” translate the observation into a collaboration rule: what information you need earlier, what pace works better, what kind of feedback helps, or what boundary prevents unnecessary strain."
+      },
+      {
+        "heading": "Common misunderstanding",
+        "body": "The main misunderstanding is to turn a score into a moral ranking or a prediction. Big Five scores should not decide whether someone is capable, trustworthy, hireable, compatible, or likely to succeed. They are better used as structured notes for reflection and discussion."
+      },
+      {
+        "heading": "Review prompts",
+        "body": "For the next two weeks, review situations where Extraversion felt relevant. Write down the situation, your first reaction, the benefit, the cost, and one small adjustment. If the pattern does not repeat, do not force the trait explanation. If it does repeat, treat it as a working hypothesis to test, not a permanent identity."
+      },
+      {
+        "heading": "Method boundary",
+        "body": "FermatMind uses Big Five results for self-understanding, career exploration, communication review, and skill growth. It is not a medical, hiring, admissions, legal, or financial decision tool. Public materials currently do not provide specific reliability, validity, norm, or percentile values unless separately documented and reviewed."
+      },
+      {
+        "heading": "Draft and indexability boundary",
+        "body": "This English trait page remains draft-review content. It can support CMS manual review and importer dry-run validation, but it should not enter English SEO expansion, sitemap, llms, or JSON-LD runtime until editorial parity and claim boundaries are approved."
+      },
+      {
+        "heading": "FAQ",
+        "body": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response.\n\nNo. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes.\n\nNo. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions.\n\nUse the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit.\n\nIt still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is a high Extraversion score better?",
+        "answer": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response."
+      },
+      {
+        "question": "Can Extraversion infer career outcomes?",
+        "answer": "No. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes."
+      },
+      {
+        "question": "Is Extraversion a diagnosis?",
+        "answer": "No. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions."
+      },
+      {
+        "question": "What should I do if the description only partly fits?",
+        "answer": "Use the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit."
+      },
+      {
+        "question": "Why does this English page remain draft-only?",
+        "answer": "It still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "internal_links": [
+      "/en/personality/big-five",
+      "/en/personality/big-five/how-to-read-big-five-results"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "extraversion",
+    "locale": "zh-CN",
+    "content_type": "trait_page",
+    "title": "外向性：大五人格维度解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/extraversion",
+    "seo": {
+      "title": "外向性是什么？大五人格外向性高低分与复盘方法",
+      "description": "理解大五人格外向性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。",
+      "primary_keyword": "外向性",
+      "secondary_keywords": [
+        "社交能量",
+        "表达方式",
+        "内向外向",
+        "刺激偏好"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "这个维度在描述什么",
+        "body": "外向性不是身份标签，也不是能力评级。它描述的是人在一类场景中的稳定倾向：更常用什么方式理解信息、安排行动、处理关系或回应压力。费马测试（FermatMind）把大五结果视为结构化参考和工作假设，适合用来复盘行为模式，但不用于医疗诊断、职业录用、升学录取或金融法律决策。"
+      },
+      {
+        "heading": "高分倾向",
+        "body": "更容易从互动、表达、现场反馈和外部刺激中获得能量。想法往往在说出来的过程中变清楚。"
+      },
+      {
+        "heading": "中间区间",
+        "body": "可社交也需要独处，能根据任务切换表达模式。社交消耗取决于对象、节奏和控制感。 中间区间尤其不适合被解释成“没有特点”。更准确的理解是：你的行为表达更依赖场景、对象、目标压力和资源状态。"
+      },
+      {
+        "heading": "低分倾向",
+        "body": "更偏好低刺激环境、深度思考和少量高质量互动。表达不一定少，只是更需要准备和边界。 低分不是缺陷，它只是说明你更常从另一套策略出发。低分在稳定性、边界、现实检验或低刺激环境中可能有明显优势。"
+      },
+      {
+        "heading": "优势与代价并存",
+        "body": "高外向性有利于快速连接、现场协作、公开表达和机会捕捉；低外向性有利于深度加工、稳定专注和高质量一对一沟通。 但同一个倾向在另一个场景里会产生代价。高分可能忽略倾听和恢复时间，低分可能错过弱连接机会或被误读为冷淡。 因此，阅读大五结果时不要问“这个分数好不好”，而要问“这个倾向在什么场景中帮了我，在什么场景中增加了成本”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "学习上，高外向者可通过讲解、讨论和模拟面试加深理解；低外向者适合书面输出、预演和独立深读。 如果要把结果用于学习或工作复盘，应记录具体任务：任务是否清晰、反馈是否及时、协作对象是谁、压力持续多久。不要把一次失败直接归因于人格，也不要用一个维度解释所有表现。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "高外向者需要即时反馈，低外向者需要反应时间。沟通时可约定：哪些事需要当场说，哪些事适合书面整理。 大五结果在关系中最有价值的用途，不是判断谁对谁错，而是帮助双方把模糊评价翻译成可执行沟通。例如“你总是这样”可以改写为“在截止日前两天，我需要更明确的更新节奏”。"
+      },
+      {
+        "heading": "压力 / 复盘场景",
+        "body": "压力下，高外向者可能不断找人讨论却不沉淀；低外向者可能过度退回内部。复盘记录：互动是在解决问题，还是在消耗问题？ 复盘时建议写下三个问题：当时的触发是什么？我的默认反应是什么？这个反应解决了什么，又制造了什么成本？"
+      },
+      {
+        "heading": "如何使用这个维度做复盘",
+        "body": "为关键沟通设置两段式流程：先书面列三点，再现场讨论十五分钟。让表达强度服务于问题，而不是替代思考。 建议连续记录七天，每天只记一个微场景：事件、反应、结果、下次调整。不要一次写长篇人格分析，过度解释会削弱行动价值。"
+      },
+      {
+        "heading": "不要这样理解",
+        "body": "外向性低不是社恐，外向性高也不是肤浅。它描述能量来源和刺激偏好，不是社交能力的全部。 也不要把这个维度用于给朋友、伴侣、同事贴标签。公开页面只能提供解释框架，不能替代当事人的具体经历和真实沟通。"
+      },
+      {
+        "heading": "SEO / GEO 摘要",
+        "body": "- Primary keyword: 外向性, 大五人格外向性\n- Secondary keywords: 社交能量, 表达方式, 内向外向, 刺激偏好\n- Search intent: informational / self-reflection\n- Suggested URL slug: extraversion\n- Title tag: 外向性是什么？大五人格外向性高低分与复盘方法\n- Meta description: 理解大五人格外向性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。\n- Structured data recommendation: FAQPage\n- Indexability gate: manual_review_required"
+      },
+      {
+        "heading": "内部链接建议",
+        "body": "- /zh/personality/big-five\n- /zh/personality/big-five/how-to-read-big-five-results\n- /zh/personality/big-five/big-five-score-ranges\n- /zh/personality/big-five/big-five-30-day-review\n- /zh/personality/big-five/big-five-vs-mbti"
+      },
+      {
+        "heading": "方法边界",
+        "body": "费马测试（FermatMind）的大五人格公开内容只用于自我认知、职业探索和能力成长中的结构化复盘。它不是临床诊断，不是心理健康评估，不是招聘、人事筛选、升学录取、收入预测或法律金融决策工具。除非未来公开说明中提供经过审核的证据，否则本页面不声明具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。\n\n不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。\n\n中间区间通常表示情境依赖更强，不应被简单解释为没有特点。\n\n不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。\n\n不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。\n\n把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分一定更好吗？",
+        "answer": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。"
+      },
+      {
+        "question": "低分是不是缺点？",
+        "answer": "不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。"
+      },
+      {
+        "question": "中间区间怎么理解？",
+        "answer": "中间区间通常表示情境依赖更强，不应被简单解释为没有特点。"
+      },
+      {
+        "question": "这个维度能预测职业吗？",
+        "answer": "不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。"
+      },
+      {
+        "question": "这个结果会固定不变吗？",
+        "answer": "不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。"
+      },
+      {
+        "question": "应该怎么用这个页面？",
+        "answer": "把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "neuroticism",
+    "locale": "en-US",
+    "content_type": "trait_page",
+    "title": "Neuroticism: Big Five Trait Guide",
+    "status": "draft_review_required",
+    "canonical_path": "/en/personality/big-five/neuroticism",
+    "seo": {
+      "title": "Neuroticism in the Big Five Personality Model",
+      "description": "Understand Neuroticism as a continuous Big Five trait, including high, mid, and low tendencies, practical use cases, and interpretation boundaries.",
+      "primary_keyword": "Big Five Neuroticism",
+      "secondary_keywords": [
+        "OCEAN personality",
+        "personality traits",
+        "self-reflection"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "What this trait describes",
+        "body": "Neuroticism describes emotional reactivity, threat sensitivity, worry, and recovery after stress. FermatMind presents it as a continuous tendency, not as a fixed identity or a clinical label. The point of the page is to help a user notice when this tendency appears, what it helps, what it costs, and what adjustment might be useful in the next real situation."
+      },
+      {
+        "heading": "High, mid, and low ranges",
+        "body": "A high Neuroticism range often means the person defaults toward early risk detection and emotional signal awareness when the situation makes that trait relevant. A mid range means behavior may shift strongly with context, role, fatigue, incentives, and relationship safety. A low range does not mean a flaw; it often points toward calm recovery and lower threat activation. Public FermatMind content should avoid treating high as better or low as worse."
+      },
+      {
+        "heading": "Work and learning use cases",
+        "body": "In work and learning, Neuroticism is most useful when connected to a concrete task. Ask what the task demanded, how your default response helped, and where it created friction. For example, the same trait pattern may be helpful in one phase and costly in another: exploration, planning, discussion, delivery, feedback, and recovery each reward different defaults."
+      },
+      {
+        "heading": "Communication and relationship use cases",
+        "body": "In communication, use Neuroticism language as a request-making tool rather than a label. Instead of saying “this is just my trait,” translate the observation into a collaboration rule: what information you need earlier, what pace works better, what kind of feedback helps, or what boundary prevents unnecessary strain."
+      },
+      {
+        "heading": "Common misunderstanding",
+        "body": "The main misunderstanding is to turn a score into a moral ranking or a prediction. Big Five scores should not decide whether someone is capable, trustworthy, hireable, compatible, or likely to succeed. They are better used as structured notes for reflection and discussion."
+      },
+      {
+        "heading": "Review prompts",
+        "body": "For the next two weeks, review situations where Neuroticism felt relevant. Write down the situation, your first reaction, the benefit, the cost, and one small adjustment. If the pattern does not repeat, do not force the trait explanation. If it does repeat, treat it as a working hypothesis to test, not a permanent identity."
+      },
+      {
+        "heading": "Method boundary",
+        "body": "FermatMind uses Big Five results for self-understanding, career exploration, communication review, and skill growth. It is not a medical, hiring, admissions, legal, or financial decision tool. Public materials currently do not provide specific reliability, validity, norm, or percentile values unless separately documented and reviewed."
+      },
+      {
+        "heading": "Draft and indexability boundary",
+        "body": "This English trait page remains draft-review content. It can support CMS manual review and importer dry-run validation, but it should not enter English SEO expansion, sitemap, llms, or JSON-LD runtime until editorial parity and claim boundaries are approved."
+      },
+      {
+        "heading": "FAQ",
+        "body": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response.\n\nNo. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes.\n\nNo. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions.\n\nUse the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit.\n\nIt still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is a high Neuroticism score better?",
+        "answer": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response."
+      },
+      {
+        "question": "Can Neuroticism infer career outcomes?",
+        "answer": "No. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes."
+      },
+      {
+        "question": "Is Neuroticism a diagnosis?",
+        "answer": "No. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions."
+      },
+      {
+        "question": "What should I do if the description only partly fits?",
+        "answer": "Use the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit."
+      },
+      {
+        "question": "Why does this English page remain draft-only?",
+        "answer": "It still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "internal_links": [
+      "/en/personality/big-five",
+      "/en/personality/big-five/how-to-read-big-five-results"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "neuroticism",
+    "locale": "zh-CN",
+    "content_type": "trait_page",
+    "title": "神经质 / 情绪敏感性：大五人格维度解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/neuroticism",
+    "seo": {
+      "title": "神经质 / 情绪敏感性是什么？大五人格神经质 / 情绪敏感性高低分与复盘方法",
+      "description": "理解大五人格神经质 / 情绪敏感性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。",
+      "primary_keyword": "神经质",
+      "secondary_keywords": [
+        "情绪稳定性",
+        "压力反应",
+        "焦虑倾向",
+        "自我复盘"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "这个维度在描述什么",
+        "body": "神经质 / 情绪敏感性不是身份标签，也不是能力评级。它描述的是人在一类场景中的稳定倾向：更常用什么方式理解信息、安排行动、处理关系或回应压力。费马测试（FermatMind）把大五结果视为结构化参考和工作假设，适合用来复盘行为模式，但不用于医疗诊断、职业录用、升学录取或金融法律决策。"
+      },
+      {
+        "heading": "高分倾向",
+        "body": "更容易觉察风险、压力、批评和不确定性，情绪波动或担忧信号出现得更早。"
+      },
+      {
+        "heading": "中间区间",
+        "body": "在普通压力下较稳定，但在高风险、高关系成本或长期疲劳时仍会出现明显情绪反应。 中间区间尤其不适合被解释成“没有特点”。更准确的理解是：你的行为表达更依赖场景、对象、目标压力和资源状态。"
+      },
+      {
+        "heading": "低分倾向",
+        "body": "更不容易被日常压力扰动，恢复速度可能较快。也可能低估问题严重性或忽略他人情绪信号。 低分不是缺陷，它只是说明你更常从另一套策略出发。低分在稳定性、边界、现实检验或低刺激环境中可能有明显优势。"
+      },
+      {
+        "heading": "优势与代价并存",
+        "body": "高分的优势是风险敏感、预警能力和对细微变化的捕捉；低分的优势是稳定、冷静和抗压恢复。 但同一个倾向在另一个场景里会产生代价。高分可能反复担忧、过度解释信号、把压力事件人格化；低分可能反应迟钝、轻视风险或缺少共情反馈。 因此，阅读大五结果时不要问“这个分数好不好”，而要问“这个倾向在什么场景中帮了我，在什么场景中增加了成本”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "学习和工作中，高分者需要明确任务边界、反馈节奏和恢复动作；低分者需要主动检查风险清单，避免过度乐观。 如果要把结果用于学习或工作复盘，应记录具体任务：任务是否清晰、反馈是否及时、协作对象是谁、压力持续多久。不要把一次失败直接归因于人格，也不要用一个维度解释所有表现。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "高分者需要更清楚的安全信号，低分者可能不理解对方为何紧张。沟通时可把情绪翻译成具体请求。 大五结果在关系中最有价值的用途，不是判断谁对谁错，而是帮助双方把模糊评价翻译成可执行沟通。例如“你总是这样”可以改写为“在截止日前两天，我需要更明确的更新节奏”。"
+      },
+      {
+        "heading": "压力 / 复盘场景",
+        "body": "压力下，高分者容易进入反复思考；低分者容易推迟处理。复盘建议记录触发、身体信号、想法、行动、恢复效果。 复盘时建议写下三个问题：当时的触发是什么？我的默认反应是什么？这个反应解决了什么，又制造了什么成本？"
+      },
+      {
+        "heading": "如何使用这个维度做复盘",
+        "body": "把一次压力事件拆成五列：触发、信号、解释、恢复动作、下次边界。目标不是消灭情绪，而是让情绪可观察、可沟通。 建议连续记录七天，每天只记一个微场景：事件、反应、结果、下次调整。不要一次写长篇人格分析，过度解释会削弱行动价值。"
+      },
+      {
+        "heading": "不要这样理解",
+        "body": "神经质不是临床诊断，也不等于心理疾病。低神经质也不等于心理更健康。这里描述的是压力反应倾向，不是医学判断。 也不要把这个维度用于给朋友、伴侣、同事贴标签。公开页面只能提供解释框架，不能替代当事人的具体经历和真实沟通。"
+      },
+      {
+        "heading": "SEO / GEO 摘要",
+        "body": "- Primary keyword: 神经质, 情绪敏感性, 大五人格神经质\n- Secondary keywords: 情绪稳定性, 压力反应, 焦虑倾向, 自我复盘\n- Search intent: informational / self-reflection\n- Suggested URL slug: neuroticism\n- Title tag: 神经质 / 情绪敏感性是什么？大五人格神经质 / 情绪敏感性高低分与复盘方法\n- Meta description: 理解大五人格神经质 / 情绪敏感性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。\n- Structured data recommendation: FAQPage\n- Indexability gate: manual_review_required"
+      },
+      {
+        "heading": "内部链接建议",
+        "body": "- /zh/personality/big-five\n- /zh/personality/big-five/how-to-read-big-five-results\n- /zh/personality/big-five/big-five-score-ranges\n- /zh/personality/big-five/big-five-30-day-review\n- /zh/personality/big-five/big-five-vs-mbti"
+      },
+      {
+        "heading": "方法边界",
+        "body": "费马测试（FermatMind）的大五人格公开内容只用于自我认知、职业探索和能力成长中的结构化复盘。它不是临床诊断，不是心理健康评估，不是招聘、人事筛选、升学录取、收入预测或法律金融决策工具。除非未来公开说明中提供经过审核的证据，否则本页面不声明具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。\n\n不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。\n\n中间区间通常表示情境依赖更强，不应被简单解释为没有特点。\n\n不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。\n\n不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。\n\n把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分一定更好吗？",
+        "answer": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。"
+      },
+      {
+        "question": "低分是不是缺点？",
+        "answer": "不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。"
+      },
+      {
+        "question": "中间区间怎么理解？",
+        "answer": "中间区间通常表示情境依赖更强，不应被简单解释为没有特点。"
+      },
+      {
+        "question": "这个维度能预测职业吗？",
+        "answer": "不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。"
+      },
+      {
+        "question": "这个结果会固定不变吗？",
+        "answer": "不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。"
+      },
+      {
+        "question": "应该怎么用这个页面？",
+        "answer": "把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "openness",
+    "locale": "en-US",
+    "content_type": "trait_page",
+    "title": "Openness: Big Five Trait Guide",
+    "status": "draft_review_required",
+    "canonical_path": "/en/personality/big-five/openness",
+    "seo": {
+      "title": "Openness in the Big Five Personality Model",
+      "description": "Understand Openness as a continuous Big Five trait, including high, mid, and low tendencies, practical use cases, and interpretation boundaries.",
+      "primary_keyword": "Big Five Openness",
+      "secondary_keywords": [
+        "OCEAN personality",
+        "personality traits",
+        "self-reflection"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "What this trait describes",
+        "body": "Openness describes curiosity, imagination, aesthetic sensitivity, and interest in unfamiliar ideas. FermatMind presents it as a continuous tendency, not as a fixed identity or a clinical label. The point of the page is to help a user notice when this tendency appears, what it helps, what it costs, and what adjustment might be useful in the next real situation."
+      },
+      {
+        "heading": "High, mid, and low ranges",
+        "body": "A high Openness range often means the person defaults toward novelty and conceptual exploration when the situation makes that trait relevant. A mid range means behavior may shift strongly with context, role, fatigue, incentives, and relationship safety. A low range does not mean a flaw; it often points toward practical continuity and familiar evidence. Public FermatMind content should avoid treating high as better or low as worse."
+      },
+      {
+        "heading": "Work and learning use cases",
+        "body": "In work and learning, Openness is most useful when connected to a concrete task. Ask what the task demanded, how your default response helped, and where it created friction. For example, the same trait pattern may be helpful in one phase and costly in another: exploration, planning, discussion, delivery, feedback, and recovery each reward different defaults."
+      },
+      {
+        "heading": "Communication and relationship use cases",
+        "body": "In communication, use Openness language as a request-making tool rather than a label. Instead of saying “this is just my trait,” translate the observation into a collaboration rule: what information you need earlier, what pace works better, what kind of feedback helps, or what boundary prevents unnecessary strain."
+      },
+      {
+        "heading": "Common misunderstanding",
+        "body": "The main misunderstanding is to turn a score into a moral ranking or a prediction. Big Five scores should not decide whether someone is capable, trustworthy, hireable, compatible, or likely to succeed. They are better used as structured notes for reflection and discussion."
+      },
+      {
+        "heading": "Review prompts",
+        "body": "For the next two weeks, review situations where Openness felt relevant. Write down the situation, your first reaction, the benefit, the cost, and one small adjustment. If the pattern does not repeat, do not force the trait explanation. If it does repeat, treat it as a working hypothesis to test, not a permanent identity."
+      },
+      {
+        "heading": "Method boundary",
+        "body": "FermatMind uses Big Five results for self-understanding, career exploration, communication review, and skill growth. It is not a medical, hiring, admissions, legal, or financial decision tool. Public materials currently do not provide specific reliability, validity, norm, or percentile values unless separately documented and reviewed."
+      },
+      {
+        "heading": "Draft and indexability boundary",
+        "body": "This English trait page remains draft-review content. It can support CMS manual review and importer dry-run validation, but it should not enter English SEO expansion, sitemap, llms, or JSON-LD runtime until editorial parity and claim boundaries are approved."
+      },
+      {
+        "heading": "FAQ",
+        "body": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response.\n\nNo. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes.\n\nNo. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions.\n\nUse the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit.\n\nIt still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is a high Openness score better?",
+        "answer": "No. High and low ranges both have strengths and trade-offs. The right interpretation depends on the situation and the cost of the default response."
+      },
+      {
+        "question": "Can Openness infer career outcomes?",
+        "answer": "No. It may support reflection about working style and collaboration preferences, but it should not be used to predict career, hiring, income, or admission outcomes."
+      },
+      {
+        "question": "Is Openness a diagnosis?",
+        "answer": "No. It is not a clinical or medical assessment, and FermatMind does not use it to diagnose mental health conditions."
+      },
+      {
+        "question": "What should I do if the description only partly fits?",
+        "answer": "Use the page as a hypothesis. Return to specific situations and keep the parts that match repeated behavior; ignore what does not fit."
+      },
+      {
+        "question": "Why does this English page remain draft-only?",
+        "answer": "It still requires separate English editorial parity, CMS review, and SEO/GEO approval before public indexation or schema runtime release."
+      }
+    ],
+    "internal_links": [
+      "/en/personality/big-five",
+      "/en/personality/big-five/how-to-read-big-five-results"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  },
+  {
+    "slug": "openness",
+    "locale": "zh-CN",
+    "content_type": "trait_page",
+    "title": "开放性：大五人格维度解释",
+    "status": "draft_review_required",
+    "canonical_path": "/zh/personality/big-five/openness",
+    "seo": {
+      "title": "开放性是什么？大五人格开放性高低分与复盘方法",
+      "description": "理解大五人格开放性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。",
+      "primary_keyword": "开放性",
+      "secondary_keywords": [
+        "OCEAN开放性",
+        "好奇心",
+        "想象力",
+        "审美敏感性"
+      ]
+    },
+    "body_sections": [
+      {
+        "heading": "这个维度在描述什么",
+        "body": "开放性不是身份标签，也不是能力评级。它描述的是人在一类场景中的稳定倾向：更常用什么方式理解信息、安排行动、处理关系或回应压力。费马测试（FermatMind）把大五结果视为结构化参考和工作假设，适合用来复盘行为模式，但不用于医疗诊断、职业录用、升学录取或金融法律决策。"
+      },
+      {
+        "heading": "高分倾向",
+        "body": "更容易被新概念、复杂问题、审美体验和抽象可能性吸引。遇到未知任务时，先问“还有没有别的解释”。"
+      },
+      {
+        "heading": "中间区间",
+        "body": "既能接受新方案，也需要看到现实收益。对新事物的兴趣会受到时间成本、风险和场景压力影响。 中间区间尤其不适合被解释成“没有特点”。更准确的理解是：你的行为表达更依赖场景、对象、目标压力和资源状态。"
+      },
+      {
+        "heading": "低分倾向",
+        "body": "更偏好熟悉、明确、可验证的路径。面对模糊想法时，会优先要求定义、流程和可落地证据。 低分不是缺陷，它只是说明你更常从另一套策略出发。低分在稳定性、边界、现实检验或低刺激环境中可能有明显优势。"
+      },
+      {
+        "heading": "优势与代价并存",
+        "body": "能在变化环境中提出新角度，连接不同知识域，适合早期探索、概念构建、内容创意和复杂问题拆解。 但同一个倾向在另一个场景里会产生代价。容易过度发散、低估执行摩擦，也可能把“新鲜”误当成“有效”。低分则可能错过创新机会，但在稳定交付中更有优势。 因此，阅读大五结果时不要问“这个分数好不好”，而要问“这个倾向在什么场景中帮了我，在什么场景中增加了成本”。"
+      },
+      {
+        "heading": "工作 / 学习场景",
+        "body": "学习上，高开放者适合用问题树、类比、跨学科笔记；低开放者适合用清单、案例和标准答案建立安全边界。 如果要把结果用于学习或工作复盘，应记录具体任务：任务是否清晰、反馈是否及时、协作对象是谁、压力持续多久。不要把一次失败直接归因于人格，也不要用一个维度解释所有表现。"
+      },
+      {
+        "heading": "关系 / 沟通场景",
+        "body": "高开放者沟通时容易跳跃，低开放者可能更需要具体例子。讨论分歧时，把“想象可能性”和“当前要执行什么”分开。 大五结果在关系中最有价值的用途，不是判断谁对谁错，而是帮助双方把模糊评价翻译成可执行沟通。例如“你总是这样”可以改写为“在截止日前两天，我需要更明确的更新节奏”。"
+      },
+      {
+        "heading": "压力 / 复盘场景",
+        "body": "压力下，高开放者可能继续扩展选项，导致迟迟不收敛；低开放者可能拒绝新信息。复盘时记录：我是在探索，还是在逃避决策？ 复盘时建议写下三个问题：当时的触发是什么？我的默认反应是什么？这个反应解决了什么，又制造了什么成本？"
+      },
+      {
+        "heading": "如何使用这个维度做复盘",
+        "body": "选择一个现实任务，先列出三个新方案，再用成本、证据、可测试性筛掉两个。开放性要落地，不是无限展开。 建议连续记录七天，每天只记一个微场景：事件、反应、结果、下次调整。不要一次写长篇人格分析，过度解释会削弱行动价值。"
+      },
+      {
+        "heading": "不要这样理解",
+        "body": "开放性高不等于聪明，开放性低不等于保守无能。它描述的是对新经验和抽象信息的偏好，不是智力或创造力的最终判定。 也不要把这个维度用于给朋友、伴侣、同事贴标签。公开页面只能提供解释框架，不能替代当事人的具体经历和真实沟通。"
+      },
+      {
+        "heading": "SEO / GEO 摘要",
+        "body": "- Primary keyword: 开放性, 大五人格开放性\n- Secondary keywords: OCEAN开放性, 好奇心, 想象力, 审美敏感性\n- Search intent: informational / self-reflection\n- Suggested URL slug: openness\n- Title tag: 开放性是什么？大五人格开放性高低分与复盘方法\n- Meta description: 理解大五人格开放性维度的高分、中间区间与低分倾向，以及它在学习、工作、沟通和压力复盘中的使用边界。\n- Structured data recommendation: FAQPage\n- Indexability gate: manual_review_required"
+      },
+      {
+        "heading": "内部链接建议",
+        "body": "- /zh/personality/big-five\n- /zh/personality/big-five/how-to-read-big-five-results\n- /zh/personality/big-five/big-five-score-ranges\n- /zh/personality/big-five/big-five-30-day-review\n- /zh/personality/big-five/big-five-vs-mbti"
+      },
+      {
+        "heading": "方法边界",
+        "body": "费马测试（FermatMind）的大五人格公开内容只用于自我认知、职业探索和能力成长中的结构化复盘。它不是临床诊断，不是心理健康评估，不是招聘、人事筛选、升学录取、收入预测或法律金融决策工具。除非未来公开说明中提供经过审核的证据，否则本页面不声明具体信度、效度、常模或百分位数值。"
+      },
+      {
+        "heading": "FAQ",
+        "body": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。\n\n不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。\n\n中间区间通常表示情境依赖更强，不应被简单解释为没有特点。\n\n不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。\n\n不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。\n\n把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "faq": [
+      {
+        "question": "高分一定更好吗？",
+        "answer": "不是。高分代表某类倾向更明显，但在不同环境中既有优势也有代价。"
+      },
+      {
+        "question": "低分是不是缺点？",
+        "answer": "不是。低分代表另一种稳定倾向，可能更适合某些任务和沟通方式。"
+      },
+      {
+        "question": "中间区间怎么理解？",
+        "answer": "中间区间通常表示情境依赖更强，不应被简单解释为没有特点。"
+      },
+      {
+        "question": "这个维度能预测职业吗？",
+        "answer": "不能作为职业、录用或收入预测。它只能辅助理解偏好、工作方式和复盘线索。"
+      },
+      {
+        "question": "这个结果会固定不变吗？",
+        "answer": "不应把结果当作永久身份。人格倾向相对稳定，但表达方式会受年龄、环境、压力和训练影响。"
+      },
+      {
+        "question": "应该怎么用这个页面？",
+        "answer": "把它当作观察框架：记录场景、行为、代价和恢复动作，而不是拿来给自己贴标签。"
+      }
+    ],
+    "internal_links": [
+      "/zh/personality/big-five",
+      "/zh/personality/big-five/how-to-read-big-five-results",
+      "/zh/personality/big-five/big-five-score-ranges"
+    ],
+    "claim_boundaries": [
+      "non_diagnostic",
+      "non_predictive",
+      "no_hiring_screening",
+      "no_specific_validation_metrics_without_public_evidence"
+    ],
+    "schema_recommendation": "FAQPage",
+    "indexability_gate": "manual_review_required"
+  }
+]

--- a/generated/big-five-content-polish/content_polish_report.json
+++ b/generated/big-five-content-polish/content_polish_report.json
@@ -1,0 +1,134 @@
+{
+  "source": "/Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json",
+  "output": "generated/big-five-content-polish/cms-import-draft.polished.json",
+  "total_rows": 42,
+  "locale_counts": {
+    "zh-CN": 36,
+    "en-US": 6
+  },
+  "content_type_counts": {
+    "combination_page": 6,
+    "cross_reading_page": 5,
+    "hub_page": 2,
+    "trait_range_page": 15,
+    "result_review_page": 4,
+    "trait_page": 10
+  },
+  "status_counts": {
+    "draft_review_required": 42
+  },
+  "indexability_gate_counts": {
+    "manual_review_required": 42
+  },
+  "short_route_residue": {
+    "/zh/big-five": 0,
+    "/en/big-five": 0
+  },
+  "bad_canonical_paths": [],
+  "english_pages": [
+    {
+      "id": "en-US:hub_page:big-five",
+      "words": 498,
+      "faq_count": 5,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "en-US:trait_page:agreeableness",
+      "words": 523,
+      "faq_count": 5,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "en-US:trait_page:conscientiousness",
+      "words": 522,
+      "faq_count": 5,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "en-US:trait_page:extraversion",
+      "words": 524,
+      "faq_count": 5,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "en-US:trait_page:neuroticism",
+      "words": 525,
+      "faq_count": 5,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "en-US:trait_page:openness",
+      "words": 521,
+      "faq_count": 5,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    }
+  ],
+  "zh_combination_pages": [
+    {
+      "id": "zh-CN:combination_page:high-agreeableness-high-neuroticism",
+      "cjk_chars": 827,
+      "faq_count": 5,
+      "repeated_generic_block_count_after_polish": 0,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "zh-CN:combination_page:high-openness-high-extraversion",
+      "cjk_chars": 836,
+      "faq_count": 5,
+      "repeated_generic_block_count_after_polish": 0,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "zh-CN:combination_page:high-openness-low-conscientiousness",
+      "cjk_chars": 874,
+      "faq_count": 5,
+      "repeated_generic_block_count_after_polish": 0,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "zh-CN:combination_page:low-agreeableness-high-conscientiousness",
+      "cjk_chars": 836,
+      "faq_count": 5,
+      "repeated_generic_block_count_after_polish": 0,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "zh-CN:combination_page:low-extraversion-high-conscientiousness",
+      "cjk_chars": 843,
+      "faq_count": 5,
+      "repeated_generic_block_count_after_polish": 0,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    },
+    {
+      "id": "zh-CN:combination_page:low-neuroticism-high-conscientiousness",
+      "cjk_chars": 822,
+      "faq_count": 5,
+      "repeated_generic_block_count_after_polish": 0,
+      "status": "draft_review_required",
+      "indexability_gate": "manual_review_required"
+    }
+  ],
+  "publish_allowed": false,
+  "seo_expansion_allowed": false,
+  "cms_write_performed": false,
+  "runtime_surface_changed": false,
+  "notes": [
+    "Polished package remains CMS/backend-authoritative draft review content.",
+    "FAQ body_sections are retained as visible draft content; importer dedupe policy must continue treating top-level faq as the structured FAQ source.",
+    "English pages remain draft-only and blocked from SEO expansion despite improved depth."
+  ],
+  "english_faq_count_issues": [],
+  "english_depth_issues": [],
+  "zh_combination_depth_issues": []
+}

--- a/generated/big-five-content-polish/content_polish_report.md
+++ b/generated/big-five-content-polish/content_polish_report.md
@@ -1,0 +1,56 @@
+# Big Five Content Polish 06
+
+Source: /Users/rainie/Desktop/fermatmind-big-five-public-assets-v2-repaired/cms/cms-import-draft.json
+Output: generated/big-five-content-polish/cms-import-draft.polished.json
+
+## Verdict
+
+- Status: polished_package_ready_for_no_write_importer_dry_run
+- Publish: blocked
+- SEO expansion: blocked
+- CMS write performed: no
+- Runtime surface changed: no
+
+## What Changed
+
+- Rewrote the 6 zh-CN combination pages with combination-specific advantages, risks, work/learning scenarios, relationship/communication scenarios, review actions, and manual review focus notes.
+- Deepened the 6 en-US draft pages while keeping them draft-only and blocked from English SEO expansion.
+- Expanded every en-US page FAQ from 3 to 5 question/answer entries.
+- Preserved `draft_review_required`, `manual_review_required`, CMS/backend authority, and non-diagnostic/non-predictive claim boundaries.
+
+## Validation Summary
+
+- Total rows: 42
+- Locale counts: {'zh-CN': 36, 'en-US': 6}
+- Content type counts: {'combination_page': 6, 'cross_reading_page': 5, 'hub_page': 2, 'trait_range_page': 15, 'result_review_page': 4, 'trait_page': 10}
+- Status counts: {'draft_review_required': 42}
+- Indexability gates: {'manual_review_required': 42}
+- Short route residue: {'/zh/big-five': 0, '/en/big-five': 0}
+- Bad canonical paths: 0
+- English FAQ count issues: 0
+- English depth issues under 450 words: 0
+- zh-CN combination pages under 800 CJK chars: 0
+
+## English Pages
+
+- en-US:hub_page:big-five: words=498, faq_count=5, status=draft_review_required, indexability_gate=manual_review_required
+- en-US:trait_page:agreeableness: words=523, faq_count=5, status=draft_review_required, indexability_gate=manual_review_required
+- en-US:trait_page:conscientiousness: words=522, faq_count=5, status=draft_review_required, indexability_gate=manual_review_required
+- en-US:trait_page:extraversion: words=524, faq_count=5, status=draft_review_required, indexability_gate=manual_review_required
+- en-US:trait_page:neuroticism: words=525, faq_count=5, status=draft_review_required, indexability_gate=manual_review_required
+- en-US:trait_page:openness: words=521, faq_count=5, status=draft_review_required, indexability_gate=manual_review_required
+
+## zh-CN Combination Pages
+
+- zh-CN:combination_page:high-agreeableness-high-neuroticism: cjk_chars=827, faq_count=5, repeated_generic_block_count_after_polish=0
+- zh-CN:combination_page:high-openness-high-extraversion: cjk_chars=836, faq_count=5, repeated_generic_block_count_after_polish=0
+- zh-CN:combination_page:high-openness-low-conscientiousness: cjk_chars=874, faq_count=5, repeated_generic_block_count_after_polish=0
+- zh-CN:combination_page:low-agreeableness-high-conscientiousness: cjk_chars=836, faq_count=5, repeated_generic_block_count_after_polish=0
+- zh-CN:combination_page:low-extraversion-high-conscientiousness: cjk_chars=843, faq_count=5, repeated_generic_block_count_after_polish=0
+- zh-CN:combination_page:low-neuroticism-high-conscientiousness: cjk_chars=822, faq_count=5, repeated_generic_block_count_after_polish=0
+
+## Remaining Boundaries
+
+- This package is for CMS manual review and backend importer no-write dry-run only.
+- Do not publish, index, enumerate in sitemap/llms, or emit JSON-LD runtime from this package.
+- English pages remain draft-only until a separate English editorial parity and SEO/GEO review approves expansion.


### PR DESCRIPTION
## What changed
- Added `generated/big-five-content-polish/cms-import-draft.polished.json` as a backend-side polished copy of the Big Five CMS draft package.
- Added JSON and Markdown polish reports under `generated/big-five-content-polish/`.
- Reconciled the previous train item `BIG5-TRAIN-LEDGER-CLOSEOUT-06` as merged in the PR train state.
- Recorded current PR local validation in `docs/codex/pr-train-state.json`.

## Why
- The v2 draft package was valid enough for review, but Chinese combination pages still had template-like blocks and English pages were thin with only 3 FAQ entries.
- This prepares a cleaner draft package for the next no-write backend importer dry-run while keeping all publishing and indexability gates closed.

## Validation
- `python3 -m json.tool generated/big-five-content-polish/cms-import-draft.polished.json >/dev/null`
- `python3 -m json.tool generated/big-five-content-polish/content_polish_report.json >/dev/null`
- Custom validation script confirmed: 42 rows, all `draft_review_required`, all `manual_review_required`, no short-route residue, no bad canonical paths, no empty body sections, en-US FAQ count >= 5, no English depth issues under 450 words, no zh-CN combination pages under 800 CJK chars, and zero mechanical forbidden-claim hits.
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Deferred items
- No CMS writes or production imports.
- No publishing.
- No sitemap, llms, JSON-LD runtime, or indexability release.
- No frontend/runtime changes.
- Importer dry-run remains scoped to `BIG5-CMS-IMPORT-DRYRUN-07`.

## Repository rule impact
- Backend-side generated draft package/report only. Content remains CMS/backend-authoritative and manual-review gated.
