### PR TITLE
IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01: add IQ method review approval workflow

### DIFF
--- a/backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php
+++ b/backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php
@@ -1,0 +1,417 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use JsonException;
+use RuntimeException;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Throwable;
+
+final class ArticleIqMethodPagesReviewApproval extends Command
+{
+    private const SCHEMA_VERSION = 'fermatmind.iq_method_pages.review_approval.v1';
+
+    private const PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01';
+
+    private const EXPECTED_STATUS = 'draft_review_only';
+
+    protected $signature = 'articles:iq-method-pages-review-approval
+        {--package= : Path to fap-web root, generated/iq-method-pages-zh-cn-v0.2, or its cms-dry-run directory}
+        {--review-packet= : Review packet JSON path}
+        {--article-lock=* : Exact lock in slug:article_id:working_revision_id form}
+        {--reviewed-by= : Admin user id or controlled reviewer actor id recorded on revisions in execute mode}
+        {--confirm= : Exact confirmation phrase required with --execute}
+        {--execute : Write approval metadata to the locked CMS drafts}
+        {--json : Emit a JSON summary}';
+
+    protected $description = 'Controlled approval workflow for zh-CN IQ method CMS Article working revisions without publishing or indexing.';
+
+    public function handle(): int
+    {
+        try {
+            $summary = $this->approve();
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function approve(): array
+    {
+        $execute = (bool) $this->option('execute');
+        $reviewedBy = (int) $this->option('reviewed-by');
+        $issues = [];
+        $gate = $this->runPublishGate($issues);
+        $locks = $this->parseLocks($issues);
+        $packetPath = $this->reviewPacketPath();
+        $packetSha = is_file($packetPath) ? hash_file('sha256', $packetPath) : null;
+        $expectedConfirmation = $this->expectedConfirmation($packetSha, $locks);
+
+        if ($reviewedBy <= 0) {
+            $issues[] = $this->issue('reviewed_by', 'reviewed_by_required', '--reviewed-by must be a positive actor id.');
+        }
+
+        if ($execute && ! hash_equals($expectedConfirmation, trim((string) $this->option('confirm')))) {
+            $issues[] = $this->issue('confirm', 'confirmation_mismatch', 'Exact confirmation phrase is required before review approval writes.', [
+                'expected_confirmation' => $expectedConfirmation,
+            ]);
+        }
+
+        $plans = $this->plansFromGate($gate, $locks, $issues);
+        $written = [];
+
+        if ($issues === [] && $execute) {
+            $written = DB::transaction(function () use ($plans, $reviewedBy, $packetPath, $packetSha): array {
+                return $this->writeApprovals($plans, $reviewedBy, $packetPath, (string) $packetSha);
+            });
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $issues === [],
+            'status' => $issues === [] ? ($execute ? 'approved' : 'dry_run_pass') : 'blocked',
+            'dry_run' => ! $execute,
+            'execute' => $execute,
+            'generated_at' => now()->toIso8601String(),
+            'pr_id' => self::PR_ID,
+            'source_gate_pr_id' => (string) ($gate['pr_id'] ?? ''),
+            'review_packet' => [
+                'path' => $packetPath,
+                'sha256' => $packetSha,
+                'packet_id' => (string) data_get($gate, 'review_packet.packet_id', ''),
+            ],
+            'reviewed_by' => $reviewedBy > 0 ? $reviewedBy : null,
+            'expected_confirmation' => $expectedConfirmation,
+            'expected_article_count' => 7,
+            'article_locks' => array_values($locks),
+            'articles' => $plans,
+            'approved_articles' => $written,
+            'issues' => $issues,
+            'side_effects' => [
+                'db_write' => $execute && $issues === [],
+                'cms_update' => $execute && $issues === [],
+                'review_approval' => $execute && $issues === [],
+                'publish' => false,
+                'indexability' => false,
+                'sitemap' => false,
+                'llms' => false,
+                'deploy' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function runPublishGate(array &$issues): array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('articles:iq-method-pages-publish-gate', [
+            '--package' => (string) $this->option('package'),
+            '--review-packet' => (string) $this->option('review-packet'),
+            '--json' => true,
+        ], $output);
+
+        try {
+            $decoded = json_decode($output->fetch(), true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            $issues[] = $this->issue('publish_gate', 'invalid_publish_gate_json', $exception->getMessage());
+
+            return [];
+        }
+
+        if (! is_array($decoded)) {
+            $issues[] = $this->issue('publish_gate', 'invalid_publish_gate_json', 'Publish gate output must be a JSON object.');
+
+            return [];
+        }
+
+        if ($exit !== self::SUCCESS || ($decoded['ok'] ?? false) !== true || (int) ($decoded['approval_candidate_count'] ?? 0) !== 7) {
+            $issues[] = $this->issue('publish_gate', 'publish_gate_not_passed', 'Publish gate must pass before review approval writes.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,array{slug:string,article_id:int,working_revision_id:int}>
+     */
+    private function parseLocks(array &$issues): array
+    {
+        $locks = [];
+        foreach ((array) $this->option('article-lock') as $index => $raw) {
+            $parts = explode(':', trim((string) $raw));
+            if (count($parts) !== 3 || ! is_numeric($parts[1]) || ! is_numeric($parts[2])) {
+                $issues[] = $this->issue('article_lock.'.$index, 'invalid_article_lock', 'Lock must be slug:article_id:working_revision_id.');
+
+                continue;
+            }
+
+            $slug = trim($parts[0]);
+            $locks[$slug] = [
+                'slug' => $slug,
+                'article_id' => (int) $parts[1],
+                'working_revision_id' => (int) $parts[2],
+            ];
+        }
+
+        if (count($locks) !== 7) {
+            $issues[] = $this->issue('article_lock', 'article_lock_count_mismatch', 'Exactly seven article locks are required.');
+        }
+
+        return $locks;
+    }
+
+    /**
+     * @param  array<string,mixed>  $gate
+     * @param  array<string,array{slug:string,article_id:int,working_revision_id:int}>  $locks
+     * @param  list<array<string,mixed>>  $issues
+     * @return list<array<string,mixed>>
+     */
+    private function plansFromGate(array $gate, array $locks, array &$issues): array
+    {
+        $plans = [];
+        foreach ((array) ($gate['approval_candidates'] ?? []) as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            $slug = (string) ($candidate['slug'] ?? '');
+            $lock = $locks[$slug] ?? null;
+            if (! is_array($lock)) {
+                $issues[] = $this->issue($slug.'.article_lock', 'article_lock_missing', 'Article lock missing for candidate slug.');
+
+                continue;
+            }
+
+            $articleId = (int) ($candidate['article_id'] ?? 0);
+            $revisionId = (int) ($candidate['working_revision_id'] ?? 0);
+            if ($lock['article_id'] !== $articleId || $lock['working_revision_id'] !== $revisionId) {
+                $issues[] = $this->issue($slug.'.article_lock', 'article_lock_mismatch', 'Article/revision lock does not match publish gate candidate.', [
+                    'expected' => $candidate,
+                    'actual' => $lock,
+                ]);
+            }
+
+            $plans[] = [
+                'slug' => $slug,
+                'article_id' => $articleId,
+                'working_revision_id' => $revisionId,
+                'from_status' => self::EXPECTED_STATUS,
+                'to_status' => 'review_pending',
+                'from_revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+                'to_revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
+                'publish' => false,
+                'indexability' => false,
+                'sitemap' => false,
+                'llms' => false,
+            ];
+        }
+
+        return $plans;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $plans
+     * @return list<array<string,mixed>>
+     */
+    private function writeApprovals(array $plans, int $reviewedBy, string $packetPath, string $packetSha): array
+    {
+        $written = [];
+        $now = now();
+
+        foreach ($plans as $plan) {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->whereKey((int) $plan['article_id'])
+                ->lockForUpdate()
+                ->firstOrFail();
+            $revision = ArticleTranslationRevision::query()
+                ->withoutGlobalScopes()
+                ->whereKey((int) $plan['working_revision_id'])
+                ->where('article_id', (int) $article->id)
+                ->lockForUpdate()
+                ->firstOrFail();
+            $seo = ArticleSeoMeta::query()
+                ->withoutGlobalScopes()
+                ->where('article_id', (int) $article->id)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->assertWritePreconditions($article, $revision, $seo);
+
+            $revision->forceFill([
+                'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
+                'reviewed_by' => $reviewedBy,
+                'reviewed_at' => $now,
+                'approved_at' => $now,
+            ])->save();
+
+            $article->forceFill([
+                'status' => 'review_pending',
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'published_at' => null,
+                'published_revision_id' => null,
+            ])->save();
+
+            $schema = is_array($seo->schema_json) ? $seo->schema_json : [];
+            data_set($schema, 'editorial_package_v1.review_approval_v1', [
+                'pr_id' => self::PR_ID,
+                'review_packet_path' => $packetPath,
+                'review_packet_sha256' => $packetSha,
+                'reviewed_by' => $reviewedBy,
+                'reviewed_at' => $now->toIso8601String(),
+                'approved_at' => $now->toIso8601String(),
+                'publish_allowed' => false,
+                'indexability_allowed' => false,
+                'sitemap_llms_allowed' => false,
+            ]);
+
+            $seo->forceFill([
+                'schema_json' => $schema,
+                'robots' => 'noindex,follow',
+                'is_indexable' => false,
+            ])->save();
+
+            $written[] = [
+                'slug' => (string) $article->slug,
+                'article_id' => (int) $article->id,
+                'working_revision_id' => (int) $revision->id,
+                'status' => (string) $article->status,
+                'working_revision_status' => (string) $revision->revision_status,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'robots' => (string) $seo->robots,
+                'sitemap_eligible' => (bool) $article->sitemap_eligible,
+                'llms_eligible' => (bool) $article->llms_eligible,
+            ];
+        }
+
+        return $written;
+    }
+
+    private function assertWritePreconditions(Article $article, ArticleTranslationRevision $revision, ArticleSeoMeta $seo): void
+    {
+        if ((string) $article->status !== self::EXPECTED_STATUS || (bool) $article->is_public || (bool) $article->is_indexable) {
+            throw new RuntimeException('article draft/noindex precondition failed before approval write.');
+        }
+        if ((bool) $article->sitemap_eligible || (bool) $article->llms_eligible || $article->published_at !== null || $article->published_revision_id !== null) {
+            throw new RuntimeException('article publish/discoverability precondition failed before approval write.');
+        }
+        if ((string) $revision->revision_status !== ArticleTranslationRevision::STATUS_HUMAN_REVIEW || $revision->approved_at !== null) {
+            throw new RuntimeException('working revision precondition failed before approval write.');
+        }
+        if ((string) $seo->robots !== 'noindex,follow' || (bool) $seo->is_indexable) {
+            throw new RuntimeException('seo noindex precondition failed before approval write.');
+        }
+    }
+
+    /**
+     * @param  array<string,array{slug:string,article_id:int,working_revision_id:int}>  $locks
+     */
+    private function expectedConfirmation(?string $packetSha, array $locks): string
+    {
+        $ids = collect($locks)
+            ->sortKeys()
+            ->map(static fn (array $lock): string => $lock['slug'].':'.$lock['article_id'].':'.$lock['working_revision_id'])
+            ->implode(',');
+
+        return 'I explicitly approve IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01 to mark IQ method page revisions reviewed and approved for locks ['.$ids.'] using review packet sha256 '.($packetSha ?? 'missing').'; no publish, no indexability, no sitemap, no llms, no search, no deploy.';
+    }
+
+    private function reviewPacketPath(): string
+    {
+        $path = trim((string) $this->option('review-packet'));
+
+        return str_starts_with($path, '/') ? $path : base_path($path);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $context = []): array
+    {
+        return array_filter([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+            'context' => $context === [] ? null : $context,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => ! (bool) $this->option('execute'),
+            'execute' => (bool) $this->option('execute'),
+            'pr_id' => self::PR_ID,
+            'issues' => [$this->issue('command', $code, $message)],
+            'side_effects' => [
+                'db_write' => false,
+                'cms_update' => false,
+                'review_approval' => false,
+                'publish' => false,
+                'indexability' => false,
+                'sitemap' => false,
+                'llms' => false,
+                'deploy' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'blocked'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? true) ? '1' : '0'));
+        $this->line('execute='.(($summary['execute'] ?? false) ? '1' : '0'));
+        $this->line('approved_count='.(string) count((array) ($summary['approved_articles'] ?? [])));
+
+        foreach ((array) ($summary['issues'] ?? []) as $issue) {
+            if (is_array($issue)) {
+                $this->line(sprintf(
+                    'issue=%s:%s:%s',
+                    (string) ($issue['field'] ?? 'unknown'),
+                    (string) ($issue['code'] ?? 'unknown'),
+                    (string) ($issue['message'] ?? ''),
+                ));
+            }
+        }
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -33,6 +33,7 @@ return Application::configure(basePath: dirname(__DIR__))
         \App\Console\Commands\ArticleImportIqMethodPagesDraft::class,
         \App\Console\Commands\ArticleIqMethodPagesPublishGate::class,
         \App\Console\Commands\ArticleIqMethodPagesReadback::class,
+        \App\Console\Commands\ArticleIqMethodPagesReviewApproval::class,
         \App\Console\Commands\PersonalityEnneagramCmsPromote::class,
         \App\Console\Commands\FapResolvePack::class,
         \App\Console\Commands\RiasecResultPageAssetAgentAuditCommand::class,

--- a/backend/tests/Feature/Console/ArticleIqMethodPagesReviewApprovalCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleIqMethodPagesReviewApprovalCommandTest.php
@@ -1,0 +1,541 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\ArticleIqMethodPagesPublishGate;
+use App\Console\Commands\ArticleIqMethodPagesReviewApproval;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+final class ArticleIqMethodPagesReviewApprovalCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $kernel = $this->app->make(Kernel::class);
+        $kernel->registerCommand($this->app->make(ArticleIqMethodPagesPublishGate::class));
+        $kernel->registerCommand($this->app->make(ArticleIqMethodPagesReviewApproval::class));
+    }
+
+    public function test_review_approval_dry_run_passes_without_writing(): void
+    {
+        [$package, $reviewPacket, $locks] = $this->importPackageAndLocks();
+
+        [$exit, $payload] = $this->callReviewApproval([
+            '--package' => $package,
+            '--review-packet' => $reviewPacket,
+            '--article-lock' => $locks,
+            '--reviewed-by' => 42,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('dry_run_pass', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['execute']);
+        $this->assertCount(7, $payload['articles']);
+        $this->assertSame([], $payload['approved_articles']);
+        $this->assertFalse($payload['side_effects']['db_write']);
+        $this->assertFalse($payload['side_effects']['publish']);
+        $this->assertFalse($payload['side_effects']['indexability']);
+        $this->assertFalse($payload['side_effects']['sitemap']);
+        $this->assertFalse($payload['side_effects']['llms']);
+
+        $article = Article::query()->withoutGlobalScopes()->where('slug', 'what-is-iq-style-reasoning-test')->firstOrFail();
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->where('article_id', $article->id)->firstOrFail();
+
+        $this->assertSame('draft_review_only', $article->status);
+        $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, $revision->revision_status);
+        $this->assertNull($revision->approved_at);
+    }
+
+    public function test_review_approval_execute_requires_exact_confirmation(): void
+    {
+        [$package, $reviewPacket, $locks] = $this->importPackageAndLocks();
+
+        [$exit, $payload] = $this->callReviewApproval([
+            '--package' => $package,
+            '--review-packet' => $reviewPacket,
+            '--article-lock' => $locks,
+            '--reviewed-by' => 42,
+            '--confirm' => 'wrong confirmation',
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('confirmation_mismatch', collect($payload['issues'])->pluck('code')->all());
+        $this->assertFalse($payload['side_effects']['db_write']);
+
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->firstOrFail();
+        $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, $revision->revision_status);
+        $this->assertNull($revision->approved_at);
+    }
+
+    public function test_review_approval_execute_writes_review_metadata_without_publish_or_indexing(): void
+    {
+        [$package, $reviewPacket, $locks] = $this->importPackageAndLocks();
+
+        [$dryRunExit, $dryRunPayload] = $this->callReviewApproval([
+            '--package' => $package,
+            '--review-packet' => $reviewPacket,
+            '--article-lock' => $locks,
+            '--reviewed-by' => 42,
+            '--json' => true,
+        ]);
+        $this->assertSame(0, $dryRunExit);
+
+        [$exit, $payload] = $this->callReviewApproval([
+            '--package' => $package,
+            '--review-packet' => $reviewPacket,
+            '--article-lock' => $locks,
+            '--reviewed-by' => 42,
+            '--confirm' => $dryRunPayload['expected_confirmation'],
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('approved', $payload['status']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['execute']);
+        $this->assertCount(7, $payload['approved_articles']);
+        $this->assertTrue($payload['side_effects']['db_write']);
+        $this->assertTrue($payload['side_effects']['review_approval']);
+        $this->assertFalse($payload['side_effects']['publish']);
+        $this->assertFalse($payload['side_effects']['indexability']);
+        $this->assertFalse($payload['side_effects']['sitemap']);
+        $this->assertFalse($payload['side_effects']['llms']);
+
+        $articles = Article::query()->withoutGlobalScopes()->orderBy('slug')->get();
+        $this->assertCount(7, $articles);
+
+        foreach ($articles as $article) {
+            $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->where('article_id', $article->id)->firstOrFail();
+            $seo = ArticleSeoMeta::query()->withoutGlobalScopes()->where('article_id', $article->id)->firstOrFail();
+
+            $this->assertSame('review_pending', $article->status);
+            $this->assertFalse((bool) $article->is_public);
+            $this->assertFalse((bool) $article->is_indexable);
+            $this->assertFalse((bool) $article->sitemap_eligible);
+            $this->assertFalse((bool) $article->llms_eligible);
+            $this->assertNull($article->published_at);
+            $this->assertNull($article->published_revision_id);
+            $this->assertSame(ArticleTranslationRevision::STATUS_APPROVED, $revision->revision_status);
+            $this->assertSame(42, (int) $revision->reviewed_by);
+            $this->assertNotNull($revision->reviewed_at);
+            $this->assertNotNull($revision->approved_at);
+            $this->assertSame('noindex,follow', $seo->robots);
+            $this->assertFalse((bool) $seo->is_indexable);
+            $this->assertSame(
+                'IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01',
+                data_get($seo->schema_json, 'editorial_package_v1.review_approval_v1.pr_id')
+            );
+            $this->assertFalse((bool) data_get($seo->schema_json, 'editorial_package_v1.review_approval_v1.publish_allowed'));
+            $this->assertFalse((bool) data_get($seo->schema_json, 'editorial_package_v1.review_approval_v1.indexability_allowed'));
+            $this->assertFalse((bool) data_get($seo->schema_json, 'editorial_package_v1.review_approval_v1.sitemap_llms_allowed'));
+        }
+    }
+
+    /**
+     * @return array{0:string,1:string,2:list<string>}
+     */
+    private function importPackageAndLocks(): array
+    {
+        $package = $this->writeIqMethodPackage();
+        $reviewPacket = $this->writeReviewPacket();
+
+        $importExit = Artisan::call('articles:import-iq-method-pages-draft', [
+            '--package' => $package,
+            '--json' => true,
+        ]);
+        $this->assertSame(0, $importExit);
+
+        [$gateExit, $gatePayload] = $this->callPublishGate([
+            '--package' => $package,
+            '--review-packet' => $reviewPacket,
+            '--json' => true,
+        ]);
+        $this->assertSame(0, $gateExit, json_encode($gatePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $this->assertTrue($gatePayload['ok']);
+
+        $locks = collect($gatePayload['approval_candidates'])
+            ->map(static fn (array $candidate): string => $candidate['slug'].':'.$candidate['article_id'].':'.$candidate['working_revision_id'])
+            ->values()
+            ->all();
+
+        return [$package, $reviewPacket, $locks];
+    }
+
+    private function writeReviewPacket(): string
+    {
+        $path = sys_get_temp_dir().'/iq-method-pages-review-approval-packet-'.Str::uuid().'.json';
+        $pages = [];
+
+        foreach ($this->pageDefinitions() as $index => $page) {
+            $pages[] = [
+                'order' => $index + 1,
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'method_review' => [
+                    'status' => 'pass',
+                    'decision' => 'Scoped method review passed for backend review approval.',
+                ],
+                'claim_review' => [
+                    'status' => 'pass',
+                    'forbidden_claims_found' => [],
+                    'contextual_boundary_mentions' => [],
+                    'contextual_boundary_decision' => 'No affirmative forbidden claims.',
+                ],
+                'approved_for_next_gate' => true,
+            ];
+        }
+
+        file_put_contents($path, json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.review_packet.v1',
+            'packet_id' => 'IQ-METHOD-PAGES-ZH-CN-REVIEW-PACKET-2026-07-05',
+            'created_at' => '2026-07-05T14:09:30+08:00',
+            'locale' => 'zh-CN',
+            'reviewer' => [
+                'name' => 'Codex GPT-5',
+                'role' => 'FermatMind operator-authorized internal method and claim boundary reviewer',
+            ],
+            'global_review_decision' => [
+                'method_review' => 'pass',
+                'claim_review' => 'pass',
+                'forbidden_claim_scan' => 'pass_with_contextual_boundary_mentions',
+                'publication_readiness' => 'ready_for_backend_publish_gate_only',
+                'public_indexing_readiness' => 'not_ready_until_separate_seo_geo_activation_gate',
+            ],
+            'pages' => $pages,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    private function writeIqMethodPackage(): string
+    {
+        $root = sys_get_temp_dir().'/iq-method-pages-review-approval-'.Str::uuid();
+        $packageRoot = $root.'/generated/iq-method-pages-zh-cn-v0.2';
+        $dryRunRoot = $packageRoot.'/cms-dry-run';
+        mkdir($dryRunRoot, 0777, true);
+
+        $articleImports = [];
+        $seoPages = [];
+        $claimPages = [];
+        $topicItems = [];
+        $landingItems = [];
+
+        foreach ($this->pageDefinitions() as $index => $page) {
+            $pageNumber = str_pad((string) ($index + 1), 2, '0', STR_PAD_LEFT);
+            $pageDir = $packageRoot.'/pages/'.$pageNumber.'-'.$page['slug'];
+            mkdir($pageDir, 0777, true);
+
+            $relativeDir = 'generated/iq-method-pages-zh-cn-v0.2/pages/'.$pageNumber.'-'.$page['slug'];
+            $articleMd = $relativeDir.'/article.md';
+            $articleCms = $relativeDir.'/article.cms.json';
+            $seoJson = $relativeDir.'/seo.json';
+            $answerSurface = $relativeDir.'/answer_surface_v1.json';
+            $internalLinks = $relativeDir.'/internal_links.json';
+            $mediaBrief = $relativeDir.'/media_brief.json';
+            $faq = $relativeDir.'/faq.json';
+            $landingSurface = $relativeDir.'/landing_surface_v1.json';
+            $geoAnswer = $relativeDir.'/geo_answer_block.json';
+            $claimAudit = $relativeDir.'/claim_audit.json';
+            $qaChecklist = $relativeDir.'/qa_checklist.md';
+
+            file_put_contents($pageDir.'/article.md', $page['content_md']);
+            file_put_contents($pageDir.'/article.cms.json', json_encode([
+                'status' => 'draft_review_only',
+                'locale' => 'zh-CN',
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'excerpt' => $page['excerpt'],
+                'content_md' => $page['content_md'],
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'category_suggestion' => $page['category'],
+                'tags' => ['IQ 风格推理测试', '测评方法与边界', '非官方非认证', '推理表现'],
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'schema_json' => [
+                    'editorial_package_v1' => [
+                        'package_version' => 'iq-method-pages-zh-cn-v0.2',
+                        'review_required_before_publish' => true,
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/seo.json', json_encode([
+                'status' => 'draft_review_only',
+                'seo_title' => $page['seo_title'],
+                'seo_description' => $page['seo_description'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/answer_surface_v1.json', json_encode([
+                'version' => 'answer_surface_v1',
+                'status' => 'draft_review_only',
+                'quick_answer' => 'IQ 风格推理测试用于理解本次推理任务表现，非官方、非临床、非认证。',
+                'faq_items' => [
+                    ['question' => '这是正式智力测评吗？', 'answer' => '不是。'],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/internal_links.json', json_encode([
+                'links_out' => [
+                    ['label' => '开始 IQ 风格推理测试', 'href' => '/zh/tests/iq-test-intelligence-quotient-assessment'],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/media_brief.json', json_encode([
+                'status' => 'media_library_upload_deferred',
+                'brief' => 'No public media URL assigned in draft import.',
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            file_put_contents($pageDir.'/faq.json', '{"items":[]}');
+            file_put_contents($pageDir.'/landing_surface_v1.json', '{"status":"draft_review_only"}');
+            file_put_contents($pageDir.'/geo_answer_block.json', '{"status":"draft_review_only"}');
+            file_put_contents($pageDir.'/claim_audit.json', '{"status":"passed_text_scan"}');
+            file_put_contents($pageDir.'/qa_checklist.md', "- draft only\n");
+
+            $articleImports[] = [
+                'order' => $index + 1,
+                'cms_resource_type' => 'Article',
+                'operation' => 'upsert_draft_only',
+                'locale' => 'zh-CN',
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'route' => '/zh/articles/'.$page['slug'],
+                'source_files' => [
+                    'article_md' => $articleMd,
+                    'article_cms_json' => $articleCms,
+                    'seo_json' => $seoJson,
+                    'faq_json' => $faq,
+                    'internal_links_json' => $internalLinks,
+                    'answer_surface_v1_json' => $answerSurface,
+                    'landing_surface_v1_json' => $landingSurface,
+                    'geo_answer_block_json' => $geoAnswer,
+                    'media_brief_json' => $mediaBrief,
+                    'claim_audit_json' => $claimAudit,
+                    'qa_checklist_md' => $qaChecklist,
+                ],
+                'required_cms_fields' => [
+                    'category' => $page['category'],
+                    'tags' => ['IQ 风格推理测试', '测评方法与边界', '非官方非认证', '推理表现'],
+                    'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                ],
+                'publish_state' => $this->draftState(),
+                'gates' => [
+                    'human_method_review_required' => true,
+                    'human_claim_review_required' => true,
+                    'cms_dry_run_required' => true,
+                    'cms_readback_required' => true,
+                    'private_url_guard_required' => true,
+                    'production_publish_allowed_in_this_pr' => false,
+                    'sitemap_llms_activation_allowed_in_this_pr' => false,
+                ],
+            ];
+            $seoPages[] = [
+                'slug' => $page['slug'],
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'robots' => 'noindex,follow',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ];
+            $claimPages[] = [
+                'slug' => $page['slug'],
+                'status' => 'draft_review_only',
+                'page_status' => 'draft_review_only_passed_text_scan',
+                'forbidden_terms_found' => [],
+                'human_review_required' => true,
+            ];
+            $topicItems[] = [
+                'slug' => $page['slug'],
+                'title' => $page['title'],
+                'href' => '/zh/articles/'.$page['slug'],
+                'status' => 'draft_review_only',
+                'is_public' => false,
+                'is_indexable' => false,
+            ];
+            $landingItems[] = [
+                'title' => $page['title'],
+                'href' => '/zh/articles/'.$page['slug'],
+                'slug' => $page['slug'],
+            ];
+        }
+
+        file_put_contents($dryRunRoot.'/cms_import_manifest.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.cms_dry_run_manifest.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'mode' => 'cms_dry_run_contract_only',
+            'source_package' => 'generated/iq-method-pages-zh-cn-v0.2',
+            'required_default_publish_state' => $this->draftState(),
+            'article_imports' => $articleImports,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/seo_geo_gate.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.seo_geo_gate.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'status' => 'hold_noindex_until_human_and_cms_readback_pass',
+            'default_gate' => $this->draftState(),
+            'pages' => $seoPages,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/claim_audit_summary.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.claim_audit_summary.v1',
+            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-DRY-RUN-01',
+            'status' => 'automated_text_scan_passed_human_review_required',
+            'pages' => $claimPages,
+            'gate_result' => 'pass_with_human_review_required',
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/topic_iq_articles_mapping.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.topic_mapping.v1',
+            'target_topic' => [
+                'locale' => 'zh-CN',
+                'slug' => 'iq-eq',
+                'route' => '/zh/topics/iq-eq',
+            ],
+            'required_display_policy' => [
+                'split_mixed_group' => true,
+                'iq_group_label' => 'IQ 文章',
+                'eq_group_label' => 'EQ 文章',
+                'frontend_hardcode_allowed' => false,
+            ],
+            'entry_groups' => [
+                [
+                    'group_key' => 'iq_articles',
+                    'label' => 'IQ 文章',
+                    'items' => $topicItems,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($dryRunRoot.'/landing_page_blocks_mapping.json', json_encode([
+            'schema_version' => 'fermatmind.iq_method_pages.landing_page_blocks_mapping.v1',
+            'target_landing_surface' => [
+                'locale' => 'zh-CN',
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'route' => '/zh/tests/iq-test-intelligence-quotient-assessment',
+            ],
+            'proposed_page_blocks' => [
+                [
+                    'block_key' => 'iq_methodology_boundary_links',
+                    'block_type' => 'article_link_cluster',
+                    'label' => 'IQ 测试方法与边界',
+                    'placement' => 'supporting_methodology_links',
+                    'items' => $landingItems,
+                ],
+            ],
+            'guardrails' => [
+                'frontend_hardcode_allowed' => false,
+                'private_flow_links_allowed' => false,
+                'result_or_order_links_allowed' => false,
+                'publish_or_indexing_change_allowed_in_this_pr' => false,
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $root;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function pageDefinitions(): array
+    {
+        $slugs = [
+            'what-is-iq-style-reasoning-test' => '什么是 IQ 风格推理测试？',
+            'online-iq-test-vs-professional-assessment' => '在线 IQ 风格测试和专业智力测评有什么区别？',
+            'iq-test-score-meaning-boundary' => 'IQ 风格测试里的原始分、正确率和完成时间说明什么？',
+            'matrix-reasoning-pattern-recognition-guide' => '矩阵推理和模式识别题在测什么？',
+            'why-fermatmind-iq-v1-not-certification' => '为什么 FermatMind IQ V1 是非认证测试？',
+            'iq-test-privacy-data-boundary' => 'IQ 风格测试的数据和隐私边界是什么？',
+            'iq-expert-review-disclosure' => 'FermatMind 如何审查 IQ 风格测试内容？',
+        ];
+
+        $pages = [];
+        foreach ($slugs as $slug => $title) {
+            $pages[] = [
+                'slug' => $slug,
+                'title' => $title,
+                'excerpt' => '解释 IQ 风格推理测试的方法、边界和信任层，保持非官方、非临床、非认证表达。',
+                'seo_title' => mb_substr($title.' 方法边界说明', 0, 70),
+                'seo_description' => '了解 FermatMind IQ V1 的方法边界：原创 30 题、约 20 分钟，只解释原始分、正确率、完成时间和维度表现。',
+                'category' => $slug === 'matrix-reasoning-pattern-recognition-guide' ? '能力与认知' : '测评方法与边界',
+                'content_md' => implode("\n\n", [
+                    'IQ 风格推理测试是一类用图形、矩阵和规律补全任务观察推理表现的在线测试。FermatMind IQ V1 使用原创 30 题，约 20 分钟，重点解释本次任务中的原始分、正确率、完成时间和维度表现。它不是外部证明，也不是医疗或教育决策工具。',
+                    '## 这是什么 / 这不是什么',
+                    '这是一套在线 IQ 风格推理任务，不是正式智力结论、外部认证或临床测评。',
+                    '## 方法解释',
+                    '页面只解释公开方法与边界，不公开题目 ID、答案、解题步骤、评分表或后端评分规则。',
+                    '## FAQ',
+                    '### 这是正式智力测评吗？',
+                    '不是。它用于理解本次推理任务表现。',
+                ]),
+            ];
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function draftState(): array
+    {
+        return [
+            'status' => 'draft_review_only',
+            'is_public' => false,
+            'is_indexable' => false,
+            'robots' => 'noindex,follow',
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array{0:int,1:array<string,mixed>}
+     */
+    private function callPublishGate(array $options): array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('articles:iq-method-pages-publish-gate', $options, $output);
+        $decoded = json_decode($output->fetch(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return [$exit, $decoded];
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array{0:int,1:array<string,mixed>}
+     */
+    private function callReviewApproval(array $options): array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('articles:iq-method-pages-review-approval', $options, $output);
+        $decoded = json_decode($output->fetch(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return [$exit, $decoded];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -404,11 +404,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files(): void
     {
         $changed = [
+            'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReadback.php',
             'backend/bootstrap/app.php',
         ];
         $bootstrapChangedLines = [
+            '+        \\App\\Console\\Commands\\ArticleIqMethodPagesReviewApproval::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPublishGate::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesReadback::class,',
         ];
@@ -7719,6 +7721,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php',
+            'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReadback.php',
             'backend/app/Models/TopicProfileEntry.php',
@@ -10649,7 +10652,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
+            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80775,7 +80775,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01"
     ],
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80791,17 +80791,17 @@
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesReviewApprovalCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       },
       "github_checks": {
-        "status": "pending",
-        "evidence": "PR #2738 opened for branch codex/iq-method-pages-review-approval-01; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2738 GitHub checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
-    "commit_sha": "edceae391cf4ccd5fd69f8f7f1a19ce2e96f345f",
+    "commit_sha": "f4da8facec47bf0afd63431fea6ea4e4183055c5",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2738",
     "failure_reason": null,
     "merged_at": null,
@@ -80838,6 +80838,11 @@
         "at": "2026-07-05T16:34:00+08:00",
         "status": "github_checks_pending",
         "summary": "Opened PR #2738 for the scoped review approval workflow and pushed the local-validation-passed implementation. Waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-07-05T16:42:00+08:00",
+        "status": "ready_to_merge",
+        "summary": "GitHub checks passed for PR #2738. Ready for squash merge under the PR train merge policy; no publish, indexability, sitemap, llms, search action, deploy, or production execution was performed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80684,7 +80684,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01"
     ],
-    "status": "ready_to_merge",
+    "status": "merged",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80698,20 +80698,24 @@
       "local_validation": {
         "status": "pass",
         "evidence": "php -l command/test, artisan list articles, focused PHPUnit, targeted Pint, route:list api, YAML/JSON parse, and git diff --check passed locally."
+      },
+      "merge_reconciliation": {
+        "status": "pass",
+        "evidence": "PR #2736 is MERGED at merge commit 5ef398f3cdbd6e4e14751524db8a5f25ab1a4f72; origin/main contains the merge commit; local main was synced; task branch codex/iq-method-pages-publish-gate-01 was deleted locally and remotely."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
-    "commit_sha": null,
+    "commit_sha": "5ef398f3cdbd6e4e14751524db8a5f25ab1a4f72",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2736",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T08:02:35Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": false,
@@ -80753,6 +80757,11 @@
         "at": "2026-07-05T16:24:00+08:00",
         "status": "ready_to_merge",
         "summary": "GitHub checks passed for PR #2736 after the current-scope freeze-classifier fix. Ready for squash merge under the PR train merge policy."
+      },
+      {
+        "at": "2026-07-05T16:25:00+08:00",
+        "status": "merged",
+        "summary": "Reconciled post-merge state for PR #2736: GitHub reports MERGED, origin/main contains merge commit 5ef398f3cdbd6e4e14751524db8a5f25ab1a4f72, local main is synced, and the task branch is deleted locally/remotely."
       }
     ]
   },
@@ -80766,7 +80775,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01"
     ],
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80774,13 +80783,17 @@
         "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01 to merge before starting review approval workflow implementation."
+        "status": "pass",
+        "evidence": "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01 PR #2736 is merged; origin/main contains merge commit 5ef398f3cdbd6e4e14751524db8a5f25ab1a4f72."
+      },
+      "local_validation": {
+        "status": "pass",
+        "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesReviewApprovalCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       }
     },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -80806,6 +80819,16 @@
         "at": "2026-07-05T13:55:29+08:00",
         "status": "pending_dependency",
         "summary": "Registered controlled review approval workflow. Execution waits for publish gate merge and still requires exact deployed SHA authorization before any production review approval write."
+      },
+      {
+        "at": "2026-07-05T16:25:00+08:00",
+        "status": "in_progress",
+        "summary": "Started controlled review approval workflow on branch codex/iq-method-pages-review-approval-01 from origin/main after publish gate dependency merge was reconciled. Scope excludes publish, indexability, sitemap/llms activation, search submission, frontend fallback, deploy, and production execution."
+      },
+      {
+        "at": "2026-07-05T16:28:00+08:00",
+        "status": "local_validation_passed",
+        "summary": "Implemented controlled review approval command and tests. Local validation passed; no production review approval write, publish, indexability, sitemap, llms, search action, deploy, or frontend fallback was performed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80775,7 +80775,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01"
     ],
-    "status": "local_validation_passed",
+    "status": "github_checks_pending",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80789,6 +80789,10 @@
       "local_validation": {
         "status": "pass",
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesReviewApprovalCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR #2738 opened for branch codex/iq-method-pages-review-approval-01; waiting for required GitHub checks."
       }
     },
     "scope_validation": {
@@ -80797,8 +80801,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "edceae391cf4ccd5fd69f8f7f1a19ce2e96f345f",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2738",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -80829,6 +80833,11 @@
         "at": "2026-07-05T16:28:00+08:00",
         "status": "local_validation_passed",
         "summary": "Implemented controlled review approval command and tests. Local validation passed; no production review approval write, publish, indexability, sitemap, llms, search action, deploy, or frontend fallback was performed."
+      },
+      {
+        "at": "2026-07-05T16:34:00+08:00",
+        "status": "github_checks_pending",
+        "summary": "Opened PR #2738 for the scoped review approval workflow and pushed the local-validation-passed implementation. Waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37231,7 +37231,7 @@ prs:
     branch: codex/iq-method-pages-review-approval-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01: add IQ method review approval workflow"
     train_scope: iq_method_pages_zh_cn_review_approval
-    status: local_validation_passed
+    status: github_checks_pending
     scope:
       - Add a controlled backend workflow that records method review and claim review approval for the 7 zh-CN IQ method CMS Article working revisions.
       - Require an explicit review packet, exact confirmation phrase, dry-run mode, and article/revision locks before any CMS draft approval write.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37231,7 +37231,7 @@ prs:
     branch: codex/iq-method-pages-review-approval-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01: add IQ method review approval workflow"
     train_scope: iq_method_pages_zh_cn_review_approval
-    status: github_checks_pending
+    status: ready_to_merge
     scope:
       - Add a controlled backend workflow that records method review and claim review approval for the 7 zh-CN IQ method CMS Article working revisions.
       - Require an explicit review packet, exact confirmation phrase, dry-run mode, and article/revision locks before any CMS draft approval write.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37185,7 +37185,7 @@ prs:
     branch: codex/iq-method-pages-publish-gate-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01: add IQ method publish readiness gate"
     train_scope: iq_method_pages_zh_cn_publish_readiness
-    status: in_progress
+    status: merged
     scope:
       - Add a backend read-only publish readiness gate for the 7 zh-CN IQ method CMS Article drafts.
       - Verify draft/readback state, required method review evidence, claim review evidence, revision approval prerequisites, and controlled publish compatibility.
@@ -37231,7 +37231,7 @@ prs:
     branch: codex/iq-method-pages-review-approval-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01: add IQ method review approval workflow"
     train_scope: iq_method_pages_zh_cn_review_approval
-    status: user_authorized
+    status: local_validation_passed
     scope:
       - Add a controlled backend workflow that records method review and claim review approval for the 7 zh-CN IQ method CMS Article working revisions.
       - Require an explicit review packet, exact confirmation phrase, dry-run mode, and article/revision locks before any CMS draft approval write.


### PR DESCRIPTION
## What changed
- Added `articles:iq-method-pages-review-approval`, a controlled backend workflow for marking the 7 zh-CN IQ method page working revisions reviewed and approved.
- Requires the publish gate to pass, a review packet, exact `slug:article_id:working_revision_id` locks, a positive reviewer actor id, and an exact confirmation phrase before any write.
- Keeps approved CMS articles unpublished and noindex: `is_public=false`, `is_indexable=false`, `robots=noindex,follow`, `sitemap_eligible=false`, `llms_eligible=false`.
- Added focused feature tests for dry-run, confirmation mismatch, and execute-mode review metadata writes without publish/indexing.
- Reconciled the already-merged publish gate ledger entry and advanced this train item to local validation passed.

## Why
- This is the review-approval step between the read-only publish gate and any future controlled publish command.
- It records review approval in CMS audit fields without mixing in public publish, indexing, sitemap, llms, search submission, frontend fallback, or deploy work.

## Validation
- `php -l backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php`
- `php -l backend/tests/Feature/Console/ArticleIqMethodPagesReviewApprovalCommandTest.php`
- `cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-review-approval|iq-method-pages'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesReviewApproval.php tests/Feature/Console/ArticleIqMethodPagesReviewApprovalCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesReviewApprovalCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files' --no-ansi`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- Scope validation: changed files are limited to the manifest allowlist for `IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01`.

## Deferred items
- No production review approval command execution.
- No article publish.
- No indexability, sitemap, or llms activation.
- No search submission, manual deploy, production deploy, frontend fallback, content rewrite, IQ scoring change, or answer-key exposure.

## Repository rule impact
- This remains backend/CMS-authoritative. It adds a controlled CMS review-approval workflow only and does not move public content authority into frontend code.