### PR TITLE
IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01: add controlled IQ method article publish workflow

### DIFF
--- a/backend/app/Console/Commands/ArticleIqMethodPagesPublish.php
+++ b/backend/app/Console/Commands/ArticleIqMethodPagesPublish.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticlePublishService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+
+final class ArticleIqMethodPagesPublish extends Command
+{
+    private const SCHEMA_VERSION = 'fermatmind.iq_method_pages.publish.v1';
+
+    private const PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01';
+
+    private const REVIEW_APPROVAL_PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01';
+
+    protected $signature = 'articles:iq-method-pages-publish
+        {--article-lock=* : Exact lock in slug:article_id:working_revision_id form}
+        {--confirm= : Exact confirmation phrase required with --execute}
+        {--execute : Publish the locked CMS drafts while keeping noindex/sitemap/llms disabled}
+        {--json : Emit a JSON summary}';
+
+    protected $description = 'Controlled publish workflow for the seven zh-CN IQ method CMS Articles while preserving noindex discoverability gates.';
+
+    public function handle(ArticlePublishService $publisher): int
+    {
+        try {
+            $summary = $this->publish($publisher);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function publish(ArticlePublishService $publisher): array
+    {
+        $execute = (bool) $this->option('execute');
+        $issues = [];
+        $locks = $this->parseLocks($issues);
+        $expectedConfirmation = $this->expectedConfirmation($locks);
+
+        if ($execute && ! hash_equals($expectedConfirmation, trim((string) $this->option('confirm')))) {
+            $issues[] = $this->issue('confirm', 'confirmation_mismatch', 'Exact confirmation phrase is required before IQ method page publish writes.', [
+                'expected_confirmation' => $expectedConfirmation,
+            ]);
+        }
+
+        $plans = $this->plansFromLocks($locks, $issues);
+        $published = [];
+
+        if ($issues === [] && $execute) {
+            $published = DB::transaction(function () use ($plans, $publisher, $expectedConfirmation): array {
+                return $this->publishPlans($plans, $publisher, $expectedConfirmation);
+            });
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $issues === [],
+            'status' => $issues === [] ? ($execute ? 'published_noindex' : 'dry_run_pass') : 'blocked',
+            'dry_run' => ! $execute,
+            'execute' => $execute,
+            'generated_at' => now()->toIso8601String(),
+            'pr_id' => self::PR_ID,
+            'source_review_approval_pr_id' => self::REVIEW_APPROVAL_PR_ID,
+            'expected_article_count' => 7,
+            'article_locks' => array_values($locks),
+            'expected_confirmation' => $expectedConfirmation,
+            'articles' => $plans,
+            'published_articles' => $published,
+            'issues' => $issues,
+            'side_effects' => [
+                'db_write' => $execute && $issues === [],
+                'cms_update' => $execute && $issues === [],
+                'publish' => $execute && $issues === [],
+                'indexability' => false,
+                'sitemap' => false,
+                'llms' => false,
+                'search' => false,
+                'deploy' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,array{slug:string,article_id:int,working_revision_id:int}>
+     */
+    private function parseLocks(array &$issues): array
+    {
+        $locks = [];
+
+        foreach ((array) $this->option('article-lock') as $index => $raw) {
+            $parts = explode(':', trim((string) $raw));
+            if (count($parts) !== 3 || ! is_numeric($parts[1]) || ! is_numeric($parts[2])) {
+                $issues[] = $this->issue('article_lock.'.$index, 'invalid_article_lock', 'Lock must be slug:article_id:working_revision_id.');
+
+                continue;
+            }
+
+            $slug = trim($parts[0]);
+            $locks[$slug] = [
+                'slug' => $slug,
+                'article_id' => (int) $parts[1],
+                'working_revision_id' => (int) $parts[2],
+            ];
+        }
+
+        if (count($locks) !== 7) {
+            $issues[] = $this->issue('article_lock', 'article_lock_count_mismatch', 'Exactly seven article locks are required.');
+        }
+
+        return $locks;
+    }
+
+    /**
+     * @param  array<string,array{slug:string,article_id:int,working_revision_id:int}>  $locks
+     * @param  list<array<string,mixed>>  $issues
+     * @return list<array<string,mixed>>
+     */
+    private function plansFromLocks(array $locks, array &$issues): array
+    {
+        $plans = [];
+
+        foreach ($locks as $lock) {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['workingRevision', 'seoMeta'])
+                ->whereKey($lock['article_id'])
+                ->first();
+            $revision = $article?->workingRevision instanceof ArticleTranslationRevision ? $article->workingRevision : null;
+            $seo = $article?->seoMeta instanceof ArticleSeoMeta ? $article->seoMeta : null;
+            $blocked = $this->preflight($lock, $article, $revision, $seo);
+
+            foreach ($blocked as $issue) {
+                $issues[] = $issue;
+            }
+
+            $plans[] = [
+                'slug' => $lock['slug'],
+                'article_id' => $lock['article_id'],
+                'working_revision_id' => $lock['working_revision_id'],
+                'status' => (string) ($article?->status ?? ''),
+                'working_revision_status' => (string) ($revision?->revision_status ?? ''),
+                'is_public' => (bool) ($article?->is_public ?? false),
+                'is_indexable' => (bool) ($article?->is_indexable ?? false),
+                'robots' => (string) ($seo?->robots ?? ''),
+                'sitemap_eligible' => (bool) ($article?->sitemap_eligible ?? false),
+                'llms_eligible' => (bool) ($article?->llms_eligible ?? false),
+                'publish' => true,
+                'indexability' => false,
+                'sitemap' => false,
+                'llms' => false,
+                'ok' => $blocked === [],
+                'blocked_by' => $blocked,
+            ];
+        }
+
+        return $plans;
+    }
+
+    /**
+     * @param  array{slug:string,article_id:int,working_revision_id:int}  $lock
+     * @return list<array<string,mixed>>
+     */
+    private function preflight(array $lock, ?Article $article, ?ArticleTranslationRevision $revision, ?ArticleSeoMeta $seo): array
+    {
+        $issues = [];
+
+        if (! $article instanceof Article) {
+            return [$this->issue($lock['slug'].'.article', 'article_not_found', 'Article not found.')];
+        }
+
+        if ((string) $article->slug !== $lock['slug']) {
+            $issues[] = $this->issue($lock['slug'].'.slug', 'article_slug_lock_mismatch', 'Article slug does not match lock.');
+        }
+        if ((string) $article->locale !== 'zh-CN') {
+            $issues[] = $this->issue($lock['slug'].'.locale', 'locale_not_zh_cn', 'IQ method page publish only accepts zh-CN articles.');
+        }
+        if ((int) ($article->working_revision_id ?? 0) !== $lock['working_revision_id']) {
+            $issues[] = $this->issue($lock['slug'].'.working_revision_id', 'working_revision_lock_mismatch', 'Working revision lock does not match article.');
+        }
+        if ((string) $article->status !== 'review_pending') {
+            $issues[] = $this->issue($lock['slug'].'.status', 'article_not_review_pending', 'Article must be review_pending before IQ publish.');
+        }
+        if ((bool) $article->is_public || $article->published_at !== null || $article->published_revision_id !== null) {
+            $issues[] = $this->issue($lock['slug'].'.publish_state', 'article_already_public_or_published', 'Article must not already be public or published.');
+        }
+        if ((bool) $article->is_indexable || (bool) $article->sitemap_eligible || (bool) $article->llms_eligible) {
+            $issues[] = $this->issue($lock['slug'].'.discoverability', 'discoverability_not_disabled', 'Indexability, sitemap, and llms must remain disabled before publish.');
+        }
+
+        if (! $revision instanceof ArticleTranslationRevision) {
+            $issues[] = $this->issue($lock['slug'].'.working_revision', 'working_revision_missing', 'Working revision missing.');
+        } elseif ((int) $revision->id !== $lock['working_revision_id']
+            || (int) $revision->article_id !== (int) $article->id
+            || (string) $revision->revision_status !== ArticleTranslationRevision::STATUS_APPROVED
+            || (int) ($revision->reviewed_by ?? 0) <= 0
+            || $revision->reviewed_at === null
+            || $revision->approved_at === null) {
+            $issues[] = $this->issue($lock['slug'].'.working_revision', 'working_revision_not_approved_for_publish', 'Working revision must match the lock and include review approval metadata.');
+        }
+
+        if (! $seo instanceof ArticleSeoMeta) {
+            $issues[] = $this->issue($lock['slug'].'.seo', 'seo_meta_missing', 'SEO meta missing.');
+        } else {
+            if ((string) $seo->robots !== 'noindex,follow' || (bool) $seo->is_indexable) {
+                $issues[] = $this->issue($lock['slug'].'.seo', 'seo_not_noindex', 'SEO meta must remain noindex before IQ publish.');
+            }
+            if ((string) data_get($seo->schema_json, 'editorial_package_v1.review_approval_v1.pr_id') !== self::REVIEW_APPROVAL_PR_ID) {
+                $issues[] = $this->issue($lock['slug'].'.review_approval', 'review_approval_metadata_missing', 'Review approval metadata missing from SEO schema.');
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $plans
+     * @return list<array<string,mixed>>
+     */
+    private function publishPlans(array $plans, ArticlePublishService $publisher, string $confirmation): array
+    {
+        $published = [];
+        $now = now();
+
+        foreach ($plans as $plan) {
+            $articleId = (int) $plan['article_id'];
+            $publisher->publishArticle($articleId, 'iq_method_pages_controlled_publish');
+
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['workingRevision', 'publishedRevision', 'seoMeta'])
+                ->whereKey($articleId)
+                ->lockForUpdate()
+                ->firstOrFail();
+            $seo = $article->seoMeta instanceof ArticleSeoMeta ? $article->seoMeta : null;
+            if (! $seo instanceof ArticleSeoMeta) {
+                throw new RuntimeException('seo meta missing after IQ publish.');
+            }
+
+            $schema = is_array($seo->schema_json) ? $seo->schema_json : [];
+            data_set($schema, 'editorial_package_v1.publish_v1', [
+                'pr_id' => self::PR_ID,
+                'source_review_approval_pr_id' => self::REVIEW_APPROVAL_PR_ID,
+                'confirmation_sha256' => hash('sha256', $confirmation),
+                'published_at' => $article->published_at?->toIso8601String() ?? $now->toIso8601String(),
+                'indexability_allowed' => false,
+                'sitemap_llms_allowed' => false,
+            ]);
+
+            $article->forceFill([
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ])->save();
+
+            $seo->forceFill([
+                'schema_json' => $schema,
+                'robots' => 'noindex,follow',
+                'is_indexable' => false,
+            ])->save();
+
+            $article->refresh();
+            $seo->refresh();
+            if ((string) $article->status !== 'published'
+                || ! (bool) $article->is_public
+                || (bool) $article->is_indexable
+                || (bool) $article->sitemap_eligible
+                || (bool) $article->llms_eligible
+                || (string) $seo->robots !== 'noindex,follow'
+                || (bool) $seo->is_indexable) {
+                throw new RuntimeException('IQ publish postcondition failed: public published article must remain noindex and sitemap/llms disabled.');
+            }
+
+            $published[] = [
+                'slug' => (string) $article->slug,
+                'article_id' => (int) $article->id,
+                'published_revision_id' => (int) $article->published_revision_id,
+                'status' => (string) $article->status,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'robots' => (string) $seo->robots,
+                'sitemap_eligible' => (bool) $article->sitemap_eligible,
+                'llms_eligible' => (bool) $article->llms_eligible,
+            ];
+        }
+
+        return $published;
+    }
+
+    /**
+     * @param  array<string,array{slug:string,article_id:int,working_revision_id:int}>  $locks
+     */
+    private function expectedConfirmation(array $locks): string
+    {
+        $ids = collect($locks)
+            ->sortKeys()
+            ->map(static fn (array $lock): string => $lock['slug'].':'.$lock['article_id'].':'.$lock['working_revision_id'])
+            ->implode(',');
+
+        return 'I explicitly approve IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01 to publish IQ method page article locks ['.$ids.'] without indexability, sitemap, llms, search, or deploy.';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $context = []): array
+    {
+        return array_filter([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+            'context' => $context === [] ? null : $context,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => ! (bool) $this->option('execute'),
+            'execute' => (bool) $this->option('execute'),
+            'pr_id' => self::PR_ID,
+            'issues' => [$this->issue('command', $code, $message)],
+            'side_effects' => [
+                'db_write' => false,
+                'cms_update' => false,
+                'publish' => false,
+                'indexability' => false,
+                'sitemap' => false,
+                'llms' => false,
+                'search' => false,
+                'deploy' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'blocked'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? true) ? '1' : '0'));
+        $this->line('execute='.(($summary['execute'] ?? false) ? '1' : '0'));
+        $this->line('published_count='.(string) count((array) ($summary['published_articles'] ?? [])));
+
+        foreach ((array) ($summary['issues'] ?? []) as $issue) {
+            if (is_array($issue)) {
+                $this->line(sprintf(
+                    'issue=%s:%s:%s',
+                    (string) ($issue['field'] ?? 'unknown'),
+                    (string) ($issue['code'] ?? 'unknown'),
+                    (string) ($issue['message'] ?? ''),
+                ));
+            }
+        }
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -32,6 +32,7 @@ return Application::configure(basePath: dirname(__DIR__))
         __DIR__.'/../app/Console/Commands',
         \App\Console\Commands\ArticleImportIqMethodPagesDraft::class,
         \App\Console\Commands\ArticleIqMethodPagesPublishGate::class,
+        \App\Console\Commands\ArticleIqMethodPagesPublish::class,
         \App\Console\Commands\ArticleIqMethodPagesReadback::class,
         \App\Console\Commands\ArticleIqMethodPagesReviewApproval::class,
         \App\Console\Commands\PersonalityEnneagramCmsPromote::class,

--- a/backend/tests/Feature/Console/ArticleIqMethodPagesPublishCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleIqMethodPagesPublishCommandTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\ArticleIqMethodPagesPublish;
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+final class ArticleIqMethodPagesPublishCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(Kernel::class)->registerCommand($this->app->make(ArticleIqMethodPagesPublish::class));
+    }
+
+    public function test_publish_dry_run_passes_without_publishing(): void
+    {
+        $locks = $this->createApprovedIqMethodArticles();
+
+        [$exit, $payload] = $this->callPublish([
+            '--article-lock' => $locks,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('dry_run_pass', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['execute']);
+        $this->assertCount(7, $payload['articles']);
+        $this->assertSame([], $payload['published_articles']);
+        $this->assertFalse($payload['side_effects']['db_write']);
+        $this->assertFalse($payload['side_effects']['publish']);
+        $this->assertFalse($payload['side_effects']['indexability']);
+        $this->assertFalse($payload['side_effects']['sitemap']);
+        $this->assertFalse($payload['side_effects']['llms']);
+
+        $article = Article::query()->withoutGlobalScopes()->where('slug', 'what-is-iq-style-reasoning-test')->firstOrFail();
+        $this->assertSame('review_pending', $article->status);
+        $this->assertFalse((bool) $article->is_public);
+        $this->assertNull($article->published_revision_id);
+    }
+
+    public function test_publish_execute_requires_exact_confirmation(): void
+    {
+        $locks = $this->createApprovedIqMethodArticles();
+
+        [$exit, $payload] = $this->callPublish([
+            '--article-lock' => $locks,
+            '--confirm' => 'wrong confirmation',
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('confirmation_mismatch', collect($payload['issues'])->pluck('code')->all());
+        $this->assertFalse($payload['side_effects']['db_write']);
+
+        $article = Article::query()->withoutGlobalScopes()->firstOrFail();
+        $this->assertSame('review_pending', $article->status);
+        $this->assertFalse((bool) $article->is_public);
+        $this->assertNull($article->published_revision_id);
+    }
+
+    public function test_publish_execute_publishes_articles_but_keeps_noindex_sitemap_and_llms_disabled(): void
+    {
+        $locks = $this->createApprovedIqMethodArticles();
+
+        [$dryRunExit, $dryRunPayload] = $this->callPublish([
+            '--article-lock' => $locks,
+            '--json' => true,
+        ]);
+        $this->assertSame(0, $dryRunExit);
+
+        [$exit, $payload] = $this->callPublish([
+            '--article-lock' => $locks,
+            '--confirm' => $dryRunPayload['expected_confirmation'],
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('published_noindex', $payload['status']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['execute']);
+        $this->assertCount(7, $payload['published_articles']);
+        $this->assertTrue($payload['side_effects']['db_write']);
+        $this->assertTrue($payload['side_effects']['publish']);
+        $this->assertFalse($payload['side_effects']['indexability']);
+        $this->assertFalse($payload['side_effects']['sitemap']);
+        $this->assertFalse($payload['side_effects']['llms']);
+        $this->assertFalse($payload['side_effects']['search']);
+        $this->assertFalse($payload['side_effects']['deploy']);
+
+        $articles = Article::query()->withoutGlobalScopes()->orderBy('slug')->get();
+        $this->assertCount(7, $articles);
+
+        foreach ($articles as $article) {
+            $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->whereKey($article->published_revision_id)->firstOrFail();
+            $seo = ArticleSeoMeta::query()->withoutGlobalScopes()->where('article_id', $article->id)->firstOrFail();
+
+            $this->assertSame('published', $article->status);
+            $this->assertTrue((bool) $article->is_public);
+            $this->assertFalse((bool) $article->is_indexable);
+            $this->assertFalse((bool) $article->sitemap_eligible);
+            $this->assertFalse((bool) $article->llms_eligible);
+            $this->assertNotNull($article->published_at);
+            $this->assertSame((int) $article->working_revision_id, (int) $article->published_revision_id);
+            $this->assertSame(ArticleTranslationRevision::STATUS_PUBLISHED, $revision->revision_status);
+            $this->assertNotNull($revision->published_at);
+            $this->assertSame('noindex,follow', $seo->robots);
+            $this->assertFalse((bool) $seo->is_indexable);
+            $this->assertSame(
+                'IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01',
+                data_get($seo->schema_json, 'editorial_package_v1.publish_v1.pr_id')
+            );
+            $this->assertFalse((bool) data_get($seo->schema_json, 'editorial_package_v1.publish_v1.indexability_allowed'));
+            $this->assertFalse((bool) data_get($seo->schema_json, 'editorial_package_v1.publish_v1.sitemap_llms_allowed'));
+        }
+    }
+
+    public function test_publish_blocks_when_discoverability_is_already_enabled(): void
+    {
+        $locks = $this->createApprovedIqMethodArticles();
+
+        Article::query()
+            ->withoutGlobalScopes()
+            ->where('slug', 'what-is-iq-style-reasoning-test')
+            ->update(['is_indexable' => true]);
+
+        [$exit, $payload] = $this->callPublish([
+            '--article-lock' => $locks,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('discoverability_not_disabled', collect($payload['issues'])->pluck('code')->all());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function createApprovedIqMethodArticles(): array
+    {
+        $category = ArticleCategory::query()->withoutGlobalScopes()->firstOrCreate(
+            ['org_id' => 0, 'slug' => 'iq-method-boundary'],
+            ['name' => 'IQ 方法与边界', 'is_active' => true]
+        );
+        $tag = ArticleTag::query()->withoutGlobalScopes()->firstOrCreate(
+            ['org_id' => 0, 'slug' => 'iq-method-pages'],
+            ['name' => 'IQ 方法页', 'is_active' => true]
+        );
+        $locks = [];
+
+        foreach ($this->pageDefinitions() as $index => $page) {
+            $body = "IQ 风格推理测试说明正文。\n\n## 方法边界\n\n非官方、非临床、非认证。\n\n## FAQ\n\n### 这是正式智力测评吗？\n\n不是。";
+            $article = Article::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'category_id' => (int) $category->id,
+                'slug' => $page['slug'],
+                'locale' => 'zh-CN',
+                'title' => $page['title'],
+                'excerpt' => 'IQ 方法页摘要',
+                'content_md' => $body,
+                'cover_image_url' => '/storage/articles/iq-method.svg',
+                'cover_image_alt' => 'IQ 方法页封面',
+                'cover_image_width' => 1200,
+                'cover_image_height' => 675,
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'status' => 'review_pending',
+                'lifecycle_state' => Article::LIFECYCLE_ACTIVE,
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+            ]);
+            $article->tags()->attach((int) $tag->id, ['org_id' => 0]);
+
+            $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'article_id' => (int) $article->id,
+                'source_article_id' => (int) $article->id,
+                'translation_group_id' => (string) $article->translation_group_id,
+                'locale' => 'zh-CN',
+                'source_locale' => 'zh-CN',
+                'revision_number' => $index + 1,
+                'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
+                'title' => $page['title'],
+                'excerpt' => 'IQ 方法页摘要',
+                'content_md' => $body,
+                'seo_title' => $page['title'].' | 费马测试',
+                'seo_description' => 'IQ 方法页 SEO 描述',
+                'reviewed_by' => 42,
+                'reviewed_at' => now()->subMinutes(10),
+                'approved_at' => now()->subMinutes(5),
+            ]);
+            $article->forceFill(['working_revision_id' => (int) $revision->id])->save();
+
+            ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'article_id' => (int) $article->id,
+                'locale' => 'zh-CN',
+                'seo_title' => $page['title'].' | 费马测试',
+                'seo_description' => 'IQ 方法页 SEO 描述',
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$page['slug'],
+                'og_title' => $page['title'].' | 费马测试',
+                'og_description' => 'IQ 方法页 OG 描述',
+                'og_image_url' => 'https://fermatmind.com/storage/articles/iq-method.svg',
+                'robots' => 'noindex,follow',
+                'schema_json' => [
+                    'editorial_package_v1' => [
+                        'review_approval_v1' => [
+                            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01',
+                            'publish_allowed' => false,
+                            'indexability_allowed' => false,
+                            'sitemap_llms_allowed' => false,
+                        ],
+                    ],
+                ],
+                'is_indexable' => false,
+            ]);
+
+            $locks[] = $page['slug'].':'.$article->id.':'.$revision->id;
+        }
+
+        return $locks;
+    }
+
+    /**
+     * @return list<array{slug:string,title:string}>
+     */
+    private function pageDefinitions(): array
+    {
+        return [
+            ['slug' => 'what-is-iq-style-reasoning-test', 'title' => '什么是 IQ 风格推理测试？'],
+            ['slug' => 'online-iq-test-vs-professional-assessment', 'title' => '在线 IQ 风格测试和专业智力测评有什么区别？'],
+            ['slug' => 'iq-test-score-meaning-boundary', 'title' => 'IQ 风格测试里的原始分、正确率和完成时间说明什么？'],
+            ['slug' => 'matrix-reasoning-pattern-recognition-guide', 'title' => '矩阵推理和模式识别题在测什么？'],
+            ['slug' => 'why-fermatmind-iq-v1-not-certification', 'title' => '为什么 FermatMind IQ V1 是非认证测试？'],
+            ['slug' => 'iq-test-privacy-data-boundary', 'title' => 'IQ 风格测试的数据和隐私边界是什么？'],
+            ['slug' => 'iq-expert-review-disclosure', 'title' => 'FermatMind 如何审查 IQ 风格测试内容？'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array{0:int,1:array<string,mixed>}
+     */
+    private function callPublish(array $options): array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('articles:iq-method-pages-publish', $options, $output);
+        $decoded = json_decode($output->fetch(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return [$exit, $decoded];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -404,12 +404,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files(): void
     {
         $changed = [
+            'backend/app/Console/Commands/ArticleIqMethodPagesPublish.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReadback.php',
             'backend/bootstrap/app.php',
         ];
         $bootstrapChangedLines = [
+            '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPublish::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesReviewApproval::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPublishGate::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesReadback::class,',
@@ -7721,6 +7723,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php',
+            'backend/app/Console/Commands/ArticleIqMethodPagesPublish.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReadback.php',
@@ -10652,7 +10655,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
+            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesPublish|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80865,7 +80865,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01"
     ],
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80881,17 +80881,17 @@
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesPublishCommandTest plus ArticlePublishControlledCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       },
       "github_checks": {
-        "status": "pending",
-        "evidence": "PR #2739 opened for branch codex/iq-method-pages-cms-publish-01; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2739 GitHub checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
-    "commit_sha": "c3b810284ba16379e2ae5fff42ada317ac0d1068",
+    "commit_sha": "11b8e3ee1839c6edbc93316bf0cf0fc490f246a6",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2739",
     "failure_reason": null,
     "merged_at": null,
@@ -80923,6 +80923,11 @@
         "at": "2026-07-05T17:02:00+08:00",
         "status": "github_checks_pending",
         "summary": "Opened PR #2739 for the scoped IQ method publish workflow and pushed the local-validation-passed implementation. Waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-07-05T17:10:00+08:00",
+        "status": "ready_to_merge",
+        "summary": "GitHub checks passed for PR #2739. Ready for squash merge under the PR train merge policy; no indexability, sitemap, llms, search action, deploy, or production execution was performed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80865,7 +80865,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01"
     ],
-    "status": "local_validation_passed",
+    "status": "github_checks_pending",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80879,6 +80879,10 @@
       "local_validation": {
         "status": "pass",
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesPublishCommandTest plus ArticlePublishControlledCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR #2739 opened for branch codex/iq-method-pages-cms-publish-01; waiting for required GitHub checks."
       }
     },
     "scope_validation": {
@@ -80887,8 +80891,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "c3b810284ba16379e2ae5fff42ada317ac0d1068",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2739",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -80914,6 +80918,11 @@
         "at": "2026-07-05T16:55:00+08:00",
         "status": "local_validation_passed",
         "summary": "Implemented controlled IQ method article publish command and tests. Local validation passed; command publishes only locked approved articles and keeps indexability, sitemap, llms, search action, deploy, and production execution disabled."
+      },
+      {
+        "at": "2026-07-05T17:02:00+08:00",
+        "status": "github_checks_pending",
+        "summary": "Opened PR #2739 for the scoped IQ method publish workflow and pushed the local-validation-passed implementation. Waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80775,7 +80775,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-GATE-01"
     ],
-    "status": "ready_to_merge",
+    "status": "merged",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80793,20 +80793,24 @@
       "github_checks": {
         "status": "pass",
         "evidence": "PR #2738 GitHub checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "merge_reconciliation": {
+        "status": "pass",
+        "evidence": "PR #2738 is MERGED at merge commit 1d26b5e496946a66561b50aaadc43b3fc9210f23; origin/main contains the merge commit; local main was synced; task branch codex/iq-method-pages-review-approval-01 was deleted locally and remotely."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
-    "commit_sha": "f4da8facec47bf0afd63431fea6ea4e4183055c5",
+    "commit_sha": "1d26b5e496946a66561b50aaadc43b3fc9210f23",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2738",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T08:27:48Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": true,
@@ -80843,6 +80847,11 @@
         "at": "2026-07-05T16:42:00+08:00",
         "status": "ready_to_merge",
         "summary": "GitHub checks passed for PR #2738. Ready for squash merge under the PR train merge policy; no publish, indexability, sitemap, llms, search action, deploy, or production execution was performed."
+      },
+      {
+        "at": "2026-07-05T16:55:00+08:00",
+        "status": "merged",
+        "summary": "Reconciled post-merge state for PR #2738: GitHub reports MERGED, origin/main contains merge commit 1d26b5e496946a66561b50aaadc43b3fc9210f23, local main is synced, and the task branch is deleted locally/remotely."
       }
     ]
   },
@@ -80856,7 +80865,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01"
     ],
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80864,13 +80873,17 @@
         "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01 to merge before starting controlled publish workflow implementation."
+        "status": "pass",
+        "evidence": "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01 PR #2738 is merged; origin/main contains merge commit 1d26b5e496946a66561b50aaadc43b3fc9210f23."
+      },
+      "local_validation": {
+        "status": "pass",
+        "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesPublishCommandTest plus ArticlePublishControlledCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       }
     },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -80896,6 +80909,11 @@
         "at": "2026-07-05T13:55:29+08:00",
         "status": "pending_dependency",
         "summary": "Registered controlled publish workflow. Execution waits for review approval merge and excludes production publish execution without exact deployed SHA and command authorization."
+      },
+      {
+        "at": "2026-07-05T16:55:00+08:00",
+        "status": "local_validation_passed",
+        "summary": "Implemented controlled IQ method article publish command and tests. Local validation passed; command publishes only locked approved articles and keeps indexability, sitemap, llms, search action, deploy, and production execution disabled."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37275,7 +37275,7 @@ prs:
     branch: codex/iq-method-pages-cms-publish-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01: add controlled IQ method article publish workflow"
     train_scope: iq_method_pages_zh_cn_publish
-    status: github_checks_pending
+    status: ready_to_merge
     scope:
       - Add or verify a controlled backend batch publish workflow for the 7 approved zh-CN IQ method CMS Articles.
       - Publish only approved working revisions and keep indexability disabled during publish.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37231,7 +37231,7 @@ prs:
     branch: codex/iq-method-pages-review-approval-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01: add IQ method review approval workflow"
     train_scope: iq_method_pages_zh_cn_review_approval
-    status: ready_to_merge
+    status: merged
     scope:
       - Add a controlled backend workflow that records method review and claim review approval for the 7 zh-CN IQ method CMS Article working revisions.
       - Require an explicit review packet, exact confirmation phrase, dry-run mode, and article/revision locks before any CMS draft approval write.
@@ -37275,7 +37275,7 @@ prs:
     branch: codex/iq-method-pages-cms-publish-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01: add controlled IQ method article publish workflow"
     train_scope: iq_method_pages_zh_cn_publish
-    status: user_authorized
+    status: local_validation_passed
     scope:
       - Add or verify a controlled backend batch publish workflow for the 7 approved zh-CN IQ method CMS Articles.
       - Publish only approved working revisions and keep indexability disabled during publish.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37275,7 +37275,7 @@ prs:
     branch: codex/iq-method-pages-cms-publish-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01: add controlled IQ method article publish workflow"
     train_scope: iq_method_pages_zh_cn_publish
-    status: local_validation_passed
+    status: github_checks_pending
     scope:
       - Add or verify a controlled backend batch publish workflow for the 7 approved zh-CN IQ method CMS Articles.
       - Publish only approved working revisions and keep indexability disabled during publish.


### PR DESCRIPTION
## What changed
- Added `articles:iq-method-pages-publish`, an IQ-specific controlled batch publish workflow for the seven zh-CN IQ method CMS Articles.
- Requires exactly seven `slug:article_id:working_revision_id` locks and an exact confirmation phrase before execute-mode writes.
- Publishes only `review_pending` Articles with approved working revisions and `review_approval_v1` metadata from the prior review-approval PR.
- Keeps discoverability disabled after publish: `is_indexable=false`, `robots=noindex,follow`, `sitemap_eligible=false`, and `llms_eligible=false`.
- Added focused tests for dry-run, confirmation mismatch, execute publish-noindex behavior, and preflight blocking when discoverability is already enabled.
- Reconciled the already-merged review-approval ledger dependency.

## Why
- IQ method pages need to become publicly readable before later readback and SEO/GEO activation, but publication must not be coupled to indexability, sitemap, llms, search, or deploy actions.
- The existing generic `articles:publish-controlled` expects indexability for SEO article publish, so IQ gets a narrower wrapper that preserves the noindex gate by design.

## Validation
- `php -l backend/app/Console/Commands/ArticleIqMethodPagesPublish.php`
- `php -l backend/tests/Feature/Console/ArticleIqMethodPagesPublishCommandTest.php`
- `cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-publish|publish-controlled'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesPublish.php app/Console/Commands/ArticlePublishControlled.php tests/Feature/Console/ArticleIqMethodPagesPublishCommandTest.php tests/Feature/Console/ArticlePublishControlledCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='ArticleIqMethodPagesPublishCommandTest|ArticlePublishControlledCommandTest' --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files' --no-ansi`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- Scope validation: changed files are limited to the manifest allowlist for `IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01`.

## Deferred items
- No production publish command execution.
- No indexability, sitemap, or llms activation.
- No search submission, manual deploy, production deploy, frontend fallback, content rewrite, IQ scoring change, or answer-key exposure.

## Repository rule impact
- This remains backend/CMS-authoritative. It adds a controlled CMS publish workflow only; frontend content authority is unchanged.