### PR TITLE
IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01: verify published IQ method articles before indexing

### DIFF
--- a/backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php
+++ b/backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php
@@ -1,0 +1,345 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\LandingSurface;
+use App\Models\PageBlock;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class ArticleIqMethodPagesPostPublishReadback extends Command
+{
+    private const SCHEMA_VERSION = 'fermatmind.iq_method_pages.post_publish_readback.v1';
+
+    private const PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01';
+
+    private const PUBLISH_PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01';
+
+    private const SLUGS = [
+        'what-is-iq-style-reasoning-test',
+        'online-iq-test-vs-professional-assessment',
+        'iq-test-score-meaning-boundary',
+        'matrix-reasoning-pattern-recognition-guide',
+        'why-fermatmind-iq-v1-not-certification',
+        'iq-test-privacy-data-boundary',
+        'iq-expert-review-disclosure',
+    ];
+
+    private const PRIVATE_PATTERNS = [
+        'attempt_route' => '~/(?:zh/|en/)?attempt(?:/|[?#\s)"\']|$)~i',
+        'result_route' => '~/(?:zh/|en/)?(?:result|results)(?:/|[?#\s)"\']|$)~i',
+        'order_route' => '~/(?:zh/|en/)?(?:orders|order)(?:/|[?#\s)"\']|$)~i',
+        'payment_route' => '~/(?:zh/|en/)?(?:pay|payment)(?:/|[?#\s)"\']|$)~i',
+        'recovery_route' => '~/(?:zh/|en/)?(?:recover|restore)(?:/|[?#\s)"\']|$)~i',
+        'scoring_secret' => '/\b(?:answer_key|correct_answer|scoring_rule|score_formula|private_result|payment_id)\b/i',
+    ];
+
+    protected $signature = 'articles:iq-method-pages-post-publish-readback
+        {--json : Emit a JSON summary}';
+
+    protected $description = 'Read-only post-publish verification for zh-CN IQ method CMS Articles before indexing or llms activation.';
+
+    public function handle(): int
+    {
+        try {
+            $summary = $this->readback();
+        } catch (Throwable $exception) {
+            $summary = [
+                'schema_version' => self::SCHEMA_VERSION,
+                'ok' => false,
+                'status' => 'blocked',
+                'pr_id' => self::PR_ID,
+                'issues' => [$this->issue('command', 'unexpected_error', $exception->getMessage())],
+                'side_effects' => $this->sideEffects(),
+            ];
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readback(): array
+    {
+        $issues = [];
+        $articles = $this->readbackArticles($issues);
+        $topic = $this->readbackTopic($issues);
+        $landing = $this->readbackLanding($issues);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $issues === [],
+            'status' => $issues === [] ? 'pass' : 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->toIso8601String(),
+            'pr_id' => self::PR_ID,
+            'source_publish_pr_id' => self::PUBLISH_PR_ID,
+            'expected_article_count' => 7,
+            'article_readbacks' => $articles,
+            'topic_readback' => $topic,
+            'landing_readback' => $landing,
+            'mismatch_count' => count($issues),
+            'issues' => $issues,
+            'side_effects' => $this->sideEffects(),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return list<array<string,mixed>>
+     */
+    private function readbackArticles(array &$issues): array
+    {
+        $readbacks = [];
+
+        foreach (self::SLUGS as $slug) {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['publishedRevision', 'workingRevision', 'seoMeta'])
+                ->where('org_id', 0)
+                ->where('locale', 'zh-CN')
+                ->where('slug', $slug)
+                ->first();
+            $seo = $article?->seoMeta instanceof ArticleSeoMeta ? $article->seoMeta : null;
+            $published = $article?->publishedRevision instanceof ArticleTranslationRevision ? $article->publishedRevision : null;
+            $before = count($issues);
+
+            if (! $article instanceof Article) {
+                $issues[] = $this->issue($slug, 'article_missing', 'Published IQ method Article was not found.');
+                $readbacks[] = ['slug' => $slug, 'ok' => false, 'status' => 'missing'];
+
+                continue;
+            }
+
+            $this->same($issues, $slug.'.status', 'published', (string) $article->status);
+            $this->same($issues, $slug.'.is_public', true, (bool) $article->is_public);
+            $this->same($issues, $slug.'.is_indexable', false, (bool) $article->is_indexable);
+            $this->same($issues, $slug.'.sitemap_eligible', false, (bool) $article->sitemap_eligible);
+            $this->same($issues, $slug.'.llms_eligible', false, (bool) $article->llms_eligible);
+            if ($article->published_at === null || $article->published_revision_id === null) {
+                $issues[] = $this->issue($slug.'.published_at', 'published_marker_missing', 'Published article must have published_at and published_revision_id.');
+            }
+
+            if (! $published instanceof ArticleTranslationRevision) {
+                $issues[] = $this->issue($slug.'.published_revision', 'published_revision_missing', 'Published revision missing.');
+            } else {
+                $this->same($issues, $slug.'.published_revision_id', (int) $article->working_revision_id, (int) $published->id);
+                $this->same($issues, $slug.'.published_revision_status', ArticleTranslationRevision::STATUS_PUBLISHED, (string) $published->revision_status);
+            }
+
+            if (! $seo instanceof ArticleSeoMeta) {
+                $issues[] = $this->issue($slug.'.seo', 'seo_meta_missing', 'SEO meta missing.');
+            } else {
+                $this->same($issues, $slug.'.canonical_url', 'https://fermatmind.com/zh/articles/'.$slug, (string) $seo->canonical_url);
+                $this->same($issues, $slug.'.robots', 'noindex,follow', (string) $seo->robots);
+                $this->same($issues, $slug.'.seo_is_indexable', false, (bool) $seo->is_indexable);
+                $this->same($issues, $slug.'.publish_pr', self::PUBLISH_PR_ID, (string) data_get($seo->schema_json, 'editorial_package_v1.publish_v1.pr_id'));
+            }
+
+            $this->assertNoPrivateTokens($issues, $slug.'.public_payload', json_encode([
+                'title' => $article->title,
+                'excerpt' => $article->excerpt,
+                'content_md' => $article->content_md,
+                'seo' => $seo?->toArray(),
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+
+            $readbacks[] = [
+                'slug' => $slug,
+                'article_id' => (int) $article->id,
+                'published_revision_id' => $article->published_revision_id !== null ? (int) $article->published_revision_id : null,
+                'status' => (string) $article->status,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'robots' => (string) ($seo?->robots ?? ''),
+                'sitemap_eligible' => (bool) $article->sitemap_eligible,
+                'llms_eligible' => (bool) $article->llms_eligible,
+                'ok' => count($issues) === $before,
+            ];
+        }
+
+        return $readbacks;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function readbackTopic(array &$issues): array
+    {
+        $profile = TopicProfile::query()->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', 'iq-eq')
+            ->first();
+
+        if (! $profile instanceof TopicProfile) {
+            $issues[] = $this->issue('topic.iq-eq', 'topic_missing', 'IQ/EQ topic profile missing.');
+
+            return ['ok' => false, 'slug' => 'iq-eq', 'status' => 'missing'];
+        }
+
+        $entries = TopicProfileEntry::query()
+            ->where('profile_id', (int) $profile->id)
+            ->where('group_key', 'iq_articles')
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
+        $actual = $entries->pluck('target_key')->values()->all();
+        if ($actual !== self::SLUGS) {
+            $issues[] = $this->issue('topic.iq_articles.items', 'topic_items_mismatch', 'Topic IQ article entries do not match expected slugs.');
+        }
+        $this->assertNoPrivateTokens($issues, 'topic.iq_articles.payload', $entries->toJson(JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return [
+            'ok' => $actual === self::SLUGS,
+            'topic_profile_id' => (int) $profile->id,
+            'slug' => 'iq-eq',
+            'group_key' => 'iq_articles',
+            'expected_items_count' => 7,
+            'actual_items_count' => $entries->count(),
+            'slugs' => $actual,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function readbackLanding(array &$issues): array
+    {
+        $surface = LandingSurface::query()->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('surface_key', 'test:iq-test-intelligence-quotient-assessment')
+            ->where('locale', 'zh-CN')
+            ->first();
+
+        if (! $surface instanceof LandingSurface) {
+            $issues[] = $this->issue('landing_surface.iq', 'landing_surface_missing', 'IQ landing surface missing.');
+
+            return ['ok' => false, 'surface_key' => 'test:iq-test-intelligence-quotient-assessment'];
+        }
+
+        $block = PageBlock::query()
+            ->where('landing_surface_id', (int) $surface->id)
+            ->where('block_key', 'iq_methodology_boundary_links')
+            ->first();
+
+        if (! $block instanceof PageBlock) {
+            $issues[] = $this->issue('landing_block.iq_methodology_boundary_links', 'landing_block_missing', 'IQ methodology boundary links block missing.');
+
+            return ['ok' => false, 'surface_key' => (string) $surface->surface_key];
+        }
+
+        $items = collect((array) data_get($block->payload_json, 'items', []));
+        $actual = $items->pluck('slug')->values()->all();
+        if ($actual !== self::SLUGS) {
+            $issues[] = $this->issue('landing_block.iq_methodology_boundary_links.items', 'landing_items_mismatch', 'Landing block article links do not match expected slugs.');
+        }
+        $this->same($issues, 'landing_block.frontend_hardcode_allowed', false, (bool) data_get($block->payload_json, 'frontend_hardcode_allowed'));
+        $this->assertNoPrivateTokens($issues, 'landing_block.iq_methodology_boundary_links.payload', json_encode($block->payload_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+
+        return [
+            'ok' => $actual === self::SLUGS,
+            'surface_key' => (string) $surface->surface_key,
+            'block_key' => 'iq_methodology_boundary_links',
+            'expected_items_count' => 7,
+            'actual_items_count' => $items->count(),
+            'slugs' => $actual,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function sideEffects(): array
+    {
+        return [
+            'db_write' => false,
+            'cms_update' => false,
+            'publish' => false,
+            'indexability' => false,
+            'sitemap' => false,
+            'llms' => false,
+            'search' => false,
+            'deploy' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function same(array &$issues, string $field, mixed $expected, mixed $actual): void
+    {
+        if ($expected !== $actual) {
+            $issues[] = $this->issue($field, 'value_mismatch', 'Readback value mismatch.', [
+                'expected' => $expected,
+                'actual' => $actual,
+            ]);
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function assertNoPrivateTokens(array &$issues, string $field, string $text): void
+    {
+        foreach (self::PRIVATE_PATTERNS as $code => $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                $issues[] = $this->issue($field, 'private_or_scoring_token_leak', 'Public IQ method payload contains a private route or scoring token.', [
+                    'pattern' => $code,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $context = []): array
+    {
+        return array_filter([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+            'context' => $context === [] ? null : $context,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'blocked'));
+        $this->line('mismatch_count='.(string) ($summary['mismatch_count'] ?? 0));
+
+        foreach ((array) ($summary['issues'] ?? []) as $issue) {
+            if (is_array($issue)) {
+                $this->line(sprintf(
+                    'issue=%s:%s:%s',
+                    (string) ($issue['field'] ?? 'unknown'),
+                    (string) ($issue['code'] ?? 'unknown'),
+                    (string) ($issue['message'] ?? ''),
+                ));
+            }
+        }
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -33,6 +33,7 @@ return Application::configure(basePath: dirname(__DIR__))
         \App\Console\Commands\ArticleImportIqMethodPagesDraft::class,
         \App\Console\Commands\ArticleIqMethodPagesPublishGate::class,
         \App\Console\Commands\ArticleIqMethodPagesPublish::class,
+        \App\Console\Commands\ArticleIqMethodPagesPostPublishReadback::class,
         \App\Console\Commands\ArticleIqMethodPagesReadback::class,
         \App\Console\Commands\ArticleIqMethodPagesReviewApproval::class,
         \App\Console\Commands\PersonalityEnneagramCmsPromote::class,

--- a/backend/tests/Feature/Console/ArticleIqMethodPagesPostPublishReadbackCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleIqMethodPagesPostPublishReadbackCommandTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\ArticleIqMethodPagesPostPublishReadback;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\LandingSurface;
+use App\Models\PageBlock;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+final class ArticleIqMethodPagesPostPublishReadbackCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(Kernel::class)->registerCommand($this->app->make(ArticleIqMethodPagesPostPublishReadback::class));
+    }
+
+    public function test_post_publish_readback_passes_for_published_noindex_iq_method_articles(): void
+    {
+        $this->createPublishedIqMethodArticles();
+        $this->createTopicAndLandingLinks();
+
+        [$exit, $payload] = $this->callReadback();
+
+        $this->assertSame(0, $exit);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['execute']);
+        $this->assertSame(0, $payload['mismatch_count']);
+        $this->assertCount(7, $payload['article_readbacks']);
+        $this->assertSame(7, $payload['topic_readback']['actual_items_count']);
+        $this->assertSame(7, $payload['landing_readback']['actual_items_count']);
+        $this->assertFalse($payload['side_effects']['db_write']);
+        $this->assertFalse($payload['side_effects']['indexability']);
+        $this->assertFalse($payload['side_effects']['sitemap']);
+        $this->assertFalse($payload['side_effects']['llms']);
+    }
+
+    public function test_post_publish_readback_blocks_if_article_is_prematurely_indexable(): void
+    {
+        $this->createPublishedIqMethodArticles();
+        $this->createTopicAndLandingLinks();
+
+        Article::query()->withoutGlobalScopes()
+            ->where('slug', 'what-is-iq-style-reasoning-test')
+            ->update(['is_indexable' => true, 'sitemap_eligible' => true]);
+
+        [$exit, $payload] = $this->callReadback();
+
+        $this->assertSame(1, $exit);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertContains('value_mismatch', collect($payload['issues'])->pluck('code')->all());
+        $this->assertContains('what-is-iq-style-reasoning-test.is_indexable', collect($payload['issues'])->pluck('field')->all());
+        $this->assertContains('what-is-iq-style-reasoning-test.sitemap_eligible', collect($payload['issues'])->pluck('field')->all());
+    }
+
+    public function test_post_publish_readback_blocks_private_or_scoring_token_leaks(): void
+    {
+        $this->createPublishedIqMethodArticles();
+        $this->createTopicAndLandingLinks();
+
+        Article::query()->withoutGlobalScopes()
+            ->where('slug', 'iq-test-privacy-data-boundary')
+            ->update(['content_md' => '公开页不应包含 answer_key 字段。']);
+
+        [$exit, $payload] = $this->callReadback();
+
+        $this->assertSame(1, $exit);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('private_or_scoring_token_leak', collect($payload['issues'])->pluck('code')->all());
+    }
+
+    private function createPublishedIqMethodArticles(): void
+    {
+        foreach ($this->slugs() as $index => $slug) {
+            $body = "IQ 方法页正文。\n\n## 方法边界\n\n非官方、非临床、非认证。";
+            $article = Article::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'slug' => $slug,
+                'locale' => 'zh-CN',
+                'title' => 'IQ 方法页 '.$index,
+                'excerpt' => 'IQ 方法页摘要',
+                'content_md' => $body,
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'status' => 'published',
+                'lifecycle_state' => Article::LIFECYCLE_ACTIVE,
+                'is_public' => true,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'published_at' => now()->subMinute(),
+            ]);
+
+            $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'article_id' => (int) $article->id,
+                'source_article_id' => (int) $article->id,
+                'translation_group_id' => (string) $article->translation_group_id,
+                'locale' => 'zh-CN',
+                'source_locale' => 'zh-CN',
+                'revision_number' => $index + 1,
+                'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+                'title' => 'IQ 方法页 '.$index,
+                'excerpt' => 'IQ 方法页摘要',
+                'content_md' => $body,
+                'reviewed_by' => 42,
+                'reviewed_at' => now()->subMinutes(10),
+                'approved_at' => now()->subMinutes(5),
+                'published_at' => now()->subMinute(),
+            ]);
+            $article->forceFill([
+                'working_revision_id' => (int) $revision->id,
+                'published_revision_id' => (int) $revision->id,
+            ])->save();
+
+            ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'article_id' => (int) $article->id,
+                'locale' => 'zh-CN',
+                'seo_title' => 'IQ 方法页 '.$index,
+                'seo_description' => 'IQ 方法页 SEO 描述',
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$slug,
+                'og_title' => 'IQ 方法页 '.$index,
+                'og_description' => 'IQ 方法页 OG 描述',
+                'og_image_url' => 'https://fermatmind.com/storage/articles/iq-method.svg',
+                'robots' => 'noindex,follow',
+                'schema_json' => [
+                    'editorial_package_v1' => [
+                        'publish_v1' => [
+                            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01',
+                            'indexability_allowed' => false,
+                            'sitemap_llms_allowed' => false,
+                        ],
+                    ],
+                ],
+                'is_indexable' => false,
+            ]);
+        }
+    }
+
+    private function createTopicAndLandingLinks(): void
+    {
+        $profile = TopicProfile::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'topic_code' => 'iq-eq',
+            'slug' => 'iq-eq',
+            'locale' => 'zh-CN',
+            'title' => 'IQ 与 EQ 主题内容聚合',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+
+        foreach ($this->slugs() as $index => $slug) {
+            TopicProfileEntry::query()->create([
+                'profile_id' => (int) $profile->id,
+                'entry_type' => 'article',
+                'group_key' => 'iq_articles',
+                'target_key' => $slug,
+                'target_locale' => 'zh-CN',
+                'target_url_override' => '/zh/articles/'.$slug,
+                'payload_json' => ['slug' => $slug],
+                'sort_order' => $index + 1,
+                'is_enabled' => true,
+            ]);
+        }
+
+        $surface = LandingSurface::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+            'locale' => 'zh-CN',
+            'title' => 'IQ 测试 landing',
+            'status' => LandingSurface::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+
+        PageBlock::query()->create([
+            'landing_surface_id' => (int) $surface->id,
+            'block_key' => 'iq_methodology_boundary_links',
+            'block_type' => 'article_link_cluster',
+            'title' => 'IQ 测试方法与边界',
+            'payload_json' => [
+                'frontend_hardcode_allowed' => false,
+                'items' => collect($this->slugs())
+                    ->map(static fn (string $slug): array => ['slug' => $slug, 'href' => '/zh/articles/'.$slug])
+                    ->all(),
+            ],
+            'sort_order' => 1,
+            'is_enabled' => true,
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(): array
+    {
+        return [
+            'what-is-iq-style-reasoning-test',
+            'online-iq-test-vs-professional-assessment',
+            'iq-test-score-meaning-boundary',
+            'matrix-reasoning-pattern-recognition-guide',
+            'why-fermatmind-iq-v1-not-certification',
+            'iq-test-privacy-data-boundary',
+            'iq-expert-review-disclosure',
+        ];
+    }
+
+    /**
+     * @return array{0:int,1:array<string,mixed>}
+     */
+    private function callReadback(): array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('articles:iq-method-pages-post-publish-readback', ['--json' => true], $output);
+        $decoded = json_decode($output->fetch(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return [$exit, $decoded];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -404,6 +404,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files(): void
     {
         $changed = [
+            'backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublish.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php',
@@ -411,6 +412,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/bootstrap/app.php',
         ];
         $bootstrapChangedLines = [
+            '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPostPublishReadback::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPublish::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesReviewApproval::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPublishGate::class,',
@@ -7723,6 +7725,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php',
+            'backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublish.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php',
@@ -10655,7 +10658,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesPublish|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
+            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesPostPublishReadback|ArticleIqMethodPagesPublish|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80950,7 +80950,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01"
     ],
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80966,17 +80966,17 @@
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesPostPublishReadbackCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       },
       "github_checks": {
-        "status": "pending",
-        "evidence": "PR #2742 opened for branch codex/iq-method-pages-post-publish-readback-01; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "All reported GitHub checks passed for PR #2742 at head 7dfd5f494f8e6decc53322195ab9372c349e6efa: Semgrep OSS, Semgrep blocking secrets, content-pack-build-validate, hygiene, semgrep sarif non-blocking upload, supply-chain, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
-    "commit_sha": "025d1039e10e49143faa310e3faaeb0bc3671fd3",
+    "commit_sha": "7dfd5f494f8e6decc53322195ab9372c349e6efa",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2742",
     "failure_reason": null,
     "merged_at": null,
@@ -81008,6 +81008,11 @@
         "at": "2026-07-05T17:33:00+08:00",
         "status": "github_checks_pending",
         "summary": "Opened PR #2742 for the scoped post-publish readback workflow and pushed the local-validation-passed implementation. Waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-07-05T17:52:00+08:00",
+        "status": "ready_to_merge",
+        "summary": "All reported GitHub checks passed for PR #2742 at head 7dfd5f494f8e6decc53322195ab9372c349e6efa. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80950,7 +80950,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01"
     ],
-    "status": "local_validation_passed",
+    "status": "github_checks_pending",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80964,6 +80964,10 @@
       "local_validation": {
         "status": "pass",
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesPostPublishReadbackCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR #2742 opened for branch codex/iq-method-pages-post-publish-readback-01; waiting for required GitHub checks."
       }
     },
     "scope_validation": {
@@ -80972,8 +80976,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "025d1039e10e49143faa310e3faaeb0bc3671fd3",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2742",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -80999,6 +81003,11 @@
         "at": "2026-07-05T17:25:00+08:00",
         "status": "local_validation_passed",
         "summary": "Implemented read-only post-publish IQ method article readback command and tests. Local validation passed; no indexability, sitemap, llms, search action, deploy, production execution, or CMS mutation was performed."
+      },
+      {
+        "at": "2026-07-05T17:33:00+08:00",
+        "status": "github_checks_pending",
+        "summary": "Opened PR #2742 for the scoped post-publish readback workflow and pushed the local-validation-passed implementation. Waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -80865,7 +80865,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-REVIEW-APPROVAL-01"
     ],
-    "status": "ready_to_merge",
+    "status": "merged",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80883,20 +80883,24 @@
       "github_checks": {
         "status": "pass",
         "evidence": "PR #2739 GitHub checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "merge_reconciliation": {
+        "status": "pass",
+        "evidence": "PR #2739 is MERGED at merge commit b0b643b29cd2bce5cf6687e52bcd82892467455c; origin/main contains the merge commit; local main is synced in the active worktree; task branch codex/iq-method-pages-cms-publish-01 was absent locally and deleted remotely."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
-    "commit_sha": "11b8e3ee1839c6edbc93316bf0cf0fc490f246a6",
+    "commit_sha": "b0b643b29cd2bce5cf6687e52bcd82892467455c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2739",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T08:48:18Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": true,
@@ -80928,6 +80932,11 @@
         "at": "2026-07-05T17:10:00+08:00",
         "status": "ready_to_merge",
         "summary": "GitHub checks passed for PR #2739. Ready for squash merge under the PR train merge policy; no indexability, sitemap, llms, search action, deploy, or production execution was performed."
+      },
+      {
+        "at": "2026-07-05T17:25:00+08:00",
+        "status": "merged",
+        "summary": "Reconciled post-merge state for PR #2739: GitHub reports MERGED, origin/main contains merge commit b0b643b29cd2bce5cf6687e52bcd82892467455c, active local main is synced, and the task branch is absent locally/deleted remotely."
       }
     ]
   },
@@ -80941,7 +80950,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01"
     ],
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -80949,13 +80958,17 @@
         "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01 to merge before starting post-publish readback implementation."
+        "status": "pass",
+        "evidence": "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01 PR #2739 is merged; origin/main contains merge commit b0b643b29cd2bce5cf6687e52bcd82892467455c."
+      },
+      "local_validation": {
+        "status": "pass",
+        "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesPostPublishReadbackCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       }
     },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -80981,6 +80994,11 @@
         "at": "2026-07-05T13:55:29+08:00",
         "status": "pending_dependency",
         "summary": "Registered post-publish readback. Execution waits for controlled publish merge and must keep indexability, sitemap, and llms disabled."
+      },
+      {
+        "at": "2026-07-05T17:25:00+08:00",
+        "status": "local_validation_passed",
+        "summary": "Implemented read-only post-publish IQ method article readback command and tests. Local validation passed; no indexability, sitemap, llms, search action, deploy, production execution, or CMS mutation was performed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37321,7 +37321,7 @@ prs:
     branch: codex/iq-method-pages-post-publish-readback-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01: verify published IQ method articles before indexing"
     train_scope: iq_method_pages_zh_cn_post_publish_readback
-    status: github_checks_pending
+    status: ready_to_merge
     scope:
       - Add a read-only post-publish readback command for the 7 zh-CN IQ method CMS Articles.
       - Verify public article payloads, approved/published revision consistency, canonical, robots=noindex,follow, topic IQ grouping, landing links, and private-route/scoring-token guards.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37275,7 +37275,7 @@ prs:
     branch: codex/iq-method-pages-cms-publish-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01: add controlled IQ method article publish workflow"
     train_scope: iq_method_pages_zh_cn_publish
-    status: ready_to_merge
+    status: merged
     scope:
       - Add or verify a controlled backend batch publish workflow for the 7 approved zh-CN IQ method CMS Articles.
       - Publish only approved working revisions and keep indexability disabled during publish.
@@ -37321,7 +37321,7 @@ prs:
     branch: codex/iq-method-pages-post-publish-readback-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01: verify published IQ method articles before indexing"
     train_scope: iq_method_pages_zh_cn_post_publish_readback
-    status: user_authorized
+    status: local_validation_passed
     scope:
       - Add a read-only post-publish readback command for the 7 zh-CN IQ method CMS Articles.
       - Verify public article payloads, approved/published revision consistency, canonical, robots=noindex,follow, topic IQ grouping, landing links, and private-route/scoring-token guards.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37321,7 +37321,7 @@ prs:
     branch: codex/iq-method-pages-post-publish-readback-01
     title: "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01: verify published IQ method articles before indexing"
     train_scope: iq_method_pages_zh_cn_post_publish_readback
-    status: local_validation_passed
+    status: github_checks_pending
     scope:
       - Add a read-only post-publish readback command for the 7 zh-CN IQ method CMS Articles.
       - Verify public article payloads, approved/published revision consistency, canonical, robots=noindex,follow, topic IQ grouping, landing links, and private-route/scoring-token guards.


### PR DESCRIPTION
## What changed
- Added `articles:iq-method-pages-post-publish-readback`, a read-only post-publish verifier for the seven zh-CN IQ method Articles.
- Verifies articles are published/public but still noindex, sitemap-ineligible, and llms-ineligible.
- Verifies published revision consistency, canonical URLs, topic `iq_articles` grouping, landing methodology links, and private/scoring token guards.
- Added focused tests for pass state, premature indexability blocking, and private/scoring token leak blocking.
- Reconciled the already-merged publish workflow ledger dependency.

## Why
- This is the required stop between public publish and SEO/GEO activation. The pages can be readable, but indexing and AI surfaces must remain blocked until the separate activation gate.

## Validation
- `php -l backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php`
- `php -l backend/tests/Feature/Console/ArticleIqMethodPagesPostPublishReadbackCommandTest.php`
- `cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-post-publish-readback|iq-method-pages'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php tests/Feature/Console/ArticleIqMethodPagesPostPublishReadbackCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesPostPublishReadbackCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files' --no-ansi`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- Scope validation: changed files are limited to the manifest allowlist for `IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01`.

## Deferred items
- No indexability, sitemap, or llms activation.
- No search submission, manual deploy, production deploy, frontend fallback, content rewrite, IQ scoring change, or answer-key exposure.

## Repository rule impact
- This remains backend/CMS-authoritative and read-only. It does not move content authority into frontend code.