### PR TITLE
MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-01: read back MBTI FAQ production runtime

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82001,9 +82001,9 @@
     "depends_on": [
       "MBTI-MAIN-FREE-FAQ-CONTENT-01-CLOSEOUT"
     ],
-    "status": "local_checks_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "0f67e3a04ff3829ede6ee492fa883483b055d387",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2744",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -82063,6 +82063,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Production API readback found 8 FAQ entries, but public page visible FAQ and FAQPage JSON-LD remain 4. Generated read-only evidence report; JSON/YAML/diff checks and allowed-path scope validation passed."
+      },
+      {
+        "at": "2026-07-05T08:59:39Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened PR #2744 for read-only production runtime FAQ readback evidence."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82002,7 +82002,7 @@
       "MBTI-MAIN-FREE-FAQ-CONTENT-01-CLOSEOUT"
     ],
     "status": "pr_open",
-    "commit_sha": "0f67e3a04ff3829ede6ee492fa883483b055d387",
+    "commit_sha": "819f500afca9db72c04f5a19b5f4d99261c4063a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2744",
     "failure_reason": null,
     "merged_at": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82002,7 +82002,7 @@
       "MBTI-MAIN-FREE-FAQ-CONTENT-01-CLOSEOUT"
     ],
     "status": "pr_open",
-    "commit_sha": "819f500afca9db72c04f5a19b5f4d99261c4063a",
+    "commit_sha": "e02e0f8efc646ef3b58d99f1bbec91509d1650cd",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2744",
     "failure_reason": null,
     "merged_at": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81991,5 +81991,79 @@
         "summary": "Registered Big Five CMS staging-to-release readiness PR train item from the active /goal objective. Authorization-gated items must stop until their explicit gates are satisfied."
       }
     ]
+  },
+  "MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-01": {
+    "id": "MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-01",
+    "repo": "fap-api",
+    "title": "MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-01: read back MBTI FAQ production runtime",
+    "base": "main",
+    "branch": "codex/mbti-main-faq-production-runtime-readback-01",
+    "depends_on": [
+      "MBTI-MAIN-FREE-FAQ-CONTENT-01-CLOSEOUT"
+    ],
+    "status": "local_checks_passed",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding this PR-train item in the attached /goal execution request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "MBTI-MAIN-FREE-FAQ-CONTENT-01-CLOSEOUT PR #2740 is merged, and origin/main contains merge commit 5b716cbb06da6ab32d14927ab7384b34f9aa0911."
+      },
+      "production_api_readback": {
+        "status": "pass",
+        "command": "curl -sS 'https://api.fermatmind.com/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh'",
+        "evidence": "Production API returned HTTP 200 and content_i18n_json.zh.faq count = 8 at 2026-07-05T08:59:39Z."
+      },
+      "public_page_readback": {
+        "status": "blocked_faq_not_propagated",
+        "command": "curl -sSL 'https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types'",
+        "evidence": "Public page redirected from www to apex and returned HTTP 200, but rendered visible FAQ count = 4 and FAQPage JSON-LD mainEntity count = 4."
+      },
+      "schema_parity_decision": {
+        "status": "skip_schema_repair",
+        "evidence": "Visible FAQ count equals JSON-LD count and questions at 4, so MBTI-MAIN-FAQ-SCHEMA-PARITY-REPAIR-01 is not eligible. The observed blocker is API 8 vs public page/schema 4 propagation, not visible 8 vs schema mismatch."
+      },
+      "private_url_boundary": {
+        "status": "pass",
+        "evidence": "No private attempt/order/payment/report/result/token hrefs were found in the public page readback."
+      },
+      "local_validation": {
+        "status": "pass",
+        "command": "python3 -m json.tool generated/seo-ops-mbti-main-faq-runtime-readback-20260705/scan_manifest.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "evidence": "PASS: generated scan manifest parses, train YAML parses, state JSON parses, and git diff whitespace check passes."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to allowed paths: generated/seo-ops-mbti-main-faq-runtime-readback-20260705/**, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": false
+    },
+    "transitions": [
+      {
+        "at": "2026-07-05T08:59:39Z",
+        "from": "user_authorized",
+        "to": "in_progress",
+        "note": "Started read-only production runtime FAQ readback from latest main after MBTI closeout merge was verified. Scope is generated evidence plus authorized train metadata only; no runtime, CMS, sitemap, llms, Search Channel, or deploy action."
+      },
+      {
+        "at": "2026-07-05T08:59:39Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Production API readback found 8 FAQ entries, but public page visible FAQ and FAQPage JSON-LD remain 4. Generated read-only evidence report; JSON/YAML/diff checks and allowed-path scope validation passed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37691,3 +37691,39 @@ prs:
     deploy_allowed: false
     content_authority: CMS/backend
     next_task: null
+
+  - id: MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-01
+    repo: fap-api
+    depends_on:
+      - MBTI-MAIN-FREE-FAQ-CONTENT-01-CLOSEOUT
+    branch: codex/mbti-main-faq-production-runtime-readback-01
+    title: "MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-01: read back MBTI FAQ production runtime"
+    train_scope: mbti_main_faq_runtime_readback
+    status: user_authorized
+    scope:
+      - Add a read-only generated evidence report for the MBTI main FAQ production runtime state.
+      - Verify production API FAQ count, public page visible FAQ count, FAQPage JSON-LD count, question parity, and private URL boundary.
+      - Decide whether schema parity repair is needed, without mutating CMS, runtime code, deploy state, sitemap, llms, Search Channel, or production data.
+    allowed_paths:
+      - generated/seo-ops-mbti-main-faq-runtime-readback-20260705/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web, runtime code, API adapters, schema renderers, CMS content, sitemap, llms, canonical, noindex, Search Channel, deployment configuration, or production data.
+      - Trigger staging deploy, production deploy, manual deploy, URL submission, CMS write, production import, or database migration.
+    validation:
+      - python3 -m json.tool generated/seo-ops-mbti-main-faq-runtime-readback-20260705/scan_manifest.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: MBTI-MAIN-FAQ-SCHEMA-PARITY-REPAIR-01

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/API_READBACK.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/API_READBACK.md
@@ -1,0 +1,22 @@
+# API Readback
+
+Endpoint:
+
+`https://api.fermatmind.com/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh`
+
+Result:
+
+- HTTP status: 200
+- FAQ path: `content_i18n_json.zh.faq`
+- FAQ count: 8
+
+Questions:
+
+1. MBTI 测试免费吗？
+2. MBTI 完整结果能看到什么？
+3. MBTI 测试一般多久？
+4. MBTI 能决定职业吗？
+5. MBTI 是心理诊断吗？
+6. 16 型人格结果会变吗？
+7. MBTI 和大五人格有什么区别？
+8. 做完 MBTI 后下一步看什么？

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/CLAIM_PRIVATE_URL_RECHECK.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/CLAIM_PRIVATE_URL_RECHECK.md
@@ -1,0 +1,13 @@
+# Claim And Private URL Boundary Recheck
+
+Claim boundary:
+
+- Page title and metadata keep MBTI positioned as self-understanding and career exploration support.
+- The visible disclaimer says results are for self-understanding and not diagnosis, treatment, hiring screening, or career guarantee.
+
+Private URL boundary:
+
+- No private attempt/order/payment/report/result/token hrefs were found in the public page readback.
+- The page includes public test start links under `/zh/tests/mbti-personality-test-16-personality-types/take?...`; those are public entry links, not private result or order links.
+
+Result: pass.

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/EXECUTIVE_DECISION.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/EXECUTIVE_DECISION.md
@@ -1,0 +1,11 @@
+# MBTI Main FAQ Production Runtime Readback
+
+Decision: BLOCKED_FAQ_NOT_PROPAGATED
+
+Observed at: 2026-07-05T08:59:39Z
+
+The production backend API already returns 8 FAQ entries for the zh MBTI main test landing content, but the production public page still renders 4 visible FAQ entries and 4 FAQPage JSON-LD entries.
+
+This does not satisfy the condition for `MBTI-MAIN-FAQ-SCHEMA-PARITY-REPAIR-01`, because visible FAQ and JSON-LD are currently in parity with each other at 4. The mismatch is API 8 vs public page/schema 4, so the next action should not be schema renderer repair unless a later readback shows visible FAQ = 8 with JSON-LD mismatch.
+
+No CMS write, production import, deployment, sitemap, llms, Search Channel, or runtime code change was performed.

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/FAQ_SCHEMA_PARITY_READBACK.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/FAQ_SCHEMA_PARITY_READBACK.md
@@ -1,0 +1,19 @@
+# FAQ Schema Parity Readback
+
+Result:
+
+- FAQPage JSON-LD detected: yes
+- FAQPage `mainEntity` count: 4
+- Visible FAQ count: 4
+- Visible questions equal JSON-LD questions: yes
+
+JSON-LD questions:
+
+1. 费马的 MBTI免费测试会收费吗？
+2. 这份 16型人格完整结果/报告包含哪些内容？
+3. MBTI免费测试结果可以作为职业或心理诊断吗？
+4. 完成测试后还能重新查看或重复测试吗？
+
+Decision:
+
+`MBTI-MAIN-FAQ-SCHEMA-PARITY-REPAIR-01` is skipped for now. The conditional repair only applies if visible FAQ = 8 but JSON-LD is not 8 or questions differ. Current production evidence is visible FAQ = 4 and JSON-LD = 4.

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/PAGE_VISIBLE_FAQ_READBACK.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/PAGE_VISIBLE_FAQ_READBACK.md
@@ -1,0 +1,22 @@
+# Public Page Visible FAQ Readback
+
+URL requested:
+
+`https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+Result:
+
+- `www` redirected with HTTP 308 to `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- Final HTTP status: 200
+- Visible FAQ count from rendered HTML: 4
+
+Visible questions:
+
+1. 费马的 MBTI免费测试会收费吗？
+2. 这份 16型人格完整结果/报告包含哪些内容？
+3. MBTI免费测试结果可以作为职业或心理诊断吗？
+4. 完成测试后还能重新查看或重复测试吗？
+
+Runtime note:
+
+The public page has not propagated the 8-entry backend API FAQ payload into visible FAQ content.

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/scan_manifest.json
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705/scan_manifest.json
@@ -1,0 +1,62 @@
+{
+  "id": "MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-01",
+  "generated_at": "2026-07-05T08:59:39Z",
+  "repo": "fap-api",
+  "scope": "read-only production runtime evidence",
+  "urls": {
+    "api": "https://api.fermatmind.com/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh",
+    "public_page_requested": "https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "public_page_final": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types"
+  },
+  "observations": {
+    "api_status": 200,
+    "api_faq_path": "content_i18n_json.zh.faq",
+    "api_faq_count": 8,
+    "public_page_redirect": "HTTP 308 from www to apex",
+    "public_page_status": 200,
+    "visible_faq_count": 4,
+    "faqpage_json_ld_count": 4,
+    "visible_questions_equal_json_ld_questions": true,
+    "private_url_hits": []
+  },
+  "api_questions": [
+    "MBTI 测试免费吗？",
+    "MBTI 完整结果能看到什么？",
+    "MBTI 测试一般多久？",
+    "MBTI 能决定职业吗？",
+    "MBTI 是心理诊断吗？",
+    "16 型人格结果会变吗？",
+    "MBTI 和大五人格有什么区别？",
+    "做完 MBTI 后下一步看什么？"
+  ],
+  "visible_questions": [
+    "费马的 MBTI免费测试会收费吗？",
+    "这份 16型人格完整结果/报告包含哪些内容？",
+    "MBTI免费测试结果可以作为职业或心理诊断吗？",
+    "完成测试后还能重新查看或重复测试吗？"
+  ],
+  "json_ld_questions": [
+    "费马的 MBTI免费测试会收费吗？",
+    "这份 16型人格完整结果/报告包含哪些内容？",
+    "MBTI免费测试结果可以作为职业或心理诊断吗？",
+    "完成测试后还能重新查看或重复测试吗？"
+  ],
+  "decision": "BLOCKED_FAQ_NOT_PROPAGATED",
+  "schema_repair_pr": {
+    "id": "MBTI-MAIN-FAQ-SCHEMA-PARITY-REPAIR-01",
+    "eligible": false,
+    "reason": "visible FAQ and FAQPage JSON-LD are both 4 and question-parity passes; the blocker is API 8 vs public page/schema 4 propagation."
+  },
+  "actions_not_taken": [
+    "CMS write",
+    "production import",
+    "database migration",
+    "runtime code change",
+    "fap-web change",
+    "sitemap or llms change",
+    "Search Channel action",
+    "staging deploy wait",
+    "manual deploy",
+    "production deploy"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added a read-only generated evidence bundle for MBTI main FAQ production runtime readback.
- Registered the user-authorized PR-train item and state entry for `MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-01`.
- Recorded the decision `BLOCKED_FAQ_NOT_PROPAGATED`: production API has 8 FAQ entries, but the public page and FAQPage JSON-LD still render 4.

## Why
- The just-merged MBTI FAQ content needed production runtime evidence before deciding whether schema repair or D0 observation should continue.
- Current evidence shows this is not a schema parity repair case: visible FAQ and JSON-LD match each other at 4, while the backend API has 8.

## Validation
- `curl -sS 'https://api.fermatmind.com/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh'`
- `curl -sSL 'https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types'`
- `python3 -m json.tool generated/seo-ops-mbti-main-faq-runtime-readback-20260705/scan_manifest.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Deferred items
- No schema parity repair in this PR; conditional repair is skipped unless a later readback shows visible FAQ = 8 with JSON-LD mismatch.
- No D0/D1/D7/D28 observation baseline in this PR because public page FAQ propagation is blocked.
- No fap-web/runtime changes, CMS writes, production import, Search Channel action, sitemap/llms change, staging deploy wait, manual deploy, or production deploy.

## Repository rule impact
- Documentation/generated evidence only. No content authority, runtime, API, CMS, SEO surface, sitemap, llms, or deployment rule change.
