### PR TITLE
IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01: add IQ method SEO/GEO activation gate

### DIFF
--- a/backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php
+++ b/backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php
@@ -1,0 +1,431 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\LandingSurface;
+use App\Models\PageBlock;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class ArticleIqMethodPagesSeoGeoActivationGate extends Command
+{
+    private const SCHEMA_VERSION = 'fermatmind.iq_method_pages.seo_geo_activation_gate.v1';
+
+    private const PR_ID = 'IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01';
+
+    private const POST_PUBLISH_READBACK_PR_ID = 'IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01';
+
+    private const SLUGS = [
+        'what-is-iq-style-reasoning-test',
+        'online-iq-test-vs-professional-assessment',
+        'iq-test-score-meaning-boundary',
+        'matrix-reasoning-pattern-recognition-guide',
+        'why-fermatmind-iq-v1-not-certification',
+        'iq-test-privacy-data-boundary',
+        'iq-expert-review-disclosure',
+    ];
+
+    private const REQUIRED_VISIBLE_TERMS = [
+        'IQ',
+        '非官方',
+        '非临床',
+        '非认证',
+    ];
+
+    private const FORBIDDEN_CLAIM_PATTERNS = [
+        'official_iq' => '/(?:官方\s*IQ|official\s+IQ)/iu',
+        'certified_iq' => '/(?:认证\s*IQ|certified\s+IQ|PDF\s*certificate|certificate)/iu',
+        'clinical_diagnosis' => '/(?:临床诊断|诊断级|clinical\s+diagnosis|clinical-grade)/iu',
+        'mensa_claim' => '/\bMensa\b|门萨/u',
+        'percentile_claim' => '/(?:percentile|百分位)/iu',
+        'employment_or_admission' => '/(?:招聘|录用|升学录取|薪资预测|hire|admission|salary\s+prediction)/iu',
+        'fixed_intelligence' => '/(?:真实智商|固定智力|固定能力|real\s+IQ)/iu',
+    ];
+
+    private const PRIVATE_PATTERNS = [
+        'attempt_route' => '~/(?:zh/|en/)?attempt(?:/|[?#\s)"\']|$)~i',
+        'result_route' => '~/(?:zh/|en/)?(?:result|results)(?:/|[?#\s)"\']|$)~i',
+        'order_route' => '~/(?:zh/|en/)?(?:orders|order)(?:/|[?#\s)"\']|$)~i',
+        'payment_route' => '~/(?:zh/|en/)?(?:pay|payment)(?:/|[?#\s)"\']|$)~i',
+        'recovery_route' => '~/(?:zh/|en/)?(?:recover|restore)(?:/|[?#\s)"\']|$)~i',
+        'scoring_secret' => '/\b(?:answer_key|correct_answer|scoring_rule|score_formula|private_result|payment_id)\b/i',
+    ];
+
+    protected $signature = 'articles:iq-method-pages-seo-geo-activation-gate
+        {--json : Emit a JSON summary}';
+
+    protected $description = 'Read-only SEO/GEO activation gate for the 7 published zh-CN IQ method CMS Articles.';
+
+    public function handle(): int
+    {
+        try {
+            $summary = $this->gate();
+        } catch (Throwable $exception) {
+            $summary = [
+                'schema_version' => self::SCHEMA_VERSION,
+                'ok' => false,
+                'status' => 'blocked',
+                'pr_id' => self::PR_ID,
+                'issues' => [$this->issue('command', 'unexpected_error', $exception->getMessage())],
+                'side_effects' => $this->sideEffects(),
+            ];
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function gate(): array
+    {
+        $issues = [];
+        $articles = $this->gateArticles($issues);
+        $topic = $this->gateTopic($issues);
+        $landing = $this->gateLanding($issues);
+        $activationCandidates = array_values(array_map(
+            static fn (array $article): array => [
+                'article_id' => (int) $article['article_id'],
+                'slug' => (string) $article['slug'],
+                'canonical_url' => (string) $article['canonical_url'],
+                'current_robots' => (string) $article['robots'],
+                'next_robots' => 'index,follow',
+                'current_is_indexable' => false,
+                'next_is_indexable' => true,
+                'current_sitemap_eligible' => false,
+                'next_sitemap_eligible' => true,
+                'current_llms_eligible' => false,
+                'next_llms_eligible' => true,
+                'activation_command' => 'php artisan articles:iq-method-pages-seo-geo-activate --article-id='.(int) $article['article_id'].' --expected-slug='.(string) $article['slug'].' --dry-run --json',
+            ],
+            array_filter($articles, static fn (array $article): bool => ($article['activation_candidate'] ?? false) === true),
+        ));
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $issues === [] && count($activationCandidates) === 7,
+            'status' => $issues === [] && count($activationCandidates) === 7 ? 'pass' : 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'generated_at' => now()->toIso8601String(),
+            'pr_id' => self::PR_ID,
+            'source_post_publish_readback_pr_id' => self::POST_PUBLISH_READBACK_PR_ID,
+            'expected_article_count' => 7,
+            'activation_candidate_count' => count($activationCandidates),
+            'activation_candidates' => $activationCandidates,
+            'articles' => $articles,
+            'topic_gate' => $topic,
+            'landing_gate' => $landing,
+            'issue_count' => count($issues),
+            'issues' => $issues,
+            'next_allowed_action' => $issues === [] && count($activationCandidates) === 7
+                ? 'run IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01 dry-run; production execute still requires exact deployed SHA and command authorization'
+                : 'fix SEO/GEO activation prerequisites before indexability, sitemap, or llms writes',
+            'side_effects' => $this->sideEffects(),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return list<array<string,mixed>>
+     */
+    private function gateArticles(array &$issues): array
+    {
+        $readbacks = [];
+
+        foreach (self::SLUGS as $slug) {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['publishedRevision', 'workingRevision', 'seoMeta'])
+                ->where('org_id', 0)
+                ->where('locale', 'zh-CN')
+                ->where('slug', $slug)
+                ->first();
+            $before = count($issues);
+
+            if (! $article instanceof Article) {
+                $issues[] = $this->issue($slug, 'article_missing', 'Published IQ method Article was not found.');
+                $readbacks[] = ['slug' => $slug, 'ok' => false, 'activation_candidate' => false];
+
+                continue;
+            }
+
+            $seo = $article->seoMeta instanceof ArticleSeoMeta ? $article->seoMeta : null;
+            $published = $article->publishedRevision instanceof ArticleTranslationRevision ? $article->publishedRevision : null;
+            $canonicalUrl = 'https://fermatmind.com/zh/articles/'.$slug;
+
+            $this->same($issues, $slug.'.status', 'published', (string) $article->status);
+            $this->same($issues, $slug.'.is_public', true, (bool) $article->is_public);
+            $this->same($issues, $slug.'.current_is_indexable', false, (bool) $article->is_indexable);
+            $this->same($issues, $slug.'.current_sitemap_eligible', false, (bool) $article->sitemap_eligible);
+            $this->same($issues, $slug.'.current_llms_eligible', false, (bool) $article->llms_eligible);
+            if ($published === null) {
+                $issues[] = $this->issue($slug.'.published_revision', 'published_revision_missing', 'Published revision missing.');
+            } else {
+                $this->same($issues, $slug.'.published_revision_status', ArticleTranslationRevision::STATUS_PUBLISHED, (string) $published->revision_status);
+                $this->same($issues, $slug.'.published_revision_id', (int) $article->published_revision_id, (int) $published->id);
+            }
+
+            if (! $seo instanceof ArticleSeoMeta) {
+                $issues[] = $this->issue($slug.'.seo_meta', 'seo_meta_missing', 'SEO meta missing.');
+            } else {
+                $this->same($issues, $slug.'.canonical_url', $canonicalUrl, (string) $seo->canonical_url);
+                $this->same($issues, $slug.'.current_robots', 'noindex,follow', (string) $seo->robots);
+                $this->same($issues, $slug.'.current_seo_is_indexable', false, (bool) $seo->is_indexable);
+                $this->same($issues, $slug.'.publish_pr', 'IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01', (string) data_get($seo->schema_json, 'editorial_package_v1.publish_v1.pr_id'));
+            }
+
+            $body = (string) $article->content_md;
+            $this->assertVisibleEvidence($issues, $slug, $body);
+            $this->assertNoForbiddenClaims($issues, $slug.'.claim_boundary', $this->publicPayloadText($article, $seo));
+            $this->assertNoPrivateTokens($issues, $slug.'.public_payload', $this->publicPayloadText($article, $seo));
+
+            $readbacks[] = [
+                'slug' => $slug,
+                'article_id' => (int) $article->id,
+                'published_revision_id' => $article->published_revision_id !== null ? (int) $article->published_revision_id : null,
+                'status' => (string) $article->status,
+                'is_public' => (bool) $article->is_public,
+                'current_is_indexable' => (bool) $article->is_indexable,
+                'robots' => (string) ($seo?->robots ?? ''),
+                'canonical_url' => (string) ($seo?->canonical_url ?? ''),
+                'sitemap_eligible' => (bool) $article->sitemap_eligible,
+                'llms_eligible' => (bool) $article->llms_eligible,
+                'visible_evidence_ready' => $this->visibleEvidenceReady($body),
+                'activation_candidate' => count($issues) === $before,
+            ];
+        }
+
+        return $readbacks;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function gateTopic(array &$issues): array
+    {
+        $profile = TopicProfile::query()->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', 'zh-CN')
+            ->where('slug', 'iq-eq')
+            ->first();
+
+        if (! $profile instanceof TopicProfile) {
+            $issues[] = $this->issue('topic.iq-eq', 'topic_missing', 'IQ/EQ topic profile missing.');
+
+            return ['ok' => false, 'slug' => 'iq-eq'];
+        }
+
+        $entries = TopicProfileEntry::query()
+            ->where('profile_id', (int) $profile->id)
+            ->where('group_key', 'iq_articles')
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
+        $actual = $entries->pluck('target_key')->values()->all();
+        if ($actual !== self::SLUGS) {
+            $issues[] = $this->issue('topic.iq_articles.items', 'topic_items_mismatch', 'Topic IQ article entries do not match expected slugs.');
+        }
+        $this->assertNoPrivateTokens($issues, 'topic.iq_articles.payload', $entries->toJson(JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return [
+            'ok' => $actual === self::SLUGS,
+            'topic_profile_id' => (int) $profile->id,
+            'slug' => 'iq-eq',
+            'group_key' => 'iq_articles',
+            'slugs' => $actual,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return array<string,mixed>
+     */
+    private function gateLanding(array &$issues): array
+    {
+        $surface = LandingSurface::query()->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('surface_key', 'test:iq-test-intelligence-quotient-assessment')
+            ->where('locale', 'zh-CN')
+            ->first();
+
+        if (! $surface instanceof LandingSurface) {
+            $issues[] = $this->issue('landing_surface.iq', 'landing_surface_missing', 'IQ landing surface missing.');
+
+            return ['ok' => false, 'surface_key' => 'test:iq-test-intelligence-quotient-assessment'];
+        }
+
+        $block = PageBlock::query()
+            ->where('landing_surface_id', (int) $surface->id)
+            ->where('block_key', 'iq_methodology_boundary_links')
+            ->first();
+
+        if (! $block instanceof PageBlock) {
+            $issues[] = $this->issue('landing_block.iq_methodology_boundary_links', 'landing_block_missing', 'IQ methodology boundary links block missing.');
+
+            return ['ok' => false, 'surface_key' => (string) $surface->surface_key];
+        }
+
+        $items = collect((array) data_get($block->payload_json, 'items', []));
+        $actual = $items->pluck('slug')->values()->all();
+        if ($actual !== self::SLUGS) {
+            $issues[] = $this->issue('landing_block.iq_methodology_boundary_links.items', 'landing_items_mismatch', 'Landing block article links do not match expected slugs.');
+        }
+        $this->same($issues, 'landing_block.frontend_hardcode_allowed', false, (bool) data_get($block->payload_json, 'frontend_hardcode_allowed'));
+        $this->assertNoPrivateTokens($issues, 'landing_block.iq_methodology_boundary_links.payload', json_encode($block->payload_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+
+        return [
+            'ok' => $actual === self::SLUGS,
+            'surface_key' => (string) $surface->surface_key,
+            'block_key' => 'iq_methodology_boundary_links',
+            'slugs' => $actual,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function sideEffects(): array
+    {
+        return [
+            'db_write' => false,
+            'cms_update' => false,
+            'publish' => false,
+            'indexability' => false,
+            'sitemap' => false,
+            'llms' => false,
+            'search' => false,
+            'deploy' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function same(array &$issues, string $field, mixed $expected, mixed $actual): void
+    {
+        if ($expected !== $actual) {
+            $issues[] = $this->issue($field, 'value_mismatch', 'Activation gate value mismatch.', [
+                'expected' => $expected,
+                'actual' => $actual,
+            ]);
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function assertVisibleEvidence(array &$issues, string $slug, string $body): void
+    {
+        if (! $this->visibleEvidenceReady($body)) {
+            $issues[] = $this->issue($slug.'.visible_evidence', 'visible_evidence_missing', 'Article body must expose IQ method evidence, FAQ/body explanation, and non-official/non-clinical/non-certification boundary text before SEO/GEO activation.');
+        }
+    }
+
+    private function visibleEvidenceReady(string $body): bool
+    {
+        if (mb_strlen(trim($body)) < 300) {
+            return false;
+        }
+        if (preg_match('/(?:FAQ|常见问题|问答)/u', $body) !== 1) {
+            return false;
+        }
+
+        foreach (self::REQUIRED_VISIBLE_TERMS as $term) {
+            if (! str_contains($body, $term)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function assertNoForbiddenClaims(array &$issues, string $field, string $text): void
+    {
+        foreach (self::FORBIDDEN_CLAIM_PATTERNS as $code => $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                $issues[] = $this->issue($field, 'forbidden_claim_detected', 'Public IQ method activation payload contains a forbidden claim.', [
+                    'pattern' => $code,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     */
+    private function assertNoPrivateTokens(array &$issues, string $field, string $text): void
+    {
+        foreach (self::PRIVATE_PATTERNS as $code => $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                $issues[] = $this->issue($field, 'private_or_scoring_token_leak', 'Public IQ method activation payload contains a private route or scoring token.', [
+                    'pattern' => $code,
+                ]);
+            }
+        }
+    }
+
+    private function publicPayloadText(Article $article, ?ArticleSeoMeta $seo): string
+    {
+        return json_encode([
+            'title' => $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => $article->content_md,
+            'seo' => $seo?->toArray(),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) ?: '';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $context = []): array
+    {
+        return array_filter([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+            'context' => $context === [] ? null : $context,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'blocked'));
+        $this->line('activation_candidate_count='.(string) ($summary['activation_candidate_count'] ?? 0));
+        $this->line('issue_count='.(string) ($summary['issue_count'] ?? 0));
+
+        foreach ((array) ($summary['issues'] ?? []) as $issue) {
+            if (is_array($issue)) {
+                $this->line(sprintf(
+                    'issue=%s:%s:%s',
+                    (string) ($issue['field'] ?? 'unknown'),
+                    (string) ($issue['code'] ?? 'unknown'),
+                    (string) ($issue['message'] ?? ''),
+                ));
+            }
+        }
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -34,6 +34,7 @@ return Application::configure(basePath: dirname(__DIR__))
         \App\Console\Commands\ArticleIqMethodPagesPublishGate::class,
         \App\Console\Commands\ArticleIqMethodPagesPublish::class,
         \App\Console\Commands\ArticleIqMethodPagesPostPublishReadback::class,
+        \App\Console\Commands\ArticleIqMethodPagesSeoGeoActivationGate::class,
         \App\Console\Commands\ArticleIqMethodPagesReadback::class,
         \App\Console\Commands\ArticleIqMethodPagesReviewApproval::class,
         \App\Console\Commands\PersonalityEnneagramCmsPromote::class,

--- a/backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivationGateCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivationGateCommandTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\ArticleIqMethodPagesSeoGeoActivationGate;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\LandingSurface;
+use App\Models\PageBlock;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+final class ArticleIqMethodPagesSeoGeoActivationGateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(Kernel::class)->registerCommand($this->app->make(ArticleIqMethodPagesSeoGeoActivationGate::class));
+    }
+
+    public function test_activation_gate_passes_for_published_noindex_iq_method_articles(): void
+    {
+        $this->createPublishedIqMethodArticles();
+        $this->createTopicAndLandingLinks();
+
+        [$exit, $payload] = $this->callGate();
+
+        $this->assertSame(0, $exit, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['execute']);
+        $this->assertSame(7, $payload['activation_candidate_count']);
+        $this->assertCount(7, $payload['activation_candidates']);
+        $this->assertSame('what-is-iq-style-reasoning-test', $payload['activation_candidates'][0]['slug']);
+        $this->assertSame('index,follow', $payload['activation_candidates'][0]['next_robots']);
+        $this->assertStringContainsString('articles:iq-method-pages-seo-geo-activate', $payload['activation_candidates'][0]['activation_command']);
+        $this->assertFalse($payload['side_effects']['db_write']);
+        $this->assertFalse($payload['side_effects']['indexability']);
+        $this->assertFalse($payload['side_effects']['sitemap']);
+        $this->assertFalse($payload['side_effects']['llms']);
+
+        $fresh = Article::query()->withoutGlobalScopes()->where('slug', 'what-is-iq-style-reasoning-test')->firstOrFail();
+        $this->assertFalse((bool) $fresh->is_indexable);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+    }
+
+    public function test_activation_gate_blocks_forbidden_claims(): void
+    {
+        $this->createPublishedIqMethodArticles();
+        $this->createTopicAndLandingLinks();
+
+        Article::query()->withoutGlobalScopes()
+            ->where('slug', 'what-is-iq-style-reasoning-test')
+            ->update(['content_md' => $this->body()."\n\n这是官方 IQ 和 Mensa 认证。"]);
+
+        [$exit, $payload] = $this->callGate();
+
+        $this->assertSame(1, $exit);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('forbidden_claim_detected', collect($payload['issues'])->pluck('code')->all());
+        $this->assertSame(6, $payload['activation_candidate_count']);
+    }
+
+    public function test_activation_gate_blocks_premature_discoverability_flags(): void
+    {
+        $this->createPublishedIqMethodArticles();
+        $this->createTopicAndLandingLinks();
+
+        Article::query()->withoutGlobalScopes()
+            ->where('slug', 'iq-test-privacy-data-boundary')
+            ->update(['sitemap_eligible' => true, 'llms_eligible' => true]);
+
+        [$exit, $payload] = $this->callGate();
+
+        $this->assertSame(1, $exit);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('iq-test-privacy-data-boundary.current_sitemap_eligible', collect($payload['issues'])->pluck('field')->all());
+        $this->assertContains('iq-test-privacy-data-boundary.current_llms_eligible', collect($payload['issues'])->pluck('field')->all());
+    }
+
+    private function createPublishedIqMethodArticles(): void
+    {
+        foreach ($this->slugs() as $index => $slug) {
+            $article = Article::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'slug' => $slug,
+                'locale' => 'zh-CN',
+                'title' => 'IQ 方法页 '.$index,
+                'excerpt' => 'IQ 方法页摘要，说明非官方、非临床、非认证边界。',
+                'content_md' => $this->body(),
+                'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+                'status' => 'published',
+                'lifecycle_state' => Article::LIFECYCLE_ACTIVE,
+                'is_public' => true,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'published_at' => now()->subMinute(),
+            ]);
+
+            $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'article_id' => (int) $article->id,
+                'source_article_id' => (int) $article->id,
+                'translation_group_id' => (string) $article->translation_group_id,
+                'locale' => 'zh-CN',
+                'source_locale' => 'zh-CN',
+                'revision_number' => $index + 1,
+                'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+                'title' => 'IQ 方法页 '.$index,
+                'excerpt' => 'IQ 方法页摘要，说明非官方、非临床、非认证边界。',
+                'content_md' => $this->body(),
+                'reviewed_by' => 42,
+                'reviewed_at' => now()->subMinutes(10),
+                'approved_at' => now()->subMinutes(5),
+                'published_at' => now()->subMinute(),
+            ]);
+            $article->forceFill([
+                'working_revision_id' => (int) $revision->id,
+                'published_revision_id' => (int) $revision->id,
+            ])->save();
+
+            ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'article_id' => (int) $article->id,
+                'locale' => 'zh-CN',
+                'seo_title' => 'IQ 方法页 '.$index,
+                'seo_description' => 'IQ 方法页 SEO 描述，说明非官方、非临床、非认证边界。',
+                'canonical_url' => 'https://fermatmind.com/zh/articles/'.$slug,
+                'og_title' => 'IQ 方法页 '.$index,
+                'og_description' => 'IQ 方法页 OG 描述',
+                'og_image_url' => 'https://fermatmind.com/storage/articles/iq-method.svg',
+                'robots' => 'noindex,follow',
+                'schema_json' => [
+                    'editorial_package_v1' => [
+                        'publish_v1' => [
+                            'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01',
+                            'indexability_allowed' => false,
+                            'sitemap_llms_allowed' => false,
+                        ],
+                    ],
+                ],
+                'is_indexable' => false,
+            ]);
+        }
+    }
+
+    private function createTopicAndLandingLinks(): void
+    {
+        $profile = TopicProfile::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'topic_code' => 'iq-eq',
+            'slug' => 'iq-eq',
+            'locale' => 'zh-CN',
+            'title' => 'IQ 与 EQ 主题内容聚合',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+
+        foreach ($this->slugs() as $index => $slug) {
+            TopicProfileEntry::query()->create([
+                'profile_id' => (int) $profile->id,
+                'entry_type' => 'article',
+                'group_key' => 'iq_articles',
+                'target_key' => $slug,
+                'target_locale' => 'zh-CN',
+                'target_url_override' => '/zh/articles/'.$slug,
+                'payload_json' => ['slug' => $slug],
+                'sort_order' => $index + 1,
+                'is_enabled' => true,
+            ]);
+        }
+
+        $surface = LandingSurface::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'surface_key' => 'test:iq-test-intelligence-quotient-assessment',
+            'locale' => 'zh-CN',
+            'title' => 'IQ 测试 landing',
+            'status' => LandingSurface::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+
+        PageBlock::query()->create([
+            'landing_surface_id' => (int) $surface->id,
+            'block_key' => 'iq_methodology_boundary_links',
+            'block_type' => 'article_link_cluster',
+            'title' => 'IQ 测试方法与边界',
+            'payload_json' => [
+                'frontend_hardcode_allowed' => false,
+                'items' => collect($this->slugs())
+                    ->map(static fn (string $slug): array => ['slug' => $slug, 'href' => '/zh/articles/'.$slug])
+                    ->all(),
+            ],
+            'sort_order' => 1,
+            'is_enabled' => true,
+        ]);
+    }
+
+    private function body(): string
+    {
+        return <<<'MARKDOWN'
+# 什么是 IQ 风格推理测试？
+
+这篇文章解释 FermatMind IQ V1 的方法边界。IQ 风格推理测试使用图形、矩阵、规律补全、空间关系和限时作答任务，帮助用户理解本次推理任务表现。
+
+## 方法边界
+
+FermatMind IQ V1 是非官方、非临床、非认证的在线推理任务。页面只解释本次 30 题任务里的原始分、正确率、完成时间和维度表现，不把结果扩展成人群排名、长期能力标签或任何诊断结论。
+
+## 可见证据
+
+公开页面必须让读者看见方法、题型、数据和隐私边界。内容不展示题目答案、评分规则、私人结果链接、订单链接、支付信息或恢复链接。测试材料保护是方法可信度的一部分。
+
+## FAQ
+
+### 这是正式智力测评吗？
+
+不是。它是 IQ 风格的推理任务说明，用于理解本次答题表现。
+
+### 页面能说明什么？
+
+它能说明图形推理、模式识别和完成时间如何作为本次任务信号被解释。
+
+### 页面不能说明什么？
+
+它不能给出官方证明、临床判断、教育录取判断、用人判断或长期能力结论。
+MARKDOWN;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugs(): array
+    {
+        return [
+            'what-is-iq-style-reasoning-test',
+            'online-iq-test-vs-professional-assessment',
+            'iq-test-score-meaning-boundary',
+            'matrix-reasoning-pattern-recognition-guide',
+            'why-fermatmind-iq-v1-not-certification',
+            'iq-test-privacy-data-boundary',
+            'iq-expert-review-disclosure',
+        ];
+    }
+
+    /**
+     * @return array{0:int,1:array<string,mixed>}
+     */
+    private function callGate(): array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('articles:iq-method-pages-seo-geo-activation-gate', ['--json' => true], $output);
+        $decoded = json_decode($output->fetch(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return [$exit, $decoded];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -405,6 +405,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php',
+            'backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublish.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php',
@@ -413,6 +414,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ];
         $bootstrapChangedLines = [
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPostPublishReadback::class,',
+            '+        \\App\\Console\\Commands\\ArticleIqMethodPagesSeoGeoActivationGate::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPublish::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesReviewApproval::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPublishGate::class,',
@@ -7726,6 +7728,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php',
+            'backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublish.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublishGate.php',
@@ -10658,7 +10661,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesPostPublishReadback|ArticleIqMethodPagesPublish|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
+            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesPostPublishReadback|ArticleIqMethodPagesSeoGeoActivationGate|ArticleIqMethodPagesPublish|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81036,7 +81036,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01"
     ],
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -81052,17 +81052,17 @@
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesSeoGeoActivationGateCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       },
       "github_checks": {
-        "status": "pending",
-        "evidence": "PR #2745 opened for branch codex/iq-method-pages-seo-geo-activate-gate-01; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "All reported GitHub checks passed for PR #2745 at head 20fb71cd1d05ea17f6390335023c7d749936ac95: Semgrep OSS, Semgrep blocking secrets, content-pack-build-validate, hygiene, semgrep sarif non-blocking upload, supply-chain, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
-    "commit_sha": "5f291d94f805732bb08461ceb2c775c94b9350c5",
+    "commit_sha": "20fb71cd1d05ea17f6390335023c7d749936ac95",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2745",
     "failure_reason": null,
     "merged_at": null,
@@ -81099,6 +81099,11 @@
         "at": "2026-07-05T17:25:00Z",
         "status": "pr_open_github_checks_pending",
         "summary": "Opened PR #2745 for the scoped read-only SEO/GEO activation gate and pushed local-validation-passed implementation. Waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-07-05T17:31:00Z",
+        "status": "ready_to_merge",
+        "summary": "All reported GitHub checks passed for PR #2745 at head 20fb71cd1d05ea17f6390335023c7d749936ac95. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81036,7 +81036,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01"
     ],
-    "status": "local_validation_passed",
+    "status": "pr_open_github_checks_pending",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -81050,6 +81050,10 @@
       "local_validation": {
         "status": "pass",
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesSeoGeoActivationGateCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR #2745 opened for branch codex/iq-method-pages-seo-geo-activate-gate-01; waiting for required GitHub checks."
       }
     },
     "scope_validation": {
@@ -81058,8 +81062,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "5f291d94f805732bb08461ceb2c775c94b9350c5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2745",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -81090,6 +81094,11 @@
         "at": "2026-07-05T17:23:00Z",
         "status": "local_validation_passed",
         "summary": "Implemented read-only SEO/GEO activation gate command and tests. Local validation passed; no CMS writes, indexability flips, sitemap activation, llms activation, search submission, deploy, or production execution was performed."
+      },
+      {
+        "at": "2026-07-05T17:25:00Z",
+        "status": "pr_open_github_checks_pending",
+        "summary": "Opened PR #2745 for the scoped read-only SEO/GEO activation gate and pushed local-validation-passed implementation. Waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -265,7 +265,7 @@
     "depends_on": [
       "MBTI-CMS-12"
     ],
-    "status": "ready_to_merge",
+    "status": "merged",
     "commit_sha": "2caacc1ac",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2720",
     "failure_reason": null,
@@ -80979,14 +80979,14 @@
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
-    "commit_sha": "7dfd5f494f8e6decc53322195ab9372c349e6efa",
+    "commit_sha": "45868838e364135e24333beb3ca33df010dab81c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2742",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T09:09:39Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": false,
@@ -81018,6 +81018,11 @@
         "at": "2026-07-05T17:52:00+08:00",
         "status": "ready_to_merge",
         "summary": "All reported GitHub checks passed for PR #2742 at head 7dfd5f494f8e6decc53322195ab9372c349e6efa. Recording ready_to_merge before squash merge per PR-train ledger policy."
+      },
+      {
+        "at": "2026-07-05T17:13:00Z",
+        "status": "merged",
+        "summary": "Reconciled post-merge state for PR #2742: GitHub reports MERGED at 2026-07-05T09:09:39Z, origin/main contains merge commit 45868838e364135e24333beb3ca33df010dab81c, local main is synced, and the task branch is deleted locally/remotely."
       }
     ]
   },
@@ -81031,7 +81036,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01"
     ],
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -81039,13 +81044,17 @@
         "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01 to merge before starting SEO/GEO activation gate implementation."
+        "status": "pass",
+        "evidence": "IQ-METHOD-PAGES-ZH-CN-CMS-POST-PUBLISH-READBACK-01 PR #2742 is merged; origin/main contains merge commit 45868838e364135e24333beb3ca33df010dab81c."
+      },
+      "local_validation": {
+        "status": "pass",
+        "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesSeoGeoActivationGateCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       }
     },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -81071,6 +81080,16 @@
         "at": "2026-07-05T13:55:29+08:00",
         "status": "pending_dependency",
         "summary": "Registered read-only SEO/GEO activation gate. Execution waits for post-publish readback merge and excludes sitemap/llms/indexability writes."
+      },
+      {
+        "at": "2026-07-05T17:14:00Z",
+        "status": "implementation_in_progress",
+        "summary": "Dependency PR #2742 merged and local main synced. Started read-only SEO/GEO activation gate implementation; no CMS writes, indexability flips, sitemap activation, llms activation, search submission, or deploy execution."
+      },
+      {
+        "at": "2026-07-05T17:23:00Z",
+        "status": "local_validation_passed",
+        "summary": "Implemented read-only SEO/GEO activation gate command and tests. Local validation passed; no CMS writes, indexability flips, sitemap activation, llms activation, search submission, deploy, or production execution was performed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26100,7 +26100,7 @@ prs:
     branch: codex/seo-agent-article41-draft-claim-risk-qa-01
     title: "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01 Add article draft claim-risk QA"
     train_scope: seo_agent_gsc_draft_canary_closeout
-    status: pr_open_github_checks_pending
+    status: ready_to_merge
     scope:
       - Add a backend-only read-only claim-risk QA command for article CMS draft proposals.
       - Emit sanitized JSON evidence for title, meta, FAQ, and internal-link claim-risk verdicts.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26100,7 +26100,7 @@ prs:
     branch: codex/seo-agent-article41-draft-claim-risk-qa-01
     title: "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01 Add article draft claim-risk QA"
     train_scope: seo_agent_gsc_draft_canary_closeout
-    status: local_validation_passed
+    status: pr_open_github_checks_pending
     scope:
       - Add a backend-only read-only claim-risk QA command for article CMS draft proposals.
       - Emit sanitized JSON evidence for title, meta, FAQ, and internal-link claim-risk verdicts.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20721,7 +20721,7 @@ prs:
     base: main
     title: "IQ-NORM-03 unlock IQ score claims through norm authority"
     train_scope: iq_production_launch
-    status: ready_to_merge
+    status: merged
     scope:
       - Wire IQ scoring/report claim fields to backend norm authority only.
     allowed_paths:
@@ -26100,7 +26100,7 @@ prs:
     branch: codex/seo-agent-article41-draft-claim-risk-qa-01
     title: "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01 Add article draft claim-risk QA"
     train_scope: seo_agent_gsc_draft_canary_closeout
-    status: user_authorized
+    status: local_validation_passed
     scope:
       - Add a backend-only read-only claim-risk QA command for article CMS draft proposals.
       - Emit sanitized JSON evidence for title, meta, FAQ, and internal-link claim-risk verdicts.


### PR DESCRIPTION
## What changed
- Added `articles:iq-method-pages-seo-geo-activation-gate`, a read-only gate for the seven zh-CN IQ method CMS Articles.
- The gate verifies published/noindex state, canonical URLs, visible FAQ/body evidence, claim boundary, topic IQ grouping, landing page block links, and private/scoring token leakage guards.
- Added feature tests for pass state, forbidden claim blocking, and premature sitemap/llms blocking.
- Registered the command and updated the Big Five runtime freeze classifier whitelist for this scoped IQ CMS command.
- Reconciled the prior post-publish readback PR train ledger state after PR #2742 merged.

## Why
This PR creates the required no-write SEO/GEO activation gate before any future indexability, sitemap, or llms eligibility mutation. It keeps backend/CMS authority intact and prevents activation if the seven IQ method pages are missing evidence, leaking private/scoring fields, or already discoverable too early.

## Validation
- `php -l backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php`
- `php -l backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivationGateCommandTest.php`
- `cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-seo-geo-activation-gate|iq-method-pages'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivationGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ArticleIqMethodPagesSeoGeoActivationGateCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ResultPageV2CoreBodyPreviewTest --no-ansi`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Deferred items
- No CMS writes or production DB mutations.
- No indexability flips, sitemap activation, llms activation, search submission, GSC/IndexNow action, staging deploy wait, manual deploy, or production deploy.
- The actual activation workflow remains scoped to `IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01` and still requires exact deployed SHA and command authorization before any production execution.

## Repository rule impact
This is backend/CMS-authoritative operational tooling. It does not add frontend fallback content and does not change public content authority.
