### PR TITLE
IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01: add controlled IQ method sitemap and llms activation

### DIFF
--- a/backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php
+++ b/backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php
@@ -1,0 +1,502 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Audit\AuditLogger;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+
+final class ArticleIqMethodPagesSeoGeoActivate extends Command
+{
+    private const SCHEMA_VERSION = 'fermatmind.iq_method_pages.seo_geo_activate.v1';
+
+    private const PR_ID = 'IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-01';
+
+    private const ACTIVATION_GATE_PR_ID = 'IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01';
+
+    private const SLUGS = [
+        'what-is-iq-style-reasoning-test',
+        'online-iq-test-vs-professional-assessment',
+        'iq-test-score-meaning-boundary',
+        'matrix-reasoning-pattern-recognition-guide',
+        'why-fermatmind-iq-v1-not-certification',
+        'iq-test-privacy-data-boundary',
+        'iq-expert-review-disclosure',
+    ];
+
+    private const FORBIDDEN_CLAIM_PATTERNS = [
+        'official_iq' => '/(?:官方\s*IQ|official\s+IQ)/iu',
+        'certified_iq' => '/(?:认证\s*IQ|certified\s+IQ|PDF\s*certificate|certificate)/iu',
+        'clinical_diagnosis' => '/(?:临床诊断|诊断级|clinical\s+diagnosis|clinical-grade)/iu',
+        'mensa_claim' => '/\bMensa\b|门萨/u',
+        'percentile_claim' => '/(?:percentile|百分位)/iu',
+        'employment_or_admission' => '/(?:招聘|录用|升学录取|薪资预测|hire|admission|salary\s+prediction)/iu',
+        'fixed_intelligence' => '/(?:真实智商|固定智力|固定能力|real\s+IQ)/iu',
+    ];
+
+    private const PRIVATE_PATTERNS = [
+        'attempt_route' => '~/(?:zh/|en/)?attempt(?:/|[?#\s)"\']|$)~i',
+        'result_route' => '~/(?:zh/|en/)?(?:result|results)(?:/|[?#\s)"\']|$)~i',
+        'order_route' => '~/(?:zh/|en/)?(?:orders|order)(?:/|[?#\s)"\']|$)~i',
+        'payment_route' => '~/(?:zh/|en/)?(?:pay|payment)(?:/|[?#\s)"\']|$)~i',
+        'recovery_route' => '~/(?:zh/|en/)?(?:recover|restore)(?:/|[?#\s)"\']|$)~i',
+        'scoring_secret' => '/(?:answer_key|correct_answer|scoring_rule|score_formula|private_result|payment_id)/i',
+    ];
+
+    protected $signature = 'articles:iq-method-pages-seo-geo-activate
+        {--article-id= : Exact article id to lock}
+        {--expected-slug= : Expected IQ method article slug lock}
+        {--confirm= : Exact user confirmation phrase for execute mode}
+        {--dry-run : Validate and plan without writing}
+        {--execute : Activate indexability, sitemap eligibility, and llms eligibility}
+        {--json : Emit a JSON summary}
+        {--no-content-change : Required execute-mode hold: do not modify article content}
+        {--no-publish : Required execute-mode hold: do not publish or promote}
+        {--no-search : Required execute-mode hold: do not submit search channels}
+        {--no-schema-hreflang : Required execute-mode hold: do not modify schema or hreflang gates}
+        {--no-revalidation : Required execute-mode hold: do not revalidate frontend paths}';
+
+    protected $description = 'Controlled SEO/GEO activation for one locked zh-CN IQ method CMS Article.';
+
+    public function handle(AuditLogger $auditLogger): int
+    {
+        try {
+            $summary = $this->buildSummary($auditLogger);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildSummary(AuditLogger $auditLogger): array
+    {
+        $execute = (bool) $this->option('execute');
+        $dryRun = ! $execute;
+        $articleId = (int) $this->option('article-id');
+        $expectedSlug = trim((string) $this->option('expected-slug'));
+        $expectedConfirmation = $this->expectedConfirmation($articleId, $expectedSlug);
+        $confirmation = trim((string) $this->option('confirm'));
+        $errors = [];
+
+        if ((bool) $this->option('dry-run') && $execute) {
+            $errors[] = $this->issue('dry_run', 'execute_dry_run_conflict', '--execute cannot be combined with --dry-run.');
+        }
+        if ($execute) {
+            foreach (['no-content-change', 'no-publish', 'no-search', 'no-schema-hreflang', 'no-revalidation'] as $flag) {
+                if ((bool) $this->option($flag) !== true) {
+                    $errors[] = $this->issue($flag, 'required_safety_flag_missing', 'All no-side-effect safety flags are required for execute mode.');
+                }
+            }
+            if (! hash_equals($expectedConfirmation, $confirmation)) {
+                $errors[] = $this->issue('confirm', 'confirmation_mismatch', 'Exact confirmation phrase is required before IQ method SEO/GEO activation.', [
+                    'expected_confirmation' => $expectedConfirmation,
+                ]);
+            }
+        }
+
+        if ($articleId <= 0) {
+            $errors[] = $this->issue('article_id', 'article_id_required', '--article-id is required.');
+        }
+        if ($expectedSlug === '') {
+            $errors[] = $this->issue('expected_slug', 'expected_slug_required', '--expected-slug is required.');
+        }
+
+        $plan = $articleId > 0 ? $this->preflight($articleId, $expectedSlug) : null;
+        if ($plan === null) {
+            $errors[] = $this->issue('article_id', 'article_not_found', 'Article was not found.');
+        } else {
+            foreach ((array) ($plan['errors'] ?? []) as $error) {
+                if (is_array($error)) {
+                    $errors[] = $error;
+                }
+            }
+        }
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $articleId, $expectedSlug, $expectedConfirmation, $plan, $errors);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_activate_iq_method_article_discoverability', $articleId, $expectedSlug, $expectedConfirmation, $plan, []);
+        }
+
+        $executedPlan = DB::transaction(function () use ($articleId, $expectedSlug): array {
+            $lockedPlan = $this->preflight($articleId, $expectedSlug, lockForUpdate: true);
+            if ($lockedPlan === null) {
+                throw new RuntimeException('planned article disappeared before IQ method SEO/GEO activation.');
+            }
+
+            $errors = (array) ($lockedPlan['errors'] ?? []);
+            if ($errors !== []) {
+                $codes = collect($errors)
+                    ->map(static fn (mixed $error): string => is_array($error) ? (string) ($error['code'] ?? '') : '')
+                    ->filter()
+                    ->implode(',');
+
+                throw new RuntimeException('IQ method SEO/GEO activation preflight failed before write: '.$codes);
+            }
+
+            DB::table('articles')
+                ->where('id', $articleId)
+                ->update([
+                    'is_indexable' => true,
+                    'sitemap_eligible' => true,
+                    'llms_eligible' => true,
+                    'updated_at' => now(),
+                ]);
+
+            DB::table('article_seo_meta')
+                ->where('article_id', $articleId)
+                ->update([
+                    'is_indexable' => true,
+                    'robots' => 'index,follow',
+                    'updated_at' => now(),
+                ]);
+
+            return $this->postActivationReadback($articleId, $expectedSlug, (array) ($lockedPlan['before'] ?? [])) ?? $lockedPlan;
+        });
+
+        $auditLogger->log(
+            Request::create('/ops/articles/iq-method-pages-seo-geo-activate', 'POST'),
+            'articles_iq_method_pages_seo_geo_activate',
+            'article',
+            (string) $articleId,
+            [
+                'command' => 'articles:iq-method-pages-seo-geo-activate',
+                'pr_id' => self::PR_ID,
+                'activation_gate_pr_id' => self::ACTIVATION_GATE_PR_ID,
+                'article_id' => $articleId,
+                'slug' => $expectedSlug,
+                'confirmation_sha256' => hash('sha256', $confirmation),
+                'updates_scope' => [
+                    'articles.is_indexable',
+                    'articles.sitemap_eligible',
+                    'articles.llms_eligible',
+                    'article_seo_meta.is_indexable',
+                    'article_seo_meta.robots',
+                ],
+                'no_content_change' => true,
+                'no_publish' => true,
+                'no_search' => true,
+                'no_schema_hreflang' => true,
+                'no_revalidation' => true,
+                'before' => $plan['before'] ?? null,
+                'after' => $executedPlan['after'] ?? null,
+            ],
+            reason: 'controlled_iq_method_pages_seo_geo_activation',
+            result: 'success',
+        );
+
+        return $this->summary(true, false, 'activated_iq_method_article_discoverability', $articleId, $expectedSlug, $expectedConfirmation, $executedPlan, []);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function preflight(int $articleId, string $expectedSlug, bool $lockForUpdate = false): ?array
+    {
+        $article = $this->articleQuery($lockForUpdate)->find($articleId);
+        if (! $article instanceof Article) {
+            return null;
+        }
+
+        $before = $this->snapshot($article);
+        $after = $before;
+        $after['is_indexable'] = true;
+        $after['sitemap_eligible'] = true;
+        $after['llms_eligible'] = true;
+        $after['seo_robots'] = 'index,follow';
+        $after['seo_is_indexable'] = true;
+        $errors = [];
+
+        if (! in_array($expectedSlug, self::SLUGS, true)) {
+            $errors[] = $this->issue('expected_slug', 'slug_not_in_iq_method_set', 'Expected slug is not one of the seven IQ method pages.');
+        }
+        if ((string) $article->slug !== $expectedSlug) {
+            $errors[] = $this->issue('article.slug', 'expected_slug_mismatch', 'Article slug does not match expected lock.');
+        }
+        if ((int) $article->org_id !== 0 || (string) $article->locale !== 'zh-CN') {
+            $errors[] = $this->issue('article.locale', 'article_scope_mismatch', 'Article must be org_id=0 and locale zh-CN.');
+        }
+        if ((string) $article->status !== 'published' || ! (bool) $article->is_public) {
+            $errors[] = $this->issue('article.status', 'article_not_public_published', 'Article must already be public and published.');
+        }
+        if ((bool) $article->is_indexable || (bool) $article->sitemap_eligible || (bool) $article->llms_eligible) {
+            $errors[] = $this->issue('article.discoverability', 'article_already_or_partly_discoverable', 'Article must still be noindex and excluded from sitemap/llms before controlled activation.');
+        }
+
+        $revision = $article->publishedRevision;
+        if (! $revision instanceof ArticleTranslationRevision || (string) $revision->revision_status !== ArticleTranslationRevision::STATUS_PUBLISHED) {
+            $errors[] = $this->issue('article.published_revision_id', 'published_revision_missing_or_invalid', 'Article must have a published revision.');
+        }
+
+        $seoMeta = $article->seoMeta;
+        if (! $seoMeta instanceof ArticleSeoMeta) {
+            $errors[] = $this->issue('seo_meta', 'seo_meta_missing', 'Article SEO meta must exist before activation.');
+        } else {
+            if ((bool) $seoMeta->is_indexable || (string) $seoMeta->robots !== 'noindex,follow') {
+                $errors[] = $this->issue('seo_meta.robots', 'seo_meta_not_in_noindex_hold', 'SEO meta must still be noindex,follow before controlled activation.');
+            }
+            if ((string) $seoMeta->canonical_url !== 'https://fermatmind.com/zh/articles/'.$expectedSlug) {
+                $errors[] = $this->issue('seo_meta.canonical_url', 'canonical_url_mismatch', 'SEO meta canonical must match the locked article URL.');
+            }
+        }
+
+        $publicPayload = $this->publicPayloadText($article, $seoMeta instanceof ArticleSeoMeta ? $seoMeta : null);
+        $this->assertNoForbiddenClaims($errors, 'claim_boundary', $publicPayload);
+        $this->assertNoPrivateTokens($errors, 'public_payload', $publicPayload);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'article_id' => $articleId,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'canonical_url' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->canonical_url : null,
+            'before' => $before,
+            'after' => $after,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function postActivationReadback(int $articleId, string $expectedSlug, array $before): ?array
+    {
+        $article = $this->articleQuery()->find($articleId);
+        if (! $article instanceof Article) {
+            return null;
+        }
+
+        $after = $this->snapshot($article);
+        $errors = [];
+
+        if ((string) $article->slug !== $expectedSlug) {
+            $errors[] = $this->issue('article.slug', 'expected_slug_mismatch_after_write', 'Article slug changed during activation.');
+        }
+        if (! (bool) $article->is_indexable || ! (bool) $article->sitemap_eligible || ! (bool) $article->llms_eligible) {
+            $errors[] = $this->issue('article.discoverability', 'article_discoverability_write_incomplete', 'Article discoverability flags were not fully activated.');
+        }
+        if (! $article->seoMeta instanceof ArticleSeoMeta || ! (bool) $article->seoMeta->is_indexable || (string) $article->seoMeta->robots !== 'index,follow') {
+            $errors[] = $this->issue('seo_meta.robots', 'seo_meta_activation_write_incomplete', 'SEO meta indexability and robots were not fully activated.');
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'article_id' => $articleId,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'canonical_url' => $article->seoMeta instanceof ArticleSeoMeta ? (string) $article->seoMeta->canonical_url : null,
+            'before' => $before,
+            'after' => $after,
+            'errors' => $errors,
+        ];
+    }
+
+    private function articleQuery(bool $lockForUpdate = false): mixed
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            ])
+            ->when($lockForUpdate, static fn ($query) => $query->lockForUpdate());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(Article $article): array
+    {
+        $revision = $article->publishedRevision;
+        $seoMeta = $article->seoMeta;
+
+        return [
+            'article_id' => (int) $article->id,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'published_revision_id' => $article->published_revision_id === null ? null : (int) $article->published_revision_id,
+            'published_revision_status' => $revision instanceof ArticleTranslationRevision ? (string) $revision->revision_status : null,
+            'content_md_sha256' => hash('sha256', (string) $article->content_md),
+            'content_html_sha256' => hash('sha256', (string) $article->content_html),
+            'seo_meta_exists' => $seoMeta instanceof ArticleSeoMeta,
+            'seo_robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
+            'seo_is_indexable' => $seoMeta instanceof ArticleSeoMeta ? (bool) $seoMeta->is_indexable : null,
+            'canonical_url' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->canonical_url : null,
+            'schema_json_sha256' => $seoMeta instanceof ArticleSeoMeta
+                ? hash('sha256', (string) json_encode($seoMeta->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE))
+                : null,
+        ];
+    }
+
+    private function expectedConfirmation(int $articleId, string $expectedSlug): string
+    {
+        return "I explicitly approve articles:iq-method-pages-seo-geo-activate execute for article id {$articleId} slug {$expectedSlug} after activation gate passes.";
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function assertNoForbiddenClaims(array &$errors, string $field, string $text): void
+    {
+        foreach (self::FORBIDDEN_CLAIM_PATTERNS as $code => $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                $errors[] = $this->issue($field, 'forbidden_claim_detected', 'Public IQ method activation payload contains a forbidden claim.', [
+                    'pattern' => $code,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function assertNoPrivateTokens(array &$errors, string $field, string $text): void
+    {
+        foreach (self::PRIVATE_PATTERNS as $code => $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                $errors[] = $this->issue($field, 'private_or_scoring_token_leak', 'Public IQ method activation payload contains a private route or scoring token.', [
+                    'pattern' => $code,
+                ]);
+            }
+        }
+    }
+
+    private function publicPayloadText(Article $article, ?ArticleSeoMeta $seo): string
+    {
+        return json_encode([
+            'title' => $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => $article->content_md,
+            'seo' => $seo?->toArray(),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) ?: '';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function summary(bool $ok, bool $dryRun, string $action, int $articleId, string $expectedSlug, string $expectedConfirmation, ?array $plan, array $errors): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'execute' => ! $dryRun,
+            'action' => $action,
+            'would_write' => $ok && ! $dryRun,
+            'pr_id' => self::PR_ID,
+            'activation_gate_pr_id' => self::ACTIVATION_GATE_PR_ID,
+            'article_id' => $articleId,
+            'expected_slug' => $expectedSlug,
+            'expected_confirmation' => $expectedConfirmation,
+            'updates_scope' => [
+                'articles.is_indexable',
+                'articles.sitemap_eligible',
+                'articles.llms_eligible',
+                'article_seo_meta.is_indexable',
+                'article_seo_meta.robots',
+            ],
+            'protected_holds' => [
+                'no_content_change' => true,
+                'no_publish' => true,
+                'no_search' => true,
+                'no_schema_hreflang' => true,
+                'no_revalidation' => true,
+            ],
+            'external_search_submission_attempted' => false,
+            'schema_hreflang_write_attempted' => false,
+            'content_write_attempted' => false,
+            'publish_attempted' => false,
+            'revalidation_attempted' => false,
+            'plan' => $plan,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $extra = []): array
+    {
+        return array_merge([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ], $extra);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        $articleId = (int) $this->option('article-id');
+        $expectedSlug = trim((string) $this->option('expected-slug'));
+
+        return $this->summary(false, ! (bool) $this->option('execute'), 'will_skip', $articleId, $expectedSlug, $this->expectedConfirmation($articleId, $expectedSlug), null, [[
+            'field' => 'command',
+            'code' => $code,
+            'message' => $message,
+        ]]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? ''));
+        $this->line('article_id='.(string) ($summary['article_id'] ?? ''));
+        $this->line('expected_slug='.(string) ($summary['expected_slug'] ?? ''));
+        $this->line('expected_confirmation='.(string) ($summary['expected_confirmation'] ?? ''));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('error='.$this->issueLine($error));
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return implode('|', array_filter([
+            'field='.(string) ($issue['field'] ?? ''),
+            'code='.(string) ($issue['code'] ?? ''),
+            'message='.(string) ($issue['message'] ?? ''),
+        ]));
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -34,6 +34,7 @@ return Application::configure(basePath: dirname(__DIR__))
         \App\Console\Commands\ArticleIqMethodPagesPublishGate::class,
         \App\Console\Commands\ArticleIqMethodPagesPublish::class,
         \App\Console\Commands\ArticleIqMethodPagesPostPublishReadback::class,
+        \App\Console\Commands\ArticleIqMethodPagesSeoGeoActivate::class,
         \App\Console\Commands\ArticleIqMethodPagesSeoGeoActivationGate::class,
         \App\Console\Commands\ArticleIqMethodPagesReadback::class,
         \App\Console\Commands\ArticleIqMethodPagesReviewApproval::class,

--- a/backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivateCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivateCommandTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\ArticleIqMethodPagesSeoGeoActivate;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\AuditLog;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+final class ArticleIqMethodPagesSeoGeoActivateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(Kernel::class)->registerCommand($this->app->make(ArticleIqMethodPagesSeoGeoActivate::class));
+    }
+
+    public function test_dry_run_plans_iq_method_discoverability_activation_without_writes(): void
+    {
+        $article = $this->createPublishedNoindexIqMethodArticle();
+
+        [$exit, $payload] = $this->callActivate([
+            '--article-id' => (string) $article->id,
+            '--expected-slug' => 'what-is-iq-style-reasoning-test',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exit, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['would_write']);
+        $this->assertSame('would_activate_iq_method_article_discoverability', $payload['action']);
+        $this->assertFalse(data_get($payload, 'plan.before.is_indexable'));
+        $this->assertSame('noindex,follow', data_get($payload, 'plan.before.seo_robots'));
+        $this->assertTrue(data_get($payload, 'plan.after.is_indexable'));
+        $this->assertSame('index,follow', data_get($payload, 'plan.after.seo_robots'));
+        $this->assertFalse($payload['external_search_submission_attempted']);
+        $this->assertFalse($payload['schema_hreflang_write_attempted']);
+
+        $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail((int) $article->id);
+        $this->assertFalse((bool) $fresh->is_indexable);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+        $this->assertSame('noindex,follow', (string) $fresh->seoMeta?->robots);
+        $this->assertSame(0, AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_iq_method_pages_seo_geo_activate')->count());
+    }
+
+    public function test_execute_activates_only_indexability_sitemap_llms_and_robots(): void
+    {
+        $article = $this->createPublishedNoindexIqMethodArticle();
+        $contentHash = hash('sha256', (string) $article->content_md);
+        $publishedRevisionId = (int) $article->published_revision_id;
+        $schemaHash = hash('sha256', (string) json_encode($article->seoMeta?->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+        [$exit, $payload] = $this->callActivate([
+            '--article-id' => (string) $article->id,
+            '--expected-slug' => 'what-is-iq-style-reasoning-test',
+            '--confirm' => 'I explicitly approve articles:iq-method-pages-seo-geo-activate execute for article id '.(int) $article->id.' slug what-is-iq-style-reasoning-test after activation gate passes.',
+            '--execute' => true,
+            '--json' => true,
+            '--no-content-change' => true,
+            '--no-publish' => true,
+            '--no-search' => true,
+            '--no-schema-hreflang' => true,
+            '--no-revalidation' => true,
+        ]);
+
+        $this->assertSame(0, $exit, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['would_write']);
+        $this->assertSame('activated_iq_method_article_discoverability', $payload['action']);
+
+        $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail((int) $article->id);
+        $this->assertSame('published', (string) $fresh->status);
+        $this->assertTrue((bool) $fresh->is_public);
+        $this->assertTrue((bool) $fresh->is_indexable);
+        $this->assertTrue((bool) $fresh->sitemap_eligible);
+        $this->assertTrue((bool) $fresh->llms_eligible);
+        $this->assertSame('index,follow', (string) $fresh->seoMeta?->robots);
+        $this->assertTrue((bool) $fresh->seoMeta?->is_indexable);
+        $this->assertSame($contentHash, hash('sha256', (string) $fresh->content_md));
+        $this->assertSame($publishedRevisionId, (int) $fresh->published_revision_id);
+        $this->assertSame($schemaHash, hash('sha256', (string) json_encode($fresh->seoMeta?->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)));
+
+        $audit = AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_iq_method_pages_seo_geo_activate')->first();
+        $this->assertInstanceOf(AuditLog::class, $audit);
+        $this->assertSame('article', (string) $audit->target_type);
+        $this->assertSame((string) $article->id, (string) $audit->target_id);
+        $this->assertSame('articles:iq-method-pages-seo-geo-activate', data_get($audit->meta_json, 'command'));
+        $this->assertSame([
+            'articles.is_indexable',
+            'articles.sitemap_eligible',
+            'articles.llms_eligible',
+            'article_seo_meta.is_indexable',
+            'article_seo_meta.robots',
+        ], data_get($audit->meta_json, 'updates_scope'));
+        $this->assertTrue((bool) data_get($audit->meta_json, 'no_search'));
+    }
+
+    public function test_execute_requires_confirmation_and_all_safety_flags(): void
+    {
+        $article = $this->createPublishedNoindexIqMethodArticle();
+
+        [$exit, $payload] = $this->callActivate([
+            '--article-id' => (string) $article->id,
+            '--expected-slug' => 'what-is-iq-style-reasoning-test',
+            '--execute' => true,
+            '--json' => true,
+            '--no-content-change' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertErrorCode($payload, 'required_safety_flag_missing');
+        $this->assertErrorCode($payload, 'confirmation_mismatch');
+
+        $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail((int) $article->id);
+        $this->assertFalse((bool) $fresh->is_indexable);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+        $this->assertSame('noindex,follow', (string) $fresh->seoMeta?->robots);
+    }
+
+    public function test_preflight_blocks_private_or_scoring_token_leaks_without_write(): void
+    {
+        $article = $this->createPublishedNoindexIqMethodArticle();
+        Article::query()->withoutGlobalScopes()
+            ->where('id', (int) $article->id)
+            ->update(['content_md' => $this->body()."\n\nanswer_key should never appear."]);
+
+        [$exit, $payload] = $this->callActivate([
+            '--article-id' => (string) $article->id,
+            '--expected-slug' => 'what-is-iq-style-reasoning-test',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertFalse($payload['ok']);
+        $this->assertErrorCode($payload, 'private_or_scoring_token_leak');
+
+        $fresh = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+        $this->assertFalse((bool) $fresh->is_indexable);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createPublishedNoindexIqMethodArticle(array $overrides = []): Article
+    {
+        $article = Article::query()->withoutGlobalScopes()->create(array_merge([
+            'org_id' => 0,
+            'slug' => 'what-is-iq-style-reasoning-test',
+            'locale' => 'zh-CN',
+            'title' => '什么是 IQ 风格推理测试？',
+            'excerpt' => '解释 IQ 风格推理测试的任务形式和非官方、非临床、非认证边界。',
+            'content_md' => $this->body(),
+            'content_html' => '<h1>什么是 IQ 风格推理测试？</h1>',
+            'related_test_slug' => 'iq-test-intelligence-quotient-assessment',
+            'status' => 'published',
+            'lifecycle_state' => Article::LIFECYCLE_ACTIVE,
+            'is_public' => true,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'published_at' => now()->subMinute(),
+        ], $overrides));
+
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'reviewed_by' => 42,
+            'reviewed_at' => now()->subMinutes(10),
+            'approved_at' => now()->subMinutes(5),
+            'published_at' => now()->subMinute(),
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'canonical_url' => 'https://fermatmind.com/zh/articles/what-is-iq-style-reasoning-test',
+            'og_title' => (string) $article->title,
+            'og_description' => (string) $article->excerpt,
+            'og_image_url' => 'https://fermatmind.com/storage/articles/iq-method.svg',
+            'robots' => 'noindex,follow',
+            'schema_json' => [
+                'schema_gates_v1' => [
+                    'article' => true,
+                    'breadcrumb' => true,
+                    'faq' => true,
+                ],
+                'editorial_package_v1' => [
+                    'publish_v1' => [
+                        'pr_id' => 'IQ-METHOD-PAGES-ZH-CN-CMS-PUBLISH-01',
+                    ],
+                ],
+            ],
+            'is_indexable' => false,
+        ]);
+
+        return $article->fresh(['publishedRevision', 'seoMeta']) ?? $article;
+    }
+
+    private function body(): string
+    {
+        return <<<'MARKDOWN'
+# 什么是 IQ 风格推理测试？
+
+这篇文章解释 FermatMind IQ V1 的方法边界。IQ 风格推理测试使用图形、矩阵、规律补全、空间关系和限时作答任务，帮助用户理解本次推理任务表现。
+
+## 方法边界
+
+FermatMind IQ V1 是非官方、非临床、非认证的在线推理任务。页面只解释本次 30 题任务里的原始分、正确率、完成时间和维度表现，不把结果扩展成人群排名、长期能力标签或任何诊断结论。
+
+## FAQ
+
+### 这是正式智力测评吗？
+
+不是。它是 IQ 风格的推理任务说明，用于理解本次答题表现。
+MARKDOWN;
+    }
+
+    /**
+     * @param  array<string,mixed>  $arguments
+     * @return array{0:int,1:array<string,mixed>}
+     */
+    private function callActivate(array $arguments): array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('articles:iq-method-pages-seo-geo-activate', $arguments, $output);
+        $decoded = json_decode($output->fetch(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return [$exit, $decoded];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            (array) ($payload['errors'] ?? [])
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -405,6 +405,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php',
+            'backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublish.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
@@ -414,6 +415,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ];
         $bootstrapChangedLines = [
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPostPublishReadback::class,',
+            '+        \\App\\Console\\Commands\\ArticleIqMethodPagesSeoGeoActivate::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesSeoGeoActivationGate::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesPublish::class,',
             '+        \\App\\Console\\Commands\\ArticleIqMethodPagesReviewApproval::class,',
@@ -7728,6 +7730,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPostPublishReadback.php',
+            'backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivationGate.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesPublish.php',
             'backend/app/Console/Commands/ArticleIqMethodPagesReviewApproval.php',
@@ -10661,7 +10664,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesPostPublishReadback|ArticleIqMethodPagesSeoGeoActivationGate|ArticleIqMethodPagesPublish|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
+            if (preg_match('/\b(?:ArticleImportIqMethodPagesDraft|ArticleIqMethodPagesPostPublishReadback|ArticleIqMethodPagesSeoGeoActivate|ArticleIqMethodPagesSeoGeoActivationGate|ArticleIqMethodPagesPublish|ArticleIqMethodPagesReviewApproval|ArticleIqMethodPagesPublishGate|ArticleIqMethodPagesReadback)\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81122,7 +81122,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01"
     ],
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -81138,17 +81138,17 @@
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesSeoGeoActivateCommandTest plus ArticleDiscoverabilityReleaseCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       },
       "github_checks": {
-        "status": "pending",
-        "evidence": "PR #2746 opened for branch codex/iq-method-pages-seo-geo-activate-01; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "All reported GitHub checks passed for PR #2746 at head e1e8980295cfd8c8dbb8e1c872cc49ae48de2305: Semgrep OSS, Semgrep blocking secrets, content-pack-build-validate, hygiene, semgrep sarif non-blocking upload, supply-chain, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
-    "commit_sha": "ff1fdad6457d52a6906924cec8d37830316e521e",
+    "commit_sha": "e1e8980295cfd8c8dbb8e1c872cc49ae48de2305",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2746",
     "failure_reason": null,
     "merged_at": null,
@@ -81185,6 +81185,11 @@
         "at": "2026-07-05T17:49:00Z",
         "status": "pr_open_github_checks_pending",
         "summary": "Opened PR #2746 for the scoped controlled IQ method SEO/GEO activation workflow and pushed local-validation-passed implementation. Waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-07-05T17:57:00Z",
+        "status": "ready_to_merge",
+        "summary": "All reported GitHub checks passed for PR #2746 at head e1e8980295cfd8c8dbb8e1c872cc49ae48de2305. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81122,7 +81122,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01"
     ],
-    "status": "local_validation_passed",
+    "status": "pr_open_github_checks_pending",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -81136,6 +81136,10 @@
       "local_validation": {
         "status": "pass",
         "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesSeoGeoActivateCommandTest plus ArticleDiscoverabilityReleaseCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR #2746 opened for branch codex/iq-method-pages-seo-geo-activate-01; waiting for required GitHub checks."
       }
     },
     "scope_validation": {
@@ -81144,8 +81148,8 @@
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "ff1fdad6457d52a6906924cec8d37830316e521e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2746",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -81176,6 +81180,11 @@
         "at": "2026-07-05T17:47:00Z",
         "status": "local_validation_passed",
         "summary": "Implemented controlled IQ method SEO/GEO activation command and tests. Local validation passed; no production activation, search submission, staging deploy wait, manual deploy, or production deploy was executed."
+      },
+      {
+        "at": "2026-07-05T17:49:00Z",
+        "status": "pr_open_github_checks_pending",
+        "summary": "Opened PR #2746 for the scoped controlled IQ method SEO/GEO activation workflow and pushed local-validation-passed implementation. Waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -544,7 +544,7 @@
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01 add controlled analytics funnel refresh write guard",
     "transitions": [
       {
@@ -81060,14 +81060,14 @@
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
-    "commit_sha": "20fb71cd1d05ea17f6390335023c7d749936ac95",
+    "commit_sha": "de2b1ac0a675b17dd2ffbb64b36f3369ce859a07",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2745",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T09:31:42Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": false,
@@ -81104,6 +81104,11 @@
         "at": "2026-07-05T17:31:00Z",
         "status": "ready_to_merge",
         "summary": "All reported GitHub checks passed for PR #2745 at head 20fb71cd1d05ea17f6390335023c7d749936ac95. Recording ready_to_merge before squash merge per PR-train ledger policy."
+      },
+      {
+        "at": "2026-07-05T17:36:00Z",
+        "status": "merged",
+        "summary": "Reconciled post-merge state for PR #2745: GitHub reports MERGED at 2026-07-05T09:31:42Z, origin/main contains merge commit de2b1ac0a675b17dd2ffbb64b36f3369ce859a07, local main is synced, and the task branch is deleted locally/remotely."
       }
     ]
   },
@@ -81117,7 +81122,7 @@
     "depends_on": [
       "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01"
     ],
-    "status": "pending_dependency",
+    "status": "local_validation_passed",
     "authorized_by_user": "2026-07-05 user explicitly authorized adding the IQ method publish and SEO/GEO activation PR-train entries to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json.",
     "checks": {
       "manifest_registration": {
@@ -81125,13 +81130,17 @@
         "evidence": "User authorized adding this missing PR-train item after the scan split publish/activation into gated tasks."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Wait for IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01 to merge before starting controlled SEO/GEO activation implementation."
+        "status": "pass",
+        "evidence": "IQ-METHOD-PAGES-ZH-CN-SEO-GEO-ACTIVATE-GATE-01 PR #2745 is merged; origin/main contains merge commit de2b1ac0a675b17dd2ffbb64b36f3369ce859a07."
+      },
+      "local_validation": {
+        "status": "pass",
+        "evidence": "php -l command/test, artisan list articles, targeted Pint, focused ArticleIqMethodPagesSeoGeoActivateCommandTest plus ArticleDiscoverabilityReleaseCommandTest, focused BigFive freeze classifier tests, YAML/JSON parse, and git diff --check passed locally."
       }
     },
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -81157,6 +81166,16 @@
         "at": "2026-07-05T13:55:29+08:00",
         "status": "pending_dependency",
         "summary": "Registered controlled SEO/GEO activation workflow. Execution waits for activation gate merge and excludes production activation writes without exact deployed SHA and command authorization."
+      },
+      {
+        "at": "2026-07-05T17:37:00Z",
+        "status": "implementation_in_progress",
+        "summary": "Dependency PR #2745 merged and local main synced. Started controlled IQ method SEO/GEO activation workflow implementation; production activation execution remains blocked without exact deployed SHA and command authorization."
+      },
+      {
+        "at": "2026-07-05T17:47:00Z",
+        "status": "local_validation_passed",
+        "summary": "Implemented controlled IQ method SEO/GEO activation command and tests. Local validation passed; no production activation, search submission, staging deploy wait, manual deploy, or production deploy was executed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26142,7 +26142,7 @@ prs:
     branch: codex/seo-agent-article41-draft-preview-runtime-qa-01
     title: "SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01 Add article draft preview runtime QA"
     train_scope: seo_agent_gsc_draft_canary_closeout
-    status: pr_open_github_checks_pending
+    status: ready_to_merge
     scope:
       - Add backend-only read-only preview/runtime QA for article draft revisions.
       - Verify draft preview/read path evidence and live published revision isolation.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21340,7 +21340,7 @@ prs:
     base: main
     title: "docs(foundation): add Daily Giving social sync readiness"
     train_scope: foundation_daily_giving_social_sync
-    status: ready_to_merge
+    status: merged
     scope:
       - Produce a read-only readiness/planning report for Foundation Daily Giving social sync.
       - Classify existing manual social URL support and future MVP boundaries.
@@ -26142,7 +26142,7 @@ prs:
     branch: codex/seo-agent-article41-draft-preview-runtime-qa-01
     title: "SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01 Add article draft preview runtime QA"
     train_scope: seo_agent_gsc_draft_canary_closeout
-    status: user_authorized
+    status: local_validation_passed
     scope:
       - Add backend-only read-only preview/runtime QA for article draft revisions.
       - Verify draft preview/read path evidence and live published revision isolation.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26142,7 +26142,7 @@ prs:
     branch: codex/seo-agent-article41-draft-preview-runtime-qa-01
     title: "SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01 Add article draft preview runtime QA"
     train_scope: seo_agent_gsc_draft_canary_closeout
-    status: local_validation_passed
+    status: pr_open_github_checks_pending
     scope:
       - Add backend-only read-only preview/runtime QA for article draft revisions.
       - Verify draft preview/read path evidence and live published revision isolation.


### PR DESCRIPTION
## What changed
- Added `articles:iq-method-pages-seo-geo-activate`, a locked controlled activation command for one zh-CN IQ method CMS Article at a time.
- The command supports dry-run and execute modes with exact `article-id` / `expected-slug` locks, exact confirmation text, and required safety flags.
- Execute mode only updates `articles.is_indexable`, `articles.sitemap_eligible`, `articles.llms_eligible`, `article_seo_meta.is_indexable`, and `article_seo_meta.robots`.
- Added tests for dry-run planning, execute field scope, missing confirmation/safety flags, and private/scoring token blocking.
- Registered the command and updated the Big Five runtime freeze classifier whitelist.
- Reconciled the prior activation gate PR train ledger state after PR #2745 merged.

## Why
The seven IQ method pages need a backend-authoritative, auditable path to become indexable and eligible for sitemap/llms enumeration after the readback and SEO/GEO activation gate pass. This PR adds that controlled workflow without executing production activation.

## Validation
- `php -l backend/app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php`
- `php -l backend/tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivateCommandTest.php`
- `cd backend && php artisan list articles --no-ansi | rg 'iq-method-pages-seo-geo-activate|discoverability-release'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/ArticleIqMethodPagesSeoGeoActivate.php app/Console/Commands/ArticleDiscoverabilityRelease.php tests/Feature/Console/ArticleIqMethodPagesSeoGeoActivateCommandTest.php tests/Feature/Console/ArticleDiscoverabilityReleaseCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php bootstrap/app.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='ArticleIqMethodPagesSeoGeoActivateCommandTest|ArticleDiscoverabilityReleaseCommandTest' --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=ResultPageV2CoreBodyPreviewTest --no-ansi`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Deferred items
- No production activation command was executed.
- No search submission, GSC/IndexNow action, staging deploy wait, manual deploy, or production deploy.
- Production execution still requires exact deployed SHA authorization and exact command authorization for each locked article.

## Repository rule impact
This keeps CMS/backend as the content and SEO/GEO authority. It adds backend operational tooling only; no frontend fallback content or static public content was added.
