### PR TITLE
MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-02: record FAQ parity pass

### DIFF
--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/API_READBACK.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/API_READBACK.md
@@ -1,0 +1,25 @@
+# API Readback
+
+Endpoint:
+
+`https://api.fermatmind.com/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh`
+
+Observed at: 2026-07-05T10:07:27Z
+
+Result:
+
+- HTTP status: 200
+- `x-fastcgi-cache`: `BYPASS`
+- FAQ path: `content_i18n_json.zh.faq`
+- FAQ count: 8
+
+Questions:
+
+1. MBTI 测试免费吗？
+2. MBTI 完整结果能看到什么？
+3. MBTI 测试一般多久？
+4. MBTI 能决定职业吗？
+5. MBTI 是心理诊断吗？
+6. 16 型人格结果会变吗？
+7. MBTI 和大五人格有什么区别？
+8. 做完 MBTI 后下一步看什么？

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/CLAIM_PRIVATE_URL_RECHECK.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/CLAIM_PRIVATE_URL_RECHECK.md
@@ -1,0 +1,15 @@
+# Claim And Private URL Boundary Recheck
+
+Observed at: 2026-07-05T10:07:27Z
+
+Private URL boundary:
+
+- No private attempt/order/payment/report/result/token hrefs were found in the public page readback.
+- Public `/take` entry links are present and are not private result/order/payment URLs.
+
+Claim boundary:
+
+- FAQ entries remain bounded as self-understanding and exploratory guidance.
+- No diagnosis, hiring suitability, career guarantee, salary prediction, or authority overclaim was introduced by this readback.
+
+Result: pass.

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/EXECUTIVE_DECISION.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/EXECUTIVE_DECISION.md
@@ -1,0 +1,21 @@
+# MBTI Main FAQ Production Runtime Readback 02
+
+Decision: `RUNTIME_FAQ_PARITY_PASS`
+
+Observed at: 2026-07-05T10:07:27Z
+
+The canonical production zh MBTI test landing URL now renders the backend API's 8 FAQ entries without a cache-bust query.
+
+Pass criteria:
+
+- API FAQ = 8: pass
+- visible FAQ = 8: pass
+- FAQPage JSON-LD = 8: pass
+- visible questions == JSON-LD questions: pass
+- private URL boundary: pass
+
+Cache/revalidation repair is not needed from current evidence. The prior stale 4-entry canonical HTML has been replaced by an 8-entry cache HIT response.
+
+Next eligible task: `MBTI-MAIN-FAQ-D0-OBSERVATION-BASELINE-01`.
+
+No runtime code, CMS content, sitemap, llms, Search Channel, deployment, production import, or database mutation was changed.

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/FAQ_SCHEMA_PARITY_READBACK.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/FAQ_SCHEMA_PARITY_READBACK.md
@@ -1,0 +1,25 @@
+# FAQ Schema Parity Readback
+
+Observed at: 2026-07-05T10:07:27Z
+
+Result:
+
+- FAQPage JSON-LD detected: yes
+- FAQPage `mainEntity` count: 8
+- Visible FAQ count: 8
+- Visible questions equal JSON-LD questions: yes
+
+JSON-LD questions:
+
+1. MBTI 测试免费吗？
+2. MBTI 完整结果能看到什么？
+3. MBTI 测试一般多久？
+4. MBTI 能决定职业吗？
+5. MBTI 是心理诊断吗？
+6. 16 型人格结果会变吗？
+7. MBTI 和大五人格有什么区别？
+8. 做完 MBTI 后下一步看什么？
+
+Decision:
+
+Schema parity repair remains unnecessary. Visible FAQ and FAQPage JSON-LD are both 8 and share the same questions.

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/PAGE_VISIBLE_FAQ_READBACK.md
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/PAGE_VISIBLE_FAQ_READBACK.md
@@ -1,0 +1,30 @@
+# Public Page Visible FAQ Readback
+
+URL requested:
+
+`https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+Final URL:
+
+`https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+Observed at: 2026-07-05T10:07:27Z
+
+Result:
+
+- `www` redirected with HTTP 308 to apex
+- Final HTTP status: 200
+- Final `x-proxy-cache`: `HIT`
+- Visible FAQ count from rendered HTML: 8
+- Old 4-entry question text was not present
+
+Visible questions:
+
+1. MBTI 测试免费吗？
+2. MBTI 完整结果能看到什么？
+3. MBTI 测试一般多久？
+4. MBTI 能决定职业吗？
+5. MBTI 是心理诊断吗？
+6. 16 型人格结果会变吗？
+7. MBTI 和大五人格有什么区别？
+8. 做完 MBTI 后下一步看什么？

--- a/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/scan_manifest.json
+++ b/generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/scan_manifest.json
@@ -1,0 +1,83 @@
+{
+  "id": "MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-02",
+  "repo": "fap-api",
+  "generated_at": "2026-07-05T10:07:27Z",
+  "scope": "read-only production runtime evidence",
+  "urls": {
+    "api": "https://api.fermatmind.com/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh",
+    "public_page_requested": "https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+    "public_page_final": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types"
+  },
+  "observations": {
+    "api_status": 200,
+    "api_cache_header": "x-fastcgi-cache: BYPASS",
+    "api_faq_path": "content_i18n_json.zh.faq",
+    "api_faq_count": 8,
+    "public_page_redirect": "HTTP 308 from www to apex",
+    "public_page_status": 200,
+    "public_page_cache_header": "x-proxy-cache: HIT",
+    "visible_faq_count": 8,
+    "faqpage_json_ld_count": 8,
+    "visible_questions_equal_json_ld_questions": true,
+    "private_url_hits": [],
+    "contains_new_api_question": true,
+    "contains_old_four_entry_question": false
+  },
+  "api_questions": [
+    "MBTI 测试免费吗？",
+    "MBTI 完整结果能看到什么？",
+    "MBTI 测试一般多久？",
+    "MBTI 能决定职业吗？",
+    "MBTI 是心理诊断吗？",
+    "16 型人格结果会变吗？",
+    "MBTI 和大五人格有什么区别？",
+    "做完 MBTI 后下一步看什么？"
+  ],
+  "visible_questions": [
+    "MBTI 测试免费吗？",
+    "MBTI 完整结果能看到什么？",
+    "MBTI 测试一般多久？",
+    "MBTI 能决定职业吗？",
+    "MBTI 是心理诊断吗？",
+    "16 型人格结果会变吗？",
+    "MBTI 和大五人格有什么区别？",
+    "做完 MBTI 后下一步看什么？"
+  ],
+  "json_ld_questions": [
+    "MBTI 测试免费吗？",
+    "MBTI 完整结果能看到什么？",
+    "MBTI 测试一般多久？",
+    "MBTI 能决定职业吗？",
+    "MBTI 是心理诊断吗？",
+    "16 型人格结果会变吗？",
+    "MBTI 和大五人格有什么区别？",
+    "做完 MBTI 后下一步看什么？"
+  ],
+  "decision": "RUNTIME_FAQ_PARITY_PASS",
+  "next_eligible_task": "MBTI-MAIN-FAQ-D0-OBSERVATION-BASELINE-01",
+  "skipped_repairs": [
+    {
+      "id": "MBTI-MAIN-FAQ-CACHE-REVALIDATION-REPAIR-01",
+      "reason": "canonical URL now serves 8 visible FAQ entries and 8 FAQPage JSON-LD entries without cache-bust"
+    },
+    {
+      "id": "MBTI-MAIN-FAQ-WEB-ADAPTER-PROPAGATION-REPAIR-01",
+      "reason": "runtime already consumes content_i18n_json.zh.faq"
+    },
+    {
+      "id": "MBTI-MAIN-FAQ-RUNTIME-DATA-SOURCE-REPAIR-01",
+      "reason": "runtime data source now renders API FAQ 8/8 on canonical URL"
+    }
+  ],
+  "actions_not_taken": [
+    "runtime code change",
+    "CMS write",
+    "production import",
+    "database migration",
+    "sitemap or llms change",
+    "Search Channel action",
+    "staging deploy wait",
+    "manual deploy",
+    "production deploy"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added read-only generated evidence for `MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-02`.
- Recorded that the production canonical zh MBTI test page now passes FAQ runtime parity without cache-bust.

## Why
- The previous readback found API FAQ = 8 but canonical page/schema = 4.
- fap-web diagnosis showed this was stale HTML/cache, not adapter or schema renderer failure.
- The canonical URL now returns 8 visible FAQ entries and 8 FAQPage JSON-LD entries, so repair PRs are skipped.

## Validation
- `curl -sS 'https://api.fermatmind.com/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh'`
- `curl -sSL 'https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types'`
- `python3 -m json.tool generated/seo-ops-mbti-main-faq-runtime-readback-20260705-02/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Deferred items
- Skipped `MBTI-MAIN-FAQ-CACHE-REVALIDATION-REPAIR-01`: canonical URL now serves 8/8 without cache-bust.
- Skipped adapter/data-source repair: runtime already consumes `content_i18n_json.zh.faq`.
- No runtime code, CMS write, production import, sitemap/llms change, Search Channel action, staging deploy wait, manual deploy, or production deploy.
- Next eligible task: `MBTI-MAIN-FAQ-D0-OBSERVATION-BASELINE-01`.

## Repository rule impact
- Generated evidence only. No backend runtime, CMS authority, public API, SEO surface, sitemap, llms, canonical/noindex, structured data, Search Channel, or deployment rule change.
