### PR TITLE
MBTI-MAIN-FAQ-D0-OBSERVATION-BASELINE-01: record D0 evidence

### DIFF
--- a/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/EXECUTIVE_DECISION.md
+++ b/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/EXECUTIVE_DECISION.md
@@ -1,0 +1,31 @@
+# MBTI-MAIN-FAQ-D0-OBSERVATION-BASELINE-01
+
+Captured at: `2026-07-05T11:04:12Z`
+
+Decision: `D0_BASELINE_CAPTURED_READ_ONLY`
+
+This generated-only baseline records D0 observation data after `MBTI-MAIN-FAQ-PRODUCTION-RUNTIME-READBACK-02` confirmed production FAQ parity.
+
+Runtime guardrail:
+
+- API FAQ count: `8`
+- Public visible FAQ expected-question hits: `8`
+- FAQPage JSON-LD mainEntity count: `8`
+- Canonical public page cache state during readback: `x-proxy-cache: HIT`
+- Private URL / claim-boundary checks: inherited pass from Readback-02; this PR did not re-open private result/order surfaces.
+
+Observation sources:
+
+- Google Search Console, property `sc-domain:fermatmind.com`, search type `Web`, window `last 24 hours`, last updated `2.5 hours ago`.
+- Google Analytics 4, property `费马心理`, traffic acquisition report, date `2026-07-05`.
+- Public API lookup and canonical public page HTML readback.
+
+Decision rules:
+
+- Do not use this D0 snapshot to trigger TDK, first-screen, FAQ, schema, sitemap, llms, Search submission, CMS, or runtime changes.
+- Do not treat GSC or GA as purchase truth.
+- Wait for D7 or later before deciding whether another content/runtime optimization PR is justified.
+
+Next eligible observation:
+
+- `MBTI-MAIN-FAQ-D1-D7-D28-OBSERVATION-*`, with D7 as the first decision-quality checkpoint.

--- a/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/GA_D0_BASELINE.md
+++ b/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/GA_D0_BASELINE.md
@@ -1,0 +1,28 @@
+# GA D0 Baseline
+
+Source: Google Analytics UI
+Property: `费马心理`
+Report: `Traffic acquisition: Session default channel group`
+Date: `2026-07-05` (`today`)
+Sampling / completeness note shown by GA: report used `100%` of available data.
+
+## Today Traffic Acquisition
+
+| Channel | Sessions | Engaged sessions | Engagement rate | Avg engagement time / session | Events | Total revenue |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Total | 15 | 4 | 26.67% | 5m 15s | 94 | CNY 0.00 |
+| Direct | 10 | 2 | 20% | 3m 57s | 61 | CNY 0.00 |
+| Organic Search | 4 | 2 | 50% | 4m 27s | 26 | CNY 0.00 |
+| Unassigned | 4 | 0 | 0% | 5m 23s | 7 | CNY 0.00 |
+
+## Organic Sessions
+
+Organic Search sessions for `2026-07-05`: `4`
+
+This is traffic acquisition data only. It is not purchase truth and does not prove checkout, payment, report unlock, or revenue behavior.
+
+## Article-To-Test / Start-Test Events
+
+The scoped GA Traffic acquisition report did not expose `article_to_test` or `start_test` event rows in this read-only pass. Those event-level values are therefore recorded as `not available from current read source`, not as zero.
+
+No GA configuration, audience, conversion, exploration, or report definition was changed.

--- a/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/GSC_D0_BASELINE.md
+++ b/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/GSC_D0_BASELINE.md
@@ -1,0 +1,60 @@
+# GSC D0 Baseline
+
+Source: Google Search Console UI
+Property: `sc-domain:fermatmind.com`
+Search type: `Web`
+Window: `last 24 hours`
+Chart range shown: `2026-07-04 17:00` to `2026-07-05 16:00`
+Last updated: `2.5 hours ago`
+
+## Domain-Level 24h Snapshot
+
+| Metric | Value |
+| --- | ---: |
+| Clicks | 6 |
+| Impressions | 1,022 |
+| CTR | 0.6% |
+| Avg position | 8.7 |
+
+## MBTI Landing Page Filter
+
+Filter: page contains `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+| Metric | Value |
+| --- | ---: |
+| Clicks | 1 |
+| Impressions | 139 |
+| CTR | 0.7% |
+| Avg position | 7.7 |
+
+GSC displayed its standard warning that totals and table rows may be incomplete after filters are applied.
+
+## Query x Page Rows
+
+Rows shown under the MBTI landing page filter:
+
+| Query | Clicks | Impressions | CTR | Avg position |
+| --- | ---: | ---: | ---: | ---: |
+| mbti测试结果 | 1 | 1 | 100% | 7.0 |
+| mbti测试 | 0 | 56 | 0% | 8.7 |
+| 16人格测试 | 0 | 10 | 0% | 6.6 |
+| mbti免费测试 | 0 | 8 | 0% | 4.6 |
+| 16型人格测试 | 0 | 6 | 0% | 8.0 |
+| mbti 测试 免費 | 0 | 4 | 0% | 4.0 |
+| mbti16人格测试 | 0 | 2 | 0% | 8.0 |
+| 16种人格测试 | 0 | 2 | 0% | 8.5 |
+| imbt测试 | 0 | 2 | 0% | 9.0 |
+| 费马测试 | 0 | 1 | 0% | 1.0 |
+
+Pagination displayed: rows `1-10` of `30`.
+
+## Tracked Query Watchlist
+
+| Query | D0 status |
+| --- | --- |
+| mbti测试 | Present, 56 impressions, 0 clicks |
+| mbti免费测试 | Present, 8 impressions, 0 clicks |
+| 16人格测试 | Present, 10 impressions, 0 clicks |
+| 16型人格测试 | Present, 6 impressions, 0 clicks |
+
+Interpretation boundary: this is an early D0 observation only. It is not enough evidence for a follow-up TDK, first-screen, FAQ, or schema change.

--- a/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/RUNTIME_GUARDRAIL_READBACK.md
+++ b/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/RUNTIME_GUARDRAIL_READBACK.md
@@ -1,0 +1,44 @@
+# Runtime Guardrail Readback
+
+Captured at: `2026-07-05T11:04:12Z`
+
+## API Lookup
+
+Endpoint:
+
+`https://api.fermatmind.com/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types&locale=zh`
+
+Observed:
+
+- HTTP status: `200`
+- Cache header: `x-fastcgi-cache: BYPASS`
+- `content_i18n_json.zh.faq` count: `8`
+
+FAQ questions:
+
+1. MBTI 测试免费吗？
+2. MBTI 完整结果能看到什么？
+3. MBTI 测试一般多久？
+4. MBTI 能决定职业吗？
+5. MBTI 是心理诊断吗？
+6. 16 型人格结果会变吗？
+7. MBTI 和大五人格有什么区别？
+8. 做完 MBTI 后下一步看什么？
+
+## Canonical Public Page
+
+URL:
+
+`https://www.fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+
+Observed:
+
+- Final URL: `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types`
+- HTTP status: `200`
+- `x-proxy-cache: HIT`
+- `cache-control: public, s-maxage=60, stale-while-revalidate=300`
+- Expected visible FAQ question hits: `8`
+- FAQPage JSON-LD mainEntity count: `8`
+- FAQPage JSON-LD questions match expected API questions: `true`
+
+This confirms D0 measurement was taken after the public canonical page had stabilized on the 8-entry FAQ state.

--- a/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/scan_manifest.json
+++ b/generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/scan_manifest.json
@@ -1,0 +1,69 @@
+{
+  "id": "MBTI-MAIN-FAQ-D0-OBSERVATION-BASELINE-01",
+  "repo": "fap-api",
+  "generated_at": "2026-07-05T11:04:12Z",
+  "scope": "read-only D0 observation baseline after MBTI FAQ runtime parity passed",
+  "runtime_change": false,
+  "cms_write": false,
+  "database_mutation": false,
+  "search_submission": false,
+  "sitemap_change": false,
+  "llms_change": false,
+  "deployment_triggered": false,
+  "production_deploy_triggered": false,
+  "pr_train_manifest_changed": false,
+  "sources": {
+    "gsc": {
+      "property": "sc-domain:fermatmind.com",
+      "search_type": "Web",
+      "window": "last 24 hours",
+      "last_updated": "2.5 hours ago",
+      "domain": {
+        "clicks": 6,
+        "impressions": 1022,
+        "ctr": "0.6%",
+        "avg_position": 8.7
+      },
+      "page_filter": {
+        "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+        "clicks": 1,
+        "impressions": 139,
+        "ctr": "0.7%",
+        "avg_position": 7.7
+      },
+      "query_page_rows": [
+        {"query": "mbti测试结果", "clicks": 1, "impressions": 1, "ctr": "100%", "avg_position": 7.0},
+        {"query": "mbti测试", "clicks": 0, "impressions": 56, "ctr": "0%", "avg_position": 8.7},
+        {"query": "16人格测试", "clicks": 0, "impressions": 10, "ctr": "0%", "avg_position": 6.6},
+        {"query": "mbti免费测试", "clicks": 0, "impressions": 8, "ctr": "0%", "avg_position": 4.6},
+        {"query": "16型人格测试", "clicks": 0, "impressions": 6, "ctr": "0%", "avg_position": 8.0},
+        {"query": "mbti 测试 免費", "clicks": 0, "impressions": 4, "ctr": "0%", "avg_position": 4.0},
+        {"query": "mbti16人格测试", "clicks": 0, "impressions": 2, "ctr": "0%", "avg_position": 8.0},
+        {"query": "16种人格测试", "clicks": 0, "impressions": 2, "ctr": "0%", "avg_position": 8.5},
+        {"query": "imbt测试", "clicks": 0, "impressions": 2, "ctr": "0%", "avg_position": 9.0},
+        {"query": "费马测试", "clicks": 0, "impressions": 1, "ctr": "0%", "avg_position": 1.0}
+      ]
+    },
+    "ga": {
+      "property": "费马心理",
+      "report": "Traffic acquisition: Session default channel group",
+      "date": "2026-07-05",
+      "organic_search_sessions": 4,
+      "total_sessions": 15,
+      "organic_search_engaged_sessions": 2,
+      "organic_search_events": 26,
+      "purchase_truth": false,
+      "article_to_test": "not_available_from_current_read_source",
+      "start_test": "not_available_from_current_read_source"
+    },
+    "runtime_guardrail": {
+      "api_faq_count": 8,
+      "visible_faq_expected_question_hits": 8,
+      "jsonld_faq_count": 8,
+      "canonical_x_proxy_cache": "HIT",
+      "visible_questions_equal_jsonld_questions": true
+    }
+  },
+  "decision": "D0_BASELINE_CAPTURED_READ_ONLY",
+  "next_recommended_checkpoint": "D7 before deciding follow-up content/runtime optimization"
+}


### PR DESCRIPTION
## What changed
- Added generated-only D0 observation baseline evidence for the MBTI main FAQ rollout.
- Recorded GSC 24h domain/page/query metrics, GA today Organic Search sessions, and runtime FAQ guardrail readback.
- Kept PR-train manifest/state unchanged because this is an ad-hoc generated evidence PR for a missing manifest item.

## Why
- Readback-02 confirmed production FAQ parity at 8/8.
- D0 baseline should be captured only after canonical URL without cache-bust is stable at 8 visible FAQ / 8 JSON-LD FAQ.

## Validation
- `python3 -m json.tool generated/seo-ops-mbti-main-faq-d0-observation-baseline-20260705/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Browser read-only verification against GSC and GA UI
- Public API/page readback with curl/Python

## Deferred items
- No TDK, first-screen, FAQ, schema, sitemap, llms, Search submission, CMS, runtime, staging deploy, manual deploy, or production deploy changes.
- `article_to_test` / `start_test` event-level rows were not exposed in the scoped GA Traffic acquisition report; recorded as not available from current read source, not zero.
- D7 or later should be the first decision-quality checkpoint for further optimization.