### PR TITLE
BIG5-CMS-STAGING-AUTH-PACKET-10A: generate Big Five staging CMS write authorization packet

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81876,7 +81876,7 @@
     "deploy_allowed": false,
     "scheduler_activation": false,
     "content_authority": "CMS/backend",
-    "next_task": "BIG5-CMS-STAGING-WRITE-IMPORT-10",
+    "next_task": "BIG5-CMS-STAGING-AUTH-PACKET-10A",
     "transitions": [
       {
         "at": "2026-07-05T08:50:40Z",
@@ -81895,6 +81895,76 @@
       }
     ]
   },
+  "BIG5-CMS-STAGING-AUTH-PACKET-10A": {
+    "id": "BIG5-CMS-STAGING-AUTH-PACKET-10A",
+    "repo": "fap-api",
+    "title": "BIG5-CMS-STAGING-AUTH-PACKET-10A: generate Big Five staging CMS write authorization packet",
+    "base": "main",
+    "branch": "codex/big5-cms-staging-auth-packet-10a",
+    "depends_on": [
+      "BIG5-CMS-STAGING-IMPORT-RUNBOOK-09"
+    ],
+    "status": "local_checks_passed",
+    "authorized_by_user": "2026-07-05 user explicitly authorized this Big Five CMS staging write readiness PR train in the /goal objective file.",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User provided explicit id/title/scope/branch/dependency details in the active /goal objective and allowed missing manifest/state entries to be added before implementation."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "BIG5-CMS-STAGING-IMPORT-RUNBOOK-09 PR #2741 is merged and origin/main contains merge commit 1b9e4e8fbb169ae16c141bee9aa5f726381717f5."
+      },
+      "authorization_packet": {
+        "status": "pass",
+        "evidence": "Generated generated/big-five-cms-staging-write-import/authorization_packet.json and .md. Packet contains no secrets, records staging target alias, package path, SHA-256, expected row count 42, rollback strategy, and confirmation phrase; it does not execute CMS writes or add a write command."
+      },
+      "local_validation": {
+        "status": "pass",
+        "command": "python3 -m json.tool generated/big-five-cms-staging-write-import/authorization_packet.json >/dev/null && python3 -m json.tool generated/big-five-content-polish/cms-import-draft.polished.json >/dev/null && python3 -m json.tool generated/big-five-cms-import-dryrun/dryrun_report.json >/dev/null && python3 -m json.tool generated/big-five-cms-preview-readback-qa/readback_qa_report.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && rg -n \"BIG5-CMS-STAGING-AUTH-PACKET-10A|BIG5-CMS-STAGING-WRITE-IMPORT-10|BIG5-CMS-PREVIEW-RENDER-QA-11\" docs/codex/pr-train.yaml docs/codex/pr-train-state.json && git diff --check",
+        "evidence": "PASS: authorization packet JSON parses, Big Five source/dry-run/readback JSON artifacts parse, packet SHA and row count match the source package, train YAML/state JSON parse, requested ids are registered, and diff whitespace check passes."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to BIG5-CMS-STAGING-AUTH-PACKET-10A allowed paths: generated/big-five-cms-staging-write-import/authorization_packet.json, generated/big-five-cms-staging-write-import/authorization_packet.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_write_execution": false,
+    "production_migration_execution_allowed": false,
+    "database_mutation": false,
+    "cms_mutation": false,
+    "api_runtime_change": false,
+    "publish_allowed": false,
+    "search_channel_action": false,
+    "deploy_allowed": false,
+    "scheduler_activation": false,
+    "content_authority": "CMS/backend",
+    "next_task": "BIG5-CMS-STAGING-WRITE-IMPORT-10",
+    "transitions": [
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "status": "in_progress",
+        "summary": "Started non-secret authorization packet generation after BIG5-CMS-STAGING-IMPORT-RUNBOOK-09 merge was verified. Scope excludes CMS writes, write command implementation, publishing, indexability, sitemap/llms/JSON-LD runtime, search, and deploy."
+      },
+      {
+        "at": "2026-07-05T00:00:00Z",
+        "status": "local_checks_passed",
+        "summary": "Generated non-secret authorization packet and completed local validation. No CMS write, write command, publish, indexability, sitemap/llms/JSON-LD runtime, search, or deploy action was performed."
+      }
+    ]
+  },
   "BIG5-CMS-STAGING-WRITE-IMPORT-10": {
     "id": "BIG5-CMS-STAGING-WRITE-IMPORT-10",
     "repo": "fap-api",
@@ -81902,9 +81972,9 @@
     "base": "main",
     "branch": "codex/big5-cms-staging-write-import-10",
     "depends_on": [
-      "BIG5-CMS-STAGING-IMPORT-RUNBOOK-09"
+      "BIG5-CMS-STAGING-AUTH-PACKET-10A"
     ],
-    "status": "blocked_pending_staging_dev_write_authorization",
+    "status": "pending_dependency",
     "authorized_by_user": "2026-07-05 user explicitly authorized this Big Five CMS staging-to-release readiness PR train in the /goal objective file.",
     "checks": {
       "manifest_registration": {
@@ -81912,12 +81982,12 @@
         "evidence": "User provided explicit id/title/scope/branch/dependency details in the /goal objective and allowed missing manifest/state entries to be added before implementation."
       },
       "dependency": {
-        "status": "pass",
-        "evidence": "BIG5-CMS-STAGING-IMPORT-RUNBOOK-09 PR #2741 is merged and origin/main contains merge commit 1b9e4e8fbb169ae16c141bee9aa5f726381717f5."
+        "status": "pending",
+        "evidence": "Execution waits for BIG5-CMS-STAGING-AUTH-PACKET-10A to merge before evaluating staging/dev connection availability and write execution."
       },
       "authorization_gate": {
-        "status": "blocked",
-        "evidence": "No exact staging/dev CMS write authorization packet is present yet. Execution must stop before any CMS write."
+        "status": "pending_dependency",
+        "evidence": "Authorization packet generation moved to BIG5-CMS-STAGING-AUTH-PACKET-10A; PR 10 must still stop if no runtime staging/dev CMS connection is available after 10A merges."
       }
     },
     "scope_validation": {
@@ -81948,6 +82018,11 @@
         "at": "2026-07-05T08:50:40Z",
         "status": "blocked_pending_staging_dev_write_authorization",
         "summary": "Registered Big Five CMS staging-to-release readiness PR train item from the active /goal objective. Authorization-gated items must stop until their explicit gates are satisfied."
+      },
+      {
+        "at": "2026-07-05T11:27:58Z",
+        "status": "pending_dependency",
+        "summary": "Updated dependency to BIG5-CMS-STAGING-AUTH-PACKET-10A so the non-secret authorization packet is generated before any staging/dev write evaluation."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37527,18 +37527,64 @@ prs:
     search_channel_action: false
     deploy_allowed: false
     content_authority: CMS/backend
+    next_task: BIG5-CMS-STAGING-AUTH-PACKET-10A
+
+  - id: BIG5-CMS-STAGING-AUTH-PACKET-10A
+    repo: fap-api
+    depends_on:
+      - BIG5-CMS-STAGING-IMPORT-RUNBOOK-09
+    branch: codex/big5-cms-staging-auth-packet-10a
+    title: "BIG5-CMS-STAGING-AUTH-PACKET-10A: generate Big Five staging CMS write authorization packet"
+    train_scope: big_five_cms_staging_write_readiness
+    status: user_authorized
+    scope:
+      - Generate a non-secret staging/dev authorization packet for Big Five CMS draft write readiness.
+      - Output generated/big-five-cms-staging-write-import/authorization_packet.json.
+      - Record package path, package SHA-256, expected row count, target environment, connection alias, rollback strategy, and confirmation phrase.
+      - Use staging as the default target environment and a non-secret placeholder connection alias.
+      - Keep this evidence-only; do not execute CMS writes, add a write command, publish, release indexability, sitemap, llms, JSON-LD runtime, search submission, or deploy.
+    allowed_paths:
+      - generated/big-five-cms-staging-write-import/authorization_packet.json
+      - generated/big-five-cms-staging-write-import/authorization_packet.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Modify backend runtime, importer logic, public API runtime, production CMS content, sitemap/llms runtime, JSON-LD runtime, canonical/noindex behavior, permissions, scheduler behavior, secrets, staging deploy, or production deploy.
+      - Store passwords, tokens, private DSNs, private hosts, or secret material.
+      - Execute BIG5-CMS-STAGING-WRITE-IMPORT-10 or any CMS write scope in this PR.
+    validation:
+      - python3 -m json.tool generated/big-five-cms-staging-write-import/authorization_packet.json >/dev/null
+      - python3 -m json.tool generated/big-five-content-polish/cms-import-draft.polished.json >/dev/null
+      - python3 -m json.tool generated/big-five-cms-import-dryrun/dryrun_report.json >/dev/null
+      - python3 -m json.tool generated/big-five-cms-preview-readback-qa/readback_qa_report.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - rg -n "BIG5-CMS-STAGING-AUTH-PACKET-10A|BIG5-CMS-STAGING-WRITE-IMPORT-10|BIG5-CMS-PREVIEW-RENDER-QA-11" docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
     next_task: BIG5-CMS-STAGING-WRITE-IMPORT-10
 
   - id: BIG5-CMS-STAGING-WRITE-IMPORT-10
     repo: fap-api
     depends_on:
-      - BIG5-CMS-STAGING-IMPORT-RUNBOOK-09
+      - BIG5-CMS-STAGING-AUTH-PACKET-10A
     branch: codex/big5-cms-staging-write-import-10
     title: "BIG5-CMS-STAGING-WRITE-IMPORT-10: execute authorized Big Five staging CMS write import"
     train_scope: big_five_cms_staging_write_import
-    status: blocked_pending_staging_dev_write_authorization
+    status: pending_dependency
     scope:
-      - Execute the Big Five CMS staging/dev draft import only after explicit operator authorization.
+      - Execute the Big Five CMS staging/dev draft import only after BIG5-CMS-STAGING-AUTH-PACKET-10A is merged and runtime staging/dev connection availability is verified.
       - Record exact package path, package SHA, target environment, command, rollback handle, and resulting evidence.
       - Keep imported rows draft/review, noindex, not public, not sitemap eligible, not llms eligible, and without runtime JSON-LD release.
       - Do not touch production, publish content, release SEO/GEO discoverability, trigger deploy, or submit search.
@@ -37554,7 +37600,7 @@ prs:
       - generated/pr-train-sidecar-issues/**
     do_not:
       - Modify fap-web.
-      - Execute any CMS write unless the thread contains the exact staging/dev authorization packet and confirmation phrase from the runbook.
+      - Execute any CMS write unless BIG5-CMS-STAGING-AUTH-PACKET-10A is merged and the runtime staging/dev connection is available.
       - Run production import, publish, indexability release, sitemap/llms release, JSON-LD runtime release, search submission, manual deploy, staging deploy wait, or production deploy.
     validation:
       - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"

--- a/generated/big-five-cms-staging-write-import/authorization_packet.json
+++ b/generated/big-five-cms-staging-write-import/authorization_packet.json
@@ -1,0 +1,100 @@
+{
+  "packet_id": "BIG5-CMS-STAGING-AUTH-PACKET-10A",
+  "status": "authorization_packet_generated",
+  "generated_at_utc": "2026-07-05T00:00:00Z",
+  "repo": "fap-api",
+  "target_pr": "BIG5-CMS-STAGING-WRITE-IMPORT-10",
+  "authorization_scope": "staging_or_dev_draft_write_only",
+  "contains_secrets": false,
+  "target": {
+    "environment": "staging",
+    "backend_connection_alias": "staging-cms-nonsecret-alias",
+    "database_connection_name": "staging",
+    "connection_secret_material_included": false,
+    "notes": "This packet records the non-secret operator authorization envelope only. Runtime credentials, DSNs, passwords, tokens, and private hosts must be supplied by the approved staging/dev runtime environment, not this repository artifact."
+  },
+  "source": {
+    "git_sha_at_packet_generation": "38a599056a10886e161c9d99cacb31d87b465a87",
+    "package_path": "generated/big-five-content-polish/cms-import-draft.polished.json",
+    "package_sha256": "15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6",
+    "package_size_bytes": 260476,
+    "expected_row_count": 42,
+    "allowed_content_types": [
+      "hub_page",
+      "trait_page",
+      "trait_range_page",
+      "combination_page",
+      "cross_reading_page",
+      "result_review_page"
+    ],
+    "allowed_locales": [
+      "zh-CN",
+      "en-US"
+    ]
+  },
+  "preflight_evidence": {
+    "dry_run_report": "generated/big-five-cms-import-dryrun/dryrun_report.json",
+    "dry_run_ok": true,
+    "dry_run_row_count": 42,
+    "dry_run_writes_committed": false,
+    "dry_run_cms_write_attempted": false,
+    "dry_run_publish_attempted": false,
+    "dry_run_index_attempted": false,
+    "dry_run_sitemap_llms_release_attempted": false,
+    "preview_readback_planning_report": "generated/big-five-cms-preview-readback-qa/readback_qa_report.json",
+    "preview_readback_planning_status": "pass"
+  },
+  "authorized_actions": {
+    "staging_or_dev_cms_draft_write": true,
+    "production_import": false,
+    "publish": false,
+    "indexability_release": false,
+    "sitemap_release": false,
+    "llms_release": false,
+    "jsonld_runtime_release": false,
+    "search_submission": false,
+    "manual_deploy": false,
+    "staging_deploy_wait": false,
+    "production_deploy": false
+  },
+  "required_write_guardrails": {
+    "reject_production_environment": true,
+    "reject_production_database_connection": true,
+    "reject_package_sha_mismatch": true,
+    "reject_row_count_mismatch": true,
+    "reject_old_short_big_five_routes": true,
+    "reject_private_result_order_share_payment_account_urls": true,
+    "reject_sensitive_query_parameters": true,
+    "keep_rows_draft_review": true,
+    "keep_rows_noindex": true,
+    "keep_rows_not_public": true,
+    "keep_rows_not_sitemap_eligible": true,
+    "keep_rows_not_llms_eligible": true,
+    "keep_runtime_jsonld_blocked": true,
+    "keep_faq_field_as_only_structured_faq_source": true
+  },
+  "rollback": {
+    "strategy": "import_batch_id_plus_pre_import_snapshot_or_export",
+    "required_before_write": true,
+    "acceptable_handles": [
+      "import_batch_id",
+      "per_row_previous_revision_ids",
+      "pre_import_export_file",
+      "staging_database_snapshot_id",
+      "deterministic_delete_criteria_for_import_batch"
+    ],
+    "must_not_touch_production": true
+  },
+  "operator_authorization": {
+    "operator_name_or_handle": "rainie",
+    "approval_record": "Codex thread goal d59d041f-27b5-4bec-ad1b-c3de20141b7b authorized generating this non-secret packet; staging/dev write execution remains conditional on runtime connection availability.",
+    "confirmation_phrase": "I authorize Big Five CMS staging/dev draft import only. No production import, publish, indexability, sitemap, llms, JSON-LD runtime, deploy, or search release is authorized."
+  },
+  "execution_boundary": {
+    "this_packet_executes_writes": false,
+    "this_packet_adds_write_command": false,
+    "pr_10_must_stop_if_no_staging_dev_connection": true,
+    "pr_10_must_not_simulate_success": true,
+    "pr_11_must_wait_for_pr_10_write_evidence": true
+  }
+}

--- a/generated/big-five-cms-staging-write-import/authorization_packet.md
+++ b/generated/big-five-cms-staging-write-import/authorization_packet.md
@@ -1,0 +1,45 @@
+# Big Five CMS Staging Authorization Packet 10A
+
+Packet: `BIG5-CMS-STAGING-AUTH-PACKET-10A`
+
+JSON packet:
+`generated/big-five-cms-staging-write-import/authorization_packet.json`
+
+## Verdict
+
+- Status: authorization packet generated
+- Contains secrets: no
+- Executes CMS write: no
+- Adds write command: no
+- Production import authorized: no
+- Publish/index/sitemap/llms/JSON-LD release authorized: no
+
+## Source
+
+- Git SHA: `38a599056a10886e161c9d99cacb31d87b465a87`
+- Package path:
+  `generated/big-five-content-polish/cms-import-draft.polished.json`
+- Package SHA-256:
+  `15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6`
+- Expected rows: `42`
+- Target environment: `staging`
+- Connection alias: `staging-cms-nonsecret-alias`
+- Database connection name: `staging`
+
+## Boundary
+
+This packet only resolves the non-secret authorization evidence required before
+`BIG5-CMS-STAGING-WRITE-IMPORT-10` can evaluate a staging/dev write. Runtime
+credentials, private hosts, DSNs, passwords, and tokens are intentionally not
+stored in the repository.
+
+PR 10 must still stop if no staging/dev CMS connection is available. It must not
+use production, simulate a successful write, publish content, release
+indexability, emit JSON-LD runtime, add sitemap/llms entries, submit search URLs,
+or trigger deploys.
+
+## Confirmation Phrase
+
+```text
+I authorize Big Five CMS staging/dev draft import only. No production import, publish, indexability, sitemap, llms, JSON-LD runtime, deploy, or search release is authorized.
+```


### PR DESCRIPTION
## What changed
- Added `generated/big-five-cms-staging-write-import/authorization_packet.json`.
- Added `generated/big-five-cms-staging-write-import/authorization_packet.md`.
- Registered `BIG5-CMS-STAGING-AUTH-PACKET-10A` in the PR train and updated PR 10 to depend on it.

## Why
PR 10 needs a non-secret staging/dev authorization packet before any staging write can be evaluated. This PR records the package path, package SHA-256, expected row count, target environment alias, rollback strategy, confirmation phrase, and explicit no-production/no-publish/no-SEO-release boundaries.

## Validation
- `python3 -m json.tool generated/big-five-cms-staging-write-import/authorization_packet.json >/dev/null`
- `python3 -m json.tool generated/big-five-content-polish/cms-import-draft.polished.json >/dev/null`
- `python3 -m json.tool generated/big-five-cms-import-dryrun/dryrun_report.json >/dev/null`
- `python3 -m json.tool generated/big-five-cms-preview-readback-qa/readback_qa_report.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`\n- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`\n- packet semantic check: source SHA and row count match package; no write execution; no write command added\n- `rg -n "BIG5-CMS-STAGING-AUTH-PACKET-10A|BIG5-CMS-STAGING-WRITE-IMPORT-10|BIG5-CMS-PREVIEW-RENDER-QA-11" docs/codex/pr-train.yaml docs/codex/pr-train-state.json`\n- `git diff --check`\n- `git diff --cached --check`\n\n## Deferred items\n- No CMS write/import was executed.\n- No write command was added.\n- No production import, publish, indexability release, sitemap/llms release, JSON-LD runtime release, search submission, staging deploy wait, manual deploy, or production deploy was triggered.\n- PR 10 must still stop if no runtime staging/dev CMS connection is available.\n\n## Repository rule impact\nGenerated-contract evidence only. Runtime content authority remains backend/CMS; this PR does not add frontend fallback content or change public runtime behavior.