### PR TITLE
BIG5-CMS-STAGING-WRITE-EVIDENCE-CLOSEOUT: record PR10 staging write evidence

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -81987,7 +81987,7 @@
     "depends_on": [
       "BIG5-CMS-STAGING-AUTH-PACKET-10A"
     ],
-    "status": "ci_fix_applied",
+    "status": "merged_staging_write_evidence_recorded",
     "authorized_by_user": "2026-07-05 user explicitly authorized this Big Five CMS staging-to-release readiness PR train in the /goal objective file.",
     "checks": {
       "manifest_registration": {
@@ -82028,27 +82028,51 @@
         "evidence": "Opened PR #2751: https://github.com/fermatmind/fap-api/pull/2751"
       },
       "github_checks": {
-        "status": "failed_then_fixed_locally",
-        "evidence": "PR #2751 verify-bigfive failed because BigFiveResultPageV2CoreBodyPreviewTest runtime freeze classifier flagged the new PR10 import-only command/service and Kernel registration as runtime changes. Logs inspected for jobs 85224630726 and 85224633459. Added explicit classifier allowlist and test for PersonalityBigFiveCmsStagingWriteImport/BigFiveCmsImportDraftStagingWriter; focused freeze test now passes locally."
+        "status": "pass",
+        "evidence": "PR #2751 verify-bigfive initially failed because BigFiveResultPageV2CoreBodyPreviewTest runtime freeze classifier flagged the new PR10 import-only command/service and Kernel registration as runtime changes. Logs inspected for jobs 85224630726 and 85224633459. Added explicit classifier allowlist and test for PersonalityBigFiveCmsStagingWriteImport/BigFiveCmsImportDraftStagingWriter; required GitHub checks passed before squash merge into main as 09b0af0e911451ffa1bcbd3f1050cb7a0cbaf4f6."
       },
       "ci_fix_validation": {
         "status": "pass",
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|big_five_cms_staging_write_import' --no-ansi; cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityBigFiveCmsStagingWriteImportCommandTest --no-ansi; cd backend && ./vendor/bin/pint --test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php; ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"; python3 -m json.tool docs/codex/pr-train-state.json >/dev/null; git diff --check",
         "evidence": "PASS: focused failing freeze tests, staging write command tests, scoped Pint, YAML/JSON validation, and diff check passed. PHPUnit emitted existing missing backend/.env warnings; assertions passed."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "origin/main contains PR #2751 squash merge commit 09b0af0e911451ffa1bcbd3f1050cb7a0cbaf4f6; local main was synced before staging runtime execution; PR10 task branch cleanup completed before evidence closeout."
+      },
+      "staging_runtime_command": {
+        "status": "pass",
+        "evidence": "Staging release /var/www/fap-api-staging/releases/28741701561-1 exposes personality:big-five-cms-import-draft-dry-run and personality:big-five-cms-staging-write-import."
+      },
+      "staging_dry_run_execution": {
+        "status": "pass",
+        "evidence": "Remote staging dry-run passed with row_count=42, write=false, writes_committed=false, and expected package SHA 15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6. Evidence: generated/big-five-cms-staging-write-import/staging_dryrun_evidence.json."
+      },
+      "staging_write_execution": {
+        "status": "pass",
+        "evidence": "Remote staging/dev write passed with row_count=42, created_asset_count=42, updated_asset_count=0, skipped_existing_count=0, writes_committed=true, rollback_handle=big5-cms-staging-15d6b6df08cf-20260705140633. Evidence: generated/big-five-cms-staging-write-import/write_evidence.json."
+      },
+      "staging_readback_gate": {
+        "status": "pass",
+        "evidence": "Readback by source_package_hash found 42 rows; is_public/index/sitemap/llms/published_at/runtime_jsonld counts are all 0; robots=noindex,follow; launch_state=review; review_state=cms_import_draft_pending_review; FAQ-like body_sections count=0. Evidence: generated/big-five-cms-staging-write-import/staging_write_readback_gate.json."
+      },
+      "evidence_closeout_scope_validation": {
+        "status": "pass",
+        "evidence": "Evidence closeout changed only generated/big-five-cms-staging-write-import/** and docs/codex/pr-train-state.json, both allowed by the PR10 manifest scope."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
-    "commit_sha": "e743e0fa2e677de2d3f270846cf54122a6fdf2d7",
+    "commit_sha": "09b0af0e911451ffa1bcbd3f1050cb7a0cbaf4f6",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2751",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T13:03:07Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": true,
@@ -82100,6 +82124,11 @@
         "at": "2026-07-05T12:57:31Z",
         "status": "ci_fix_applied",
         "summary": "Inspected failed verify-bigfive job and fixed the PR10-caused runtime freeze classifier allowlist gap within backend/tests/Unit scope. No CMS write, publish, indexability, sitemap/llms/JSON-LD runtime, search, deploy, or production action was performed."
+      },
+      {
+        "at": "2026-07-05T14:10:00Z",
+        "status": "merged_staging_write_evidence_recorded",
+        "summary": "Recorded PR10 merge, staging dry-run, staging/dev draft write, readback gate, rollback handle, and evidence artifacts. No production import, publish, indexability release, sitemap/llms release, JSON-LD runtime release, search submission, manual deploy, or production deploy was performed."
       }
     ]
   },
@@ -82112,7 +82141,7 @@
     "depends_on": [
       "BIG5-CMS-STAGING-WRITE-IMPORT-10"
     ],
-    "status": "pending_dependency",
+    "status": "pending",
     "authorized_by_user": "2026-07-05 user explicitly authorized this Big Five CMS staging-to-release readiness PR train in the /goal objective file.",
     "checks": {
       "manifest_registration": {
@@ -82120,8 +82149,8 @@
         "evidence": "User provided explicit id/title/scope/branch/dependency details in the /goal objective and allowed missing manifest/state entries to be added before implementation."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Execution waits for BIG5-CMS-STAGING-WRITE-IMPORT-10 to merge."
+        "status": "pass",
+        "evidence": "BIG5-CMS-STAGING-WRITE-IMPORT-10 PR #2751 is merged and its staging/dev write/readback evidence is recorded in generated/big-five-cms-staging-write-import/."
       }
     },
     "scope_validation": {
@@ -82152,6 +82181,11 @@
         "at": "2026-07-05T08:50:40Z",
         "status": "pending_dependency",
         "summary": "Registered Big Five CMS staging-to-release readiness PR train item from the active /goal objective. Authorization-gated items must stop until their explicit gates are satisfied."
+      },
+      {
+        "at": "2026-07-05T14:10:00Z",
+        "status": "pending",
+        "summary": "Dependency BIG5-CMS-STAGING-WRITE-IMPORT-10 is merged and staging write evidence is recorded; PR11 may start preview/readback QA."
       }
     ]
   },

--- a/generated/big-five-cms-staging-write-import/staging_dryrun_evidence.json
+++ b/generated/big-five-cms-staging-write-import/staging_dryrun_evidence.json
@@ -1,0 +1,632 @@
+{
+    "artifact": "BIG5-CMS-STAGING-WRITE-IMPORT-10",
+    "status": "pass",
+    "ok": true,
+    "target_environment": "staging",
+    "package_path": "/var/www/fap-api-staging/releases/28741701561-1/backend/../generated/big-five-content-polish/cms-import-draft.polished.json",
+    "source_sha256": "15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6",
+    "row_count": 42,
+    "expected_row_count": 42,
+    "row_count_matches_expected": true,
+    "dry_run": true,
+    "write": false,
+    "writes_committed": false,
+    "cms_write_attempted": false,
+    "publish_attempted": false,
+    "index_attempted": false,
+    "search_release_attempted": false,
+    "sitemap_llms_release_attempted": false,
+    "jsonld_runtime_release_attempted": false,
+    "created_asset_count": 0,
+    "updated_asset_count": 0,
+    "skipped_existing_count": 0,
+    "rollback_handle": {
+        "import_batch_id": "big5-cms-staging-15d6b6df08cf-20260705140616",
+        "source_package": "big-five-cms-import-draft-polished.v2",
+        "source_hash": "15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6",
+        "deterministic_delete_criteria": {
+            "framework": "big_five",
+            "source_package": "big-five-cms-import-draft-polished.v2",
+            "source_hash": "15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6",
+            "is_public": false,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false
+        },
+        "pre_import_snapshot": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "restore_note": "Restore pre_import_snapshot rows or delete rows matching deterministic_delete_criteria in staging/dev only. Do not touch production."
+    },
+    "rows": [
+        {
+            "position": 1,
+            "canonical_path": "/zh/personality/big-five/combinations/high-agreeableness-high-neuroticism",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "high-agreeableness-high-neuroticism",
+                "slug": "big-five/high-agreeableness-high-neuroticism",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 2,
+            "canonical_path": "/zh/personality/big-five/combinations/high-openness-high-extraversion",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "high-openness-high-extraversion",
+                "slug": "big-five/high-openness-high-extraversion",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 3,
+            "canonical_path": "/zh/personality/big-five/combinations/high-openness-low-conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "high-openness-low-conscientiousness",
+                "slug": "big-five/high-openness-low-conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 4,
+            "canonical_path": "/zh/personality/big-five/combinations/low-agreeableness-high-conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "low-agreeableness-high-conscientiousness",
+                "slug": "big-five/low-agreeableness-high-conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 5,
+            "canonical_path": "/zh/personality/big-five/combinations/low-extraversion-high-conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "low-extraversion-high-conscientiousness",
+                "slug": "big-five/low-extraversion-high-conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 6,
+            "canonical_path": "/zh/personality/big-five/combinations/low-neuroticism-high-conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "low-neuroticism-high-conscientiousness",
+                "slug": "big-five/low-neuroticism-high-conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 7,
+            "canonical_path": "/zh/personality/big-five/big-five-learning-style",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-learning-style",
+                "slug": "big-five/big-five-learning-style",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 8,
+            "canonical_path": "/zh/personality/big-five/big-five-relationship-communication",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-relationship-communication",
+                "slug": "big-five/big-five-relationship-communication",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 9,
+            "canonical_path": "/zh/personality/big-five/big-five-riasec-career",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-riasec-career",
+                "slug": "big-five/big-five-riasec-career",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 10,
+            "canonical_path": "/zh/personality/big-five/big-five-stress-management",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-stress-management",
+                "slug": "big-five/big-five-stress-management",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 11,
+            "canonical_path": "/zh/personality/big-five/big-five-vs-mbti",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-vs-mbti",
+                "slug": "big-five/big-five-vs-mbti",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 12,
+            "canonical_path": "/en/personality/big-five",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "hub",
+                "entity_key": "big-five",
+                "slug": "big-five/big-five",
+                "locale": "en"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 13,
+            "canonical_path": "/zh/personality/big-five",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "hub",
+                "entity_key": "big-five",
+                "slug": "big-five/big-five",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 14,
+            "canonical_path": "/zh/personality/big-five/agreeableness-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "agreeableness-high",
+                "slug": "big-five/agreeableness-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 15,
+            "canonical_path": "/zh/personality/big-five/agreeableness-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "agreeableness-low",
+                "slug": "big-five/agreeableness-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 16,
+            "canonical_path": "/zh/personality/big-five/agreeableness-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "agreeableness-mid",
+                "slug": "big-five/agreeableness-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 17,
+            "canonical_path": "/zh/personality/big-five/conscientiousness-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "conscientiousness-high",
+                "slug": "big-five/conscientiousness-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 18,
+            "canonical_path": "/zh/personality/big-five/conscientiousness-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "conscientiousness-low",
+                "slug": "big-five/conscientiousness-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 19,
+            "canonical_path": "/zh/personality/big-five/conscientiousness-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "conscientiousness-mid",
+                "slug": "big-five/conscientiousness-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 20,
+            "canonical_path": "/zh/personality/big-five/extraversion-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "extraversion-high",
+                "slug": "big-five/extraversion-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 21,
+            "canonical_path": "/zh/personality/big-five/extraversion-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "extraversion-low",
+                "slug": "big-five/extraversion-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 22,
+            "canonical_path": "/zh/personality/big-five/extraversion-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "extraversion-mid",
+                "slug": "big-five/extraversion-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 23,
+            "canonical_path": "/zh/personality/big-five/neuroticism-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "neuroticism-high",
+                "slug": "big-five/neuroticism-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 24,
+            "canonical_path": "/zh/personality/big-five/neuroticism-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "neuroticism-low",
+                "slug": "big-five/neuroticism-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 25,
+            "canonical_path": "/zh/personality/big-five/neuroticism-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "neuroticism-mid",
+                "slug": "big-five/neuroticism-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 26,
+            "canonical_path": "/zh/personality/big-five/openness-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "openness-high",
+                "slug": "big-five/openness-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 27,
+            "canonical_path": "/zh/personality/big-five/openness-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "openness-low",
+                "slug": "big-five/openness-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 28,
+            "canonical_path": "/zh/personality/big-five/openness-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "openness-mid",
+                "slug": "big-five/openness-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 29,
+            "canonical_path": "/zh/personality/big-five/big-five-30-day-review",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-30-day-review",
+                "slug": "big-five/big-five-30-day-review",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 30,
+            "canonical_path": "/zh/personality/big-five/big-five-score-ranges",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-score-ranges",
+                "slug": "big-five/big-five-score-ranges",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 31,
+            "canonical_path": "/zh/personality/big-five/discuss-results-with-others",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "discuss-results-with-others",
+                "slug": "big-five/discuss-results-with-others",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 32,
+            "canonical_path": "/zh/personality/big-five/how-to-read-big-five-results",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "how-to-read-big-five-results",
+                "slug": "big-five/how-to-read-big-five-results",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 33,
+            "canonical_path": "/en/personality/big-five/agreeableness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "agreeableness",
+                "slug": "big-five/agreeableness",
+                "locale": "en"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 34,
+            "canonical_path": "/zh/personality/big-five/agreeableness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "agreeableness",
+                "slug": "big-five/agreeableness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 35,
+            "canonical_path": "/en/personality/big-five/conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "conscientiousness",
+                "slug": "big-five/conscientiousness",
+                "locale": "en"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 36,
+            "canonical_path": "/zh/personality/big-five/conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "conscientiousness",
+                "slug": "big-five/conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 37,
+            "canonical_path": "/en/personality/big-five/extraversion",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "extraversion",
+                "slug": "big-five/extraversion",
+                "locale": "en"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 38,
+            "canonical_path": "/zh/personality/big-five/extraversion",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "extraversion",
+                "slug": "big-five/extraversion",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 39,
+            "canonical_path": "/en/personality/big-five/neuroticism",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "neuroticism",
+                "slug": "big-five/neuroticism",
+                "locale": "en"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 40,
+            "canonical_path": "/zh/personality/big-five/neuroticism",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "neuroticism",
+                "slug": "big-five/neuroticism",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 41,
+            "canonical_path": "/en/personality/big-five/openness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "openness",
+                "slug": "big-five/openness",
+                "locale": "en"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        },
+        {
+            "position": 42,
+            "canonical_path": "/zh/personality/big-five/openness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "openness",
+                "slug": "big-five/openness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": null,
+            "action": "create_draft_asset"
+        }
+    ],
+    "errors": [],
+    "warnings": []
+}

--- a/generated/big-five-cms-staging-write-import/staging_write_readback_gate.json
+++ b/generated/big-five-cms-staging-write-import/staging_write_readback_gate.json
@@ -1,0 +1,20 @@
+{
+  "env": "staging",
+  "row_count": 42,
+  "is_public_true": 0,
+  "index_eligible_true": 0,
+  "sitemap_eligible_true": 0,
+  "llms_eligible_true": 0,
+  "published_at_not_null": 0,
+  "robots_values": [
+    "noindex,follow"
+  ],
+  "launch_states": [
+    "review"
+  ],
+  "review_states": [
+    "cms_import_draft_pending_review"
+  ],
+  "faq_body_section_count": 0,
+  "runtime_jsonld_enabled_count": 0
+}

--- a/generated/big-five-cms-staging-write-import/write_evidence.json
+++ b/generated/big-five-cms-staging-write-import/write_evidence.json
@@ -1,0 +1,632 @@
+{
+    "artifact": "BIG5-CMS-STAGING-WRITE-IMPORT-10",
+    "status": "pass",
+    "ok": true,
+    "target_environment": "staging",
+    "package_path": "/var/www/fap-api-staging/releases/28741701561-1/backend/../generated/big-five-content-polish/cms-import-draft.polished.json",
+    "source_sha256": "15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6",
+    "row_count": 42,
+    "expected_row_count": 42,
+    "row_count_matches_expected": true,
+    "dry_run": false,
+    "write": true,
+    "writes_committed": true,
+    "cms_write_attempted": true,
+    "publish_attempted": false,
+    "index_attempted": false,
+    "search_release_attempted": false,
+    "sitemap_llms_release_attempted": false,
+    "jsonld_runtime_release_attempted": false,
+    "created_asset_count": 42,
+    "updated_asset_count": 0,
+    "skipped_existing_count": 0,
+    "rollback_handle": {
+        "import_batch_id": "big5-cms-staging-15d6b6df08cf-20260705140633",
+        "source_package": "big-five-cms-import-draft-polished.v2",
+        "source_hash": "15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6",
+        "deterministic_delete_criteria": {
+            "framework": "big_five",
+            "source_package": "big-five-cms-import-draft-polished.v2",
+            "source_hash": "15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6",
+            "is_public": false,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false
+        },
+        "pre_import_snapshot": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "restore_note": "Restore pre_import_snapshot rows or delete rows matching deterministic_delete_criteria in staging/dev only. Do not touch production."
+    },
+    "rows": [
+        {
+            "position": 1,
+            "canonical_path": "/zh/personality/big-five/combinations/high-agreeableness-high-neuroticism",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "high-agreeableness-high-neuroticism",
+                "slug": "big-five/high-agreeableness-high-neuroticism",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 1,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 2,
+            "canonical_path": "/zh/personality/big-five/combinations/high-openness-high-extraversion",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "high-openness-high-extraversion",
+                "slug": "big-five/high-openness-high-extraversion",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 2,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 3,
+            "canonical_path": "/zh/personality/big-five/combinations/high-openness-low-conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "high-openness-low-conscientiousness",
+                "slug": "big-five/high-openness-low-conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 3,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 4,
+            "canonical_path": "/zh/personality/big-five/combinations/low-agreeableness-high-conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "low-agreeableness-high-conscientiousness",
+                "slug": "big-five/low-agreeableness-high-conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 4,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 5,
+            "canonical_path": "/zh/personality/big-five/combinations/low-extraversion-high-conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "low-extraversion-high-conscientiousness",
+                "slug": "big-five/low-extraversion-high-conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 5,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 6,
+            "canonical_path": "/zh/personality/big-five/combinations/low-neuroticism-high-conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "low-neuroticism-high-conscientiousness",
+                "slug": "big-five/low-neuroticism-high-conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 6,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 7,
+            "canonical_path": "/zh/personality/big-five/big-five-learning-style",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-learning-style",
+                "slug": "big-five/big-five-learning-style",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 7,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 8,
+            "canonical_path": "/zh/personality/big-five/big-five-relationship-communication",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-relationship-communication",
+                "slug": "big-five/big-five-relationship-communication",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 8,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 9,
+            "canonical_path": "/zh/personality/big-five/big-five-riasec-career",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-riasec-career",
+                "slug": "big-five/big-five-riasec-career",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 9,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 10,
+            "canonical_path": "/zh/personality/big-five/big-five-stress-management",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-stress-management",
+                "slug": "big-five/big-five-stress-management",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 10,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 11,
+            "canonical_path": "/zh/personality/big-five/big-five-vs-mbti",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-vs-mbti",
+                "slug": "big-five/big-five-vs-mbti",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 11,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 12,
+            "canonical_path": "/en/personality/big-five",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "hub",
+                "entity_key": "big-five",
+                "slug": "big-five/big-five",
+                "locale": "en"
+            },
+            "existing_asset_id": 12,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 13,
+            "canonical_path": "/zh/personality/big-five",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "hub",
+                "entity_key": "big-five",
+                "slug": "big-five/big-five",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 13,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 14,
+            "canonical_path": "/zh/personality/big-five/agreeableness-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "agreeableness-high",
+                "slug": "big-five/agreeableness-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 14,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 15,
+            "canonical_path": "/zh/personality/big-five/agreeableness-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "agreeableness-low",
+                "slug": "big-five/agreeableness-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 15,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 16,
+            "canonical_path": "/zh/personality/big-five/agreeableness-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "agreeableness-mid",
+                "slug": "big-five/agreeableness-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 16,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 17,
+            "canonical_path": "/zh/personality/big-five/conscientiousness-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "conscientiousness-high",
+                "slug": "big-five/conscientiousness-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 17,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 18,
+            "canonical_path": "/zh/personality/big-five/conscientiousness-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "conscientiousness-low",
+                "slug": "big-five/conscientiousness-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 18,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 19,
+            "canonical_path": "/zh/personality/big-five/conscientiousness-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "conscientiousness-mid",
+                "slug": "big-five/conscientiousness-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 19,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 20,
+            "canonical_path": "/zh/personality/big-five/extraversion-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "extraversion-high",
+                "slug": "big-five/extraversion-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 20,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 21,
+            "canonical_path": "/zh/personality/big-five/extraversion-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "extraversion-low",
+                "slug": "big-five/extraversion-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 21,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 22,
+            "canonical_path": "/zh/personality/big-five/extraversion-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "extraversion-mid",
+                "slug": "big-five/extraversion-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 22,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 23,
+            "canonical_path": "/zh/personality/big-five/neuroticism-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "neuroticism-high",
+                "slug": "big-five/neuroticism-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 23,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 24,
+            "canonical_path": "/zh/personality/big-five/neuroticism-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "neuroticism-low",
+                "slug": "big-five/neuroticism-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 24,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 25,
+            "canonical_path": "/zh/personality/big-five/neuroticism-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "neuroticism-mid",
+                "slug": "big-five/neuroticism-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 25,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 26,
+            "canonical_path": "/zh/personality/big-five/openness-high",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "openness-high",
+                "slug": "big-five/openness-high",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 26,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 27,
+            "canonical_path": "/zh/personality/big-five/openness-low",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "openness-low",
+                "slug": "big-five/openness-low",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 27,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 28,
+            "canonical_path": "/zh/personality/big-five/openness-mid",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "openness-mid",
+                "slug": "big-five/openness-mid",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 28,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 29,
+            "canonical_path": "/zh/personality/big-five/big-five-30-day-review",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-30-day-review",
+                "slug": "big-five/big-five-30-day-review",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 29,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 30,
+            "canonical_path": "/zh/personality/big-five/big-five-score-ranges",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "big-five-score-ranges",
+                "slug": "big-five/big-five-score-ranges",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 30,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 31,
+            "canonical_path": "/zh/personality/big-five/discuss-results-with-others",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "discuss-results-with-others",
+                "slug": "big-five/discuss-results-with-others",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 31,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 32,
+            "canonical_path": "/zh/personality/big-five/how-to-read-big-five-results",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "polarity",
+                "entity_key": "how-to-read-big-five-results",
+                "slug": "big-five/how-to-read-big-five-results",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 32,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 33,
+            "canonical_path": "/en/personality/big-five/agreeableness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "agreeableness",
+                "slug": "big-five/agreeableness",
+                "locale": "en"
+            },
+            "existing_asset_id": 33,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 34,
+            "canonical_path": "/zh/personality/big-five/agreeableness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "agreeableness",
+                "slug": "big-five/agreeableness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 34,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 35,
+            "canonical_path": "/en/personality/big-five/conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "conscientiousness",
+                "slug": "big-five/conscientiousness",
+                "locale": "en"
+            },
+            "existing_asset_id": 35,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 36,
+            "canonical_path": "/zh/personality/big-five/conscientiousness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "conscientiousness",
+                "slug": "big-five/conscientiousness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 36,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 37,
+            "canonical_path": "/en/personality/big-five/extraversion",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "extraversion",
+                "slug": "big-five/extraversion",
+                "locale": "en"
+            },
+            "existing_asset_id": 37,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 38,
+            "canonical_path": "/zh/personality/big-five/extraversion",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "extraversion",
+                "slug": "big-five/extraversion",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 38,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 39,
+            "canonical_path": "/en/personality/big-five/neuroticism",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "neuroticism",
+                "slug": "big-five/neuroticism",
+                "locale": "en"
+            },
+            "existing_asset_id": 39,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 40,
+            "canonical_path": "/zh/personality/big-five/neuroticism",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "neuroticism",
+                "slug": "big-five/neuroticism",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 40,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 41,
+            "canonical_path": "/en/personality/big-five/openness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "openness",
+                "slug": "big-five/openness",
+                "locale": "en"
+            },
+            "existing_asset_id": 41,
+            "action": "created_controlled_draft"
+        },
+        {
+            "position": 42,
+            "canonical_path": "/zh/personality/big-five/openness",
+            "identity": {
+                "framework": "big_five",
+                "entity_type": "domain",
+                "entity_key": "openness",
+                "slug": "big-five/openness",
+                "locale": "zh-CN"
+            },
+            "existing_asset_id": 42,
+            "action": "created_controlled_draft"
+        }
+    ],
+    "errors": [],
+    "warnings": []
+}

--- a/generated/big-five-cms-staging-write-import/write_evidence.md
+++ b/generated/big-five-cms-staging-write-import/write_evidence.md
@@ -1,0 +1,41 @@
+# Big Five CMS Staging Write Evidence
+
+## Summary
+- Target environment: `staging`
+- Package SHA-256: `15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6`
+- Row count: `42`
+- Dry-run status: `pass`, writes committed: `False`
+- Write status: `pass`, writes committed: `True`
+- Created assets: `42`
+- Updated assets: `0`
+- Skipped existing assets: `0`
+
+## Gates
+- Publish attempted: `False`
+- Index attempted: `False`
+- Sitemap / llms release attempted: `False`
+- Runtime JSON-LD release attempted: `False`
+
+## Readback Gate
+- Rows found by source hash: `42`
+- `is_public=true`: `0`
+- `index_eligible=true`: `0`
+- `sitemap_eligible=true`: `0`
+- `llms_eligible=true`: `0`
+- `published_at` not null: `0`
+- Robots values: `noindex,follow`
+- Launch states: `review`
+- Review states: `cms_import_draft_pending_review`
+- FAQ-like body sections: `0`
+- Runtime JSON-LD enabled rows: `0`
+
+## Rollback Handle
+- Import batch id: `big5-cms-staging-15d6b6df08cf-20260705140633`
+- Source package: `big-five-cms-import-draft-polished.v2`
+- Source hash: `15d6b6df08cf3ce7c9cd8a859b566c5bfd5fc4f6c6b279c493d48bc9e447ebc6`
+- Restore note: Restore pre_import_snapshot rows or delete rows matching deterministic_delete_criteria in staging/dev only. Do not touch production.
+
+## Boundaries
+- No production import was run.
+- No publish, indexability, sitemap, llms, runtime JSON-LD, search submission, manual deploy, or production deploy was triggered.
+- This evidence records staging/dev draft import only.


### PR DESCRIPTION
## What changed
- Added PR10 staging dry-run/write/readback evidence artifacts under generated/big-five-cms-staging-write-import/.
- Updated docs/codex/pr-train-state.json to record PR #2751 merge, staging write execution, readback gates, rollback handle, and PR11 dependency readiness.

## Why
- PR10 implementation merged before runtime staging write evidence could be generated. This evidence-only closeout records the authorized staging/dev draft write outcome without expanding PR11 scope.

## Validation
- python3 -m json.tool generated/big-five-cms-staging-write-import/write_evidence.json >/dev/null
- python3 -m json.tool generated/big-five-cms-staging-write-import/staging_dryrun_evidence.json >/dev/null
- python3 -m json.tool generated/big-five-cms-staging-write-import/staging_write_readback_gate.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"\n- git diff --check\n- rg -n "DB_PASSWORD|DATABASE_URL|mysql://|postgres://|BEGIN .*PRIVATE|Authorization:|Bearer |ssh-rsa|password\\s*[:=]" generated/big-five-cms-staging-write-import/staging_dryrun_evidence.json generated/big-five-cms-staging-write-import/write_evidence.json generated/big-five-cms-staging-write-import/staging_write_readback_gate.json generated/big-five-cms-staging-write-import/write_evidence.md || true\n\n## Deferred items\n- No production import.\n- No CMS publish or indexability release.\n- No sitemap, llms, JSON-LD runtime, search submission, manual deploy, staging deploy wait, or production deploy.\n- PR11 will separately validate preview/readback QA.\n\n## Repository rule impact\n- CMS/backend remains the content authority. This PR records evidence only and does not add frontend fallback content or runtime discoverability changes.