### PR TITLE
BIG5-CMS-PREVIEW-RENDER-QA-LEDGER-CLOSEOUT: record PR11 merge

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -3963,7 +3963,7 @@
     "failure_reason": null,
     "local_cleanup_executed": false,
     "merged_at": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2753",
     "remote_branch_deleted": false,
     "repo": "fap-api",
     "status": "ready_to_merge",
@@ -49944,7 +49944,7 @@
     "depends_on": [
       "IQ-V1-FREE-FULL-RESULT-CONTROLLED-SMOKE-01"
     ],
-    "status": "local_checks_passed",
+    "status": "merged",
     "authorized_by_user": "2026-07-04 attached /goal IQ-V1-FIVE-PR-TRAIN-EXECUTION-01 explicitly authorized this five-PR train plus manifest/state registration for missing entries.",
     "checks": {
     },
@@ -82168,20 +82168,28 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to PR11 allowed paths: backend/app/Console/Commands/**, backend/app/Services/Cms/**, backend/tests/Feature/**, backend/tests/Unit/**, docs/codex/pr-train-state.json, and generated/big-five-cms-preview-render-qa/**."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PR #2753 required GitHub checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "post_merge_revalidation": {
+        "status": "pass",
+        "evidence": "PR #2753 was squash-merged into main as fa57db325464d0dd1ecd9464695a9701fd5c307e; local main equals origin/main; worktree clean; local and remote task branches are deleted."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
-    "commit_sha": null,
+    "commit_sha": "fa57db325464d0dd1ecd9464695a9701fd5c307e",
     "pr_url": null,
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-05T14:38:14Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_write_execution": false,
     "production_migration_execution_allowed": false,
     "database_mutation": false,
@@ -82208,6 +82216,11 @@
         "at": "2026-07-05T14:35:00Z",
         "status": "local_checks_passed",
         "summary": "Implemented read-only Big Five CMS preview/render QA command and generated staging readback QA evidence. Local scoped checks passed. No CMS write, production import, publish, indexability release, sitemap/llms release, JSON-LD runtime release, search submission, manual deploy, staging deploy wait, or production deploy was performed."
+      },
+      {
+        "at": "2026-07-05T14:40:00Z",
+        "status": "merged",
+        "summary": "PR #2753 merged as fa57db325464d0dd1ecd9464695a9701fd5c307e after all GitHub checks passed. Local main equals origin/main, worktree is clean, and task branches are deleted. No staging deploy wait, manual deploy, production deploy, production import, publish, or SEO/GEO release was performed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Updated docs/codex/pr-train-state.json to record PR #2753 as merged.
- Recorded checks green, merge commit, branch cleanup, and post-merge revalidation facts.

## Why
- PR11 merged after its branch state was written as local_checks_passed. Repository rules require closing the PR-train ledger after merge.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"\n- git diff --check\n\n## Deferred items\n- No runtime code changes.\n- No CMS write, production import, publish, indexability release, sitemap/llms, JSON-LD runtime, search submission, manual deploy, staging deploy wait, or production deploy.\n\n## Repository rule impact\n- Ledger-only closeout. CMS/backend authority and SEO/GEO gates are unchanged.