### PR TITLE
BIG5-CMS-PREVIEW-RENDER-QA-LEDGER-REPAIR: fix PR11 status

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82141,7 +82141,7 @@
     "depends_on": [
       "BIG5-CMS-STAGING-WRITE-IMPORT-10"
     ],
-    "status": "pending",
+    "status": "merged",
     "authorized_by_user": "2026-07-05 user explicitly authorized this Big Five CMS staging-to-release readiness PR train in the /goal objective file.",
     "checks": {
       "manifest_registration": {
@@ -82185,7 +82185,7 @@
       "post_merge_revalidated": true
     },
     "commit_sha": "fa57db325464d0dd1ecd9464695a9701fd5c307e",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2753",
     "failure_reason": null,
     "merged_at": "2026-07-05T14:38:14Z",
     "remote_branch_deleted": true,


### PR DESCRIPTION
## What changed
- Fixed PR11 ledger status from `pending` to `merged`.
- Added the missing PR #2753 URL to the PR11 ledger node.

## Why
- The previous ledger closeout recorded merge/check/cleanup facts but left two fields stale. This is a two-line ledger-only repair.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- git diff --check

## Deferred items
- No runtime code changes.
- No CMS write, production import, publish, indexability release, sitemap/llms, JSON-LD runtime, search submission, manual deploy, staging deploy wait, or production deploy.

## Repository rule impact
- Ledger-only repair. CMS/backend authority and SEO/GEO gates are unchanged.