### PR TITLE
RIASEC-ZH-TEST-LANDING-P0-DIAGNOSTIC-01: add read-only handoff

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/BACKEND_AUTHORITY_MAP.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/BACKEND_AUTHORITY_MAP.md
@@ -1,0 +1,41 @@
+# Backend Authority Map
+
+Target route: `/zh/tests/holland-career-interest-test-riasec`
+
+## Authority Summary
+
+Future FAQ, TDK, GEO answer-surface, CTA copy, and public SEO changes for this landing page should be treated as backend/CMS-authoritative work. The frontend should remain a renderer/consumer and must not add local editorial fallback content.
+
+## Evidence Map
+
+| Evidence | File / lines | Authority implication |
+| --- | --- | --- |
+| Scale registry primary slug | `backend/database/seeders/ScaleRegistrySeeder.php:332-359` | `RIASEC` owns primary slug `holland-career-interest-test-riasec`, forms `riasec_60` and `riasec_140`, and default form `riasec_60`. |
+| Commercial state | `backend/database/seeders/ScaleRegistrySeeder.php:366-372` | RIASEC is `FREE` / `free_only`; no report unlock SKU is declared. |
+| SEO/content i18n | `backend/database/seeders/ScaleRegistrySeeder.php:373-410` | Backend holds zh title/description/excerpt/SEO copy and the 60/140 scale explanation. |
+| Sitemap fallback inclusion | `backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php:31-45` | Backend sitemap source includes `/zh/tests/holland-career-interest-test-riasec`; private fallback paths are filtered separately. |
+| GSC gate | `backend/docs/seo/generated/gsc-data-quality-gate.v1.json` | GSC opportunity use remains blocked until live quality gate passes. |
+| Opportunity queue contract | `backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json` | Future seo_intel use must be read-only, private-ops only, and gated by GSC data quality. |
+| Repository authority rules | `backend/AGENTS.md` | CMS/backend is the source of truth for publishable content, landing SEO, FAQ, public metadata, and public API resources. |
+
+## fap-api vs fap-web Boundary
+
+`fap-api` / backend authority:
+
+- scale registry and public assessment metadata;
+- CMS/landing surface/page block authority;
+- FAQ, SEO metadata, public content fields, and publication state;
+- sitemap source and URL/discoverability contracts;
+- seo_intel/GSC quality-gated read models.
+
+`fap-web` renderer/consumer:
+
+- render public landing content returned by backend/public APIs;
+- preserve canonical, JSON-LD, CTA, and display parity from backend data;
+- avoid local editorial fallback content for CMS-backed public surfaces.
+
+## Current Authority Decision
+
+`BACKEND_AUTHORITY_CONFIRMED`
+
+No authority ambiguity blocks this diagnostic handoff. Any future copy or metadata repair should be separately authorized in backend/CMS authority scope, not implemented as frontend fallback.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/BLOCKED_OR_UNVERIFIED_ASSUMPTIONS.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/BLOCKED_OR_UNVERIFIED_ASSUMPTIONS.md
@@ -1,0 +1,76 @@
+# Blocked or Unverified Assumptions
+
+This file records what was not proven by the diagnostic and must not be treated as completed evidence.
+
+## Blocked
+
+### GSC/seo_intel Quality
+
+Status: `blocked`
+
+Reason:
+
+- `backend/docs/seo/generated/gsc-data-quality-gate.v1.json` records `data_origin=fixture`.
+- `data_quality_gate_status=blocked`.
+- `opportunity_queue_eligible=false`.
+
+Implication: no CTR, impression, average-position, or query/page repair should be triggered from current GSC/seo_intel evidence.
+
+## Unverified
+
+### Visible FAQ vs FAQPage JSON-LD Parity
+
+Status: `unverified`
+
+Reason:
+
+- JSON-LD FAQPage has four questions.
+- Simple visible-heading extraction did not find those same questions after the FAQ heading.
+- The extraction method may miss accordion/button/non-heading rendered FAQ labels.
+
+Implication: open a separate read-only DOM parity readback before any FAQPage schema or visible FAQ repair.
+
+### CMS Live Source Row
+
+Status: `not_checked`
+
+Reason: this diagnostic did not access production CMS databases or write-capable admin surfaces.
+
+Implication: backend authority is confirmed from repo evidence and public runtime, but exact production CMS row provenance was not audited.
+
+### GA / Product Event Impact
+
+Status: `not_checked`
+
+Reason: this diagnostic did not query GA, product analytics, payment events, or conversion funnels.
+
+Implication: CTA performance claims are not made here.
+
+### GSC Query/Page Metrics
+
+Status: `not_checked`
+
+Reason: GSC data quality gate is blocked and raw GSC payload use is forbidden.
+
+Implication: no formal CTR/impression/average-position metric is included.
+
+### Screenshot-Derived Metrics
+
+Status: `not_used`
+
+Reason: screenshot-derived metrics are explicitly forbidden as formal evidence in this goal.
+
+Implication: all runtime evidence in this diagnostic comes from public HTML/readback and repo files, not screenshot measurement.
+
+## Non-Goals Confirmed
+
+This PR does not prove or perform:
+
+- CMS write/publish/import;
+- production deploy;
+- runtime/API mutation;
+- sitemap/llms/schema/hreflang mutation;
+- title/meta/FAQ copy update;
+- Search Channel enqueue;
+- search provider submission;
+- frontend fallback content.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/CLAIM_BOUNDARY_REVIEW.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/CLAIM_BOUNDARY_REVIEW.md
@@ -1,0 +1,45 @@
+# Claim Boundary Review
+
+Target: `/zh/tests/holland-career-interest-test-riasec`
+
+## Verdict
+
+Status: `PASS_WITH_MONITORING`
+
+The current public readback does not show high-risk claims that RIASEC precisely predicts a major, admission result, hiring outcome, salary, clinical state, or career success. Existing language frames the page as free career-interest exploration and states that results are directional reference rather than a promised major or admission result.
+
+## Observed Safe Boundary Signals
+
+- Meta description says: `结果用于方向参考，不承诺专业或录取结果。`
+- FAQPage includes a diagnostic-boundary question: `这是诊断吗？`
+- The page contains `探索`.
+- The page does not contain the inspected high-risk terms `精准` or `推荐`.
+- CTAs route to public test start pages, not private claims or report endpoints.
+
+## Allowed Framing
+
+Future backend/CMS-authority copy may safely frame RIASEC as:
+
+- a career-interest exploration tool;
+- a structured reference for comparing interest dimensions;
+- a way to start course, major, job activity, and career evidence checks;
+- a decision-support input that should be paired with curriculum, constraints, practical experience, and human review.
+
+## Forbidden or High-Risk Framing
+
+Future copy must not claim:
+
+- precise career recommendation;
+- guaranteed best major;
+- admission, hiring, salary, or career-success prediction;
+- clinical, medical, or psychological diagnosis;
+- official provider affiliation or official-instrument equivalence without source-backed approval;
+- reliability, validity, norm, percentile, or sample claims without approved public evidence.
+
+## Diagnostic Answer
+
+The current page is coherent enough that direct mutation is premature. The strongest future improvement is not an emergency repair; it is a separate authority dry-run that makes the boundary easier for answer engines to quote:
+
+`RIASEC is an exploration signal, not a precise career or major recommendation.`
+
+That wording must be reviewed and written in backend/CMS authority, not added as a frontend fallback.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/CTA_INTERNAL_LINK_AUDIT.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/CTA_INTERNAL_LINK_AUDIT.md
@@ -1,0 +1,64 @@
+# CTA / Internal-Link Audit
+
+Target: `/zh/tests/holland-career-interest-test-riasec`
+
+## CTA Verdict
+
+Status: `PASS_READ_ONLY`
+
+Observed CTA links are public, non-private, and route to the expected RIASEC take surface with explicit form selection.
+
+## Primary CTAs
+
+| URL | Anchor text | Assessment |
+| --- | --- | --- |
+| `/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60` | `开始免费霍兰德测试` | Public route; no private token or order identifier. |
+| `/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140` | `开始霍兰德职业兴趣增强版免费测试` | Public route; no private token or order identifier. |
+| `/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140` | `开始霍兰德职业兴趣免费测试` | Public route; no private token or order identifier. |
+
+Repeated CTAs were observed later on the page for both forms. This is acceptable from a URL safety perspective.
+
+## Internal Links
+
+Public related links observed include:
+
+- `/zh/articles/unwanted-major-repeat-or-stay-riasec-decision-checklist`
+- `/zh/articles/major-career-mismatch-job-search-skills-plan`
+- `/zh/articles/unwanted-major-adjustment-riasec-transfer-plan`
+- `/zh/articles/hot-major-fit-riasec-course-career-checklist`
+- `/zh/articles/math-not-good-computer-ai-major-course-riasec-checklist`
+- `/zh/articles/gaokao-major-adjustment-unacceptable-major-checklist`
+- `/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist`
+- `/zh/articles/college-major-choice-holland-mbti-career-test`
+- `/zh/articles/career-confusion-test-map`
+- `/zh/articles/career-interest-vs-personality-test-differences`
+- `/zh/articles/mbti-vs-holland-career-choice`
+- `/zh/articles/riasec-holland-career-interest-test-explained`
+- `/zh/articles/gaokao-score-major-shortlist-riasec-checklist`
+- `/zh/articles/big-five-personality-test-vs-mbti`
+
+Public test links observed include:
+
+- `/zh/tests/mbti-personality-test-16-personality-types`
+- `/zh/tests/big-five-personality-test-ocean-model`
+- `/zh/tests/enneagram-personality-test-nine-types`
+- `/zh/tests/holland-career-interest-test-riasec`
+- `/zh/tests/iq-test-intelligence-quotient-assessment`
+- `/zh/tests/eq-test-emotional-intelligence-assessment`
+
+## Private URL Guard
+
+No URL containing token, attempt, order, payment, result, report, claim, private, or share-token patterns was observed in the extracted links.
+
+## Analytics Safety
+
+From the URL surface inspected here, CTA links are analytics-safe because they use public canonical/take routes and explicit public form query parameters only:
+
+- `form=riasec_60`
+- `form=riasec_140`
+
+No user identifier, payment identifier, order number, attempt id, result id, or private report URL was observed.
+
+## Recommendation
+
+No immediate CTA repair is required. If the next SEO/GEO dry-run proceeds, evaluate whether CTA copy should better distinguish "60题标准版" and "140题增强版" in the same backend authority scope as FAQ answer-surface planning.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/CURRENT_RUNTIME_READBACK.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/CURRENT_RUNTIME_READBACK.md
@@ -1,0 +1,109 @@
+# Current Runtime Readback
+
+Target: `https://fermatmind.com/zh/tests/holland-career-interest-test-riasec`
+
+Readback time: `2026-07-05T14:44:55Z`
+
+Method: public HTML fetch and static extraction. This is a read-only runtime readback; it did not use screenshots as formal metrics and did not mutate runtime state.
+
+## HTTP and Indexability
+
+| Field | Value |
+| --- | --- |
+| HTTP status | `200` |
+| Final URL | `https://fermatmind.com/zh/tests/holland-career-interest-test-riasec` |
+| Cache-Control | `public, s-maxage=60, stale-while-revalidate=300` |
+| X-Proxy-Cache | `MISS` |
+| Title | `免费霍兰德职业兴趣测试：RIASEC 完整结果 | FermatMind` |
+| Meta description | `免费完成霍兰德职业兴趣测试，查看 RIASEC 兴趣排序和职业探索线索。结果用于方向参考，不承诺专业或录取结果。` |
+| Robots | `index, follow` |
+| Canonical | `https://fermatmind.com/zh/tests/holland-career-interest-test-riasec` |
+| Alternate links | `3` |
+
+## Discoverability Surfaces
+
+| Surface | HTTP status | Contains target path |
+| --- | ---: | --- |
+| `sitemap.xml` | 200 | yes |
+| `llms.txt` | 200 | yes |
+| `llms-full.txt` | 200 | yes |
+| `robots.txt` | 200 | no direct path entry observed |
+
+`robots.txt` not containing the path is not treated as a blocker because the page-level robots tag is `index, follow` and the path is present in sitemap/llms surfaces.
+
+## Heading Readback
+
+Primary headings observed:
+
+- H1: `免费霍兰德职业兴趣测试：RIASEC完整结果`
+- H2: `选择霍兰德职业兴趣版本`
+- H3: `60题标准版`
+- H3: `140题增强版`
+- H2: `何时使用这份测评`
+- H3: `你将获得什么`
+- H3: `相关文章`
+- H2: `FAQ`
+- H3: `免责声明`
+- H3: `准备开始？`
+
+The page also renders related article headings tied to major choice, course cost, job activity, career interest, MBTI-vs-Holland comparison, and RIASEC explanation intents.
+
+## Structured Data Readback
+
+JSON-LD types observed:
+
+- `WebPage`
+- `BreadcrumbList`
+- `SoftwareApplication`
+- `FAQPage`
+
+FAQPage `mainEntity` count: `4`
+
+FAQPage questions:
+
+1. `需要多久？`
+2. `每道题都要回答吗？`
+3. `可以重复测试吗？`
+4. `这是诊断吗？`
+
+## Visible FAQ Parity Note
+
+The simple heading parser found these headings after the `FAQ` H2:
+
+- `免责声明`
+- `准备开始？`
+
+This does not prove the visible FAQ questions are absent because the runtime may render questions using non-heading markup, hydrated UI, or hidden/accordion controls. It does prove that parity is not established by this diagnostic extraction.
+
+Recorded issue: `faq_visible_jsonld_parity_unverified`
+
+Required follow-up: a separate read-only DOM/Playwright readback that extracts rendered visible FAQ labels and compares them to FAQPage JSON-LD questions.
+
+## Text Presence Checks
+
+| Text | Present in HTML |
+| --- | --- |
+| `霍兰德职业兴趣测试免费吗` | no |
+| `免费` | yes |
+| `60题` | yes |
+| `140题` | yes |
+| `探索` | yes |
+| `精准` | no |
+| `推荐` | no |
+| `专业` | yes |
+| `课程` | yes |
+| `工作活动` | yes |
+
+Interpretation: free intent is present through title/H1/meta/CTA copy, but the exact FAQ-style query "霍兰德职业兴趣测试免费吗" is not directly answered in the observed HTML. This is a future answer-surface opportunity, not a repair authorization in this PR.
+
+## CTA and Link Readback
+
+Primary CTA links observed:
+
+- `/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60` with text `开始免费霍兰德测试`
+- `/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140` with text `开始霍兰德职业兴趣增强版免费测试`
+- repeated public `/take?form=riasec_60` and `/take?form=riasec_140` links near later CTA blocks
+
+Related public links observed include zh article routes about unwanted major adjustment, major-career mismatch, hot major fit, high school major choice, MBTI vs Holland, RIASEC explanation, and test hub links for MBTI, Big Five, Enneagram, IQ, and EQ.
+
+Private URL hits: none.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,52 @@
+# RIASEC-ZH-TEST-LANDING-P0-DIAGNOSTIC-01
+
+Final verdict: `RIASEC_P0_DIAGNOSTIC_HANDOFF_READY`
+
+## Decision
+
+Run type: generated-only, read-only diagnostic handoff.
+
+Target page: `https://fermatmind.com/zh/tests/holland-career-interest-test-riasec`
+
+Current decision: `P0_DIAGNOSTIC_ONLY`
+
+No repair is authorized in this PR. The page is public, indexable, and backend authority exists, but GSC/seo_intel quality is still blocked by fixture-origin data and FAQ visible-vs-JSON-LD parity needs a dedicated readback before any FAQPage or GEO answer-surface mutation.
+
+## Executive Findings
+
+| Area | Finding | Decision |
+| --- | --- | --- |
+| Runtime | Page returns 200, canonical is stable, robots is `index, follow`, and sitemap/llms/llms-full include the path. | Healthy enough for diagnostic handoff. |
+| Backend authority | RIASEC scale authority exists in backend registry with primary slug, `riasec_60`, `riasec_140`, `free_only`, and zh SEO/content fields. | Future writes must stay backend/CMS-authoritative. |
+| GSC/seo_intel | Current GSC quality gate records `data_origin=fixture`, `data_quality_gate_status=blocked`, and `opportunity_queue_eligible=false`. | CTR repair is not justified yet. |
+| FAQ/GEO | Title/H1/CTA answer free intent partially, 60/140 are visible, and boundary language is present. Exact free-question FAQ coverage is missing. | Recommend a separate FAQ/GEO authority dry-run only after parity readback. |
+| FAQ parity | FAQPage JSON-LD has four questions, while simple HTML heading readback after the FAQ heading did not expose those same questions. | Record as parity uncertainty; do not repair here. |
+| CTA/private URL | CTAs point to public `/take?form=riasec_60` and `/take?form=riasec_140`; no token/order/payment/result/report URL was observed. | Pass for this diagnostic. |
+
+## Next Recommended Action
+
+Open one separate read-only PR:
+
+`RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01`
+
+Purpose: prove whether visible FAQ text and FAQPage JSON-LD are truly generated from the same runtime source, using a stronger DOM/readback method than this diagnostic parser.
+
+Only after parity is proven should the operator consider a backend/CMS-authority FAQ/GEO dry-run for the "免费吗", 60-vs-140, exploration-signal, and course/job/major validation answer surfaces.
+
+## Explicit Non-Actions
+
+- No CMS write.
+- No CMS publish.
+- No content import.
+- No Search Channel enqueue.
+- No search provider submission.
+- No URL Truth write.
+- No sitemap, llms, schema, or hreflang mutation.
+- No frontend fallback content.
+- No fap-web edit.
+- No deploy.
+- No runtime/API mutation.
+- No title/meta/FAQ copy write.
+- No invented GSC metrics.
+- No raw GSC payloads.
+- No screenshot-derived metrics as formal evidence.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/FAQ_GEO_ANSWER_SURFACE_AUDIT.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/FAQ_GEO_ANSWER_SURFACE_AUDIT.md
@@ -1,0 +1,90 @@
+# FAQ / GEO Answer-Surface Audit
+
+Target: `/zh/tests/holland-career-interest-test-riasec`
+
+This audit is read-only. It records answer-surface coverage and next-step prompts; it does not write FAQ, schema, metadata, or CMS content.
+
+## Diagnostic Questions
+
+### 1. Does the page clearly answer "霍兰德职业兴趣测试免费吗" above the fold or in FAQ?
+
+Status: `partial`
+
+Evidence:
+
+- Title: `免费霍兰德职业兴趣测试：RIASEC 完整结果 | FermatMind`
+- H1: `免费霍兰德职业兴趣测试：RIASEC完整结果`
+- Meta description starts with `免费完成霍兰德职业兴趣测试`
+- CTA text includes `开始免费霍兰德测试`
+- Exact phrase `霍兰德职业兴趣测试免费吗` was not found in HTML.
+- FAQPage questions do not include a direct free/pricing question.
+
+Interpretation: the page answers free intent through title/H1/meta/CTA, but not as a direct FAQ/GEO question-answer block. This is a future authority dry-run candidate, not an immediate repair.
+
+### 2. Does the page explain the difference between 60题标准版 and 140题增强版?
+
+Status: `present`
+
+Evidence:
+
+- H2: `选择霍兰德职业兴趣版本`
+- H3: `60题标准版`
+- H3: `140题增强版`
+- CTA routes differentiate `form=riasec_60` and `form=riasec_140`.
+- Backend registry describes the default public form as 60 questions and the enhanced 140-question form as supported by the same scale.
+
+Interpretation: the distinction is visible and backed by backend authority. A future dry-run could still improve answer-block clarity, but current evidence does not require urgent repair.
+
+### 3. Does the page state RIASEC is an exploration signal, not a precise career or major recommendation?
+
+Status: `present_with_room_to_strengthen`
+
+Evidence:
+
+- Meta description: `结果用于方向参考，不承诺专业或录取结果。`
+- FAQPage question includes `这是诊断吗？`
+- HTML includes `探索`.
+- HTML did not include `精准` or `推荐`.
+
+Interpretation: the boundary is present and avoids overclaiming. A future FAQ/GEO dry-run could make "not a precise career or major recommendation" more explicit, but the current page is not making a detected high-risk precise-prediction claim.
+
+### 4. Does the page connect RIASEC result to course / job activity / major validation without overclaiming?
+
+Status: `present`
+
+Evidence:
+
+- HTML contains `专业`, `课程`, and `工作活动`.
+- Related article links include:
+  - `录取专业不理想要不要复读？课程成本、转专业窗口和霍兰德兴趣决策清单`
+  - `专业不对口怎么找工作？JD拆解、技能证据和实习验证清单`
+  - `热门专业适合我吗？用课程、职业活动和霍兰德兴趣做高考专业选择清单`
+  - `高考志愿选专业：霍兰德、MBTI和职业兴趣测试怎么用`
+  - `不知道自己适合什么职业怎么办？从职业兴趣、性格偏好到现实验证`
+
+Interpretation: the page routes RIASEC toward validation workflows without observed claims that it guarantees major, admission, hiring, salary, or career success outcomes.
+
+### 5. Does visible FAQ match FAQPage JSON-LD?
+
+Status: `unverified`
+
+Evidence:
+
+- FAQPage JSON-LD question count: `4`
+- JSON-LD questions:
+  - `需要多久？`
+  - `每道题都要回答吗？`
+  - `可以重复测试吗？`
+  - `这是诊断吗？`
+- Simple visible-heading extraction after the `FAQ` heading found:
+  - `免责声明`
+  - `准备开始？`
+
+Interpretation: this diagnostic cannot prove visible FAQ and JSON-LD parity. It records a parity uncertainty and recommends a separate read-only DOM readback. This PR does not authorize schema or renderer repair.
+
+## Recommended Follow-Up
+
+1. First: `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01`
+2. Then, only if parity is understood: `RIASEC-ZH-TEST-LANDING-FAQ-GEO-AUTHORITY-DRYRUN-01`
+
+No current evidence justifies direct mutation before the gated readbacks.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/FUTURE_DRY_RUN_OPTIONS.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/FUTURE_DRY_RUN_OPTIONS.md
@@ -1,0 +1,89 @@
+# Future Dry-Run Options
+
+This diagnostic does not authorize writes. The options below are follow-up PR candidates only.
+
+## Option 1: FAQ Parity Readback
+
+PR id: `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01`
+
+Type: generated-only read-only evidence PR.
+
+Purpose: verify whether rendered visible FAQ questions match FAQPage JSON-LD questions on the public page.
+
+Likely output:
+
+- rendered DOM FAQ extraction;
+- JSON-LD FAQPage extraction;
+- visible-vs-JSON-LD equality result;
+- source-of-truth notes;
+- exact repair prompt if mismatch is confirmed.
+
+Forbidden:
+
+- no schema mutation;
+- no frontend repair;
+- no FAQ copy write;
+- no CMS write;
+- no deploy.
+
+Recommended priority: first.
+
+## Option 2: FAQ/GEO Authority Dry-Run
+
+PR id: `RIASEC-ZH-TEST-LANDING-FAQ-GEO-AUTHORITY-DRYRUN-01`
+
+Type: generated-only backend authority planning PR.
+
+Purpose: propose backend/CMS-authority answer-surface improvements for:
+
+- "霍兰德职业兴趣测试免费吗";
+- difference between `60题标准版` and `140题增强版`;
+- RIASEC as exploration signal, not a precise career or major recommendation;
+- course, job activity, and major validation framing without overclaiming.
+
+Prerequisite: FAQ parity readback completed or explicitly held.
+
+Forbidden:
+
+- no final FAQ copy write;
+- no title/meta write;
+- no schema write;
+- no CMS import/publish.
+
+Recommended priority: second.
+
+## Option 3: CTA/Internal Link Deep Readback
+
+PR id: `RIASEC-ZH-TEST-LANDING-CTA-INTERNAL-LINK-DIAGNOSTIC-01`
+
+Type: generated-only read-only evidence PR.
+
+Purpose: check CTA placement, repeated route safety, public related-link status, and whether RIASEC pillar links support course/job/major validation intent without cannibalization.
+
+Forbidden:
+
+- no CTA copy write;
+- no frontend route change;
+- no CMS link mutation.
+
+Recommended priority: optional after FAQ/GEO.
+
+## Option 4: GSC/seo_intel Observation Gate
+
+PR id: `RIASEC-ZH-TEST-LANDING-GSC-SEO-INTEL-QUALITY-READBACK-01`
+
+Type: generated-only read-only evidence PR.
+
+Purpose: re-check whether GSC/seo_intel data has moved from fixture/blocked to live/readable and whether CTR/impression data can justify a repair.
+
+Prerequisite: `gsc_data_quality_gate` must pass on live GSC API data.
+
+Forbidden:
+
+- no raw GSC payloads;
+- no invented GSC metrics;
+- no Search Channel enqueue;
+- no search provider submission;
+- no URL Truth write.
+
+Recommended priority: later, only after data quality gate changes.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,94 @@
+# Next Exact Authorization Prompts
+
+Use one prompt at a time. Do not combine these scopes.
+
+## Recommended Next Prompt
+
+```text
+Authorize Codex to open one generated-only read-only PR in fap-api:
+
+RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01
+
+Scope:
+- Public runtime readback for /zh/tests/holland-career-interest-test-riasec.
+- Extract rendered visible FAQ questions with a DOM-capable method.
+- Extract FAQPage JSON-LD mainEntity questions.
+- Compare visible FAQ questions against JSON-LD questions.
+- Record whether both surfaces share the same data source or whether a repair PR is needed.
+
+Allowed output path:
+backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-faq-parity-readback-01/
+
+Forbidden:
+- no CMS write
+- no CMS publish
+- no content import
+- no schema/hreflang/sitemap/llms mutation
+- no frontend fallback content
+- no fap-web edit
+- no deploy
+- no runtime/API mutation
+- no FAQ/title/meta copy write
+- no Search Channel or search provider submission
+
+Required checks:
+- python3 -m json.tool backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-faq-parity-readback-01/scan_manifest.json >/dev/null
+- git diff --check
+- git diff --cached --check
+```
+
+## Optional Follow-Up Prompt After Parity Is Known
+
+```text
+Authorize Codex to open one generated-only backend authority dry-run PR in fap-api:
+
+RIASEC-ZH-TEST-LANDING-FAQ-GEO-AUTHORITY-DRYRUN-01
+
+Scope:
+- Propose, but do not write, backend/CMS-authority FAQ and GEO answer-surface changes for /zh/tests/holland-career-interest-test-riasec.
+- Cover direct free-test intent, 60题 vs 140题 difference, exploration-signal boundary, and course/job-activity/major-validation framing.
+- Preserve claim boundaries: no precise career recommendation, no guaranteed major/admission/hiring/salary/career outcome, no unsupported psychometric validity/norm claims.
+- Output exact future repair authorization prompts only if needed.
+
+Allowed output path:
+backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-faq-geo-authority-dryrun-01/
+
+Forbidden:
+- no CMS write
+- no CMS publish
+- no content import
+- no runtime/API mutation
+- no final title/meta/FAQ copy write
+- no schema/hreflang/sitemap/llms mutation
+- no fap-web edit
+- no deploy
+- no Search Channel or search provider submission
+
+Required checks:
+- python3 -m json.tool backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-faq-geo-authority-dryrun-01/scan_manifest.json >/dev/null
+- git diff --check
+- git diff --cached --check
+```
+
+## Later Prompt When GSC Quality Gate Passes
+
+```text
+Authorize Codex to open one generated-only read-only PR in fap-api:
+
+RIASEC-ZH-TEST-LANDING-GSC-SEO-INTEL-QUALITY-READBACK-01
+
+Scope:
+- Verify whether backend GSC/seo_intel quality gate for /zh/tests/holland-career-interest-test-riasec is passable using approved read models.
+- Use only sanitized/hash/aggregate evidence.
+- Decide whether CTR/impression evidence justifies a future repair prompt.
+
+Forbidden:
+- no live GSC call unless separately authorized by the existing backend GSC live-read SOP
+- no raw query or raw URL payloads
+- no CMS write
+- no Search Channel enqueue
+- no search provider submission
+- no URL Truth write
+- no runtime/API mutation
+- no deploy
+```

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/PRIVATE_URL_GUARD.md
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/PRIVATE_URL_GUARD.md
@@ -1,0 +1,54 @@
+# Private URL Guard
+
+Target: `/zh/tests/holland-career-interest-test-riasec`
+
+## Verdict
+
+Status: `PASS_READ_ONLY`
+
+No private URLs were observed in the extracted public page links.
+
+## Patterns Checked
+
+The extracted links were reviewed for private or sensitive URL patterns including:
+
+- `token`
+- `attempt`
+- `order`
+- `payment`
+- `result`
+- `report`
+- `claim`
+- `private`
+- `share_token`
+
+Observed hit count: `0`
+
+## Public Routes Observed
+
+Accepted public CTA routes:
+
+- `/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60`
+- `/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140`
+
+Accepted public internal-link route classes:
+
+- `/zh/articles/...`
+- `/zh/tests/...`
+- `/zh/tests`
+- `/zh/articles`
+- `/zh/career`
+- `/zh/careers`
+
+## Guardrail
+
+Future SEO/GEO work must keep private assessment results, attempts, reports, orders, claims, payment flows, and tokenized share URLs out of:
+
+- sitemap;
+- llms surfaces;
+- JSON-LD;
+- public internal links;
+- generated reports intended for public SEO/GEO evidence;
+- analytics logs that expose identifiable private URLs.
+
+No private URL repair is required in this PR.

--- a/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/scan_manifest.json
@@ -1,0 +1,119 @@
+{
+  "version": 1,
+  "id": "RIASEC-ZH-TEST-LANDING-P0-DIAGNOSTIC-01",
+  "repo": "fap-api",
+  "generated_at": "2026-07-05T14:44:55Z",
+  "run_type": "generated_only_read_only_diagnostic",
+  "target": {
+    "path": "/zh/tests/holland-career-interest-test-riasec",
+    "url": "https://fermatmind.com/zh/tests/holland-career-interest-test-riasec",
+    "locale": "zh",
+    "surface": "test_landing_page"
+  },
+  "final_verdict": "RIASEC_P0_DIAGNOSTIC_HANDOFF_READY",
+  "runtime_readback": {
+    "http_status": 200,
+    "final_url": "https://fermatmind.com/zh/tests/holland-career-interest-test-riasec",
+    "cache_control": "public, s-maxage=60, stale-while-revalidate=300",
+    "x_proxy_cache": "MISS",
+    "title": "免费霍兰德职业兴趣测试：RIASEC 完整结果 | FermatMind",
+    "meta_description": "免费完成霍兰德职业兴趣测试，查看 RIASEC 兴趣排序和职业探索线索。结果用于方向参考，不承诺专业或录取结果。",
+    "robots": "index, follow",
+    "canonical": "https://fermatmind.com/zh/tests/holland-career-interest-test-riasec",
+    "alternate_count": 3,
+    "json_ld_types": [
+      "WebPage",
+      "BreadcrumbList",
+      "SoftwareApplication",
+      "FAQPage"
+    ],
+    "faq_json_ld_count": 4,
+    "faq_json_ld_questions": [
+      "需要多久？",
+      "每道题都要回答吗？",
+      "可以重复测试吗？",
+      "这是诊断吗？"
+    ],
+    "visible_faq_headings_after_faq": [
+      "免责声明",
+      "准备开始？"
+    ],
+    "visible_jsonld_faq_parity": "unverified",
+    "private_url_hit_count": 0
+  },
+  "discoverability_readback": {
+    "sitemap_xml_contains_path": true,
+    "llms_txt_contains_path": true,
+    "llms_full_txt_contains_path": true,
+    "robots_txt_contains_path": false
+  },
+  "backend_authority": {
+    "confirmed": true,
+    "scale_registry_primary_slug": "holland-career-interest-test-riasec",
+    "forms": [
+      "riasec_60",
+      "riasec_140"
+    ],
+    "default_form_code": "riasec_60",
+    "paywall_mode": "free_only",
+    "commercial_price_tier": "FREE",
+    "future_writes_authority": "backend_cms",
+    "fap_web_role": "renderer_consumer_only"
+  },
+  "gsc_seo_intel": {
+    "data_quality_gate_status": "blocked",
+    "data_origin": "fixture",
+    "opportunity_queue_eligible": false,
+    "ctr_repair_justified": false
+  },
+  "diagnostic_questions": {
+    "free_question_answered_above_fold_or_faq": "partial_title_h1_meta_cta_yes_exact_faq_no",
+    "sixty_vs_one_forty_explained": "present",
+    "exploration_signal_not_precise_recommendation": "present_with_room_to_strengthen",
+    "course_job_activity_major_validation_without_overclaim": "present",
+    "visible_faq_matches_faqpage_json_ld": "unverified",
+    "cta_links_public_non_private_analytics_safe": "pass",
+    "fap_api_backend_correct_authority": "yes",
+    "fap_web_renderer_consumer_only": "yes",
+    "immediate_repair_required": "no_wait_for_gated_gsc_seo_intel_and_parity_readback"
+  },
+  "forbidden_actions": {
+    "cms_write": false,
+    "cms_publish": false,
+    "content_import": false,
+    "search_channel_enqueue": false,
+    "search_provider_submission": false,
+    "url_truth_write": false,
+    "sitemap_mutation": false,
+    "llms_mutation": false,
+    "schema_mutation": false,
+    "hreflang_mutation": false,
+    "frontend_fallback_content": false,
+    "fap_web_edit": false,
+    "deploy": false,
+    "runtime_api_mutation": false,
+    "title_meta_faq_copy_write": false,
+    "invented_gsc_metrics": false,
+    "raw_gsc_payloads": false,
+    "screenshot_derived_metrics_as_formal_evidence": false
+  },
+  "required_output_files": [
+    "EXECUTIVE_DECISION.md",
+    "CURRENT_RUNTIME_READBACK.md",
+    "BACKEND_AUTHORITY_MAP.md",
+    "FAQ_GEO_ANSWER_SURFACE_AUDIT.md",
+    "CTA_INTERNAL_LINK_AUDIT.md",
+    "CLAIM_BOUNDARY_REVIEW.md",
+    "PRIVATE_URL_GUARD.md",
+    "FUTURE_DRY_RUN_OPTIONS.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "BLOCKED_OR_UNVERIFIED_ASSUMPTIONS.md",
+    "scan_manifest.json"
+  ],
+  "required_checks": [
+    "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/scan_manifest.json >/dev/null",
+    "git diff --check",
+    "git diff --cached --check"
+  ],
+  "recommended_next_pr": "RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01"
+}


### PR DESCRIPTION
## What changed

- Added a generated-only read-only diagnostic handoff for `/zh/tests/holland-career-interest-test-riasec`.
- Covered runtime readback, backend authority mapping, FAQ/GEO answer-surface audit, CTA/internal-link audit, claim boundary review, private URL guard, future dry-run options, exact next authorization prompts, blocked assumptions, and a JSON scan manifest.
- Final verdict recorded as `RIASEC_P0_DIAGNOSTIC_HANDOFF_READY`.

## Why

- This page was selected as the next P0 opportunity after MBTI FAQ closeout.
- Runtime is healthy and indexable, backend authority exists, and current copy is coherent enough that direct mutation is premature.
- GSC/seo_intel quality gate is still blocked by fixture-origin data, so CTR repair is not justified.
- FAQ visible-vs-JSON-LD parity is not proven and should be handled by a separate read-only readback before any repair.

## Validation

- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Deferred items

- No CMS write, publish, or content import.
- No Search Channel enqueue or search provider submission.
- No URL Truth, sitemap, llms, schema, or hreflang mutation.
- No fap-web edit or frontend fallback content.
- No deploy and no runtime/API mutation.
- No title/meta/FAQ copy write.
- No invented GSC metrics, raw GSC payloads, or screenshot-derived formal metrics.
- Recommended next PR: `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01`.
