### PR TITLE
PR-C: fap-api production Big Five content audit

### DIFF
--- a/backend/app/Console/Commands/PersonalityBigFiveProductionContentAudit.php
+++ b/backend/app/Console/Commands/PersonalityBigFiveProductionContentAudit.php
@@ -1,0 +1,499 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityBigFiveProductionContentAudit extends Command
+{
+    private const V2_SOURCE_PACKAGE = 'big-five-cms-import-draft-polished.v2';
+
+    protected $signature = 'personality:big-five-production-content-audit
+        {--target-env=production : Required target environment; production for real audit}
+        {--expected-existing-count=34 : Expected current production Big Five public asset count across supported locales}
+        {--expected-existing-count-per-locale=17 : Expected current production Big Five public asset count per locale}
+        {--expected-v2-count=0 : Expected v2 package row count in production}
+        {--v2-source-package=big-five-cms-import-draft-polished.v2 : v2 source package marker to check}
+        {--allow-testing : Permit APP_ENV=testing with sqlite for automated tests only}
+        {--json : Emit the full JSON audit report}
+        {--output= : Optional path to write the JSON audit report}
+        {--markdown-output= : Optional path to write a human-readable markdown audit report}';
+
+    protected $description = 'Read-only production audit for Big Five personality public content assets.';
+
+    public function handle(): int
+    {
+        try {
+            $summary = $this->guardedAudit();
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary($exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary($exception->getMessage(), 'unexpected_error');
+        }
+
+        $this->writeJsonOutput($summary);
+        $this->writeMarkdownOutput($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function guardedAudit(): array
+    {
+        $targetEnvironment = strtolower(trim((string) $this->option('target-env')));
+        $this->guardRuntimeEnvironment($targetEnvironment);
+
+        if (! Schema::hasTable((new PersonalityPublicContentAsset)->getTable())) {
+            throw new RuntimeException('personality_public_content_assets table is missing; run migrations before audit.');
+        }
+
+        $expectedExistingCount = max(0, (int) $this->option('expected-existing-count'));
+        $expectedExistingCountPerLocale = max(0, (int) $this->option('expected-existing-count-per-locale'));
+        $expectedV2Count = max(0, (int) $this->option('expected-v2-count'));
+        $v2SourcePackage = trim((string) $this->option('v2-source-package')) ?: self::V2_SOURCE_PACKAGE;
+
+        $assets = PersonalityPublicContentAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
+            ->orderBy('locale')
+            ->orderBy('entity_type')
+            ->orderBy('entity_key')
+            ->get();
+
+        $rows = $assets
+            ->map(fn (PersonalityPublicContentAsset $asset): array => $this->rowPayload($asset, $v2SourcePackage))
+            ->values()
+            ->all();
+
+        $counts = $this->counts($rows, $v2SourcePackage);
+        $errors = $this->errors($counts, $expectedExistingCount, $expectedExistingCountPerLocale, $expectedV2Count);
+        $warnings = $this->warnings($counts);
+
+        return [
+            'artifact' => 'BIG5-PRODUCTION-CONTENT-AUDIT-C',
+            'status' => $errors === [] ? 'pass' : 'fail',
+            'ok' => $errors === [],
+            'target_environment' => $targetEnvironment,
+            'audited_table' => 'personality_public_content_assets',
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'expected_existing_count' => $expectedExistingCount,
+            'expected_v2_count' => $expectedV2Count,
+            'expected_existing_count_per_locale' => $expectedExistingCountPerLocale,
+            'v2_source_package' => $v2SourcePackage,
+            'counts' => $counts,
+            'production_observations' => [
+                'existing_asset_count_matches_expected' => $counts['total_big_five_rows'] === $expectedExistingCount,
+                'existing_asset_count_per_locale_matches_expected' => $this->localeCountsMatch((array) $counts['locale_counts'], $expectedExistingCountPerLocale),
+                'v2_package_absent_from_production' => $counts['v2_source_package_rows'] === $expectedV2Count,
+                'body_missing_rows_present' => $counts['renderable_body_missing_rows'] > 0,
+                'public_api_visible_rows' => $counts['publicly_readable_rows'],
+                'schema_runtime_enabled_rows' => $counts['schema_runtime_eligible_rows'],
+            ],
+            'release_safety' => [
+                'writes_committed' => false,
+                'cms_write_attempted' => false,
+                'publish_attempted' => false,
+                'index_attempted' => false,
+                'sitemap_llms_release_attempted' => false,
+                'jsonld_runtime_release_attempted' => false,
+                'production_deploy_attempted' => false,
+            ],
+            'rows' => $rows,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    private function guardRuntimeEnvironment(string $targetEnvironment): void
+    {
+        if ((bool) $this->option('allow-testing')) {
+            if (app()->environment() !== 'testing' || config('database.default') !== 'sqlite') {
+                throw new RuntimeException('--allow-testing is only valid for APP_ENV=testing with sqlite.');
+            }
+
+            return;
+        }
+
+        if ($targetEnvironment !== 'production') {
+            throw new RuntimeException('--target-env must be production for this read-only audit.');
+        }
+
+        if (! app()->environment(['production', 'prod'])) {
+            throw new RuntimeException('Production audit requires APP_ENV=production.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,mixed>
+     */
+    private function counts(array $rows, string $v2SourcePackage): array
+    {
+        $localeCounts = [];
+        $entityTypeCounts = [];
+        $launchStateCounts = [];
+        $sourcePackageCounts = [];
+        $robotsCounts = [];
+
+        foreach ($rows as $row) {
+            $this->increment($localeCounts, (string) ($row['locale'] ?? ''));
+            $this->increment($entityTypeCounts, (string) ($row['entity_type'] ?? ''));
+            $this->increment($launchStateCounts, (string) ($row['launch_state'] ?? ''));
+            $this->increment($sourcePackageCounts, (string) ($row['source_package'] ?? ''));
+            $this->increment($robotsCounts, (string) ($row['robots'] ?? ''));
+        }
+
+        return [
+            'total_big_five_rows' => count($rows),
+            'v2_source_package_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (string) ($row['source_package'] ?? '') === $v2SourcePackage
+            )),
+            'renderable_body_missing_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (int) ($row['renderable_body_section_count'] ?? 0) === 0
+            )),
+            'empty_section_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (int) ($row['empty_section_count'] ?? 0) > 0
+            )),
+            'publicly_readable_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (bool) ($row['publicly_readable'] ?? false)
+            )),
+            'is_public_true_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (bool) ($row['is_public'] ?? false)
+            )),
+            'index_eligible_true_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (bool) ($row['index_eligible'] ?? false)
+            )),
+            'sitemap_eligible_true_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (bool) ($row['sitemap_eligible'] ?? false)
+            )),
+            'llms_eligible_true_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (bool) ($row['llms_eligible'] ?? false)
+            )),
+            'schema_runtime_eligible_rows' => count(array_filter(
+                $rows,
+                static fn (array $row): bool => (bool) ($row['schema_runtime_eligible'] ?? false)
+            )),
+            'locale_counts' => $localeCounts,
+            'entity_type_counts' => $entityTypeCounts,
+            'launch_state_counts' => $launchStateCounts,
+            'source_package_counts' => $sourcePackageCounts,
+            'robots_counts' => $robotsCounts,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function rowPayload(PersonalityPublicContentAsset $asset, string $v2SourcePackage): array
+    {
+        $sections = is_array($asset->content_sections_json) ? $asset->content_sections_json : [];
+        $canonical = is_array($asset->canonical_json) ? $asset->canonical_json : [];
+        $renderableBodySectionCount = 0;
+        $emptySectionCount = 0;
+
+        foreach ($sections as $section) {
+            if (! is_array($section)) {
+                $emptySectionCount++;
+
+                continue;
+            }
+
+            $body = trim((string) ($section['body_md'] ?? $section['body'] ?? $section['body_html'] ?? $section['html'] ?? ''));
+            if ($body === '') {
+                $emptySectionCount++;
+            } else {
+                $renderableBodySectionCount++;
+            }
+        }
+
+        $schemaRuntimeEligible = $this->schemaRuntimeEligible($asset);
+
+        return [
+            'id' => (int) $asset->id,
+            'locale' => (string) $asset->locale,
+            'entity_type' => (string) $asset->entity_type,
+            'entity_key' => (string) $asset->entity_key,
+            'slug' => (string) $asset->slug,
+            'canonical_path' => (string) data_get($canonical, 'path', ''),
+            'title' => (string) $asset->title,
+            'source_package' => (string) ($asset->source_package ?? ''),
+            'source_hash_present' => trim((string) ($asset->source_hash ?? '')) !== '',
+            'is_v2_source_package' => (string) ($asset->source_package ?? '') === $v2SourcePackage,
+            'section_count' => count($sections),
+            'renderable_body_section_count' => $renderableBodySectionCount,
+            'empty_section_count' => $emptySectionCount,
+            'faq_count' => is_array($asset->faq_json) ? count($asset->faq_json) : 0,
+            'robots' => PersonalityPublicContentAsset::normalizeRobots((string) $asset->robots),
+            'is_public' => (bool) $asset->is_public,
+            'index_eligible' => (bool) $asset->index_eligible,
+            'sitemap_eligible' => (bool) $asset->sitemap_eligible,
+            'llms_eligible' => (bool) $asset->llms_eligible,
+            'launch_state' => (string) $asset->launch_state,
+            'review_state' => (string) $asset->review_state,
+            'publicly_readable' => $this->publiclyReadable($asset),
+            'schema_runtime_eligible' => $schemaRuntimeEligible,
+            'schema_payload_exposed_by_public_api' => $schemaRuntimeEligible && is_array($asset->schema_json) && $asset->schema_json !== [],
+            'published_at' => $asset->published_at?->toAtomString(),
+            'updated_at' => $asset->updated_at?->toAtomString(),
+        ];
+    }
+
+    private function publiclyReadable(PersonalityPublicContentAsset $asset): bool
+    {
+        return (bool) $asset->is_public
+            && in_array((string) $asset->launch_state, [
+                PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+                PersonalityPublicContentAsset::LAUNCH_PUBLISHED,
+            ], true)
+            && ($asset->published_at === null || $asset->published_at->isPast());
+    }
+
+    private function schemaRuntimeEligible(PersonalityPublicContentAsset $asset): bool
+    {
+        return (string) $asset->launch_state === PersonalityPublicContentAsset::LAUNCH_PUBLISHED
+            && (bool) $asset->index_eligible
+            && PersonalityPublicContentAsset::normalizeRobots((string) $asset->robots) === PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW;
+    }
+
+    /**
+     * @param  array<string,int>  $counts
+     */
+    private function increment(array &$counts, string $key): void
+    {
+        $normalized = $key === '' ? '__empty__' : $key;
+        $counts[$normalized] = ($counts[$normalized] ?? 0) + 1;
+        ksort($counts);
+    }
+
+    /**
+     * @param  array<string,int>  $localeCounts
+     */
+    private function localeCountsMatch(array $localeCounts, int $expectedExistingCountPerLocale): bool
+    {
+        foreach (PersonalityPublicContentAsset::SUPPORTED_LOCALES as $locale) {
+            if ((int) ($localeCounts[$locale] ?? 0) !== $expectedExistingCountPerLocale) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string,mixed>  $counts
+     * @return list<array<string,string>>
+     */
+    private function errors(array $counts, int $expectedExistingCount, int $expectedExistingCountPerLocale, int $expectedV2Count): array
+    {
+        $errors = [];
+
+        if ((int) ($counts['total_big_five_rows'] ?? -1) !== $expectedExistingCount) {
+            $errors[] = $this->issue('counts.total_big_five_rows', 'unexpected_existing_big_five_count', 'Production Big Five asset count did not match the expected current count.');
+        }
+
+        if (! $this->localeCountsMatch((array) ($counts['locale_counts'] ?? []), $expectedExistingCountPerLocale)) {
+            $errors[] = $this->issue('counts.locale_counts', 'unexpected_existing_big_five_locale_count', 'Production Big Five asset count per locale did not match the expected current count.');
+        }
+
+        if ((int) ($counts['v2_source_package_rows'] ?? -1) !== $expectedV2Count) {
+            $errors[] = $this->issue('counts.v2_source_package_rows', 'unexpected_v2_package_presence', 'v2 Big Five CMS import package presence did not match expectation.');
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $counts
+     * @return list<array<string,string>>
+     */
+    private function warnings(array $counts): array
+    {
+        $warnings = [];
+
+        if ((int) ($counts['renderable_body_missing_rows'] ?? 0) > 0) {
+            $warnings[] = $this->issue('counts.renderable_body_missing_rows', 'body_missing_rows_present', 'Some production Big Five rows have no renderable section body; this explains title-only public page cards.');
+        }
+
+        if ((int) ($counts['schema_runtime_eligible_rows'] ?? 0) > 0) {
+            $warnings[] = $this->issue('counts.schema_runtime_eligible_rows', 'schema_runtime_rows_present', 'Some production Big Five rows are schema-runtime eligible; verify this is intentional before SEO release.');
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('target_environment='.(string) ($summary['target_environment'] ?? ''));
+        $this->line('total_big_five_rows='.(string) data_get($summary, 'counts.total_big_five_rows', 0));
+        $this->line('v2_source_package_rows='.(string) data_get($summary, 'counts.v2_source_package_rows', 0));
+        $this->line('renderable_body_missing_rows='.(string) data_get($summary, 'counts.renderable_body_missing_rows', 0));
+        $this->line('schema_runtime_eligible_rows='.(string) data_get($summary, 'counts.schema_runtime_eligible_rows', 0));
+        $this->line('writes_committed=0');
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeJsonOutput(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/') ? $output : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeMarkdownOutput(array $summary): void
+    {
+        $output = trim((string) $this->option('markdown-output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/') ? $output : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, $this->markdown($summary));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function markdown(array $summary): string
+    {
+        $counts = is_array($summary['counts'] ?? null) ? $summary['counts'] : [];
+        $lines = [
+            '# Big Five Production Content Audit',
+            '',
+            '- Artifact: `'.((string) ($summary['artifact'] ?? '')).'`',
+            '- Status: `'.((string) ($summary['status'] ?? 'fail')).'`',
+            '- Target environment: `'.((string) ($summary['target_environment'] ?? '')).'`',
+            '- Total Big Five rows: `'.((string) ($counts['total_big_five_rows'] ?? 0)).'`',
+            '- v2 source package rows: `'.((string) ($counts['v2_source_package_rows'] ?? 0)).'`',
+            '- Rows with no renderable body: `'.((string) ($counts['renderable_body_missing_rows'] ?? 0)).'`',
+            '- Schema runtime eligible rows: `'.((string) ($counts['schema_runtime_eligible_rows'] ?? 0)).'`',
+            '',
+            '## Safety',
+            '',
+            '- Writes committed: `false`',
+            '- CMS write attempted: `false`',
+            '- Publish attempted: `false`',
+            '- Sitemap / llms release attempted: `false`',
+            '- JSON-LD runtime release attempted: `false`',
+            '- Production deploy attempted: `false`',
+            '',
+            '## Notes',
+            '',
+            '- This audit reads `personality_public_content_assets` only.',
+            '- It does not import v2 content, publish content, release indexability, or trigger deploys.',
+        ];
+
+        $errors = is_array($summary['errors'] ?? null) ? $summary['errors'] : [];
+        if ($errors !== []) {
+            $lines[] = '';
+            $lines[] = '## Errors';
+            foreach ($errors as $error) {
+                if (! is_array($error)) {
+                    continue;
+                }
+                $lines[] = '- `'.((string) ($error['code'] ?? 'error')).'`: '.((string) ($error['message'] ?? ''));
+            }
+        }
+
+        $warnings = is_array($summary['warnings'] ?? null) ? $summary['warnings'] : [];
+        if ($warnings !== []) {
+            $lines[] = '';
+            $lines[] = '## Warnings';
+            foreach ($warnings as $warning) {
+                if (! is_array($warning)) {
+                    continue;
+                }
+                $lines[] = '- `'.((string) ($warning['code'] ?? 'warning')).'`: '.((string) ($warning['message'] ?? ''));
+            }
+        }
+
+        return implode(PHP_EOL, $lines).PHP_EOL;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $message, string $code = 'runtime_error'): array
+    {
+        return [
+            'artifact' => 'BIG5-PRODUCTION-CONTENT-AUDIT-C',
+            'status' => 'fail',
+            'ok' => false,
+            'release_safety' => [
+                'writes_committed' => false,
+                'cms_write_attempted' => false,
+                'publish_attempted' => false,
+                'index_attempted' => false,
+                'sitemap_llms_release_attempted' => false,
+                'jsonld_runtime_release_attempted' => false,
+                'production_deploy_attempted' => false,
+            ],
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityBigFiveProductionContentAuditCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityBigFiveProductionContentAuditCommandTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\PersonalityBigFiveProductionContentAudit;
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class PersonalityBigFiveProductionContentAuditCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const V2_SOURCE_PACKAGE = 'big-five-cms-import-draft-polished.v2';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(Kernel::class)->registerCommand($this->app->make(PersonalityBigFiveProductionContentAudit::class));
+    }
+
+    public function test_production_content_audit_passes_for_thirty_four_old_assets_and_no_v2_rows(): void
+    {
+        $this->seedOldProductionRows(34, missingBodyRows: 34);
+
+        $beforeCount = PersonalityPublicContentAsset::query()->count();
+        $exitCode = Artisan::call('personality:big-five-production-content-audit', [
+            '--allow-testing' => true,
+            '--json' => true,
+        ]);
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame(34, $payload['counts']['total_big_five_rows']);
+        $this->assertSame(0, $payload['counts']['v2_source_package_rows']);
+        $this->assertSame(34, $payload['counts']['renderable_body_missing_rows']);
+        $this->assertSame(34, $payload['counts']['publicly_readable_rows']);
+        $this->assertSame(17, $payload['counts']['locale_counts']['en']);
+        $this->assertSame(17, $payload['counts']['locale_counts']['zh-CN']);
+        $this->assertSame(0, $payload['counts']['schema_runtime_eligible_rows']);
+        $this->assertTrue($payload['production_observations']['existing_asset_count_matches_expected']);
+        $this->assertTrue($payload['production_observations']['existing_asset_count_per_locale_matches_expected']);
+        $this->assertTrue($payload['production_observations']['v2_package_absent_from_production']);
+        $this->assertTrue($payload['production_observations']['body_missing_rows_present']);
+        $this->assertFalse($payload['release_safety']['writes_committed']);
+        $this->assertFalse($payload['release_safety']['cms_write_attempted']);
+        $this->assertFalse($payload['release_safety']['publish_attempted']);
+        $this->assertFalse($payload['release_safety']['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['release_safety']['jsonld_runtime_release_attempted']);
+        $this->assertSame($beforeCount, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_production_content_audit_fails_when_v2_rows_are_present(): void
+    {
+        $this->seedOldProductionRows(34, missingBodyRows: 10);
+        $this->createAsset(position: 35, sourcePackage: self::V2_SOURCE_PACKAGE, renderableBody: true);
+
+        $exitCode = Artisan::call('personality:big-five-production-content-audit', [
+            '--allow-testing' => true,
+            '--json' => true,
+        ]);
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame(35, $payload['counts']['total_big_five_rows']);
+        $this->assertSame(1, $payload['counts']['v2_source_package_rows']);
+        $this->assertContains('unexpected_existing_big_five_count', array_column($payload['errors'], 'code'));
+        $this->assertContains('unexpected_existing_big_five_locale_count', array_column($payload['errors'], 'code'));
+        $this->assertContains('unexpected_v2_package_presence', array_column($payload['errors'], 'code'));
+    }
+
+    public function test_production_content_audit_writes_json_and_markdown_evidence_without_database_writes(): void
+    {
+        $this->seedOldProductionRows(34, missingBodyRows: 3);
+
+        $jsonOutput = 'storage/framework/testing/big-five-production-audit.json';
+        $markdownOutput = 'storage/framework/testing/big-five-production-audit.md';
+        $beforeCount = PersonalityPublicContentAsset::query()->count();
+
+        $exitCode = Artisan::call('personality:big-five-production-content-audit', [
+            '--allow-testing' => true,
+            '--output' => $jsonOutput,
+            '--markdown-output' => $markdownOutput,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($beforeCount, PersonalityPublicContentAsset::query()->count());
+        $this->assertFileExists(base_path($jsonOutput));
+        $this->assertFileExists(base_path($markdownOutput));
+
+        $json = json_decode((string) file_get_contents(base_path($jsonOutput)), true, 512, JSON_THROW_ON_ERROR);
+        $markdown = (string) file_get_contents(base_path($markdownOutput));
+
+        $this->assertSame('BIG5-PRODUCTION-CONTENT-AUDIT-C', $json['artifact']);
+        $this->assertSame(3, $json['counts']['renderable_body_missing_rows']);
+        $this->assertStringContainsString('# Big Five Production Content Audit', $markdown);
+        $this->assertStringContainsString('Writes committed: `false`', $markdown);
+    }
+
+    private function seedOldProductionRows(int $count, int $missingBodyRows): void
+    {
+        for ($position = 1; $position <= $count; $position++) {
+            $this->createAsset(
+                position: $position,
+                sourcePackage: 'big-five-public-profile-agent-v1',
+                renderableBody: $position > $missingBodyRows
+            );
+        }
+    }
+
+    private function createAsset(int $position, string $sourcePackage, bool $renderableBody): void
+    {
+        $locale = $position % 2 === 0 ? 'en' : 'zh-CN';
+        $entityType = $position === 1 ? PersonalityPublicContentAsset::ENTITY_HUB : PersonalityPublicContentAsset::ENTITY_DOMAIN;
+        $entityKey = $position === 1 ? 'big-five' : 'trait-'.$position;
+        $slug = $position === 1 ? 'big-five' : 'big-five/trait-'.$position;
+        $pathLocale = $locale === 'zh-CN' ? 'zh' : 'en';
+
+        PersonalityPublicContentAsset::query()->create([
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'entity_type' => $entityType,
+            'entity_key' => $entityKey,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => 'Big Five Audit Page '.$position,
+            'summary' => 'Read-only audit fixture.',
+            'content_sections_json' => [[
+                'key' => 'overview',
+                'title' => 'Overview',
+                'body_md' => $renderableBody ? 'A renderable production body section.' : '',
+            ]],
+            'seo_json' => [
+                'title' => 'Big Five Audit Page '.$position,
+                'description' => 'Read-only audit fixture.',
+            ],
+            'canonical_json' => [
+                'path' => '/'.$pathLocale.'/personality/'.$slug,
+            ],
+            'hreflang_json' => [],
+            'faq_json' => [],
+            'media_json' => [],
+            'schema_json' => [
+                'runtime_jsonld_enabled' => false,
+            ],
+            'method_boundary_json' => [
+                'claim_boundaries' => ['non_diagnostic', 'non_predictive'],
+            ],
+            'evidence_notes_json' => [],
+            'internal_links_json' => [],
+            'is_public' => true,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            'review_state' => 'legacy_production_content',
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => $sourcePackage,
+            'source_hash' => hash('sha256', $sourcePackage),
+            'published_at' => null,
+            'last_reviewed_at' => null,
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -431,6 +431,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_big_five_production_content_audit_command(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityBigFiveProductionContentAudit.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_iq_method_pages_cms_readback_files(): void
     {
         $changed = [
@@ -5080,6 +5089,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBigFiveProductionContentAuditFile($file)) {
+                continue;
+            }
+
             if ($this->isMbti64CmsRevisionDraftFile($file)) {
                 continue;
             }
@@ -6620,6 +6633,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/PersonalityBigFiveCmsPreviewRenderQa.php',
             'backend/app/Services/Cms/BigFiveCmsPreviewRenderQaValidator.php',
         ], true);
+    }
+
+    private function isBigFiveProductionContentAuditFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/PersonalityBigFiveProductionContentAudit.php';
     }
 
     private function isMbti64CmsRevisionDraftFile(string $file): bool

--- a/generated/big-five-production-content-audit/production_bigfive_content_audit.json
+++ b/generated/big-five-production-content-audit/production_bigfive_content_audit.json
@@ -1,0 +1,89 @@
+{
+  "artifact": "BIG5-PRODUCTION-CONTENT-AUDIT-C-PUBLIC-API-EVIDENCE",
+  "scanned_at": "2026-07-05T16:03:47.219Z",
+  "scan_mode": "public_api_readonly_no_credentials_no_db_write",
+  "status": "pass",
+  "conclusion": {
+    "production_public_api_big_five_total_rows": 34,
+    "production_public_api_big_five_rows_per_locale": {
+      "zh-CN": 17,
+      "en": 17
+    },
+    "v2_42_package_rows_visible_in_public_api": 0,
+    "title_only_section_rows_visible_in_public_api": 34,
+    "schema_runtime_eligible_rows_visible_in_public_api": 0,
+    "index_eligible_true_rows_visible_in_public_api": 0,
+    "sitemap_eligible_true_rows_visible_in_public_api": 0,
+    "llms_eligible_true_rows_visible_in_public_api": 0
+  },
+  "locale_summaries": {
+    "zh-CN": {
+      "locale": "zh-CN",
+      "ok": true,
+      "api_total": 17,
+      "item_count": 17,
+      "v2_source_package_rows": 0,
+      "source_package_counts": {
+        "big-five-v1-content-editorial-repair-02": 17
+      },
+      "robots_counts": {
+        "noindex,follow": 17
+      },
+      "launch_state_counts": {
+        "content_ready": 17
+      },
+      "schema_runtime_eligible_rows": 0,
+      "index_eligible_true_rows": 0,
+      "sitemap_eligible_true_rows": 0,
+      "llms_eligible_true_rows": 0,
+      "title_only_section_rows": 17,
+      "sample_canonical_paths": [
+        "/zh/personality/big-five/agreeableness",
+        "/zh/personality/big-five/conscientiousness",
+        "/zh/personality/big-five/extraversion",
+        "/zh/personality/big-five/neuroticism",
+        "/zh/personality/big-five/openness"
+      ],
+      "endpoint": "https://api.fermatmind.com/api/v0.5/personality-content-assets?framework=big_five&locale=zh-CN&per_page=100"
+    },
+    "en": {
+      "locale": "en",
+      "ok": true,
+      "api_total": 17,
+      "item_count": 17,
+      "v2_source_package_rows": 0,
+      "source_package_counts": {
+        "big-five-v1-content-editorial-repair-02": 17
+      },
+      "robots_counts": {
+        "noindex,follow": 17
+      },
+      "launch_state_counts": {
+        "content_ready": 17
+      },
+      "schema_runtime_eligible_rows": 0,
+      "index_eligible_true_rows": 0,
+      "sitemap_eligible_true_rows": 0,
+      "llms_eligible_true_rows": 0,
+      "title_only_section_rows": 17,
+      "sample_canonical_paths": [
+        "/en/personality/big-five/agreeableness",
+        "/en/personality/big-five/conscientiousness",
+        "/en/personality/big-five/extraversion",
+        "/en/personality/big-five/neuroticism",
+        "/en/personality/big-five/openness"
+      ],
+      "endpoint": "https://api.fermatmind.com/api/v0.5/personality-content-assets?framework=big_five&locale=en&per_page=100"
+    }
+  },
+  "safety": {
+    "writes_committed": false,
+    "cms_write_attempted": false,
+    "production_import_attempted": false,
+    "publish_attempted": false,
+    "index_attempted": false,
+    "sitemap_llms_release_attempted": false,
+    "jsonld_runtime_release_attempted": false,
+    "production_deploy_attempted": false
+  }
+}

--- a/generated/big-five-production-content-audit/production_bigfive_content_audit.md
+++ b/generated/big-five-production-content-audit/production_bigfive_content_audit.md
@@ -1,0 +1,36 @@
+# Big Five Production Content Audit
+
+Scanned at: 2026-07-05T16:03:47.219Z
+
+## Verdict
+
+- Status: `pass`
+- Production public API Big Five rows: `34` total, `17` zh-CN, `17` en
+- v2 package rows visible in public API: `0`
+- Title-only section rows visible in public API: `34`
+- Schema runtime eligible rows visible in public API: `0`
+- Index / sitemap / llms eligible rows visible in public API: `0` / `0` / `0`
+
+## Scope
+
+- Read-only public API scan only.
+- No CMS write, production import, publish, indexability release, sitemap/llms release, JSON-LD runtime release, or deploy was attempted.
+- Direct production DB/CMS readback should use `php artisan personality:big-five-production-content-audit --target-env=production --json` on the production runtime.
+
+## Evidence Endpoints
+
+- zh-CN: https://api.fermatmind.com/api/v0.5/personality-content-assets?framework=big_five&locale=zh-CN&per_page=100
+- en: https://api.fermatmind.com/api/v0.5/personality-content-assets?framework=big_five&locale=en&per_page=100
+
+## Sample Canonical Paths
+
+- /zh/personality/big-five/agreeableness
+- /zh/personality/big-five/conscientiousness
+- /zh/personality/big-five/extraversion
+- /zh/personality/big-five/neuroticism
+- /zh/personality/big-five/openness
+- /en/personality/big-five/agreeableness
+- /en/personality/big-five/conscientiousness
+- /en/personality/big-five/extraversion
+- /en/personality/big-five/neuroticism
+- /en/personality/big-five/openness

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -46,5 +46,15 @@
     "why_not_current_pr_scope": "Current PR scope only adds the read-only IQ method pages CMS readback command/test, registers the command, extends the Big Five runtime-freeze classifier exemption for that command, and updates PR-train metadata. The observed full-suite failures are in Career, Content, MBTI personalization/PDF, Architecture, ClinicalCombo, and Commerce surfaces outside the changed READBACK files.",
     "required_checks_affected": "unknown_until_github_checks; local focused validation passed and GitHub required checks must still be inspected before merge",
     "recommended_follow_up": "Track and fix the failing Career/Content/MBTI/PDF/Architecture/ClinicalCombo/Commerce tests under their owning PR scopes. Do not mix those repairs into IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01."
+  },
+  {
+    "repo": "fermatmind/fap-api",
+    "pr_id": "PR-C",
+    "branch": "codex/big5-production-content-audit-c",
+    "blocker_type": "local_environment_unavailable",
+    "evidence": "bash scripts/verify_mbti.sh failed at [1/8] health: http://127.0.0.1:1827 with curl: (7) Failed to connect to 127.0.0.1 port 1827.",
+    "why_not_current_pr_scope": "PR-C only adds a read-only Big Five production content audit command, focused tests, and generated evidence. It does not start, stop, configure, or route the local API server.",
+    "required_checks_affected": "Local verify_mbti.sh could not run without the expected local server. Targeted PHPUnit, syntax, Pint, command discovery, route list, and scope validation passed.",
+    "recommended_follow_up": "Run bash scripts/verify_mbti.sh in an environment where the Laravel API is listening on 127.0.0.1:1827, or use the repository's standard local stack bootstrap before this check."
   }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -74,3 +74,13 @@
 - recommended follow-up:
   - Track and fix the failing Career/Content/MBTI/PDF/Architecture/ClinicalCombo/Commerce tests under their owning PR scopes.
   - Do not mix those repairs into the IQ method pages CMS readback PR.
+
+## PR-C verify_mbti local server unavailable
+
+- repo: `fermatmind/fap-api`
+- PR id / branch: PR-C / `codex/big5-production-content-audit-c`
+- blocker type: `local_environment_unavailable`
+- evidence: `bash scripts/verify_mbti.sh` failed at `[1/8] health: http://127.0.0.1:1827` with `curl: (7) Failed to connect to 127.0.0.1 port 1827`.
+- why not current PR scope: PR-C only adds a read-only Big Five production content audit command, focused tests, and generated evidence. It does not start, stop, configure, or route the local API server.
+- whether required checks are affected: Local `verify_mbti.sh` could not run without the expected local server. Targeted PHPUnit, syntax, Pint, command discovery, route list, and scope validation passed.
+- recommended follow-up: Run `bash scripts/verify_mbti.sh` in an environment where the Laravel API is listening on `127.0.0.1:1827`, or use the repository's standard local stack bootstrap before this check.


### PR DESCRIPTION
## What changed
- Added `personality:big-five-production-content-audit`, a read-only Big Five production content asset audit command.
- Added feature tests for the 34-row production shape: 17 zh-CN + 17 en, v2 package absent, body sections title-only, no schema/index/sitemap/llms release.
- Added generated public API evidence under `generated/big-five-production-content-audit/`.
- Appended a sidecar issue for local `verify_mbti.sh` failing because no local API server was listening on `127.0.0.1:1827`.

## Why
The live Big Five page still shows title-only content cards. Before publishing v2 content or releasing SEO discoverability, we need a repeatable read-only audit confirming the current production asset state and that the v2 42-row package has not been promoted into production.

## Validation
- `php -l app/Console/Commands/PersonalityBigFiveProductionContentAudit.php`
- `php -l tests/Feature/Console/PersonalityBigFiveProductionContentAuditCommandTest.php`
- `./vendor/bin/pint --test app/Console/Commands/PersonalityBigFiveProductionContentAudit.php tests/Feature/Console/PersonalityBigFiveProductionContentAuditCommandTest.php`
- `php artisan list | rg 'personality:big-five-production-content-audit|big-five-production'`
- `php artisan route:list --path=api --except-vendor`
- `php artisan test --filter=PersonalityBigFiveProductionContentAuditCommandTest --display-warnings`
- `node -e "JSON.parse(require('fs').readFileSync('generated/big-five-production-content-audit/production_bigfive_content_audit.json','utf8')); JSON.parse(require('fs').readFileSync('generated/pr-train-sidecar-issues/sidecar_issues.json','utf8')); console.log('json ok')"`
- `git diff --check`

`bash scripts/verify_mbti.sh` was attempted and failed before app logic because `127.0.0.1:1827` was not serving `/api/healthz`; this is recorded in `generated/pr-train-sidecar-issues/`.

## Production API evidence
- Public API scan only, no credentials and no database writes.
- `zh-CN`: 17 Big Five rows.
- `en`: 17 Big Five rows.
- v2 `big-five-cms-import-draft-polished.v2` rows visible in public API: 0.
- title-only section rows visible in public API: 34.
- schema/index/sitemap/llms eligible rows visible in public API: 0.

## Deferred items
- No production CMS import/write.
- No publish/content-ready transition.
- No sitemap, llms, JSON-LD runtime, canonical indexability, search release, staging wait, or production deploy.
- PR12 remains blocked pending an explicit CMS manual-review-approved Chinese page list.
- PR13 remains blocked pending explicit SEO discoverability release authorization.

## Repository rule impact
Backend remains the CMS/public API authority. This PR adds a read-only audit command and evidence only; it does not change content ownership, runtime publication gates, SEO/GEO enumeration, or frontend fallback behavior.