### PR TITLE
SIX-TEST-HUB-COMPLETENESS-READONLY-AUDIT-01: audit six core test hubs

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/BACKEND_AUTHORITY_AND_FREE_RESULT_AUDIT.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/BACKEND_AUTHORITY_AND_FREE_RESULT_AUDIT.md
@@ -1,0 +1,49 @@
+# Backend Authority And Free Result Audit
+
+This file records repository-visible backend evidence only. It does not authorize runtime, CMS, commercial, sitemap, or `llms` changes.
+
+## Strategy Baseline
+
+The current strategy document `backend/docs/seo/fermatmind-free-assessment-global-seo-geo-strategy-2026-07-04.md` sets the six major assessment categories as MBTI, Big Five, Enneagram, RIASEC/Holland, IQ, and EQ. It also states the current SEO wedge:
+
+- free assessment experience;
+- free complete personal result view;
+- public SEO pages explain tests, methods, interpretation, boundaries, and next steps;
+- private result/attempt/order/payment flows remain private/noindex by default.
+
+## Registry Evidence
+
+Source: `backend/database/seeders/ScaleRegistrySeeder.php`.
+
+| Scale | Registry code | Primary slug | Free/result authority evidence | Notable caveat |
+| --- | --- | --- | --- | --- |
+| MBTI | `MBTI` | `mbti-personality-test-16-personality-types` | `seo_i18n_json.zh.title` says `免费 MBTI 测试：16 型人格完整结果`; `content_i18n_json.zh.faq` includes 8 scale-specific FAQ entries. | Commercial fields still contain MBTI report SKU compatibility; current public landing is already aligned with free-result claim. |
+| Big Five | `BIG5_OCEAN` | `big-five-personality-test-ocean-model` | `capabilities_json.paywall_mode=free_only`; view policy has no blur and no upgrade SKU. | `commercial_json.price_tier=PAID` and `report_unlock_sku=SKU_BIG5_FULL_REPORT_299` remain present. Do not rewrite money-intent copy until this authority conflict is reconciled. |
+| Enneagram | `ENNEAGRAM` | `enneagram-personality-test-nine-types` | `paywall_mode=free_only`, two forms, `price_tier=FREE`, no unlock SKU. | FAQ comes from generic registry helper, not a scale-specific free-complete-result FAQ set. |
+| RIASEC | `RIASEC` | `holland-career-interest-test-riasec` | `paywall_mode=free_only`, two forms, `price_tier=FREE`, no unlock SKU, public page currently says free/complete result. | FAQ comes from generic registry helper in production scan; held RIASEC parity readback must not be executed in this train. |
+| IQ | `IQ_RAVEN` | `iq-test-intelligence-quotient-assessment` | Registry is public/active and `commercial_json.price_tier=FREE`. | `view_policy_json` still has `blur_others=true` and `teaser_percent=0.35`; prior sidecar evidence records missing norm table/calibrated IQ estimate. Do not claim clinical/official IQ validity. |
+| EQ | `EQ_60` | `eq-test-emotional-intelligence-assessment` | `paywall_mode=free_only`, rich free sections, no unlock SKU, `price_tier=FREE`. | FAQ comes from generic registry helper, not a scale-specific free-complete-result FAQ set. |
+
+## Result/Report Content Inventory Evidence
+
+Source: `backend/docs/seo/result-en-parity-00-assessment-result-content-inventory.md`.
+
+Relevant read-only findings:
+
+- MBTI still has external content package/export and frontend clone-content authority risks for result/report copy.
+- Big Five v1 has balanced compiled rows, but v2 result-page assets are Chinese-heavy and English counterparts are missing.
+- Enneagram has zh-CN registry catalogs without English registry counterparts.
+- RIASEC lifecycle/result assets are zh-CN-only in the scanned content inventory.
+- IQ report sections have Chinese dimension labels and missing English IQ/pro payloads.
+- EQ has balanced compiled packs in the scanned repo-visible assets, but future sensitive/paid result surfaces should stay fail-closed on locale fallback.
+
+## Authority Conclusion
+
+The hub-level SEO money-page skeleton is present for all six tests, but the free-complete-result closeout is not equally proven across all six. The next implementation work should be split by authority problem:
+
+1. Commercial/access authority conflict: Big Five first.
+2. Scale-specific FAQ authority: Enneagram, RIASEC, IQ, EQ.
+3. IQ claim/norm authority: IQ before stronger money-intent copy.
+4. Result interpretation inventory: needed before adding or promoting result guide pages.
+
+This audit should not be used as permission to patch frontend fallback content or to invent new FAQ copy locally.

--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/BLOCKERS_AND_NEXT_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/BLOCKERS_AND_NEXT_PROMPTS.md
@@ -1,0 +1,53 @@
+# Blockers And Next Prompts
+
+## Current PR Outcome
+
+`SIX-TEST-HUB-COMPLETENESS-READONLY-AUDIT-01` is complete as a generated-only audit. It should not block the requested train if local checks and GitHub required checks pass.
+
+## External Issues Recorded In This Audit
+
+These issues were not introduced by this PR and do not affect this PR's generated-only checks.
+
+| Issue | Evidence | Why outside current scope | Required follow-up |
+| --- | --- | --- | --- |
+| Big Five free-result/commercial mismatch | Registry has `paywall_mode=free_only`, but `commercial_json.price_tier=PAID` and `report_unlock_sku=SKU_BIG5_FULL_REPORT_299`. | Current PR is read-only and must not alter commercial policy or result access. | `BIG5-FREE-COMPLETE-RESULT-AUTHORITY-AUDIT-01` candidate. |
+| Non-MBTI hubs use generic FAQ | Production FAQPage JSON-LD count is 4 for Big Five, Enneagram, RIASEC, IQ, and EQ. | Current PR may not create FAQ content or modify schema/runtime. | Separate backend/CMS FAQ authority PRs after owner-page map. |
+| IQ `llms-full` absence | Production discoverability scan did not find `/zh/tests/iq-test-intelligence-quotient-assessment` in `llms-full.txt`. | Current PR may not modify `llms-full.txt` or discoverability runtime. | IQ claim/discoverability eligibility audit. |
+| IQ norm/claim boundary unresolved | Existing result inventory and sidecar evidence record missing norm/calibrated IQ evidence. | Current PR cannot create scientific authority or norm tables. | IQ claim-readiness and result authority PR before stronger IQ money copy. |
+| RIASEC FAQ parity readback held | Operator explicitly held `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01`. | Current train explicitly excludes that task. | Reauthorize separately if needed. |
+
+## Next Requested Train Item
+
+Proceed to:
+
+`MONEY-INTENT-OWNER-PAGE-MAP-READONLY-01`
+
+Recommended scope:
+
+- map core money-intent query families to exactly one owner page;
+- record conflicts where multiple pages compete;
+- keep output generated-only/read-only;
+- do not change title, meta, H1, FAQ, sitemap, `llms`, schema, CMS content, or runtime.
+
+## Candidate Follow-Up PRs After Current Read-Only Train
+
+These are not authorized by this audit and should not be opened automatically inside this PR train:
+
+1. `BIG5-FREE-COMPLETE-RESULT-AUTHORITY-AUDIT-01`
+2. `NON-MBTI-TEST-HUB-FAQ-AUTHORITY-PLAN-01`
+3. `IQ-TEST-HUB-CLAIM-AND-LLMSFULL-READINESS-01`
+4. `ENNEAGRAM-TEST-HUB-FREE-RESULT-FAQ-READBACK-01`
+5. `EQ-TEST-HUB-FREE-RESULT-FAQ-READBACK-01`
+
+## Stop Boundary
+
+Stop before any task that requires:
+
+- CMS writes;
+- production imports;
+- DB migrations;
+- runtime adapter/schema repair;
+- sitemap or `llms` mutation;
+- Search Console URL submission;
+- production deploy or manual cache purge;
+- editing fap-web.

--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,59 @@
+# SIX-TEST-HUB-COMPLETENESS-READONLY-AUDIT-01
+
+Date: 2026-07-06
+Repo: fap-api
+Scope: generated-only / read-only SEO-GEO audit
+Runtime impact: none
+CMS impact: none
+Search submission impact: none
+Deploy impact: none
+
+## Decision
+
+Decision output: `six_test_hub_completeness_audit_completed_follow_up_required`
+
+The six core test hubs exist as public, indexable, crawlable test landing pages:
+
+- MBTI: `/zh/tests/mbti-personality-test-16-personality-types`
+- Big Five: `/zh/tests/big-five-personality-test-ocean-model`
+- Enneagram: `/zh/tests/enneagram-personality-test-nine-types`
+- RIASEC: `/zh/tests/holland-career-interest-test-riasec`
+- IQ: `/zh/tests/iq-test-intelligence-quotient-assessment`
+- EQ: `/zh/tests/eq-test-emotional-intelligence-assessment`
+
+The current state is not yet a complete six-test hub closeout. MBTI is the only hub that currently shows a strong closed loop for the new free-test/free-complete-result/FAQ/claim-safe landing pattern. RIASEC has the strongest non-MBTI money-page position, but its public FAQ parity remains weaker than MBTI and the previously requested RIASEC FAQ readback remains explicitly held. Big Five, Enneagram, IQ, and EQ are public and usable, but still rely on generic FAQ and weaker free-complete-result landing proof.
+
+## High-Signal Findings
+
+| Test | Current status | Main gap | Follow-up type |
+| --- | --- | --- | --- |
+| MBTI | Strongest closeout. Production page returns 200, index/follow, stable canonical, 8 FAQ JSON-LD items, public CTA links, sitemap/llms/llms-full presence. | D7/D28 observation only; do not keep rewriting 24h data. | Observation PRs only after windows. |
+| Big Five | Public page returns 200 and has CTA/FAQ/indexability. Backend registry has `paywall_mode=free_only`, but `commercial_json.price_tier=PAID` and `report_unlock_sku=SKU_BIG5_FULL_REPORT_299` are still present. | Free-complete-result promise and commercial authority conflict need a separate authority audit before title/FAQ changes. | `BIG5-FREE-COMPLETE-RESULT-AUTHORITY-AUDIT-01` candidate. |
+| Enneagram | Public page returns 200 and supports two forms. Backend registry is free-only. | FAQ remains generic 4-item set; landing page does not yet carry a scale-specific free-complete-result FAQ pattern. | Enneagram hub content/FAQ authority audit candidate. |
+| RIASEC | Public page returns 200, free/full wording is visible, two forms are linked, and sitemap/llms/llms-full are present. | FAQ JSON-LD still has 4 generic items. RIASEC FAQ parity readback is explicitly held outside this train. | Keep held readback out of this PR train until reauthorized. |
+| IQ | Public page returns 200 and has CTA/FAQ/indexability. | IQ still needs stricter claim-boundary and norm/estimate evidence; `llms-full.txt` did not contain the IQ page in this scan. | IQ claim/readiness audit before any money-intent rewrite. |
+| EQ | Public page returns 200 and has CTA/FAQ/indexability. | FAQ remains generic 4-item set; no scale-specific free-complete-result landing closeout yet. | EQ hub content/FAQ authority audit candidate. |
+
+## Operational Recommendation
+
+Continue the requested PR train, but keep this audit as evidence only. The next PR should be:
+
+1. `MONEY-INTENT-OWNER-PAGE-MAP-READONLY-01`
+
+Do not open repair PRs from this audit until the owner-page map and data-quality scans finish. The most important deferred implementation work is likely:
+
+- Big Five free-complete-result authority reconciliation.
+- Generic FAQ replacement with scale-specific backend/CMS-authoritative FAQ for non-MBTI hubs.
+- IQ claim and `llms-full` eligibility review.
+- Result-interpretation page inventory before adding new public interpretation pages.
+
+## Deferred Items
+
+This PR intentionally does not:
+
+- change CMS content, seeders, import packages, runtime adapters, schema renderers, sitemap, `llms.txt`, or `llms-full.txt`;
+- submit URLs to search engines;
+- inspect or mutate production user result URLs;
+- create or alter FAQ content;
+- change pricing, paywall, report access, or commercial policy;
+- execute the held `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01`.

--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/SIX_TEST_COMPLETENESS_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/SIX_TEST_COMPLETENESS_MATRIX.md
@@ -1,0 +1,55 @@
+# Six Test Hub Completeness Matrix
+
+Evidence collected on 2026-07-06 from production public HTML and repository-visible backend authority. The runtime scan was read-only and did not use credentials, private attempt IDs, CMS writes, search submission, deploy, or cache invalidation.
+
+## Runtime Matrix
+
+| Code | Public URL | HTTP | Robots | Canonical | H1 | FAQPage JSON-LD | Visible/runtime notes | Discoverability |
+| --- | --- | ---: | --- | --- | --- | ---: | --- | --- |
+| MBTI | `https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types` | 200 | `index, follow` | self | `免费 MBTI测试：16 型人格完整结果` | 8 | Primary and secondary take CTAs present; FAQ is scale-specific. | sitemap yes; llms yes; llms-full yes |
+| BIG5_OCEAN | `https://fermatmind.com/zh/tests/big-five-personality-test-ocean-model` | 200 | `index, follow` | self | `大五人格免费测试` | 4 | Take CTAs present; FAQ is generic. | sitemap yes; llms yes; llms-full yes |
+| ENNEAGRAM | `https://fermatmind.com/zh/tests/enneagram-personality-test-nine-types` | 200 | `index, follow` | self | `九型人格免费测试` | 4 | Two take CTAs present; FAQ is generic. | sitemap yes; llms yes; llms-full yes |
+| RIASEC | `https://fermatmind.com/zh/tests/holland-career-interest-test-riasec` | 200 | `index, follow` | self | `免费霍兰德职业兴趣测试：RIASEC完整结果` | 4 | Two take CTAs present; FAQ remains generic in this scan. | sitemap yes; llms yes; llms-full yes |
+| IQ_RAVEN | `https://fermatmind.com/zh/tests/iq-test-intelligence-quotient-assessment` | 200 | `index, follow` | self | `智商【IQ】测试` | 4 | Take CTA present; FAQ is generic; IQ result authority remains evidence-sensitive. | sitemap yes; llms yes; llms-full no |
+| EQ_60 | `https://fermatmind.com/zh/tests/eq-test-emotional-intelligence-assessment` | 200 | `index, follow` | self | `情商【EQ】测试` | 4 | Take CTA present; FAQ is generic. | sitemap yes; llms yes; llms-full yes |
+
+## Completeness Gates
+
+| Gate | MBTI | Big Five | Enneagram | RIASEC | IQ | EQ |
+| --- | --- | --- | --- | --- | --- | --- |
+| Backend registry public scale | Pass | Pass | Pass | Pass | Pass | Pass |
+| Public landing page 200 | Pass | Pass | Pass | Pass | Pass | Pass |
+| Indexable robots/canonical | Pass | Pass | Pass | Pass | Pass | Pass |
+| Public test CTA present | Pass | Pass | Pass | Pass | Pass | Pass |
+| Sitemap presence | Pass | Pass | Pass | Pass | Pass | Pass |
+| `llms.txt` presence | Pass | Pass | Pass | Pass | Pass | Pass |
+| `llms-full.txt` presence | Pass | Pass | Pass | Pass | Gap | Pass |
+| Scale-specific FAQ | Pass | Gap | Gap | Gap | Gap | Gap |
+| FAQPage JSON-LD present | Pass | Pass | Pass | Pass | Pass | Pass |
+| Free-complete-result landing promise | Pass | Needs authority reconciliation | Partial | Partial | Needs claim review | Partial |
+| Private URL leakage in scanned public HTML | Pass | Pass | Pass | Pass | Pass | Pass |
+| Claim-safe boundary | Pass with explicit non-diagnosis/career boundary | Pass but generic | Pass but generic | Pass with no admission/outcome promise in meta | Needs stricter norm/estimate proof | Pass but generic |
+
+## Production FAQ Questions Captured
+
+MBTI:
+
+1. `MBTI 测试免费吗？`
+2. `MBTI 完整结果能看到什么？`
+3. `MBTI 测试一般多久？`
+4. `MBTI 能决定职业吗？`
+5. `MBTI 是心理诊断吗？`
+6. `16 型人格结果会变吗？`
+7. `MBTI 和大五人格有什么区别？`
+8. `做完 MBTI 后下一步看什么？`
+
+Generic FAQ currently used by Big Five, Enneagram, RIASEC, IQ, and EQ:
+
+1. `需要多久？`
+2. `每道题都要回答吗？`
+3. `可以重复测试吗？`
+4. `这是诊断吗？`
+
+## Interpretation
+
+The six-test hub exists as a public crawlable skeleton, but only MBTI is fully aligned with the P0 closeout pattern that motivated this audit. The rest of the hubs should not be treated as complete SEO/GEO money-intent closeouts until their backend/CMS-authoritative free-result promise, FAQ specificity, claim boundaries, and result-interpretation support are separately audited and repaired.

--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/scan_manifest.json
@@ -1,0 +1,109 @@
+{
+  "task_id": "SIX-TEST-HUB-COMPLETENESS-READONLY-AUDIT-01",
+  "repo": "fap-api",
+  "generated_at": "2026-07-06",
+  "scope": "generated-only read-only audit of six core public test hubs",
+  "runtime_impact": "none",
+  "cms_impact": "none",
+  "search_submission_impact": "none",
+  "deploy_impact": "none",
+  "fap_web_impact": "none",
+  "public_pages_scanned": [
+    {
+      "code": "MBTI",
+      "url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "http_status": 200,
+      "robots": "index, follow",
+      "canonical": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "faq_jsonld_count": 8,
+      "sitemap": true,
+      "llms": true,
+      "llms_full": true,
+      "private_url_leak_detected": false
+    },
+    {
+      "code": "BIG5_OCEAN",
+      "url": "https://fermatmind.com/zh/tests/big-five-personality-test-ocean-model",
+      "http_status": 200,
+      "robots": "index, follow",
+      "canonical": "https://fermatmind.com/zh/tests/big-five-personality-test-ocean-model",
+      "faq_jsonld_count": 4,
+      "sitemap": true,
+      "llms": true,
+      "llms_full": true,
+      "private_url_leak_detected": false
+    },
+    {
+      "code": "ENNEAGRAM",
+      "url": "https://fermatmind.com/zh/tests/enneagram-personality-test-nine-types",
+      "http_status": 200,
+      "robots": "index, follow",
+      "canonical": "https://fermatmind.com/zh/tests/enneagram-personality-test-nine-types",
+      "faq_jsonld_count": 4,
+      "sitemap": true,
+      "llms": true,
+      "llms_full": true,
+      "private_url_leak_detected": false
+    },
+    {
+      "code": "RIASEC",
+      "url": "https://fermatmind.com/zh/tests/holland-career-interest-test-riasec",
+      "http_status": 200,
+      "robots": "index, follow",
+      "canonical": "https://fermatmind.com/zh/tests/holland-career-interest-test-riasec",
+      "faq_jsonld_count": 4,
+      "sitemap": true,
+      "llms": true,
+      "llms_full": true,
+      "private_url_leak_detected": false
+    },
+    {
+      "code": "IQ_RAVEN",
+      "url": "https://fermatmind.com/zh/tests/iq-test-intelligence-quotient-assessment",
+      "http_status": 200,
+      "robots": "index, follow",
+      "canonical": "https://fermatmind.com/zh/tests/iq-test-intelligence-quotient-assessment",
+      "faq_jsonld_count": 4,
+      "sitemap": true,
+      "llms": true,
+      "llms_full": false,
+      "private_url_leak_detected": false
+    },
+    {
+      "code": "EQ_60",
+      "url": "https://fermatmind.com/zh/tests/eq-test-emotional-intelligence-assessment",
+      "http_status": 200,
+      "robots": "index, follow",
+      "canonical": "https://fermatmind.com/zh/tests/eq-test-emotional-intelligence-assessment",
+      "faq_jsonld_count": 4,
+      "sitemap": true,
+      "llms": true,
+      "llms_full": true,
+      "private_url_leak_detected": false
+    }
+  ],
+  "repository_sources": [
+    "backend/database/seeders/ScaleRegistrySeeder.php",
+    "backend/docs/seo/fermatmind-free-assessment-global-seo-geo-strategy-2026-07-04.md",
+    "backend/docs/seo/result-en-parity-00-assessment-result-content-inventory.md"
+  ],
+  "decision": "six_test_hub_completeness_audit_completed_follow_up_required",
+  "next_requested_train_item": "MONEY-INTENT-OWNER-PAGE-MAP-READONLY-01",
+  "held_items": [
+    "RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01",
+    "MBTI-MAIN-FAQ-D7-OBSERVATION-01 until 2026-07-12 Asia/Shanghai",
+    "MBTI-MAIN-FAQ-D28-OBSERVATION-01 until 2026-08-02 Asia/Shanghai"
+  ],
+  "deferred_repair_candidates": [
+    "BIG5-FREE-COMPLETE-RESULT-AUTHORITY-AUDIT-01",
+    "NON-MBTI-TEST-HUB-FAQ-AUTHORITY-PLAN-01",
+    "IQ-TEST-HUB-CLAIM-AND-LLMSFULL-READINESS-01",
+    "ENNEAGRAM-TEST-HUB-FREE-RESULT-FAQ-READBACK-01",
+    "EQ-TEST-HUB-FREE-RESULT-FAQ-READBACK-01"
+  ],
+  "validation": {
+    "json_tool": "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/scan_manifest.json >/dev/null",
+    "diff_check": "git diff --check",
+    "cached_diff_check": "git diff --cached --check"
+  }
+}


### PR DESCRIPTION
## What changed
- Added a generated-only read-only audit for the six core FermatMind test hubs: MBTI, Big Five, Enneagram, RIASEC, IQ, and EQ.
- Recorded production public-page evidence for status, indexability, canonical, FAQPage JSON-LD count, CTA presence, sitemap/llms/llms-full presence, and private URL boundary.
- Recorded backend authority evidence from `ScaleRegistrySeeder.php` and existing SEO/result inventory docs.
- Added deferred follow-up candidates without modifying runtime, CMS, schema, sitemap, llms, or search submission.

## Why
This establishes the P0 six-test hub completeness baseline before any money-intent owner-page mapping or future repair PRs. It keeps evidence separate from implementation so each next PR can remain one scope.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: staged changes are limited to `backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/`

## Deferred items
- No CMS writes, runtime changes, DB migrations, schema changes, sitemap/llms edits, Search Console submission, staging deploy wait, manual deploy, or production deploy.
- Big Five commercial/free-result authority mismatch is recorded only.
- Non-MBTI generic FAQ gaps are recorded only.
- IQ claim/llms-full readiness is recorded only.
- `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01` remains held per operator instruction.
