### PR TITLE
MONEY-INTENT-OWNER-PAGE-MAP-READONLY-01: map owner pages

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/CONFLICTS_AND_GAPS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/CONFLICTS_AND_GAPS.md
@@ -1,0 +1,32 @@
+# Conflicts And Gaps
+
+## Potential Cannibalization Boundaries
+
+| Area | Evidence | Decision |
+| --- | --- | --- |
+| MBTI has test, topic, articles, and career guide URLs in sitemap. | Sitemap contains `/zh/tests/mbti-personality-test-16-personality-types`, `/zh/topics/mbti`, multiple MBTI articles, and `/zh/career/guides/from-mbti-to-job-fit`. | Keep direct test terms on the test page. Topics/articles/career guides own entity, explanation, comparison, and scenario intent. |
+| Big Five has test, topic, article, and career guide URLs. | Sitemap contains `/zh/tests/big-five-personality-test-ocean-model`, `/zh/topics/big-five`, Big Five articles, and `/zh/career/guides/big5-for-career-decisions`. | Keep direct test terms on the test page. Defer stronger free-result copy until authority conflict is reconciled. |
+| RIASEC has a broad gaokao/major/career article cluster. | Sitemap contains RIASEC test page plus explanation, can/cannot, comparison, gaokao, major, and unwanted-major scenario articles. | Keep direct `霍兰德职业兴趣测试` / `RIASEC测试` owner on the test page; cluster pages should feed it. |
+| IQ and EQ share topic/career support under `iq-eq`. | Sitemap contains IQ/EQ test pages plus `/zh/topics/iq-eq` and career guide `/zh/career/guides/iq-eq-balance-at-work`. | Keep direct IQ/EQ test terms on each test page; shared topic owns combined explanation intent. |
+| EQ automated URL discovery is noisy. | Simple substring scan for `eq` matched many career job URLs containing "equipment". | Future SEO tooling must use exact token/slug matching for EQ to avoid false positives. |
+
+## Owner Map Gaps
+
+| Gap | Why it matters | Follow-up |
+| --- | --- | --- |
+| Big Five free-complete-result authority mismatch. | Money-intent page rewrite could overstate access if backend commercial policy remains contradictory. | Keep as external follow-up from PR1; do not repair here. |
+| Non-MBTI scale-specific FAQ gaps. | Generic FAQ weakens direct answer blocks for money-intent pages. | Needs backend/CMS-authoritative FAQ PRs, not frontend fallback. |
+| Result interpretation owner pages are not fully inventoried. | Queries like `MBTI结果怎么看` and `IQ测试分数怎么看` should not fall back to private result URLs or test pages by accident. | Covered by later `RESULT-INTERPRETATION-PAGE-INVENTORY-READONLY-01`. |
+| GSC/seo_intel quality is not verified in this PR. | Owner map should be joined to reliable query/page rows before writing titles or FAQ. | Covered next by `GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01`. |
+
+## Non-Owners
+
+Do not assign public money-intent ownership to:
+
+- `/result/*`, `/attempts/*`, `/report/*`, `/orders/*`, `/payment/*`, `/checkout/*`, `/lookup/*`, `/share/*`, `/history/*`, tokenized URLs, or account/auth routes;
+- private screenshots, proof URLs, payment evidence, or user-generated report content;
+- generated docs or internal operations reports.
+
+## Sidecar Note
+
+The current local `main` worktree contains pre-existing staged generated files from an earlier task line. This did not affect this PR's isolated branch, local checks, remote checks, merge policy, or scope validation. It should be resolved separately and should not be mixed into this owner-map PR.

--- a/backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,61 @@
+# MONEY-INTENT-OWNER-PAGE-MAP-READONLY-01
+
+Date: 2026-07-06
+Repo: fap-api
+Scope: generated-only / read-only owner-page map
+Runtime impact: none
+CMS impact: none
+Search submission impact: none
+Deploy impact: none
+
+## Decision
+
+Decision output: `money_intent_owner_page_map_completed_ready_for_data_quality_scan`
+
+The owner-page rule for the six core assessment money-intent families is:
+
+> Direct "take the test / free test / complete result" query families should resolve to exactly one public test landing page per scale. Explanation, comparison, scenario, topic, and result-interpretation queries should not compete with those money pages.
+
+This audit assigns the current owner page for each core money-intent family and records conflict boundaries. It does not change titles, metadata, H1, FAQ, internal links, sitemap, `llms`, Search Console, CMS rows, runtime code, or fap-web.
+
+## Immediate Owner Map
+
+| Query family | Owner page | Status |
+| --- | --- | --- |
+| `MBTI免费测试`, `MBTI测试`, `16型人格测试`, `免费16型人格测试` | `/zh/tests/mbti-personality-test-16-personality-types` | Keep owner. Strongest current money page. |
+| `大五人格测试`, `Big Five personality test`, `OCEAN人格测试` | `/zh/tests/big-five-personality-test-ocean-model` | Keep owner, but do not strengthen "free complete result" copy until authority conflict is reconciled. |
+| `九型人格测试`, `Enneagram test`, `九型人格免费测试` | `/zh/tests/enneagram-personality-test-nine-types` | Keep owner; FAQ/content specificity gap remains. |
+| `霍兰德职业兴趣测试`, `RIASEC测试`, `职业兴趣测试`, `Holland career interest test` | `/zh/tests/holland-career-interest-test-riasec` | Keep owner; RIASEC article cluster should feed this page, not replace it. |
+| `智商测试`, `IQ测试`, `IQ test`, `intelligence quotient assessment` | `/zh/tests/iq-test-intelligence-quotient-assessment` | Keep owner with stricter claim boundary; no official/clinical IQ promise. |
+| `情商测试`, `EQ测试`, `emotional intelligence test` | `/zh/tests/eq-test-emotional-intelligence-assessment` | Keep owner; current sitemap regex scan has career "equipment" noise, so exact EQ matching should be used in future automation. |
+
+## Owner Boundary
+
+These page families are not money-intent owners:
+
+- private result, attempt, report, order, payment, lookup, share, token, account, auth, and history URLs;
+- articles that answer "what is", "vs", "can/cannot tell you", "how to use", or scenario questions;
+- topics pages that aggregate an entity cluster;
+- career guide pages that route from personality/career concepts into jobs or majors.
+
+They can support the money owner through internal links, but they should not carry the primary title/H1/meta promise for the direct test-taking query unless a future PR explicitly changes the owner map.
+
+## Next Train Item
+
+Proceed to:
+
+`GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01`
+
+Reason: before writing any title/meta/H1/FAQ repair PR, the query/page evidence layer needs quality gates. This avoids using stale or noisy GSC / seo_intel rows to rewrite money pages.
+
+## Deferred Items
+
+This PR intentionally does not:
+
+- edit owner pages or CMS rows;
+- add or rewrite FAQ;
+- alter sitemap, `llms.txt`, `llms-full.txt`, canonical, noindex, schema, or runtime;
+- query private result URLs;
+- use GSC/GA as purchase truth;
+- execute held RIASEC readback;
+- wait for or trigger deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/OWNER_PAGE_MAP.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/OWNER_PAGE_MAP.md
@@ -1,0 +1,31 @@
+# Money Intent Owner Page Map
+
+This map is a read-only routing contract for the next SEO/GEO growth work. It assigns one owner page per direct money-intent query family and records the supporting pages that should feed that owner without competing against it.
+
+## Core Assessment Money Owners
+
+| Family | Direct money-intent examples | Current owner page | Supporting pages observed in sitemap | Notes |
+| --- | --- | --- | --- | --- |
+| MBTI / 16 types | `MBTI免费测试`, `MBTI测试`, `16型人格测试`, `free MBTI test`, `16 personality test` | `/zh/tests/mbti-personality-test-16-personality-types` and locale counterpart `/en/tests/mbti-personality-test-16-personality-types` | `/zh/topics/mbti`, `/zh/articles/mbti-basics`, `/zh/articles/mbti-full-report-career-relationship-communication`, `/zh/articles/mbti-personality-test-science-vs-pseudoscience`, `/zh/articles/big-five-personality-test-vs-mbti`, `/zh/career/guides/from-mbti-to-job-fit` | MBTI is the strongest current owner. Articles should target explanation/comparison/scenario intent, not "take MBTI test" as primary owner. |
+| Big Five / OCEAN | `大五人格测试`, `Big Five personality test`, `OCEAN personality test`, `big5 test` | `/zh/tests/big-five-personality-test-ocean-model` and locale counterpart `/en/tests/big-five-personality-test-ocean-model` | `/zh/topics/big-five`, `/zh/articles/big-five-personality-test-vs-mbti`, `/zh/articles/big-five-growth-guide`, `/zh/articles/big-five-tool-guide`, `/zh/career/guides/big5-for-career-decisions` | Keep the test page as owner. Do not strengthen "free complete result" promise until the Big Five commercial/free-result authority mismatch is resolved. |
+| Enneagram / nine types | `九型人格测试`, `Enneagram test`, `nine types personality test` | `/zh/tests/enneagram-personality-test-nine-types` and locale counterpart `/en/tests/enneagram-personality-test-nine-types` | `/zh/articles/enneagram-personality-test-explained`, `/zh/articles/enneagram-workplace-friction-core-motivations` | The test page owns direct test intent. The explanation article should own "九型人格是什么/怎么看/解释" intent. |
+| RIASEC / Holland | `霍兰德职业兴趣测试`, `RIASEC测试`, `职业兴趣测试`, `Holland Code test`, `career interest test` | `/zh/tests/holland-career-interest-test-riasec` and locale counterpart `/en/tests/holland-career-interest-test-riasec` | `/zh/articles/riasec-holland-career-interest-test-explained`, `/zh/articles/holland-career-interest-test-can-and-cannot-tell-you`, `/zh/articles/career-interest-vs-personality-test-differences`, `/zh/articles/college-major-choice-holland-mbti-career-test`, gaokao/major scenario articles | The test page owns direct test intent. Scenario and gaokao pages should feed RIASEC, not replace it as money owner. |
+| IQ | `智商测试`, `IQ测试`, `IQ test`, `intelligence quotient assessment` | `/zh/tests/iq-test-intelligence-quotient-assessment` and locale counterpart `/en/tests/iq-test-intelligence-quotient-assessment` | `/zh/articles/iq-test-score-and-limits-explained`, `/zh/articles/iq-test-growth-guide`, `/zh/articles/iq-test-tool-guide`, `/zh/topics/iq-eq` | The owner can capture "IQ test" only with online-estimate and claim-boundary language. It must not claim clinical/official IQ validity without norm evidence. |
+| EQ | `情商测试`, `EQ测试`, `emotional intelligence test` | `/zh/tests/eq-test-emotional-intelligence-assessment` and locale counterpart `/en/tests/eq-test-emotional-intelligence-assessment` | `/zh/articles/eq-test-tool-guide`, `/zh/topics/iq-eq`, `/zh/career/guides/iq-eq-balance-at-work` | Use exact EQ query matching in tooling; substring `eq` creates false positives from "equipment" career URLs. |
+
+## Cross-Family Query Owners
+
+| Query family | Owner recommendation | Reason |
+| --- | --- | --- |
+| `免费性格测试`, `free personality test` | Tests hub or future personality-tests hub, not a single scale page. | The user has not selected a scale; route to a directory/hub. |
+| `MBTI vs 大五`, `Big Five vs MBTI` | `/zh/articles/big-five-personality-test-vs-mbti` | Comparison intent should not be owned by either test page. |
+| `MBTI vs 霍兰德`, `MBTI 和 RIASEC 怎么选` | `/zh/articles/mbti-vs-holland-career-choice` or locale counterpart | Comparison intent should route into both owners with claim boundaries. |
+| `职业兴趣测试和人格测试区别` | `/zh/articles/career-interest-vs-personality-test-differences` | Explainer/comparison intent; RIASEC test remains CTA target. |
+| `霍兰德职业兴趣测试准吗/能告诉你什么` | `/zh/articles/holland-career-interest-test-can-and-cannot-tell-you` | Claim-boundary explainer; direct "take test" still belongs to RIASEC test page. |
+| `IQ 测试分数怎么看` | `/zh/articles/iq-test-score-and-limits-explained` | Interpretation and limits, not direct test-taking. |
+
+## Canonical Owner Rule
+
+For future PRs, do not change a page title/meta/H1/FAQ to target a direct money-intent query unless that page is the assigned owner in this map or this map is deliberately updated in a separate read-only/manifest-authorized PR.
+
+Private result pages remain excluded from public SEO/GEO owner mapping.

--- a/backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/scan_manifest.json
@@ -1,0 +1,84 @@
+{
+  "task_id": "MONEY-INTENT-OWNER-PAGE-MAP-READONLY-01",
+  "repo": "fap-api",
+  "generated_at": "2026-07-06",
+  "scope": "generated-only read-only owner-page mapping for core money-intent query families",
+  "runtime_impact": "none",
+  "cms_impact": "none",
+  "search_submission_impact": "none",
+  "deploy_impact": "none",
+  "fap_web_impact": "none",
+  "owner_pages": [
+    {
+      "query_family": "MBTI / 16 types direct test intent",
+      "zh_owner": "/zh/tests/mbti-personality-test-16-personality-types",
+      "en_owner": "/en/tests/mbti-personality-test-16-personality-types",
+      "status": "keep_owner"
+    },
+    {
+      "query_family": "Big Five / OCEAN direct test intent",
+      "zh_owner": "/zh/tests/big-five-personality-test-ocean-model",
+      "en_owner": "/en/tests/big-five-personality-test-ocean-model",
+      "status": "keep_owner_with_authority_caution"
+    },
+    {
+      "query_family": "Enneagram / nine types direct test intent",
+      "zh_owner": "/zh/tests/enneagram-personality-test-nine-types",
+      "en_owner": "/en/tests/enneagram-personality-test-nine-types",
+      "status": "keep_owner"
+    },
+    {
+      "query_family": "RIASEC / Holland / career interest direct test intent",
+      "zh_owner": "/zh/tests/holland-career-interest-test-riasec",
+      "en_owner": "/en/tests/holland-career-interest-test-riasec",
+      "status": "keep_owner"
+    },
+    {
+      "query_family": "IQ direct test intent",
+      "zh_owner": "/zh/tests/iq-test-intelligence-quotient-assessment",
+      "en_owner": "/en/tests/iq-test-intelligence-quotient-assessment",
+      "status": "keep_owner_with_claim_boundary"
+    },
+    {
+      "query_family": "EQ direct test intent",
+      "zh_owner": "/zh/tests/eq-test-emotional-intelligence-assessment",
+      "en_owner": "/en/tests/eq-test-emotional-intelligence-assessment",
+      "status": "keep_owner_with_exact_matching_required"
+    }
+  ],
+  "non_owner_route_patterns": [
+    "/result/*",
+    "/attempts/*",
+    "/report/*",
+    "/orders/*",
+    "/payment/*",
+    "/checkout/*",
+    "/lookup/*",
+    "/share/*",
+    "/history/*",
+    "tokenized/private URLs"
+  ],
+  "evidence_sources": [
+    "backend/docs/seo/fermatmind-free-assessment-global-seo-geo-strategy-2026-07-04.md",
+    "backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/",
+    "backend/database/seeders/ScaleRegistrySeeder.php",
+    "https://fermatmind.com/sitemap.xml"
+  ],
+  "decision": "money_intent_owner_page_map_completed_ready_for_data_quality_scan",
+  "next_requested_train_item": "GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01",
+  "deferred_items": [
+    "no CMS writes",
+    "no runtime changes",
+    "no title/meta/H1/FAQ rewrites",
+    "no sitemap or llms edits",
+    "no Search Console submission",
+    "no staging deploy wait",
+    "no manual deploy",
+    "no production deploy"
+  ],
+  "validation": {
+    "json_tool": "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/scan_manifest.json >/dev/null",
+    "diff_check": "git diff --check",
+    "cached_diff_check": "git diff --cached --check"
+  }
+}


### PR DESCRIPTION
## What changed
- Added a generated-only read-only owner-page map for the core money-intent query families across MBTI, Big Five, Enneagram, RIASEC, IQ, and EQ.
- Assigned one direct test-intent owner page per scale and recorded which articles/topics/career pages should remain supporting surfaces.
- Recorded cannibalization boundaries, non-owner private route patterns, and deferred gaps.

## Why
This prevents future SEO/GEO repair PRs from splitting direct money-intent keywords across test pages, articles, topics, and private result surfaces. It creates a routing contract before GSC / seo_intel quality refresh and before any title/meta/H1/FAQ edits.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: staged changes are limited to `backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/`

## Deferred items
- No CMS writes, runtime changes, title/meta/H1/FAQ rewrites, sitemap/llms edits, Search Console submission, staging deploy wait, manual deploy, or production deploy.
- GSC / seo_intel quality gating remains deferred to `GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01`.
- Result interpretation inventory remains deferred to `RESULT-INTERPRETATION-PAGE-INVENTORY-READONLY-01`.
