### PR TITLE
GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01: scan quality gate

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,70 @@
+# GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01
+
+Date: 2026-07-06
+Repo: fap-api
+Scope: generated-only / read-only GSC and seo_intel quality refresh
+Runtime impact: none
+CMS impact: none
+Search submission impact: none
+Deploy impact: none
+
+## Decision
+
+Decision output: `gsc_seo_intel_quality_refresh_completed_gate_blocked`
+
+Current GSC / seo_intel data quality remains blocked for SEO repair decisions. No CTR, impression, average-position, query-page, title/meta/H1/FAQ, internal-link, Search Channel, or CMS repair should be triggered from current GSC evidence.
+
+The repository has the right quality-gate architecture, but this read-only scan did not find passable live read-model evidence for the current SEO/GEO PR train. The active safe state remains:
+
+- GSC live API disabled by default.
+- External API calls disabled by default.
+- GSC quality gate requires `data_origin=live_gsc_api`.
+- Fixture/mock/static/unknown origins are forbidden.
+- Opportunity queue must consume only `seo_intel` read-model rows that passed the quality gate.
+- Raw GSC payloads, raw URLs, raw queries, credentials, and sidecar direct consumption remain forbidden.
+
+## Current Status
+
+| Gate | Current result | Evidence |
+| --- | --- | --- |
+| GSC data origin | Blocked | `backend/docs/seo/generated/gsc-data-quality-gate.v1.json` records current foundation status as fixture and `opportunity_queue_eligible=false`. |
+| Live API readiness | Not activated | `.env.example` defaults `SEO_INTEL_GSC_ENABLED=false`, `SEO_INTEL_GSC_LIVE_API_ENABLED=false`, and `SEO_INTEL_ALLOW_EXTERNAL_API_CALLS=false`. |
+| Read model target | Present but not sufficient by itself | `seo_gsc_daily` exists with hashed URL/query fields, metrics, metadata, and idempotency key support. |
+| Quality gate logic | Present | `GscDataQualityGate` checks source engine, allowed data origin, forbidden origins, report date, finalization lag, freshness, and required metrics. |
+| Opportunity queue use | Not allowed from current evidence | Contracts require read-model rows after quality gate pass; sidecar artifacts are not queue inputs. |
+| Search/CMS action | Not authorized | No Search Channel enqueue, CMS write, sitemap submit, URL Inspection request, or indexing action is allowed by this PR. |
+
+## Decision For Next SEO Train
+
+Proceed to:
+
+`RESULT-INTERPRETATION-PAGE-INVENTORY-READONLY-01`
+
+Reason: GSC/seo_intel is not yet passable for repair selection. The train should continue with repository/runtime inventory work that does not depend on GSC metrics.
+
+## Stop Boundary For Future Repair PRs
+
+Do not open title/meta/H1/FAQ/CTR repair PRs from GSC until a later PR proves all of these:
+
+1. data rows are `source_engine=google`;
+2. `data_origin=live_gsc_api`;
+3. row source is not fixture/mock/static/unknown;
+4. report dates satisfy finalization lag and freshness window;
+5. rows include `canonical_url_hash`, `query_hash`, `clicks`, and `impressions`;
+6. opportunity candidates read from imported `seo_intel` rows, not raw sidecar artifacts;
+7. no purchase, order, payment, or private-result truth is inferred from GSC.
+
+## Deferred Items
+
+This PR intentionally does not:
+
+- call Google Search Console;
+- read, print, validate, or store credentials;
+- import or backfill `seo_gsc_daily`;
+- run migrations;
+- enable scheduler or queue workers;
+- enqueue Search Channel rows;
+- submit sitemap or URLs;
+- request indexing;
+- write CMS or runtime code;
+- access GA or use analytics as purchase truth.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/GATE_EVIDENCE.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/GATE_EVIDENCE.md
@@ -1,0 +1,102 @@
+# GSC / seo_intel Gate Evidence
+
+## Contract Evidence
+
+Source: `backend/docs/seo/gsc-data-quality-gate.md`.
+
+Pass requirements:
+
+- source engine must be `google`;
+- data origin must be `live_gsc_api`;
+- row source must not be `fixture`, `mock`, `static_artifact`, or `unknown`;
+- report date must satisfy configured GSC finalization lag;
+- report date must satisfy freshness window;
+- required fields must include canonical URL hash, query hash, clicks, and impressions.
+
+Current recorded status:
+
+- `data_origin=fixture`;
+- `data_quality_gate_status=blocked`;
+- `opportunity_queue_eligible=false`.
+
+## Code Evidence
+
+Source: `backend/app/Services/SeoIntel/GscDataQualityGate.php`.
+
+The gate blocks:
+
+- insufficient rows;
+- forbidden data origins;
+- data origins not in the allowed list;
+- non-google source engines;
+- missing report dates;
+- missing `canonical_url_hash`, `query_hash`, `clicks`, or `impressions`;
+- report dates newer than the finalization lag;
+- stale report dates older than the configured maximum age.
+
+Default effective values from code/config:
+
+- `gsc_backfill_lag_days=3`;
+- `gsc_data_quality.max_report_age_days=10`;
+- `allowed_data_origins=["live_gsc_api"]`;
+- `forbidden_data_origins=["fixture","mock","static_artifact","unknown"]`.
+
+## Read Model Evidence
+
+Source: `backend/database/migrations/seo_intel/2026_05_17_000900_create_seo_gsc_daily_table.php`.
+
+`seo_gsc_daily` includes:
+
+- `report_date`;
+- `canonical_url_hash`;
+- nullable `canonical_url`;
+- `query_hash`;
+- `query_display_masked`;
+- `locale`, `device`, `country`, `search_type`;
+- `source_engine`;
+- `clicks`, `impressions`, `ctr_ppm`, `average_position_milli`;
+- `is_brand_query`, `query_type`, `data_state`;
+- `metadata_json`.
+
+Source: `backend/database/migrations/seo_intel/2026_06_20_130000_add_idempotency_key_to_seo_gsc_daily_table.php`.
+
+`seo_gsc_daily.idempotency_key` is derived from report date, canonical URL hash, query hash, source engine, device, country, and search type, then protected by a unique index.
+
+## Runtime Default Evidence
+
+Source: `backend/.env.example`.
+
+Defaults keep live reads and external actions off:
+
+- `SEO_INTEL_ENABLED=false`;
+- `SEO_INTEL_WRITE_ENABLED=false`;
+- `SEO_INTEL_COLLECTORS_ENABLED=false`;
+- `SEO_INTEL_DRY_RUN_DEFAULT=true`;
+- `SEO_INTEL_ALLOW_EXTERNAL_API_CALLS=false`;
+- `SEO_INTEL_GSC_ENABLED=false`;
+- `SEO_INTEL_GSC_LIVE_API_ENABLED=false`;
+- `SEO_INTEL_GSC_AUTH_MODE=disabled`;
+- `SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false`;
+- `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false`;
+- `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false`.
+
+## Import / Readback Command Evidence
+
+Source: `backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php`.
+
+- Requires `--dry-run`.
+- Validates a sanitized artifact.
+- Emits preview only.
+- `would_write=false`.
+- Target table is `seo_gsc_daily`.
+
+Source: `backend/app/Console/Commands/SeoIntelGscReadModelCanaryReadbackCommand.php`.
+
+- Requires artifact path and exact SHA256.
+- Read-only.
+- `would_write=false`.
+- Reports idempotency/readback status without printing raw query or URL.
+
+## Current Train Interpretation
+
+This quality refresh does not produce passable GSC metrics. It preserves the existing conservative boundary: keep using repository/runtime inventory and later GSC/seo_intel quality work separately before any CTR repair loop.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/QUALITY_GATE_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/QUALITY_GATE_MATRIX.md
@@ -1,0 +1,33 @@
+# Quality Gate Matrix
+
+| Check | Pass condition | Current read-only result | Repair action allowed now? |
+| --- | --- | --- | --- |
+| Data origin | `live_gsc_api` | Blocked; documented current foundation status is fixture. | No |
+| Source engine | `google` | Gate requires this, but no live passable row set was produced in this PR. | No |
+| Required row fields | `canonical_url_hash`, `query_hash`, `clicks`, `impressions` | Schema supports these; current passable rows not proven. | No |
+| Date finalization lag | latest report date at least 3 days old | Gate enforces it; current passable rows not proven. | No |
+| Freshness | latest report date within max age window, default 10 days | Gate enforces it; current passable rows not proven. | No |
+| Forbidden source exclusion | no fixture/mock/static/unknown | Current recorded foundation status is fixture, so blocked. | No |
+| Sanitized artifact boundary | no raw query, raw URL, tokens, credentials, cookie, session, raw payload | Contracts require this; no artifact imported in this PR. | No |
+| Read model consumption | opportunity queue reads only imported `seo_intel` rows after quality gate pass | Required by contract; no eligible queue input in this PR. | No |
+| Search/CMS execution | separate explicit authorization and passing gates | Not authorized. | No |
+
+## Consequence
+
+For the current PR train, GSC / seo_intel should be treated as:
+
+- useful architecture evidence;
+- not yet a repair trigger;
+- not a source of purchase truth;
+- not a substitute for GA/product analytics;
+- not a URL Truth authority;
+- not a direct Search Channel input.
+
+## Allowed Next Use
+
+The next safe GSC-related work would be another generated-only/read-only pass that either:
+
+1. proves passable imported `seo_intel` rows already exist, using sanitized/hash evidence only; or
+2. separately authorizes a live-read sidecar artifact and then a dry-run importer/readback path.
+
+Neither is part of this PR.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/scan_manifest.json
@@ -1,0 +1,69 @@
+{
+  "task_id": "GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01",
+  "repo": "fap-api",
+  "generated_at": "2026-07-06",
+  "scope": "generated-only read-only GSC and seo_intel quality refresh",
+  "runtime_impact": "none",
+  "cms_impact": "none",
+  "search_submission_impact": "none",
+  "deploy_impact": "none",
+  "fap_web_impact": "none",
+  "live_gsc_api_call": false,
+  "credential_operation": false,
+  "seo_gsc_daily_import": false,
+  "database_write": false,
+  "scheduler_activation": false,
+  "queue_worker_activation": false,
+  "search_channel_enqueue": false,
+  "search_provider_submission": false,
+  "cms_write": false,
+  "decision": "gsc_seo_intel_quality_refresh_completed_gate_blocked",
+  "current_quality_status": {
+    "gsc_data_quality_gate": "blocked",
+    "opportunity_queue_eligible": false,
+    "allowed_data_origin": "live_gsc_api",
+    "forbidden_data_origins": [
+      "fixture",
+      "mock",
+      "static_artifact",
+      "unknown"
+    ],
+    "required_fields": [
+      "canonical_url_hash",
+      "query_hash",
+      "clicks",
+      "impressions"
+    ],
+    "lag_days_required": 3,
+    "max_report_age_days": 10
+  },
+  "evidence_sources": [
+    "backend/docs/seo/gsc-data-quality-gate.md",
+    "backend/docs/seo/gsc-live-readmodel-consumption-contract.md",
+    "backend/docs/seo/gsc-live-readonly-adapter.md",
+    "backend/docs/seo/generated/gsc-data-quality-gate.v1.json",
+    "backend/docs/seo/generated/gsc-live-readmodel-consumption-contract.v1.json",
+    "backend/app/Services/SeoIntel/GscDataQualityGate.php",
+    "backend/database/migrations/seo_intel/2026_05_17_000900_create_seo_gsc_daily_table.php",
+    "backend/database/migrations/seo_intel/2026_06_20_130000_add_idempotency_key_to_seo_gsc_daily_table.php",
+    "backend/.env.example"
+  ],
+  "next_requested_train_item": "RESULT-INTERPRETATION-PAGE-INVENTORY-READONLY-01",
+  "deferred_items": [
+    "no GSC live API call",
+    "no credential read/print/store",
+    "no seo_gsc_daily import or backfill",
+    "no GSC-derived CTR repair",
+    "no CMS write",
+    "no Search Channel enqueue",
+    "no search provider submission",
+    "no staging deploy wait",
+    "no manual deploy",
+    "no production deploy"
+  ],
+  "validation": {
+    "json_tool": "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/scan_manifest.json >/dev/null",
+    "diff_check": "git diff --check",
+    "cached_diff_check": "git diff --cached --check"
+  }
+}


### PR DESCRIPTION
## What changed
- Added a generated-only read-only GSC / seo_intel quality refresh report.
- Recorded the current quality-gate decision as blocked for repair decisions.
- Documented the gate requirements, read-model fields, default disabled runtime flags, and deferred boundaries.

## Why
The SEO train needs to know whether GSC / seo_intel can safely drive CTR, title/meta/H1/FAQ, or query-page repair decisions. This PR confirms the current safe answer is no: the quality gate remains blocked until live, sanitized, imported read-model rows pass the existing gate.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: staged changes are limited to `backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/`

## Deferred items
- No GSC live API call, credential read/print/store, seo_gsc_daily import/backfill, CMS write, Search Channel enqueue, search provider submission, staging deploy wait, manual deploy, or production deploy.
- No GSC-derived CTR/TDK/FAQ repair is authorized by this evidence.
