### PR TITLE
RESULT-INTERPRETATION-PAGE-INVENTORY-READONLY-01: inventory result guides

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,56 @@
+# RESULT-INTERPRETATION-PAGE-INVENTORY-READONLY-01
+
+Date: 2026-07-06
+Repo: fap-api
+Scope: generated-only / read-only result interpretation inventory
+Runtime impact: none
+CMS impact: none
+Search submission impact: none
+Deploy impact: none
+
+## Decision
+
+Decision output: `result_interpretation_inventory_completed_content_gaps_confirmed`
+
+The six core test families have partial public result-interpretation coverage, but not a complete, claim-safe, bilingual result-guide layer. Existing public articles can support the money pages, but they should not be treated as complete substitutes for backend/CMS-authoritative result interpretation pages.
+
+The biggest gaps are:
+
+- no uniform "结果怎么看 / how to read your result" page pattern across all six tests;
+- weak English counterpart coverage for most public interpretation assets;
+- EQ and Enneagram have thin result-interpretation coverage;
+- RIASEC has explanation/scenario content, but result-specific reading guidance remains incomplete;
+- IQ has the clearest limits article, but must keep online-estimate / non-clinical boundaries;
+- private result/report URLs remain excluded from public SEO owner mapping.
+
+## Inventory Summary
+
+| Family | Public interpretation inventory found | Current status |
+| --- | --- | --- |
+| MBTI | `mbti-full-report-career-relationship-communication`, `mbti-growth-guide`, `mbti-narrative-portrait`, career guide `from-mbti-to-job-fit` | Strongest public support layer, but result/report authority and frontend clone-content risk remain documented elsewhere. |
+| Big Five | `big-five-growth-guide`, `big-five-narrative-portrait`, `big-five-tool-guide`, career guide `big5-for-career-decisions` | Useful support layer; Big Five v2 result-page asset parity remains a known backend asset gap. |
+| Enneagram | `enneagram-personality-test-explained` | Thin; explanation page exists, but result-reading guide inventory is incomplete. |
+| RIASEC | `riasec-holland-career-interest-test-explained`, scenario pages such as gaokao/major checklists | Good cluster direction, but result-specific interpretation page is not complete. |
+| IQ | `iq-test-score-and-limits-explained`, `iq-test-growth-guide`, `iq-test-narrative-portrait`, `iq-test-tool-guide` | Best limits-bound result support; must not imply official/clinical IQ validity. |
+| EQ | `eq-test-tool-guide` | Thinest result interpretation layer among the six. |
+
+## Next Train Item
+
+Proceed to:
+
+`ZH-RIASEC-GAOKAO-MAJOR-CAREER-CLUSTER-PLAN-01`
+
+Reason: the result inventory confirms the RIASEC/gaokao/major/career cluster is a high-priority planning lane, but implementation should remain a separate scope. This PR only inventories.
+
+## Deferred Items
+
+This PR intentionally does not:
+
+- create or publish article drafts;
+- write CMS content;
+- add result interpretation pages;
+- access private result/report/attempt/share/history URLs;
+- alter result/report APIs;
+- change titles, metadata, H1, FAQ, schema, sitemap, `llms`, canonical, or noindex;
+- inspect GSC/GA as purchase truth;
+- deploy or trigger cache invalidation.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/GAPS_AND_NEXT_PR_CANDIDATES.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/GAPS_AND_NEXT_PR_CANDIDATES.md
@@ -1,0 +1,34 @@
+# Gaps And Next PR Candidates
+
+## Inventory Gaps
+
+| Gap | Impact | Suggested future scope |
+| --- | --- | --- |
+| No uniform six-test result interpretation pattern. | Search and GEO answer surfaces may not understand where to route "结果怎么看" queries. | Plan a generated-only result-guide authority map before content writes. |
+| Enneagram result-reading layer is thin. | Users may find the test page but lack a public guide for ranking, type uncertainty, wings, and motivation boundaries. | Enneagram result guide content plan. |
+| EQ result-reading layer is thinest. | EQ can attract high-intent "情商测试结果怎么看" searches but lacks enough public interpretation support. | EQ result guide content plan with non-diagnostic boundary. |
+| RIASEC result interpretation is mixed with explanation/scenario content. | RIASEC cluster is strong, but result-specific intent can be diluted. | RIASEC result guide plan after cluster planning. |
+| English result interpretation coverage is weak. | Global SEO/GEO growth is constrained by zh-heavy inventory. | EN counterpart inventory and content authority plan. |
+| Backend result/report asset parity remains incomplete. | Public articles can explain concepts, but private/free result report copy needs backend authority and locale-safe assets. | Separate result/report asset parity PRs; do not patch frontend fallback content. |
+
+## Candidate PRs Not Authorized Here
+
+These are candidate future PRs only. Do not execute them automatically inside this PR:
+
+1. `RESULT-INTERPRETATION-OWNER-MAP-READONLY-01`
+2. `ENNEAGRAM-RESULT-INTERPRETATION-CONTENT-PLAN-01`
+3. `EQ-RESULT-INTERPRETATION-CONTENT-PLAN-01`
+4. `RIASEC-RESULT-INTERPRETATION-CONTENT-PLAN-01`
+5. `GLOBAL-EN-RESULT-INTERPRETATION-PARITY-PLAN-01`
+
+## Why No Repair Now
+
+This train item is inventory-only. Content creation or CMS import would require:
+
+- explicit CMS/content authority authorization;
+- claim-boundary review;
+- page owner map update where needed;
+- bilingual counterpart decision;
+- separate validation for schema, sitemap, `llms`, canonical, noindex, and runtime rendering.
+
+None of that is included in this PR.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/RESULT_PAGE_INVENTORY.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/RESULT_PAGE_INVENTORY.md
@@ -1,0 +1,58 @@
+# Result Interpretation Page Inventory
+
+This inventory covers public, crawlable support pages that can answer "what does this test result mean" or "how should I use this result" intent. It excludes private result, report, attempt, order, share, lookup, payment, account, tokenized, and history URLs.
+
+## Sitemap-Derived Public Inventory
+
+| Scale | Public URLs found | Interpretation coverage assessment |
+| --- | --- | --- |
+| MBTI | `/zh/articles/mbti-full-report-career-relationship-communication`; `/en/articles/mbti-full-report-career-relationship-communication`; `/zh/articles/mbti-growth-guide`; `/zh/articles/mbti-narrative-portrait`; `/zh/career/guides/from-mbti-to-job-fit` | Strong support, but still split across report/career/growth/narrative angles. A single "MBTI 结果怎么看" owner is not explicitly established in this scan. |
+| Big Five | `/zh/articles/big-five-growth-guide`; `/zh/articles/big-five-narrative-portrait`; `/zh/articles/big-five-tool-guide`; `/zh/career/guides/big5-for-career-decisions` | Useful zh support. English public counterpart coverage was not found in the sitemap-derived resultish scan. |
+| Enneagram | `/zh/articles/enneagram-personality-test-explained` | Has explanation coverage, but not enough result-reading coverage for type ranking, wings, motivation, and safe use boundaries. |
+| RIASEC | `/zh/articles/riasec-holland-career-interest-test-explained`; `/zh/articles/gaokao-score-major-shortlist-riasec-checklist` | Strong RIASEC explanation/scenario start. Still needs a result-reading page that explains six dimensions, top-three code, uncertainty, and next-step use. |
+| IQ | `/zh/articles/iq-test-score-and-limits-explained`; `/zh/articles/iq-test-growth-guide`; `/zh/articles/iq-test-narrative-portrait`; `/zh/articles/iq-test-tool-guide`; `/zh/career/guides/iq-eq-balance-at-work` | Best existing limits page. Keep IQ result interpretation bounded as online estimate / cognitive reasoning reflection. |
+| EQ | `/zh/articles/eq-test-tool-guide` | Minimal. Needs a future result-reading guide for emotional awareness, regulation, empathy, relationship management, and non-diagnostic boundaries. |
+
+## Backend Result/Report Asset Risk
+
+Source: `backend/docs/seo/result-en-parity-00-assessment-result-content-inventory.md`.
+
+Relevant result/report architecture risks:
+
+- MBTI depends on external content package exports and has frontend clone-content authority risk.
+- Big Five v2 has many zh assets but no repo-visible English v2 counterparts.
+- Enneagram registry content is zh-CN-only for several result/report groups.
+- RIASEC lifecycle/result assets are zh-CN-only in scanned inventory.
+- IQ report labels and pro payloads need locale-safe authority and strict online-estimate boundaries.
+- EQ has balanced compiled packs in current scan, but future sensitive result surfaces need fail-closed no-zh-fallback gates.
+
+## Owner-Page Relationship
+
+Direct money-intent owners remain the six test landing pages from `MONEY-INTENT-OWNER-PAGE-MAP-READONLY-01`.
+
+Result interpretation pages should own query families such as:
+
+- `MBTI结果怎么看`
+- `16型人格结果怎么看`
+- `大五人格结果怎么看`
+- `九型人格结果怎么看`
+- `霍兰德职业兴趣结果怎么看`
+- `RIASEC结果怎么看`
+- `IQ测试分数怎么看`
+- `EQ测试结果怎么看`
+
+They should link back to the direct test owner, but they should not become direct "take test" money owners.
+
+## Private URL Boundary
+
+Public result interpretation pages must not expose or index:
+
+- private attempt IDs;
+- private report URLs;
+- email lookup state;
+- share tokens;
+- order/payment identifiers;
+- user screenshots or raw result payloads;
+- personalized report content without explicit public-safe approval.
+
+Private result pages can be free and useful for the user, but they are not public SEO result-interpretation pages by default.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/scan_manifest.json
@@ -1,0 +1,68 @@
+{
+  "task_id": "RESULT-INTERPRETATION-PAGE-INVENTORY-READONLY-01",
+  "repo": "fap-api",
+  "generated_at": "2026-07-06",
+  "scope": "generated-only read-only inventory of public result interpretation pages for six core tests",
+  "runtime_impact": "none",
+  "cms_impact": "none",
+  "search_submission_impact": "none",
+  "deploy_impact": "none",
+  "fap_web_impact": "none",
+  "private_result_url_access": false,
+  "decision": "result_interpretation_inventory_completed_content_gaps_confirmed",
+  "inventory": {
+    "MBTI": [
+      "/zh/articles/mbti-full-report-career-relationship-communication",
+      "/en/articles/mbti-full-report-career-relationship-communication",
+      "/zh/articles/mbti-growth-guide",
+      "/zh/articles/mbti-narrative-portrait",
+      "/zh/career/guides/from-mbti-to-job-fit"
+    ],
+    "BIG5_OCEAN": [
+      "/zh/articles/big-five-growth-guide",
+      "/zh/articles/big-five-narrative-portrait",
+      "/zh/articles/big-five-tool-guide",
+      "/zh/career/guides/big5-for-career-decisions"
+    ],
+    "ENNEAGRAM": [
+      "/zh/articles/enneagram-personality-test-explained"
+    ],
+    "RIASEC": [
+      "/zh/articles/riasec-holland-career-interest-test-explained",
+      "/zh/articles/gaokao-score-major-shortlist-riasec-checklist"
+    ],
+    "IQ_RAVEN": [
+      "/zh/articles/iq-test-score-and-limits-explained",
+      "/zh/articles/iq-test-growth-guide",
+      "/zh/articles/iq-test-narrative-portrait",
+      "/zh/articles/iq-test-tool-guide",
+      "/zh/career/guides/iq-eq-balance-at-work"
+    ],
+    "EQ_60": [
+      "/zh/articles/eq-test-tool-guide"
+    ]
+  },
+  "evidence_sources": [
+    "https://fermatmind.com/sitemap.xml",
+    "backend/docs/seo/result-en-parity-00-assessment-result-content-inventory.md",
+    "backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/OWNER_PAGE_MAP.md"
+  ],
+  "next_requested_train_item": "ZH-RIASEC-GAOKAO-MAJOR-CAREER-CLUSTER-PLAN-01",
+  "deferred_items": [
+    "no CMS write",
+    "no article draft creation",
+    "no private result URL access",
+    "no result/report API mutation",
+    "no title/meta/H1/FAQ/schema edits",
+    "no sitemap or llms edits",
+    "no search submission",
+    "no staging deploy wait",
+    "no manual deploy",
+    "no production deploy"
+  ],
+  "validation": {
+    "json_tool": "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/scan_manifest.json >/dev/null",
+    "diff_check": "git diff --check",
+    "cached_diff_check": "git diff --cached --check"
+  }
+}


### PR DESCRIPTION
## What changed
- Added a generated-only read-only inventory for public result interpretation pages across MBTI, Big Five, Enneagram, RIASEC, IQ, and EQ.
- Recorded sitemap-derived public interpretation/support pages and private URL exclusions.
- Captured gaps and future PR candidates without creating content or touching CMS/runtime.

## Why
The growth train needs a clear view of which “结果怎么看 / how to read your result” assets already exist before planning new content or authority repairs. This prevents private result URLs or direct test money pages from becoming accidental public interpretation owners.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: staged changes are limited to `backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/`

## Deferred items
- No CMS writes, article draft creation, private result URL access, result/report API mutation, title/meta/H1/FAQ/schema edits, sitemap/llms edits, search submission, staging deploy wait, manual deploy, or production deploy.
