### PR TITLE
ZH-RIASEC-GAOKAO-MAJOR-CAREER-CLUSTER-PLAN-01: plan cluster

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/CLUSTER_MAP.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/CLUSTER_MAP.md
@@ -1,0 +1,50 @@
+# Chinese RIASEC / Gaokao / Major / Career Cluster Map
+
+## Hub And Owner Pages
+
+| Layer | URL | Role |
+| --- | --- | --- |
+| Money owner | `/zh/tests/holland-career-interest-test-riasec` | Owns direct `霍兰德职业兴趣测试`, `RIASEC测试`, `职业兴趣测试` intent. |
+| Explainer | `/zh/articles/riasec-holland-career-interest-test-explained` | Owns `RIASEC是什么`, `霍兰德职业兴趣是什么`, and model explanation intent. |
+| Boundary explainer | `/zh/articles/holland-career-interest-test-can-and-cannot-tell-you` | Owns "准吗 / 能告诉你什么 / 不能告诉你什么" intent. |
+| Comparison | `/zh/articles/career-interest-vs-personality-test-differences` | Owns career-interest vs personality-test distinction. |
+| MBTI comparison | `/zh/articles/mbti-vs-holland-career-choice` and `/zh/articles/college-major-choice-holland-mbti-career-test` | Owns MBTI + Holland combined decision support intent. |
+
+## Gaokao / Major Scenario Pages
+
+| Scenario | URL | User job | Recommended CTA target |
+| --- | --- | --- | --- |
+| Score to shortlist | `/zh/articles/gaokao-score-major-shortlist-riasec-checklist` | User has score/rank and needs a major shortlist method. | RIASEC test owner plus course evidence checklist. |
+| Parent conflict | `/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist` | User needs a structured discussion with parents. | RIASEC test owner plus comparison article. |
+| Unwanted adjustment | `/zh/articles/gaokao-major-adjustment-unacceptable-major-checklist` | User is deciding whether an adjusted major is acceptable. | RIASEC test owner plus unwanted-major transfer/repeat pages. |
+| Hot major fit | `/zh/articles/hot-major-fit-riasec-course-career-checklist` | User wants to evaluate a popular major without hype. | RIASEC test owner plus career guide routes. |
+| Math / computer / AI concern | `/zh/articles/math-not-good-computer-ai-major-course-riasec-checklist` | User worries a major is mismatched to ability or interest. | RIASEC test owner plus course task checklist. |
+| Repeat or stay | `/zh/articles/unwanted-major-repeat-or-stay-riasec-decision-checklist` | User weighs repeating exam vs staying in major. | RIASEC test owner plus transfer plan page. |
+| Transfer plan | `/zh/articles/unwanted-major-adjustment-riasec-transfer-plan` | User needs a staged transfer/exploration plan. | RIASEC test owner plus career direction guide. |
+
+## Career Direction Support
+
+| URL | Role |
+| --- | --- |
+| `/zh/articles/career-confusion-test-map` | Routes confused users to tests and next steps. |
+| `/zh/articles/major-career-mismatch-job-search-skills-plan` | Bridges major mismatch into job-search/skill planning. |
+| `/zh/career/guides/how-to-choose-college-major` | Career guide layer for major choice. |
+| `/zh/career/guides/how-to-find-right-career-direction` | Career guide layer for direction exploration. |
+| `/zh/career` and `/zh/career/guides` | Career hub/guides aggregation. |
+
+## Internal Link Direction
+
+Recommended direction:
+
+- scenario pages -> RIASEC test owner;
+- scenario pages -> relevant explainer/boundary page;
+- result-reading page when created -> RIASEC test owner and scenario pages;
+- career guide pages -> RIASEC test owner when career-interest exploration is relevant;
+- RIASEC test owner -> selected high-intent scenario pages only, not every career job URL.
+
+Avoid:
+
+- sending direct test intent to articles;
+- turning career job pages into RIASEC evidence without explicit backend authority;
+- linking private result/report/share URLs into public pages;
+- using "recommended major/job" phrasing without review.

--- a/backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/EXECUTION_PLAN.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/EXECUTION_PLAN.md
@@ -1,0 +1,72 @@
+# Execution Plan
+
+This is a planning artifact only. It does not authorize CMS writes or article creation.
+
+## Phase 1: Read-Only Topic Selection
+
+Use `DAILY-MODE-C-TOPIC-SELECTION-20260706` to select one topic package from this cluster.
+
+Recommended candidate order:
+
+1. `gaokao-major-adjustment-unacceptable-major-checklist`
+2. `gaokao-score-major-shortlist-riasec-checklist`
+3. `hot-major-fit-riasec-course-career-checklist`
+4. `math-not-good-computer-ai-major-course-riasec-checklist`
+5. `unwanted-major-adjustment-riasec-transfer-plan`
+
+Selection criteria:
+
+- high user urgency;
+- clean claim boundary;
+- direct bridge to RIASEC test owner;
+- no need for GSC quality gate;
+- no production import or runtime change.
+
+## Phase 2: Distribution Asset Package
+
+Use `DAILY-DISTRIBUTION-ASSET-PACKAGE-20260706` to create generated-only distribution assets for the selected topic. Do not publish.
+
+Allowed generated assets:
+
+- short summary;
+- WeChat/social outline;
+- CTA snippets pointing to public URLs only;
+- claim-boundary checklist;
+- internal-link suggestion map.
+
+Forbidden:
+
+- CMS write;
+- public posting;
+- search submission;
+- private URL usage;
+- claims about guaranteed major, admission, job, salary, or career outcome.
+
+## Phase 3: Later Content Or Repair PRs
+
+Only after explicit authorization:
+
+- create/update CMS draft package;
+- human review;
+- claim lint;
+- publication gate;
+- post-publish smoke;
+- separate search submission if authorized.
+
+## Quality Gate
+
+Do not use GSC/seo_intel CTR or impression metrics for this cluster until `GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01` has a future pass state. Current gate state is blocked.
+
+## RIASEC Result Interpretation Follow-Up
+
+The result inventory found that RIASEC lacks a dedicated result-reading page. Proposed future PR:
+
+`RIASEC-RESULT-INTERPRETATION-CONTENT-PLAN-01`
+
+Scope:
+
+- explain six dimensions and top-three code;
+- explain how to use result with majors/courses/jobs;
+- make uncertainty and boundary statements quotable;
+- no private result URLs;
+- no precise recommendation claims.

--- a/backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,64 @@
+# ZH-RIASEC-GAOKAO-MAJOR-CAREER-CLUSTER-PLAN-01
+
+Date: 2026-07-06
+Repo: fap-api
+Scope: generated-only / read-only Chinese RIASEC, gaokao, major, and career cluster plan
+Runtime impact: none
+CMS impact: none
+Search submission impact: none
+Deploy impact: none
+
+## Decision
+
+Decision output: `zh_riasec_gaokao_major_career_cluster_plan_completed_ready_for_topic_selection`
+
+The Chinese RIASEC / gaokao / major / career cluster is the best next topical growth lane after the current read-only audits. It already has enough public URL inventory to plan a coherent cluster without writing new content in this PR.
+
+The cluster should be structured around one money owner and four support layers:
+
+1. Money owner: `/zh/tests/holland-career-interest-test-riasec`
+2. Model explainer: RIASEC / Holland career-interest explanation pages.
+3. Gaokao and major scenario pages: score, parent conflict, unwanted adjustment, hot major fit, math/computer/AI fit.
+4. Career direction pages: confusion, career-interest vs personality, job/major mismatch, career guide routing.
+5. Entity expansion later: RIASEC dimensions, majors, careers, and course checks after authority gates.
+
+## Priority Sequence
+
+| Priority | Work lane | Reason |
+| --- | --- | --- |
+| P0 | Strengthen current RIASEC test owner and existing RIASEC explanation/scenario links through evidence-only planning first. | Direct career-interest and gaokao/major intent is already clustered around RIASEC. |
+| P1 | Build a result-reading and course/major use-case bridge plan. | The result inventory showed RIASEC lacks a dedicated result interpretation page. |
+| P2 | Separate gaokao pages by decision situation: score shortlist, adjustment rejection, parent conflict, hot major, math/computer/AI concern. | These are high-intent Chinese scenarios with clear user jobs. |
+| P3 | Connect scenario pages back to test owner and career guides without deterministic career claims. | Keeps RIASEC as exploration signal, not precise recommendation. |
+
+## Claim Boundary
+
+The cluster may say RIASEC helps users compare interests, activity preferences, course/major fit questions, and career exploration directions.
+
+The cluster must not say RIASEC:
+
+- predicts admission, employment, salary, or career success;
+- selects the best major automatically;
+- proves ability, IQ, mental health, or personality quality;
+- replaces counselors, teachers, parents, or professional advice;
+- is an official provider/certification unless separately evidenced.
+
+## Next Train Item
+
+Proceed to:
+
+`DAILY-MODE-C-TOPIC-SELECTION-20260706`
+
+Reason: the cluster plan confirms RIASEC/gaokao/major/career as a good candidate lane, but actual topic selection should happen in the daily Mode C package scope, not here.
+
+## Deferred Items
+
+This PR intentionally does not:
+
+- create article drafts;
+- rewrite existing articles;
+- write CMS;
+- publish or unpublish content;
+- change internal links, CTA, sitemap, `llms`, schema, canonical, noindex, title, meta, or H1;
+- access GSC/GA as purchase truth;
+- submit URLs or trigger deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/scan_manifest.json
@@ -1,0 +1,68 @@
+{
+  "task_id": "ZH-RIASEC-GAOKAO-MAJOR-CAREER-CLUSTER-PLAN-01",
+  "repo": "fap-api",
+  "generated_at": "2026-07-06",
+  "scope": "generated-only read-only plan for Chinese RIASEC, gaokao, major, and career scenario cluster",
+  "runtime_impact": "none",
+  "cms_impact": "none",
+  "search_submission_impact": "none",
+  "deploy_impact": "none",
+  "fap_web_impact": "none",
+  "decision": "zh_riasec_gaokao_major_career_cluster_plan_completed_ready_for_topic_selection",
+  "money_owner": "/zh/tests/holland-career-interest-test-riasec",
+  "cluster_layers": [
+    "money_owner",
+    "model_explainer",
+    "boundary_explainer",
+    "comparison_pages",
+    "gaokao_major_scenario_pages",
+    "career_direction_support"
+  ],
+  "priority_candidates": [
+    "/zh/articles/gaokao-major-adjustment-unacceptable-major-checklist",
+    "/zh/articles/gaokao-score-major-shortlist-riasec-checklist",
+    "/zh/articles/hot-major-fit-riasec-course-career-checklist",
+    "/zh/articles/math-not-good-computer-ai-major-course-riasec-checklist",
+    "/zh/articles/unwanted-major-adjustment-riasec-transfer-plan"
+  ],
+  "claim_boundary": {
+    "allowed": [
+      "career-interest exploration",
+      "course and major evidence checklist",
+      "directional decision support",
+      "compare activities, environments, and interests"
+    ],
+    "forbidden": [
+      "admission prediction",
+      "guaranteed best major",
+      "hiring prediction",
+      "salary or career success prediction",
+      "medical or psychological diagnosis",
+      "official certification claim without evidence"
+    ]
+  },
+  "evidence_sources": [
+    "https://fermatmind.com/sitemap.xml",
+    "backend/docs/seo/daily-runs/2026-07-05/riasec-zh-test-landing-p0-diagnostic-01/",
+    "backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/",
+    "backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/"
+  ],
+  "next_requested_train_item": "DAILY-MODE-C-TOPIC-SELECTION-20260706",
+  "deferred_items": [
+    "no CMS write",
+    "no article draft creation",
+    "no publish or unpublish",
+    "no sitemap or llms edits",
+    "no schema/canonical/noindex changes",
+    "no search submission",
+    "no GSC/GA purchase truth",
+    "no staging deploy wait",
+    "no manual deploy",
+    "no production deploy"
+  ],
+  "validation": {
+    "json_tool": "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/scan_manifest.json >/dev/null",
+    "diff_check": "git diff --check",
+    "cached_diff_check": "git diff --cached --check"
+  }
+}


### PR DESCRIPTION
## What changed
- Added a generated-only read-only plan for the Chinese RIASEC / gaokao / major / career scenario cluster.
- Mapped the money owner, explainer layer, gaokao/major scenario pages, career direction support, internal-link direction, and claim boundaries.
- Identified the next train item as `DAILY-MODE-C-TOPIC-SELECTION-20260706`.

## Why
The previous inventories showed RIASEC has a strong Chinese scenario cluster and should be planned before daily topic selection or distribution assets. This PR keeps planning separate from content creation and CMS changes.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: staged changes are limited to `backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/`

## Deferred items
- No CMS writes, article draft creation, publishing, sitemap/llms edits, schema/canonical/noindex changes, search submission, GSC/GA purchase-truth use, staging deploy wait, manual deploy, or production deploy.
