### PR TITLE
DAILY-MODE-C-TOPIC-SELECTION-20260706: select Mode C topic

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/CANDIDATE_RANKING.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/CANDIDATE_RANKING.md
@@ -1,0 +1,41 @@
+# Candidate Ranking
+
+## Ranking Matrix
+
+| Rank | Candidate | Decision | Reason |
+| --- | --- | --- | --- |
+| 1 | `gaokao-major-adjustment-unacceptable-major-checklist` | `selected` | Highest urgency, clearest checklist shape, strong RIASEC bridge, low claim risk when bounded correctly. |
+| 2 | `gaokao-score-major-shortlist-riasec-checklist` | `alternate` | Strong planning intent, but less urgent than post-adjustment anxiety. Useful next after the selected topic. |
+| 3 | `hot-major-fit-riasec-course-career-checklist` | `alternate` | Good seasonal and parent/student conflict potential, but needs careful handling to avoid promising hot-major outcomes. |
+| 4 | `math-not-good-computer-ai-major-course-riasec-checklist` | `alternate` | Strong concrete pain point, but can drift into academic/career prediction claims if not tightly edited. |
+| 5 | `unwanted-major-adjustment-riasec-transfer-plan` | `hold` | Close to the selected topic and risks cannibalization. Fold transfer-plan ideas into the selected checklist first. |
+
+## Why Not Pick A Six-Test Hub Topic Today
+
+The six-test hub audit already found multiple hub gaps, but those are better handled as explicit hub completeness repair or planning PRs. Daily Mode C selection should not mutate hub pages, title/meta, FAQ, CTA, schema, sitemap, `llms`, or backend authority rows.
+
+## Why Not Pick A Money-Intent Rewrite Today
+
+The money-intent audit mapped owner pages, but the GSC/seo_intel quality gate is currently blocked. That makes title/meta/CTR repair premature. A new claim-safe scenario topic is lower risk than rewriting a high-intent owner page from noisy data.
+
+## Why RIASEC / Gaokao / Major Wins Today
+
+The RIASEC cluster has:
+
+- direct support from the cluster plan;
+- a clean CTA to the RIASEC owner page;
+- strong Chinese career-decision intent;
+- a natural answer-block format;
+- obvious internal-link structure;
+- low need for unavailable analytics evidence.
+
+## Deferred Follow-Up Candidates
+
+Potential future PRs after this generated-only train:
+
+- `RIASEC-RESULT-INTERPRETATION-CONTENT-PLAN-01`
+- `GAOKAO-SCORE-MAJOR-SHORTLIST-MODE-C-PACKAGE-01`
+- `HOT-MAJOR-FIT-RIASEC-MODE-C-PACKAGE-01`
+- `SIX-TEST-HUB-COMPLETENESS-REPAIR-PLAN-01`
+
+These are not authorized by this PR.

--- a/backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/EXECUTIVE_DECISION.md
@@ -1,0 +1,81 @@
+# DAILY-MODE-C-TOPIC-SELECTION-20260706
+
+Date: 2026-07-06
+Repo: fap-api
+Scope: generated-only / read-only daily Mode C topic selection
+Runtime impact: none
+CMS impact: none
+Search submission impact: none
+Deploy impact: none
+
+## Decision
+
+Decision output: `go_for_mode_c_package_prompt_gaokao_major_adjustment_unacceptable_major_checklist`
+
+The recommended Mode C topic is:
+
+`gaokao-major-adjustment-unacceptable-major-checklist`
+
+Recommended public article angle:
+
+`被调剂到不想去的专业怎么办：用兴趣、课程和转专业条件做一次冷静复盘`
+
+This topic should be selected before adjacent RIASEC topics because it has:
+
+- high immediate user urgency;
+- clean route back to the RIASEC test owner without promising admission, transfer, salary, or career outcomes;
+- a natural checklist format for GEO/AEO answer surfaces;
+- a clear claim-safe boundary: RIASEC is an exploration signal, not an admission or employment predictor;
+- a strong fit with the existing Chinese RIASEC / gaokao / major cluster plan.
+
+## Operation Type
+
+Recommended operation type: `new_article_package_prompt_only`
+
+This PR does not create the article body, CMS package, CMS draft, publication, schema, sitemap, `llms`, Search Channel, or search-provider submission. The selected topic should move next into a generated-only distribution asset package, then a separate authorized content-package lane if the operator approves.
+
+## Primary Owner And Support Routes
+
+Money owner:
+
+- `/zh/tests/holland-career-interest-test-riasec`
+
+Support routes already identified by the read-only train:
+
+- `/zh/articles/gaokao-major-adjustment-unacceptable-major-checklist`
+- `/zh/articles/riasec-holland-career-interest-test-explained`
+- `/zh/articles/gaokao-score-major-shortlist-riasec-checklist`
+- `/zh/articles/hot-major-fit-riasec-course-career-checklist`
+
+Private result, report, attempt, lookup, order, account, payment, and tokenized URLs remain excluded from the plan.
+
+## Held Lanes
+
+Held until separate exact authorization:
+
+- CMS draft/import/write/publish;
+- runtime page changes;
+- public frontend changes;
+- title/meta/H1 mutation on existing pages;
+- schema, hreflang, canonical, noindex, sitemap, `llms`, or `llms-full`;
+- GSC Request Indexing, IndexNow, Baidu, 360, Sogou, Shenma, or Search Channel writes;
+- staging or production deploy verification.
+
+## Next Train Item
+
+Proceed to:
+
+`DAILY-DISTRIBUTION-ASSET-PACKAGE-20260706`
+
+Reason: this PR selects one topic only. The next PR may generate non-published distribution assets for the selected topic, still under generated-only scope.
+
+## Deferred Items
+
+This PR intentionally does not:
+
+- write or rewrite article body content;
+- create CMS import packages;
+- publish or unpublish anything;
+- make public URL, sitemap, `llms`, schema, canonical, noindex, Search, or deploy changes;
+- use GSC/GA as purchase truth;
+- treat missing analytics exports as zero.

--- a/backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/TOPIC_SELECTION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/TOPIC_SELECTION.md
@@ -1,0 +1,97 @@
+# Topic Selection
+
+## Recommended Topic
+
+| Field | Value |
+| --- | --- |
+| Topic id | `gaokao-major-adjustment-unacceptable-major-checklist` |
+| Locale | `zh-CN` |
+| Primary silo | RIASEC / 高考 / 专业选择 / 职业探索 |
+| Operation | `new_article_package_prompt_only` |
+| Decision | `GO_FOR_MODE_C_PACKAGE_PROMPT` |
+| Primary CTA | `/zh/tests/holland-career-interest-test-riasec` |
+| Claim posture | Use RIASEC as interest/course-fit reflection only. Do not imply admission, transfer, job, salary, or career-success prediction. |
+
+## Search Intent
+
+The target reader has received, fears receiving, or is evaluating a major adjustment result that does not match their preference. Their job is not to be reassured with a fixed answer. Their job is to decide what to check next:
+
+- whether the major is truly unacceptable or only unfamiliar;
+- whether the course structure conflicts with their interests and strengths;
+- whether transfer, minor, second degree, exam, or career exploration paths exist;
+- whether to retake, accept, negotiate with family, or build a fallback plan.
+
+## Target Queries
+
+Primary query family:
+
+- `被调剂到不喜欢的专业怎么办`
+- `高考调剂到不想去的专业`
+- `不想读被调剂的专业怎么办`
+
+Secondary query family:
+
+- `专业不喜欢可以转专业吗`
+- `怎么判断专业适不适合自己`
+- `霍兰德职业兴趣测试 专业选择`
+- `职业兴趣测试 高考志愿`
+
+## Title And Meta Direction
+
+Title direction:
+
+`被调剂到不想去的专业怎么办：兴趣、课程和转专业检查清单`
+
+Meta direction:
+
+`先别用“喜欢/不喜欢”直接下结论。用课程结构、兴趣类型、转专业条件和未来职业方向做一次复盘，再决定接受、调整还是准备备选方案。`
+
+H1 direction:
+
+`被调剂到不想去的专业怎么办`
+
+These are directions for a later content package only. This PR does not write CMS title, meta, H1, or article body.
+
+## Answer Block Shape
+
+The article should answer directly:
+
+> 被调剂到不想去的专业时，先把问题拆成课程是否能接受、兴趣是否严重冲突、学校转专业条件、家庭和成本约束、未来职业方向五项。RIASEC 可以帮助你整理兴趣和活动偏好，但不能替你预测录取、转专业成功率或职业结果。
+
+## Internal Link Targets
+
+Recommended internal links for a later package:
+
+- RIASEC money owner: `/zh/tests/holland-career-interest-test-riasec`
+- RIASEC explainer: `/zh/articles/riasec-holland-career-interest-test-explained`
+- Gaokao shortlist support: `/zh/articles/gaokao-score-major-shortlist-riasec-checklist`
+- Hot major fit support: `/zh/articles/hot-major-fit-riasec-course-career-checklist`
+
+Do not link to private result, report, attempt, order, payment, share, account, or tokenized URLs.
+
+## Claim Risks
+
+Forbidden claims:
+
+- RIASEC can decide the best major.
+- RIASEC can predict admission, transfer, employment, salary, or career success.
+- A test result can overrule school policy, family constraints, medical/legal/financial advice, or professional counseling.
+- The article knows the reader's final answer without their school policy, score, family situation, and course preference.
+
+Allowed claims:
+
+- RIASEC can organize interest and activity-preference signals.
+- Course structure, major curriculum, transfer rules, and career direction should be checked separately.
+- The checklist can support a calmer conversation with family or advisors.
+
+## Observation Plan
+
+Future observation should remain read-only and separate from this PR:
+
+- GSC page/query impressions, clicks, CTR, and average position after publication;
+- GA organic sessions if available;
+- article-to-test click events if already tracked;
+- RIASEC test start events if already tracked;
+- no purchase truth inferred from GSC/GA alone.
+
+Because `GSC-SEO-INTEL-QUALITY-REFRESH-READONLY-01` blocked the current data gate, this topic selection uses inventory and strategy evidence, not current GSC query metrics.

--- a/backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/scan_manifest.json
@@ -1,0 +1,43 @@
+{
+  "id": "DAILY-MODE-C-TOPIC-SELECTION-20260706",
+  "date": "2026-07-06",
+  "repo": "fap-api",
+  "scope": "generated-only/read-only daily Mode C topic selection",
+  "decision": "GO_FOR_MODE_C_PACKAGE_PROMPT",
+  "selected_topic": {
+    "topic_id": "gaokao-major-adjustment-unacceptable-major-checklist",
+    "locale": "zh-CN",
+    "operation_type": "new_article_package_prompt_only",
+    "primary_owner_url": "/zh/tests/holland-career-interest-test-riasec"
+  },
+  "evidence_inputs": [
+    "backend/docs/seo/daily-runs/2026-07-06/six-test-hub-completeness-readonly-audit-01/",
+    "backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/",
+    "backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/",
+    "backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/",
+    "backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/"
+  ],
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "TOPIC_SELECTION.md",
+    "CANDIDATE_RANKING.md",
+    "scan_manifest.json"
+  ],
+  "forbidden_actions_not_performed": [
+    "cms_write",
+    "article_body_generation",
+    "runtime_change",
+    "frontend_change",
+    "schema_change",
+    "hreflang_change",
+    "canonical_change",
+    "noindex_change",
+    "sitemap_change",
+    "llms_change",
+    "search_submission",
+    "manual_deploy",
+    "production_deploy",
+    "staging_deploy_wait"
+  ],
+  "next_train_item": "DAILY-DISTRIBUTION-ASSET-PACKAGE-20260706"
+}


### PR DESCRIPTION
## What changed
- Added a generated-only daily Mode C topic selection report for 2026-07-06.
- Selected `gaokao-major-adjustment-unacceptable-major-checklist` as the recommended zh-CN RIASEC/gaokao/major topic.
- Added candidate ranking, claim boundaries, internal-link direction, held lanes, and a JSON scan manifest.

## Why
- The preceding read-only audits point to Chinese RIASEC / gaokao / major scenarios as the next safe growth lane.
- Current GSC/seo_intel quality gates are blocked, so this uses inventory and strategy evidence instead of noisy CTR data.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: staged files limited to `backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/`

## Deferred items
- No CMS write, article body generation, runtime/frontend change, schema/hreflang/canonical/noindex/sitemap/llms change, Search submission, deploy, or staging wait.
- Downstream distribution assets remain a separate PR scope.