### PR TITLE
DAILY-DISTRIBUTION-ASSET-PACKAGE-20260706: add unpublished assets

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/CLAIM_GUARD_AND_CHANNEL_HOLDS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/CLAIM_GUARD_AND_CHANNEL_HOLDS.md
@@ -1,0 +1,59 @@
+# Claim Guard And Channel Holds
+
+## Allowed Language
+
+Allowed:
+
+- RIASEC can help organize interests, activity preferences, and exploration directions.
+- Course structure, school transfer rules, family constraints, and career direction should be checked separately.
+- A checklist can help make the conversation calmer and more concrete.
+- The article can suggest questions to ask, not final outcomes to believe.
+
+## Forbidden Language
+
+Forbidden:
+
+- RIASEC decides the best major.
+- RIASEC predicts admission, transfer success, employment, salary, or career success.
+- A test result overrides school policy, family constraints, professional counseling, medical/legal/financial advice, or the student's lived context.
+- A single checklist can guarantee the right decision.
+- FermatMind has official school, ministry, counseling, or clinical endorsement without separate public evidence.
+
+## Channel Holds
+
+This package is held for all live channels:
+
+| Channel | Status | Reason |
+| --- | --- | --- |
+| CMS draft/import | held | Requires separate content-package authorization. |
+| Public publish | held | No full article body or operator approval in this PR. |
+| WeChat/social posting | held | Assets are planning drafts only. |
+| GSC Request Indexing | held | Search action is outside scope. |
+| IndexNow/Baidu/360/Sogou/Shenma | held | Search submission is outside scope. |
+| Sitemap/llms | held | Discoverability surfaces are outside scope. |
+| Schema/hreflang | held | Structured data and localization gates are outside scope. |
+| Deploy/revalidation | held | No runtime mutation exists in this PR. |
+
+## Public URL Guard
+
+Allowed public route references:
+
+- `/zh/tests/holland-career-interest-test-riasec`
+- `/zh/articles/riasec-holland-career-interest-test-explained`
+- `/zh/articles/gaokao-score-major-shortlist-riasec-checklist`
+- `/zh/articles/hot-major-fit-riasec-course-career-checklist`
+
+Disallowed route references:
+
+- private result/report/attempt/share/history URLs;
+- order/payment/account/auth URLs;
+- tokenized, preview-only, local, or admin URLs;
+- fake Media Library URLs.
+
+## Review Checklist Before Any Future Publication
+
+- Confirm the final article body exists and passes claim review.
+- Confirm all links are public and canonical.
+- Confirm the CTA points to the RIASEC owner page without deterministic career claims.
+- Confirm no Search submission or discoverability action is bundled with CMS publish unless separately authorized.
+- Confirm observation is read-only and does not treat GSC/GA as purchase truth.

--- a/backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/DISTRIBUTION_ASSETS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/DISTRIBUTION_ASSETS.md
@@ -1,0 +1,75 @@
+# Distribution Assets
+
+These assets are unpublished planning copy. They are not CMS content, not final article body, and not authorized for public posting by this PR.
+
+## Topic Summary
+
+Topic id: `gaokao-major-adjustment-unacceptable-major-checklist`
+
+One-line summary:
+
+`被调剂到不想去的专业时，先用课程、兴趣、转专业条件和未来方向做一次复盘，再决定接受、调整还是准备备选方案。`
+
+Short summary:
+
+`高考调剂不是只能“忍”或“重来”。先确认课程结构、兴趣冲突、学校转专业规则、家庭成本和未来职业方向，再把结果带回一次可讨论的选择。RIASEC 可以帮助整理兴趣和活动偏好，但不能预测录取、转专业成功率、就业或收入。`
+
+## WeChat Outline
+
+Suggested post outline:
+
+1. `先别急着把专业判死刑`
+2. `第一步：看课程，不只看专业名字`
+3. `第二步：把“不喜欢”拆成兴趣、能力、环境和想象差异`
+4. `第三步：查清楚转专业、辅修、双学位和考研路径`
+5. `第四步：用 RIASEC 做兴趣复盘，但不要让测试替你做决定`
+6. `第五步：把选择变成三套方案：接受并调整、入学后转向、重新规划`
+
+## Social Caption Drafts
+
+Caption A:
+
+`被调剂到不想去的专业，不要只问“要不要去”。先问五件事：课程能不能接受、兴趣冲突有多大、能不能转专业、家庭成本能否承受、未来方向还有没有路。`
+
+Caption B:
+
+`专业调剂最怕的是只看名字就下结论。把课程表、转专业规则和自己的兴趣偏好放在一起看，结论通常会更清楚。`
+
+Caption C:
+
+`RIASEC 职业兴趣测试可以帮你整理兴趣线索，但不能预测录取、就业或收入。它更适合放在专业复盘清单里，作为一个讨论工具。`
+
+## CTA Snippets
+
+Primary CTA:
+
+`想先整理自己的兴趣方向，可以从霍兰德 RIASEC 职业兴趣测试开始：/zh/tests/holland-career-interest-test-riasec`
+
+Soft CTA:
+
+`如果你还说不清自己是排斥专业名字、课程内容，还是未来职业想象，可以先做一次 RIASEC 兴趣复盘，再回到专业清单里逐项判断。`
+
+Boundary CTA:
+
+`测试结果只适合帮助你整理兴趣和活动偏好，不能替你决定志愿、转专业、就业或收入。真正做决定前，还要看学校政策、课程安排和家庭条件。`
+
+## Internal Link Suggestions
+
+| Link target | Role |
+| --- | --- |
+| `/zh/tests/holland-career-interest-test-riasec` | Primary CTA and money owner. |
+| `/zh/articles/riasec-holland-career-interest-test-explained` | Explain what RIASEC can and cannot tell users. |
+| `/zh/articles/gaokao-score-major-shortlist-riasec-checklist` | Support earlier志愿 shortlist planning. |
+| `/zh/articles/hot-major-fit-riasec-course-career-checklist` | Support adjacent hot-major fit decisions. |
+
+Do not include private result, report, attempt, order, payment, share, account, token, or lookup URLs.
+
+## Answer Surface Snippets
+
+Direct answer:
+
+`被调剂到不想去的专业时，先确认课程结构、兴趣冲突、转专业条件、家庭成本和未来职业方向。不要只凭专业名字判断，也不要让测试结果替你做决定。RIASEC 可以作为兴趣复盘工具，但不能预测录取、转专业、就业或收入。`
+
+Checklist answer:
+
+`可以按五步检查：看课程表、拆解不喜欢的原因、查学校转专业规则、列出未来职业方向、准备接受/转向/重来的备选方案。`

--- a/backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/EXECUTIVE_DECISION.md
@@ -1,0 +1,68 @@
+# DAILY-DISTRIBUTION-ASSET-PACKAGE-20260706
+
+Date: 2026-07-06
+Repo: fap-api
+Scope: generated-only / unpublished distribution asset package
+Runtime impact: none
+CMS impact: none
+Search submission impact: none
+Deploy impact: none
+
+## Decision
+
+Decision output: `distribution_asset_package_ready_for_operator_review_unpublished`
+
+This PR creates an unpublished distribution asset package for the selected daily topic:
+
+`gaokao-major-adjustment-unacceptable-major-checklist`
+
+Working topic:
+
+`被调剂到不想去的专业怎么办：兴趣、课程和转专业检查清单`
+
+The package is designed for later operator review and separate content-package work. It is not a publication action and does not create a CMS draft, article body, public page, Search submission, schema, sitemap, `llms`, deploy, or runtime change.
+
+## Asset Set
+
+Generated assets:
+
+- short summary;
+- WeChat/social outline;
+- claim-safe CTA snippets;
+- internal-link suggestion map;
+- channel hold checklist;
+- claim-boundary checklist.
+
+## Source Evidence
+
+Primary upstream decision:
+
+- `backend/docs/seo/daily-runs/2026-07-06/daily-mode-c-topic-selection-20260706/`
+
+Supporting upstream evidence:
+
+- `backend/docs/seo/daily-runs/2026-07-06/zh-riasec-gaokao-major-career-cluster-plan-01/`
+- `backend/docs/seo/daily-runs/2026-07-06/result-interpretation-page-inventory-readonly-01/`
+- `backend/docs/seo/daily-runs/2026-07-06/money-intent-owner-page-map-readonly-01/`
+- `backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/`
+
+## Held Lanes
+
+Held until separate exact authorization:
+
+- CMS write/import/publish/promote;
+- full article body generation;
+- production import or deploy;
+- runtime/frontend mutation;
+- title/meta/H1 changes on public pages;
+- schema, hreflang, canonical, noindex, sitemap, `llms`, or `llms-full`;
+- Search Channel, GSC, IndexNow, Baidu, 360, Sogou, or Shenma submission.
+
+## Train Status
+
+This is the last currently executable PR in the read-only train. The next two MBTI FAQ observation tasks are date-gated:
+
+- `MBTI-MAIN-FAQ-D7-OBSERVATION-01`: hold until 2026-07-12.
+- `MBTI-MAIN-FAQ-D28-OBSERVATION-01`: hold until 2026-08-02.
+
+`RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01` remains explicitly not executed.

--- a/backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/scan_manifest.json
@@ -1,0 +1,59 @@
+{
+  "id": "DAILY-DISTRIBUTION-ASSET-PACKAGE-20260706",
+  "date": "2026-07-06",
+  "repo": "fap-api",
+  "scope": "generated-only/unpublished distribution asset package",
+  "decision": "distribution_asset_package_ready_for_operator_review_unpublished",
+  "selected_topic": {
+    "topic_id": "gaokao-major-adjustment-unacceptable-major-checklist",
+    "working_title": "被调剂到不想去的专业怎么办：兴趣、课程和转专业检查清单",
+    "primary_owner_url": "/zh/tests/holland-career-interest-test-riasec"
+  },
+  "assets": [
+    "short_summary",
+    "wechat_outline",
+    "social_caption_drafts",
+    "cta_snippets",
+    "internal_link_suggestions",
+    "answer_surface_snippets",
+    "claim_guard",
+    "channel_holds"
+  ],
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "DISTRIBUTION_ASSETS.md",
+    "CLAIM_GUARD_AND_CHANNEL_HOLDS.md",
+    "scan_manifest.json"
+  ],
+  "forbidden_actions_not_performed": [
+    "cms_write",
+    "cms_import",
+    "article_body_generation",
+    "public_posting",
+    "runtime_change",
+    "frontend_change",
+    "schema_change",
+    "hreflang_change",
+    "canonical_change",
+    "noindex_change",
+    "sitemap_change",
+    "llms_change",
+    "search_submission",
+    "manual_deploy",
+    "production_deploy",
+    "staging_deploy_wait"
+  ],
+  "date_gated_followups": [
+    {
+      "id": "MBTI-MAIN-FAQ-D7-OBSERVATION-01",
+      "not_before": "2026-07-12"
+    },
+    {
+      "id": "MBTI-MAIN-FAQ-D28-OBSERVATION-01",
+      "not_before": "2026-08-02"
+    }
+  ],
+  "explicitly_not_executed": [
+    "RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added a generated-only, unpublished distribution asset package for `gaokao-major-adjustment-unacceptable-major-checklist`.
- Included short summaries, WeChat/social outline, CTA snippets, internal-link suggestions, answer-surface snippets, claim guard, channel holds, and a JSON scan manifest.

## Why
- The daily Mode C topic selection PR selected this RIASEC/gaokao/major topic as the next safe content lane.
- This package prepares operator-review assets without crossing into CMS, runtime, publish, or search actions.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: staged files limited to `backend/docs/seo/daily-runs/2026-07-06/daily-distribution-asset-package-20260706/`

## Deferred items
- No CMS write/import/publish, full article body generation, public posting, runtime/frontend change, schema/hreflang/canonical/noindex/sitemap/llms change, Search submission, deploy, or staging wait.
- MBTI D7/D28 observation items remain date-gated.
- RIASEC FAQ parity readback remains explicitly not executed.