### PR TITLE
PR12B: Big Five CMS publish gate

### DIFF
--- a/backend/app/Console/Commands/PersonalityBigFiveCmsPublishGate.php
+++ b/backend/app/Console/Commands/PersonalityBigFiveCmsPublishGate.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\BigFiveCmsImportDraftDryRunPlanner;
+use App\Services\Cms\BigFiveCmsPublishGateWriter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityBigFiveCmsPublishGate extends Command
+{
+    public const CONFIRMATION_PHRASE = 'I authorize these 20 zh-CN Big Five v2 pages for CMS content-ready only. Keep noindex, no sitemap, no llms, no JSON-LD runtime, no English pages, no SEO release, and no production deploy.';
+
+    protected $signature = 'personality:big-five-cms-publish-gate
+        {--package= : Path to the Big Five cms-import-draft package}
+        {--confirm-package-sha256= : Required package SHA-256}
+        {--authorized-slugs= : Required comma-separated exact 20 zh-CN trait/range slug allowlist}
+        {--target-env= : Required target environment, production, staging, or dev}
+        {--operator-approved= : Required exact confirmation phrase}
+        {--dry-run : Validate and plan without database writes}
+        {--write : Write only the authorized 20 zh-CN content-ready rows}
+        {--allow-testing : Permit APP_ENV=testing with sqlite for automated tests only}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}';
+
+    protected $description = 'Controlled Big Five CMS content-ready gate for exactly 20 authorized zh-CN v2 trait/range pages.';
+
+    public function handle(BigFiveCmsImportDraftDryRunPlanner $planner, BigFiveCmsPublishGateWriter $writer): int
+    {
+        try {
+            $summary = $this->guardedRun($planner, $writer);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary($exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary($exception->getMessage(), 'unexpected_error');
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function guardedRun(BigFiveCmsImportDraftDryRunPlanner $planner, BigFiveCmsPublishGateWriter $writer): array
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $write = (bool) $this->option('write');
+        if ($dryRun === $write) {
+            throw new RuntimeException('Exactly one of --dry-run or --write is required.');
+        }
+
+        $targetEnvironment = strtolower(trim((string) $this->option('target-env')));
+        if (! in_array($targetEnvironment, ['production', 'staging', 'dev'], true)) {
+            throw new RuntimeException('--target-env must be production, staging, or dev.');
+        }
+
+        $this->guardRuntimeEnvironment($targetEnvironment);
+
+        if (trim((string) $this->option('operator-approved')) !== self::CONFIRMATION_PHRASE) {
+            throw new RuntimeException('--operator-approved must match the Big Five CMS publish gate confirmation phrase.');
+        }
+
+        $authorizedSlugs = $this->authorizedSlugs();
+        $packagePath = $this->resolvePath((string) $this->option('package'), '--package');
+        $packageRaw = (string) File::get($packagePath);
+        $sourceSha256 = hash('sha256', $packageRaw);
+        $expectedSha256 = strtolower(trim((string) $this->option('confirm-package-sha256')));
+        if ($expectedSha256 === '' || $expectedSha256 !== $sourceSha256) {
+            throw new RuntimeException('Package SHA-256 mismatch; refusing Big Five CMS publish gate.');
+        }
+
+        $package = json_decode($packageRaw, true);
+        if (! is_array($package)) {
+            throw new RuntimeException('Package must be a JSON array or object.');
+        }
+
+        $plan = $planner->plan($package, $sourceSha256);
+        if (($plan['ok'] ?? false) !== true) {
+            throw new RuntimeException('No-write import planner failed; refusing Big Five CMS publish gate.');
+        }
+
+        if ((int) ($plan['row_count'] ?? 0) !== 42 || ($plan['row_count_matches_expected'] ?? false) !== true) {
+            throw new RuntimeException('Expected exactly 42 valid Big Five CMS rows.');
+        }
+
+        if ((int) ($plan['old_short_big_five_route_residue_count'] ?? 0) !== 0) {
+            throw new RuntimeException('Old /zh/big-five or /en/big-five route residue blocks Big Five CMS publish gate.');
+        }
+
+        return $write
+            ? $writer->write($package, $plan, $sourceSha256, $packagePath, $targetEnvironment, $authorizedSlugs)
+            : $writer->plan($package, $plan, $sourceSha256, $packagePath, $targetEnvironment, $authorizedSlugs);
+    }
+
+    private function guardRuntimeEnvironment(string $targetEnvironment): void
+    {
+        $appEnvironment = app()->environment();
+
+        if ((bool) $this->option('allow-testing')) {
+            if ($appEnvironment !== 'testing' || config('database.default') !== 'sqlite') {
+                throw new RuntimeException('--allow-testing is only valid for APP_ENV=testing with sqlite.');
+            }
+
+            return;
+        }
+
+        if ($targetEnvironment === 'production' && ! in_array($appEnvironment, ['production', 'prod'], true)) {
+            throw new RuntimeException('Target production requires APP_ENV=production.');
+        }
+
+        if ($targetEnvironment === 'staging' && $appEnvironment !== 'staging') {
+            throw new RuntimeException('Target staging requires APP_ENV=staging.');
+        }
+
+        if ($targetEnvironment === 'dev' && ! in_array($appEnvironment, ['dev', 'local'], true)) {
+            throw new RuntimeException('Target dev requires APP_ENV=dev or APP_ENV=local.');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function authorizedSlugs(): array
+    {
+        $raw = trim((string) $this->option('authorized-slugs'));
+        if ($raw === '') {
+            throw new RuntimeException('--authorized-slugs is required.');
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            explode(',', $raw)
+        )));
+    }
+
+    private function resolvePath(string $path, string $option): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            throw new RuntimeException($option.' is required.');
+        }
+
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException($option.' file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('target_environment='.(string) ($summary['target_environment'] ?? ''));
+        $this->line('row_count='.(string) ($summary['row_count'] ?? 0));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('cms_write_attempted='.(($summary['cms_write_attempted'] ?? false) ? '1' : '0'));
+        $this->line('created_asset_count='.(string) ($summary['created_asset_count'] ?? 0));
+        $this->line('updated_asset_count='.(string) ($summary['updated_asset_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $message, string $code = 'runtime_error'): array
+    {
+        return [
+            'artifact' => 'BIG5-CMS-PUBLISH-GATE-12',
+            'status' => 'fail',
+            'ok' => false,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'publish_attempted' => false,
+            'content_ready_attempted' => false,
+            'index_attempted' => false,
+            'search_release_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'jsonld_runtime_release_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Services/Cms/BigFiveCmsPublishGateWriter.php
+++ b/backend/app/Services/Cms/BigFiveCmsPublishGateWriter.php
@@ -1,0 +1,602 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+
+final class BigFiveCmsPublishGateWriter
+{
+    public const SOURCE_PACKAGE = 'big-five-cms-import-draft-polished.v2';
+
+    public const REVIEW_STATE = 'operator_approved_content_ready';
+
+    public const AUTHORIZED_ZH_CN_SLUGS = [
+        'openness',
+        'conscientiousness',
+        'extraversion',
+        'agreeableness',
+        'neuroticism',
+        'openness-high',
+        'openness-mid',
+        'openness-low',
+        'conscientiousness-high',
+        'conscientiousness-mid',
+        'conscientiousness-low',
+        'extraversion-high',
+        'extraversion-mid',
+        'extraversion-low',
+        'agreeableness-high',
+        'agreeableness-mid',
+        'agreeableness-low',
+        'neuroticism-high',
+        'neuroticism-mid',
+        'neuroticism-low',
+    ];
+
+    private const AUTHORIZED_CONTENT_TYPES = [
+        'trait_page',
+        'trait_range_page',
+    ];
+
+    /**
+     * @param  array<mixed>  $package
+     * @param  array<string,mixed>  $plan
+     * @param  list<string>  $authorizedSlugs
+     * @return array<string,mixed>
+     */
+    public function plan(
+        array $package,
+        array $plan,
+        string $sourceSha256,
+        string $packagePath,
+        string $targetEnvironment,
+        array $authorizedSlugs
+    ): array {
+        return $this->buildSummary($package, $plan, $sourceSha256, $packagePath, $targetEnvironment, $authorizedSlugs, false);
+    }
+
+    /**
+     * @param  array<mixed>  $package
+     * @param  array<string,mixed>  $plan
+     * @param  list<string>  $authorizedSlugs
+     * @return array<string,mixed>
+     */
+    public function write(
+        array $package,
+        array $plan,
+        string $sourceSha256,
+        string $packagePath,
+        string $targetEnvironment,
+        array $authorizedSlugs
+    ): array {
+        return DB::transaction(fn (): array => $this->buildSummary(
+            $package,
+            $plan,
+            $sourceSha256,
+            $packagePath,
+            $targetEnvironment,
+            $authorizedSlugs,
+            true
+        ));
+    }
+
+    /**
+     * @param  array<mixed>  $package
+     * @param  array<string,mixed>  $plan
+     * @param  list<string>  $authorizedSlugs
+     * @return array<string,mixed>
+     */
+    private function buildSummary(
+        array $package,
+        array $plan,
+        string $sourceSha256,
+        string $packagePath,
+        string $targetEnvironment,
+        array $authorizedSlugs,
+        bool $write
+    ): array {
+        if (! Schema::hasTable((new PersonalityPublicContentAsset)->getTable())) {
+            throw new RuntimeException('personality_public_content_assets table is missing; run migrations before Big Five CMS publish gate.');
+        }
+
+        $this->guardAuthorizedSlugList($authorizedSlugs);
+
+        $rows = $this->rows($package);
+        $rowPlans = array_values(is_array($plan['rows'] ?? null) ? $plan['rows'] : []);
+        if (count($rows) !== 42 || count($rowPlans) !== 42) {
+            throw new RuntimeException('Expected exactly 42 package rows and 42 dry-run row plans.');
+        }
+
+        $selected = $this->selectedRows($rows, $rowPlans);
+        if (count($selected) !== 20) {
+            throw new RuntimeException('Expected exactly 20 authorized zh-CN trait/range rows for Big Five publish gate.');
+        }
+
+        $selectedSlugs = array_map(static fn (array $row): string => (string) ($row['row']['slug'] ?? ''), $selected);
+        $this->guardAuthorizedSlugList($selectedSlugs);
+
+        $planned = [];
+        $created = 0;
+        $updated = 0;
+        $skipped = 0;
+        $errors = [];
+        $preImportSnapshot = [];
+
+        foreach ($selected as $selectedRow) {
+            $row = $selectedRow['row'];
+            $rowPlan = $selectedRow['row_plan'];
+            $identity = is_array($rowPlan['identity'] ?? null) ? $rowPlan['identity'] : [];
+            $attributes = $this->attributesForRow($row, $rowPlan, $sourceSha256, $packagePath, $targetEnvironment);
+            $existing = $this->existingAsset($identity);
+            $preImportSnapshot[] = $this->snapshotRow($existing);
+            $action = 'create_content_ready_asset';
+
+            if ($existing instanceof PersonalityPublicContentAsset) {
+                if (! $this->existingAssetIsWritableContentGateTarget($existing)) {
+                    $errors[] = [
+                        'field' => 'rows.'.((string) ($selectedRow['position'] - 1)),
+                        'code' => 'existing_asset_blocks_content_ready_gate',
+                        'message' => 'Existing published/indexable/search-released or foreign-source Big Five asset blocks PR12 publish gate.',
+                    ];
+                }
+
+                $action = $this->attributesMatch($existing, $attributes)
+                    ? 'skip_existing_same_source_content_ready'
+                    : 'update_existing_content_ready_asset';
+            }
+
+            $planned[] = [
+                'position' => $selectedRow['position'],
+                'slug' => (string) ($row['slug'] ?? ''),
+                'content_type' => (string) ($row['content_type'] ?? ''),
+                'canonical_path' => (string) ($rowPlan['canonical_path'] ?? $row['canonical_path'] ?? ''),
+                'identity' => $identity,
+                'existing_asset_id' => $existing?->id !== null ? (int) $existing->id : null,
+                'action' => $action,
+            ];
+        }
+
+        if ($errors !== []) {
+            return $this->summary($sourceSha256, $packagePath, $targetEnvironment, $write, $planned, $preImportSnapshot, 0, 0, 0, $errors);
+        }
+
+        if ($write) {
+            foreach ($planned as $index => &$plannedRow) {
+                $selectedRow = $selected[$index];
+                $identity = is_array($plannedRow['identity'] ?? null) ? $plannedRow['identity'] : [];
+                $existing = $this->existingAsset($identity);
+                $attributes = $this->attributesForRow($selectedRow['row'], $selectedRow['row_plan'], $sourceSha256, $packagePath, $targetEnvironment);
+
+                if ($existing instanceof PersonalityPublicContentAsset && $this->attributesMatch($existing, $attributes)) {
+                    $plannedRow['action'] = 'skipped_existing_same_source_content_ready';
+                    $skipped++;
+
+                    continue;
+                }
+
+                if ($existing instanceof PersonalityPublicContentAsset) {
+                    $existing->fill($attributes);
+                    $existing->save();
+                    $plannedRow['action'] = 'updated_content_ready_asset';
+                    $updated++;
+
+                    continue;
+                }
+
+                $createdAsset = PersonalityPublicContentAsset::query()->create($attributes);
+                $plannedRow['existing_asset_id'] = (int) $createdAsset->id;
+                $plannedRow['action'] = 'created_content_ready_asset';
+                $created++;
+            }
+            unset($plannedRow);
+        }
+
+        return $this->summary($sourceSha256, $packagePath, $targetEnvironment, $write, $planned, $preImportSnapshot, $created, $updated, $skipped, []);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function guardAuthorizedSlugList(array $slugs): void
+    {
+        $normalized = array_values(array_unique(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            $slugs
+        )));
+        sort($normalized);
+
+        $expected = self::AUTHORIZED_ZH_CN_SLUGS;
+        sort($expected);
+
+        if ($normalized !== $expected) {
+            throw new RuntimeException('Authorized slug list must match the exact 20 zh-CN Big Five trait/range slugs.');
+        }
+    }
+
+    /**
+     * @param  array<mixed>  $package
+     * @return list<mixed>
+     */
+    private function rows(array $package): array
+    {
+        if (array_is_list($package)) {
+            return array_values($package);
+        }
+
+        return array_values(is_array($package['rows'] ?? null) ? $package['rows'] : (is_array($package['pages'] ?? null) ? $package['pages'] : []));
+    }
+
+    /**
+     * @param  list<mixed>  $rows
+     * @param  list<mixed>  $rowPlans
+     * @return list<array{position:int,row:array<string,mixed>,row_plan:array<string,mixed>}>
+     */
+    private function selectedRows(array $rows, array $rowPlans): array
+    {
+        $selected = [];
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException('Package row must be an object.');
+            }
+
+            $rowPlan = is_array($rowPlans[$index] ?? null) ? $rowPlans[$index] : [];
+            $slug = strtolower(trim((string) ($row['slug'] ?? '')));
+            $locale = (string) ($row['locale'] ?? '');
+            $contentType = (string) ($row['content_type'] ?? '');
+
+            if ($locale !== 'zh-CN' || ! in_array($contentType, self::AUTHORIZED_CONTENT_TYPES, true)) {
+                continue;
+            }
+
+            if (! in_array($slug, self::AUTHORIZED_ZH_CN_SLUGS, true)) {
+                continue;
+            }
+
+            $this->guardSelectedRow($row, $rowPlan, $index);
+
+            $selected[] = [
+                'position' => $index + 1,
+                'row' => $row,
+                'row_plan' => $rowPlan,
+            ];
+        }
+
+        return $selected;
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $rowPlan
+     */
+    private function guardSelectedRow(array $row, array $rowPlan, int $index): void
+    {
+        $identity = is_array($rowPlan['identity'] ?? null) ? $rowPlan['identity'] : [];
+        $slug = (string) ($row['slug'] ?? '');
+        $canonicalPath = (string) ($rowPlan['canonical_path'] ?? $row['canonical_path'] ?? '');
+
+        if ((string) ($identity['entity_type'] ?? '') !== (
+            (string) ($row['content_type'] ?? '') === 'trait_page'
+                ? PersonalityPublicContentAsset::ENTITY_DOMAIN
+                : PersonalityPublicContentAsset::ENTITY_POLARITY
+        )) {
+            throw new RuntimeException('Selected row identity entity_type mismatch at row '.((string) $index).'.');
+        }
+
+        if ((string) ($identity['entity_key'] ?? '') !== $slug || (string) ($identity['slug'] ?? '') !== 'big-five/'.$slug) {
+            throw new RuntimeException('Selected row identity key/slug mismatch at row '.((string) $index).'.');
+        }
+
+        if (! str_starts_with($canonicalPath, '/zh/personality/big-five/')) {
+            throw new RuntimeException('Selected row canonical path must stay under /zh/personality/big-five at row '.((string) $index).'.');
+        }
+
+        if ($canonicalPath !== '/zh/personality/big-five/'.$slug) {
+            throw new RuntimeException('Selected row canonical path must use v2 trait-first slug format at row '.((string) $index).'.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $rowPlan
+     * @return array<string,mixed>
+     */
+    private function attributesForRow(array $row, array $rowPlan, string $sourceSha256, string $packagePath, string $targetEnvironment): array
+    {
+        $identity = is_array($rowPlan['identity'] ?? null) ? $rowPlan['identity'] : [];
+        $canonicalPath = (string) ($rowPlan['canonical_path'] ?? $row['canonical_path'] ?? '');
+        $seo = is_array($row['seo'] ?? null) ? $row['seo'] : [];
+        $faq = array_values(is_array($row['faq'] ?? null) ? $row['faq'] : []);
+        $claimBoundaries = array_values(is_array($row['claim_boundaries'] ?? null) ? $row['claim_boundaries'] : []);
+        $sections = $this->contentSections($row);
+
+        if ($sections === []) {
+            throw new RuntimeException('Selected Big Five content-ready rows must have non-empty non-FAQ body sections.');
+        }
+
+        if (count($faq) < 5) {
+            throw new RuntimeException('Selected Big Five content-ready rows must retain at least 5 structured FAQ entries.');
+        }
+
+        return [
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'entity_type' => (string) ($identity['entity_type'] ?? ''),
+            'entity_key' => (string) ($identity['entity_key'] ?? ''),
+            'slug' => (string) ($identity['slug'] ?? ''),
+            'locale' => (string) ($identity['locale'] ?? ''),
+            'title' => trim((string) ($row['title'] ?? '')),
+            'summary' => trim((string) ($seo['description'] ?? '')) ?: null,
+            'content_sections_json' => $sections,
+            'seo_json' => $seo,
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'canonical_json' => ['path' => $canonicalPath],
+            'hreflang_json' => [],
+            'faq_json' => $faq,
+            'media_json' => [],
+            'schema_json' => [
+                'recommendation' => (string) ($row['schema_recommendation'] ?? ''),
+                'draft_only' => false,
+                'runtime_jsonld_enabled' => false,
+                'runtime_release' => false,
+            ],
+            'method_boundary_json' => [
+                'claim_boundaries' => $claimBoundaries,
+                'method_boundary' => 'Big Five public CMS content-ready rows remain non-diagnostic, non-predictive, and not for hiring or high-stakes decisions.',
+                'indexability_gate' => (string) ($row['indexability_gate'] ?? ''),
+                'operator_publish_gate' => 'BIG5-CMS-PUBLISH-GATE-12',
+            ],
+            'evidence_notes_json' => [
+                [
+                    'source_type' => 'cms_import_draft',
+                    'source' => self::SOURCE_PACKAGE,
+                    'package_path' => $packagePath,
+                    'package_sha256' => $sourceSha256,
+                    'target_environment' => $targetEnvironment,
+                    'authorized_slug_count' => 20,
+                    'schema_runtime_release' => false,
+                    'sitemap_release' => false,
+                    'llms_release' => false,
+                    'indexability_release' => false,
+                ],
+            ],
+            'internal_links_json' => array_values(is_array($row['internal_links'] ?? null) ? $row['internal_links'] : []),
+            'is_public' => true,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            'review_state' => self::REVIEW_STATE,
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => self::SOURCE_PACKAGE,
+            'source_hash' => $sourceSha256,
+            'published_at' => null,
+            'last_reviewed_at' => now(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @return list<array<string,string>>
+     */
+    private function contentSections(array $row): array
+    {
+        $sections = [];
+        foreach (array_values(is_array($row['body_sections'] ?? null) ? $row['body_sections'] : []) as $index => $section) {
+            if (! is_array($section) || $this->isFaqBodySection($section)) {
+                continue;
+            }
+
+            $heading = trim((string) ($section['heading'] ?? $section['title'] ?? 'Section '.((string) ($index + 1))));
+            $body = trim((string) ($section['body_md'] ?? $section['body'] ?? ''));
+            if ($body === '') {
+                continue;
+            }
+
+            $sections[] = [
+                'key' => $this->sectionKey($heading, $index),
+                'title' => $heading,
+                'body_md' => $body,
+            ];
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<mixed>  $section
+     */
+    private function isFaqBodySection(array $section): bool
+    {
+        $heading = trim((string) ($section['heading'] ?? $section['title'] ?? ''));
+
+        return preg_match('/^(faq|常见问题|问答|问题)$/iu', $heading) === 1;
+    }
+
+    private function sectionKey(string $heading, int $index): string
+    {
+        $ascii = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '_', $heading));
+        $ascii = trim($ascii, '_');
+
+        return $ascii !== '' ? $ascii : 'section_'.((string) ($index + 1));
+    }
+
+    /**
+     * @param  array<string,mixed>  $identity
+     */
+    private function existingAsset(array $identity): ?PersonalityPublicContentAsset
+    {
+        return PersonalityPublicContentAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
+            ->where('entity_type', (string) ($identity['entity_type'] ?? ''))
+            ->where('entity_key', (string) ($identity['entity_key'] ?? ''))
+            ->where('locale', (string) ($identity['locale'] ?? ''))
+            ->first();
+    }
+
+    private function existingAssetIsWritableContentGateTarget(PersonalityPublicContentAsset $asset): bool
+    {
+        return (bool) $asset->index_eligible === false
+            && (bool) $asset->sitemap_eligible === false
+            && (bool) $asset->llms_eligible === false
+            && $asset->published_at === null
+            && $asset->robots === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW
+            && in_array((string) $asset->launch_state, [
+                PersonalityPublicContentAsset::LAUNCH_DRAFT,
+                PersonalityPublicContentAsset::LAUNCH_REVIEW,
+                PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            ], true)
+            && in_array((string) $asset->source_package, ['', self::SOURCE_PACKAGE, 'big-five-v1-content-editorial-repair-02'], true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $attributes
+     */
+    private function attributesMatch(PersonalityPublicContentAsset $existing, array $attributes): bool
+    {
+        foreach ($attributes as $key => $value) {
+            if ($key === 'last_reviewed_at') {
+                continue;
+            }
+
+            if ($this->comparable($existing->{$key}) !== $this->comparable($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function comparable(mixed $value): mixed
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d\TH:i:sP');
+        }
+
+        if (is_array($value)) {
+            $this->sortAssociativeRecursive($value);
+
+            return $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     */
+    private function sortAssociativeRecursive(array &$value): void
+    {
+        foreach ($value as &$child) {
+            if (is_array($child)) {
+                $this->sortAssociativeRecursive($child);
+            }
+        }
+
+        if (array_keys($value) !== range(0, count($value) - 1)) {
+            ksort($value);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function snapshotRow(?PersonalityPublicContentAsset $asset): ?array
+    {
+        if (! $asset instanceof PersonalityPublicContentAsset) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $asset->id,
+            'framework' => (string) $asset->framework,
+            'entity_type' => (string) $asset->entity_type,
+            'entity_key' => (string) $asset->entity_key,
+            'slug' => (string) $asset->slug,
+            'locale' => (string) $asset->locale,
+            'source_package' => (string) $asset->source_package,
+            'source_hash' => (string) $asset->source_hash,
+            'launch_state' => (string) $asset->launch_state,
+            'review_state' => (string) $asset->review_state,
+            'robots' => (string) $asset->robots,
+            'is_public' => (bool) $asset->is_public,
+            'index_eligible' => (bool) $asset->index_eligible,
+            'sitemap_eligible' => (bool) $asset->sitemap_eligible,
+            'llms_eligible' => (bool) $asset->llms_eligible,
+            'published_at' => $asset->published_at?->toAtomString(),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @param  list<array<string,mixed>|null>  $preImportSnapshot
+     * @param  list<array<string,string>>  $errors
+     * @return array<string,mixed>
+     */
+    private function summary(
+        string $sourceSha256,
+        string $packagePath,
+        string $targetEnvironment,
+        bool $write,
+        array $rows,
+        array $preImportSnapshot,
+        int $created,
+        int $updated,
+        int $skipped,
+        array $errors
+    ): array {
+        $importBatchId = 'big5-cms-publish-gate-'.substr($sourceSha256, 0, 12).'-'.gmdate('YmdHis');
+
+        return [
+            'artifact' => 'BIG5-CMS-PUBLISH-GATE-12',
+            'status' => $errors === [] ? 'pass' : 'fail',
+            'ok' => $errors === [],
+            'target_environment' => $targetEnvironment,
+            'package_path' => $packagePath,
+            'source_sha256' => $sourceSha256,
+            'row_count' => count($rows),
+            'expected_row_count' => 20,
+            'row_count_matches_expected' => count($rows) === 20,
+            'authorized_slug_count' => 20,
+            'dry_run' => ! $write,
+            'write' => $write,
+            'writes_committed' => $write && ($created + $updated) > 0,
+            'cms_write_attempted' => $write,
+            'publish_attempted' => false,
+            'content_ready_attempted' => $write,
+            'index_attempted' => false,
+            'search_release_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'jsonld_runtime_release_attempted' => false,
+            'created_asset_count' => $created,
+            'updated_asset_count' => $updated,
+            'skipped_existing_count' => $skipped,
+            'rollback_handle' => [
+                'import_batch_id' => $importBatchId,
+                'source_package' => self::SOURCE_PACKAGE,
+                'source_hash' => $sourceSha256,
+                'deterministic_revert_criteria' => [
+                    'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+                    'source_package' => self::SOURCE_PACKAGE,
+                    'source_hash' => $sourceSha256,
+                    'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+                    'review_state' => self::REVIEW_STATE,
+                    'index_eligible' => false,
+                    'sitemap_eligible' => false,
+                    'llms_eligible' => false,
+                ],
+                'pre_import_snapshot' => $preImportSnapshot,
+                'restore_note' => 'Restore pre_import_snapshot rows or revert rows matching deterministic_revert_criteria with the same exact package hash. Do not release sitemap, llms, JSON-LD, indexability, or production deploy from this handle.',
+            ],
+            'rows' => $rows,
+            'errors' => $errors,
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityBigFiveCmsPublishGateCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityBigFiveCmsPublishGateCommandTest.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\PersonalityBigFiveCmsPublishGate;
+use App\Models\PersonalityPublicContentAsset;
+use App\Services\Cms\BigFiveCmsPublishGateWriter;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityBigFiveCmsPublishGateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(Kernel::class)->registerCommand($this->app->make(PersonalityBigFiveCmsPublishGate::class));
+    }
+
+    public function test_dry_run_requires_matching_package_sha(): void
+    {
+        [$packagePath] = $this->writePackage($this->validFortyTwoRowPackage());
+
+        $exitCode = Artisan::call('personality:big-five-cms-publish-gate', [
+            '--package' => $packagePath,
+            '--confirm-package-sha256' => str_repeat('0', 64),
+            '--authorized-slugs' => $this->authorizedSlugCsv(),
+            '--target-env' => 'production',
+            '--operator-approved' => PersonalityBigFiveCmsPublishGate::CONFIRMATION_PHRASE,
+            '--dry-run' => true,
+            '--allow-testing' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertStringContainsString('SHA-256 mismatch', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_command_requires_exact_authorized_slug_list(): void
+    {
+        [$packagePath, $sha256] = $this->writePackage($this->validFortyTwoRowPackage());
+
+        $exitCode = Artisan::call('personality:big-five-cms-publish-gate', [
+            '--package' => $packagePath,
+            '--confirm-package-sha256' => $sha256,
+            '--authorized-slugs' => 'openness,conscientiousness',
+            '--target-env' => 'production',
+            '--operator-approved' => PersonalityBigFiveCmsPublishGate::CONFIRMATION_PHRASE,
+            '--dry-run' => true,
+            '--allow-testing' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertStringContainsString('exact 20 zh-CN Big Five trait/range slugs', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_write_creates_exact_twenty_authorized_zh_cn_content_ready_noindex_rows(): void
+    {
+        [$packagePath, $sha256] = $this->writePackage($this->validFortyTwoRowPackage());
+
+        $exitCode = Artisan::call('personality:big-five-cms-publish-gate', [
+            '--package' => $packagePath,
+            '--confirm-package-sha256' => $sha256,
+            '--authorized-slugs' => $this->authorizedSlugCsv(),
+            '--target-env' => 'production',
+            '--operator-approved' => PersonalityBigFiveCmsPublishGate::CONFIRMATION_PHRASE,
+            '--write' => true,
+            '--allow-testing' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertTrue($payload['cms_write_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['jsonld_runtime_release_attempted']);
+        $this->assertSame(20, $payload['row_count']);
+        $this->assertSame(20, $payload['created_asset_count']);
+        $this->assertSame(20, PersonalityPublicContentAsset::query()->count());
+
+        $this->assertSame(20, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('index_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('sitemap_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('llms_eligible', true)->count());
+        $this->assertSame(20, PersonalityPublicContentAsset::query()->where('robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW)->count());
+        $this->assertSame(20, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)->count());
+        $this->assertSame(20, PersonalityPublicContentAsset::query()->where('review_state', BigFiveCmsPublishGateWriter::REVIEW_STATE)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('locale', 'en')->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('entity_type', PersonalityPublicContentAsset::ENTITY_HUB)->count());
+
+        $rangeAsset = PersonalityPublicContentAsset::query()
+            ->where('entity_type', PersonalityPublicContentAsset::ENTITY_POLARITY)
+            ->where('entity_key', 'openness-high')
+            ->where('locale', 'zh-CN')
+            ->firstOrFail();
+
+        $this->assertSame('/zh/personality/big-five/openness-high', $rangeAsset->canonical_json['path'] ?? null);
+        $this->assertSame('big-five/openness-high', $rangeAsset->slug);
+        $this->assertCount(2, $rangeAsset->content_sections_json);
+        $this->assertNotContains('FAQ', array_column($rangeAsset->content_sections_json, 'title'));
+        $this->assertCount(5, $rangeAsset->faq_json);
+        $this->assertSame(false, $rangeAsset->schema_json['runtime_jsonld_enabled'] ?? null);
+        $this->assertSame(false, $rangeAsset->schema_json['runtime_release'] ?? null);
+        $this->assertSame($sha256, $rangeAsset->source_hash);
+        $this->assertNull($rangeAsset->published_at);
+    }
+
+    public function test_write_rejects_old_nested_range_canonical_paths(): void
+    {
+        $package = $this->validFortyTwoRowPackage();
+        foreach ($package as &$row) {
+            if (($row['slug'] ?? '') === 'openness-high') {
+                $row['canonical_path'] = '/zh/personality/big-five/openness/high';
+                break;
+            }
+        }
+        unset($row);
+
+        [$packagePath, $sha256] = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:big-five-cms-publish-gate', [
+            '--package' => $packagePath,
+            '--confirm-package-sha256' => $sha256,
+            '--authorized-slugs' => $this->authorizedSlugCsv(),
+            '--target-env' => 'production',
+            '--operator-approved' => PersonalityBigFiveCmsPublishGate::CONFIRMATION_PHRASE,
+            '--write' => true,
+            '--allow-testing' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertStringContainsString('v2 trait-first slug format', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_write_rejects_existing_published_or_indexable_asset(): void
+    {
+        [$packagePath, $sha256] = $this->writePackage($this->validFortyTwoRowPackage());
+
+        PersonalityPublicContentAsset::query()->create([
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'entity_type' => PersonalityPublicContentAsset::ENTITY_DOMAIN,
+            'entity_key' => 'openness',
+            'slug' => 'big-five/openness',
+            'locale' => 'zh-CN',
+            'title' => 'Live openness',
+            'summary' => 'Live summary',
+            'content_sections_json' => [['key' => 'overview', 'title' => 'Overview', 'body_md' => 'Live body']],
+            'seo_json' => ['title' => 'Live', 'description' => 'Live'],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW,
+            'canonical_json' => ['path' => '/zh/personality/big-five/openness'],
+            'hreflang_json' => [],
+            'faq_json' => [['question' => 'Q', 'answer' => 'A']],
+            'media_json' => [],
+            'schema_json' => ['runtime_jsonld_enabled' => true],
+            'method_boundary_json' => [],
+            'evidence_notes_json' => [],
+            'internal_links_json' => [],
+            'is_public' => true,
+            'index_eligible' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_PUBLISHED,
+            'review_state' => 'published',
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => 'foreign-live-source',
+            'source_hash' => 'foreign',
+            'published_at' => now(),
+        ]);
+
+        $exitCode = Artisan::call('personality:big-five-cms-publish-gate', [
+            '--package' => $packagePath,
+            '--confirm-package-sha256' => $sha256,
+            '--authorized-slugs' => $this->authorizedSlugCsv(),
+            '--target-env' => 'production',
+            '--operator-approved' => PersonalityBigFiveCmsPublishGate::CONFIRMATION_PHRASE,
+            '--write' => true,
+            '--allow-testing' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('existing_asset_blocks_content_ready_gate', $payload['errors'][0]['code'] ?? null);
+        $this->assertSame(1, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_write_is_idempotent_for_same_source_content_ready_rows(): void
+    {
+        [$packagePath, $sha256] = $this->writePackage($this->validFortyTwoRowPackage());
+        $options = [
+            '--package' => $packagePath,
+            '--confirm-package-sha256' => $sha256,
+            '--authorized-slugs' => $this->authorizedSlugCsv(),
+            '--target-env' => 'production',
+            '--operator-approved' => PersonalityBigFiveCmsPublishGate::CONFIRMATION_PHRASE,
+            '--write' => true,
+            '--allow-testing' => true,
+            '--json' => true,
+        ];
+
+        $this->assertSame(0, Artisan::call('personality:big-five-cms-publish-gate', $options));
+        $this->assertSame(0, Artisan::call('personality:big-five-cms-publish-gate', $options));
+
+        $payload = $this->jsonOutput();
+
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_asset_count']);
+        $this->assertSame(0, $payload['updated_asset_count']);
+        $this->assertSame(20, $payload['skipped_existing_count']);
+        $this->assertSame(20, PersonalityPublicContentAsset::query()->count());
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $package
+     * @return array{0:string,1:string}
+     */
+    private function writePackage(array $package): array
+    {
+        $packagePath = sys_get_temp_dir().'/big-five-cms-publish-gate-'.bin2hex(random_bytes(6)).'.json';
+        $packageJson = (string) json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        File::put($packagePath, $packageJson);
+
+        return [$packagePath, hash('sha256', $packageJson)];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function validFortyTwoRowPackage(): array
+    {
+        $rows = [
+            $this->validRow([
+                'slug' => 'big-five',
+                'content_type' => 'hub_page',
+                'title' => '大五人格',
+                'canonical_path' => '/zh/personality/big-five',
+                'schema_recommendation' => 'CollectionPage',
+            ]),
+            $this->validRow([
+                'slug' => 'big-five',
+                'locale' => 'en-US',
+                'content_type' => 'hub_page',
+                'title' => 'Big Five Personality',
+                'canonical_path' => '/en/personality/big-five',
+                'schema_recommendation' => 'CollectionPage',
+            ]),
+        ];
+
+        foreach (['openness', 'conscientiousness', 'extraversion', 'agreeableness', 'neuroticism'] as $trait) {
+            $rows[] = $this->validRow([
+                'slug' => $trait,
+                'content_type' => 'trait_page',
+                'title' => $trait,
+                'canonical_path' => '/zh/personality/big-five/'.$trait,
+            ]);
+            $rows[] = $this->validRow([
+                'slug' => $trait,
+                'locale' => 'en-US',
+                'content_type' => 'trait_page',
+                'title' => $trait,
+                'canonical_path' => '/en/personality/big-five/'.$trait,
+            ]);
+
+            foreach (['high', 'mid', 'low'] as $range) {
+                $slug = $trait.'-'.$range;
+                $rows[] = $this->validRow([
+                    'slug' => $slug,
+                    'content_type' => 'trait_range_page',
+                    'title' => $trait.' '.$range,
+                    'canonical_path' => '/zh/personality/big-five/'.$slug,
+                ]);
+            }
+        }
+
+        foreach ([
+            'high-openness-low-conscientiousness',
+            'low-extraversion-high-conscientiousness',
+            'high-agreeableness-high-neuroticism',
+            'high-conscientiousness-low-agreeableness',
+            'high-openness-high-extraversion',
+            'low-neuroticism-high-conscientiousness',
+        ] as $combination) {
+            $rows[] = $this->validRow([
+                'slug' => $combination,
+                'content_type' => 'combination_page',
+                'title' => $combination,
+                'canonical_path' => '/zh/personality/big-five/combinations/'.$combination,
+            ]);
+        }
+
+        foreach ([
+            'big-five-vs-mbti',
+            'big-five-and-career',
+            'big-five-and-riasec',
+            'big-five-and-stress',
+            'big-five-and-relationships',
+        ] as $crossReading) {
+            $rows[] = $this->validRow([
+                'slug' => $crossReading,
+                'content_type' => 'cross_reading_page',
+                'title' => $crossReading,
+                'canonical_path' => '/zh/personality/big-five/cross-reading/'.$crossReading,
+            ]);
+        }
+
+        foreach ([
+            'how-to-read-big-five-results',
+            'big-five-result-review-work',
+            'big-five-result-review-learning',
+            'big-five-result-review-relationships',
+        ] as $resultReview) {
+            $rows[] = $this->validRow([
+                'slug' => $resultReview,
+                'content_type' => 'result_review_page',
+                'title' => $resultReview,
+                'canonical_path' => '/zh/personality/big-five/result-review/'.$resultReview,
+            ]);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     * @return array<string,mixed>
+     */
+    private function validRow(array $overrides = []): array
+    {
+        return array_replace_recursive([
+            'slug' => 'openness',
+            'locale' => 'zh-CN',
+            'content_type' => 'trait_page',
+            'title' => '开放性',
+            'status' => 'draft_review_required',
+            'canonical_path' => '/zh/personality/big-five/openness',
+            'seo' => [
+                'title' => '开放性是什么意思？',
+                'description' => '解释大五人格开放性维度。',
+            ],
+            'body_sections' => [
+                ['heading' => '快速回答', 'body' => '开放性是大五人格的连续维度之一。'],
+                ['heading' => '方法边界', 'body' => '本页不用于诊断或招聘筛选。'],
+                ['heading' => 'FAQ', 'body' => 'FAQ 正文只用于源包兼容；结构化 FAQ 以 faq 字段为准。'],
+            ],
+            'faq' => [
+                ['question' => '开放性是什么？', 'answer' => '它描述对新经验和抽象概念的偏好。'],
+                ['question' => '高开放一定更好吗？', 'answer' => '不是，高低都有适用场景。'],
+                ['question' => '低开放是缺点吗？', 'answer' => '不是，它可能代表稳定和务实。'],
+                ['question' => '可以用于招聘吗？', 'answer' => '不可以。'],
+                ['question' => '可以用于诊断吗？', 'answer' => '不可以。'],
+            ],
+            'internal_links' => ['/zh/personality/big-five'],
+            'claim_boundaries' => [
+                'non_diagnostic',
+                'non_predictive',
+                'no_hiring_screening',
+                'no_specific_validation_metrics_without_public_evidence',
+            ],
+            'schema_recommendation' => 'FAQPage',
+            'indexability_gate' => 'manual_review_required',
+        ], $overrides);
+    }
+
+    private function authorizedSlugCsv(): string
+    {
+        return implode(',', BigFiveCmsPublishGateWriter::AUTHORIZED_ZH_CN_SLUGS);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -180,6 +180,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ];
 
         $changed = $this->gitChangedFilesInBranchDiff($runtimePaths);
+        $changed = $this->mbtiImpactingRuntimeChanges($changed, (string) getcwd(), 'origin/main');
 
         $this->assertSame([], $changed);
     }
@@ -426,6 +427,22 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $kernelChangedLines = [
             '+use App\\Console\\Commands\\PersonalityBigFiveCmsPreviewRenderQa;',
             '+        PersonalityBigFiveCmsPreviewRenderQa::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
+    public function test_runtime_freeze_classifier_ignores_big_five_cms_publish_gate_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityBigFiveCmsPublishGate.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/BigFiveCmsPublishGateWriter.php',
+            'backend/tests/Feature/Console/PersonalityBigFiveCmsPublishGateCommandTest.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityBigFiveCmsPublishGate;',
+            '+        PersonalityBigFiveCmsPublishGate::class,',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
@@ -5089,6 +5106,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBigFiveCmsPublishGateFile($file)) {
+                continue;
+            }
+
             if ($this->isBigFiveProductionContentAuditFile($file)) {
                 continue;
             }
@@ -6386,6 +6407,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsBigFiveCmsImportDraftDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveCmsStagingWriteImportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveCmsPreviewRenderQaOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsBigFiveCmsPublishGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoOpsP0CtrArticleCmsUpdateWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6632,6 +6654,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityBigFiveCmsPreviewRenderQa.php',
             'backend/app/Services/Cms/BigFiveCmsPreviewRenderQaValidator.php',
+        ], true);
+    }
+
+    private function isBigFiveCmsPublishGateFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityBigFiveCmsPublishGate.php',
+            'backend/app/Services/Cms/BigFiveCmsPublishGateWriter.php',
+            'backend/tests/Feature/Console/PersonalityBigFiveCmsPublishGateCommandTest.php',
         ], true);
     }
 
@@ -11040,6 +11071,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityBigFiveCmsPreviewRenderQa\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsBigFiveCmsPublishGateOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityBigFiveCmsPublishGate\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `personality:big-five-cms-publish-gate` for the authorized 20 zh-CN Big Five v2 trait/range pages.
- Added `BigFiveCmsPublishGateWriter` to select only the 5 trait rows and 15 v2 trait-first range rows, write them as `content_ready`, and keep all discoverability/runtime schema gates closed.
- Added feature coverage for SHA mismatch, exact slug allowlist, v2 canonical enforcement, FAQ body-section dedupe, unsafe existing row rejection, and idempotency.
- Updated the Big Five runtime freeze classifier allowlist for this controlled CMS command/service/test scope.

## Why
PR12A aligned fap-web routing with the v2 trait-first range IA. This PR gives the backend a controlled CMS content-ready gate for the operator-authorized 20 zh-CN pages without publishing, indexing, sitemap/llms inclusion, or JSON-LD runtime release.

## Validation
- `php artisan test --filter=PersonalityBigFiveCmsPublishGateCommandTest --display-warnings`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_big_five_cms_publish_gate_files --display-warnings`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --display-warnings`
- `./vendor/bin/pint --test app/Console/Commands/PersonalityBigFiveCmsPublishGate.php app/Services/Cms/BigFiveCmsPublishGateWriter.php tests/Feature/Console/PersonalityBigFiveCmsPublishGateCommandTest.php app/Console/Kernel.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan route:list --path=api --except-vendor`
- `git diff --check`

## Deferred items
- No production CMS write was executed in this PR.
- No sitemap, llms, JSON-LD runtime, canonical indexability, or production SEO release is authorized here.
- PR13 remains blocked until separate exact SEO discoverability release authorization.

## Repository rule impact
This keeps Big Five public content backend/CMS-authoritative. The command is a controlled backend write path for content-ready state only; it does not bypass noindex or discoverability gates.