### PR TITLE
fix(big-five): fit seo release review state column

### DIFF
--- a/backend/app/Services/Cms/BigFiveSeoDiscoverabilityReleaseWriter.php
+++ b/backend/app/Services/Cms/BigFiveSeoDiscoverabilityReleaseWriter.php
@@ -12,7 +12,7 @@ use RuntimeException;
 
 final class BigFiveSeoDiscoverabilityReleaseWriter
 {
-    public const REVIEW_STATE = 'operator_approved_seo_discoverability_released';
+    public const REVIEW_STATE = 'seo_discoverability_released';
 
     /**
      * @param  array<string,mixed>  $plan

--- a/backend/tests/Feature/Console/PersonalityBigFiveSeoDiscoverabilityReleaseCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityBigFiveSeoDiscoverabilityReleaseCommandTest.php
@@ -30,6 +30,11 @@ final class PersonalityBigFiveSeoDiscoverabilityReleaseCommandTest extends TestC
         $this->assertArrayHasKey('personality:big-five-seo-discoverability-release', Artisan::all());
     }
 
+    public function test_release_review_state_fits_personality_public_asset_column(): void
+    {
+        $this->assertLessThanOrEqual(32, strlen(BigFiveSeoDiscoverabilityReleaseWriter::REVIEW_STATE));
+    }
+
     public function test_dry_run_plans_exact_twenty_authorized_rows_without_writes(): void
     {
         [$packagePath, $sha256] = $this->writePackage($this->validFortyTwoRowPackage());


### PR DESCRIPTION
## What changed
- Shortened the Big Five SEO discoverability release review_state to fit the existing 32-character personality_public_content_assets.review_state column.
- Added a regression test asserting the release review state stays within the column limit.

## Why
- Production release failed before committing writes because the previous review_state value exceeded the DB column length.
- This preserves the existing release behavior and avoids a schema migration for a status-label-only issue.

## Validation
- php artisan test --filter=PersonalityBigFiveSeoDiscoverabilityReleaseCommandTest
- php artisan route:list --path=api --except-vendor
- git diff --check

## Deferred items
- Production backend deploy and Big Five SEO discoverability release command require a new exact SHA authorization after merge.
- No frontend deploy, Search Console submission, English-page changes, sitemap/llms/JSON-LD behavior changes beyond the existing PR13 command path.