### PR TITLE
MBTI-CMS-26: add CONTENT-15 mixed package importer preflight

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php
+++ b/backend/app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\MbtiContent15MixedImportPreflightPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityMbtiContent15MixedImportPreflight extends Command
+{
+    protected $signature = 'personality:mbti-content15-mixed-import-preflight
+        {--package= : Path to the MBTI-CMS-22 final dry-run JSON package}
+        {--authorization-package= : Path to the MBTI-CMS-23 authorization JSON package}
+        {--source-package-sha256= : Expected CMS-22 exact package sha256}
+        {--authorization-payload-sha256= : Expected CMS-23 authorization payload sha256}
+        {--import-scope-mode= : Expected import scope mode}
+        {--record-count= : Expected import record count}
+        {--dry-run : Required; validate and plan without database writes}
+        {--write : Unsupported in this PR; fails closed before any mutation}
+        {--json : Emit the full JSON preflight plan}
+        {--output= : Optional path to write the JSON preflight plan}';
+
+    protected $description = 'Preflight the CONTENT-15 mixed MBTI CMS import package without CMS writes.';
+
+    public function handle(MbtiContent15MixedImportPreflightPlanner $planner): int
+    {
+        try {
+            $summary = $this->guardedPlan($planner);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary($exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary($exception->getMessage(), 'unexpected_error');
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function guardedPlan(MbtiContent15MixedImportPreflightPlanner $planner): array
+    {
+        if ((bool) $this->option('write')) {
+            throw new RuntimeException('--write is intentionally unsupported in MBTI-CMS-26; MBTI-CMS-27 owns production CMS import execution after separate exact authorization.');
+        }
+
+        if (! (bool) $this->option('dry-run')) {
+            throw new RuntimeException('--dry-run is required so this command cannot be mistaken for a write/import command.');
+        }
+
+        $packagePath = $this->requiredPathOption('package');
+        $authorizationPath = $this->requiredPathOption('authorization-package');
+
+        [$package, $packageRaw, $resolvedPackagePath] = $this->readJsonFile($packagePath);
+        [$authorizationPackage, $authorizationRaw, $resolvedAuthorizationPath] = $this->readJsonFile($authorizationPath);
+
+        return array_merge($planner->plan($package, $authorizationPackage, [
+            'package_file_sha256' => hash('sha256', $packageRaw),
+            'authorization_file_sha256' => hash('sha256', $authorizationRaw),
+            'expected_source_package_sha256' => trim((string) $this->option('source-package-sha256')),
+            'expected_authorization_payload_sha256' => trim((string) $this->option('authorization-payload-sha256')),
+            'expected_import_scope_mode' => trim((string) $this->option('import-scope-mode')),
+            'expected_record_count' => trim((string) $this->option('record-count')),
+        ]), [
+            'package_path' => $resolvedPackagePath,
+            'authorization_package_path' => $resolvedAuthorizationPath,
+            'command' => 'personality:mbti-content15-mixed-import-preflight',
+        ]);
+    }
+
+    private function requiredPathOption(string $name): string
+    {
+        $path = trim((string) $this->option($name));
+        if ($path === '') {
+            throw new RuntimeException('--'.$name.' is required.');
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array{0:array<string,mixed>,1:string,2:string}
+     */
+    private function readJsonFile(string $path): array
+    {
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException('Package file not found: '.$resolved);
+        }
+
+        $raw = (string) File::get($resolved);
+        $decoded = json_decode($raw, true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Package must be a JSON object: '.$resolved);
+        }
+
+        return [$decoded, $raw, $resolved];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run_only='.(($summary['dry_run_only'] ?? false) ? '1' : '0'));
+        $this->line('write_supported_in_this_pr='.(($summary['write_supported_in_this_pr'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('cms_write_attempted='.(($summary['cms_write_attempted'] ?? false) ? '1' : '0'));
+        $this->line('profile_record_count='.(string) ($summary['profile_record_count'] ?? 0));
+        $this->line('at_comparison_count='.(string) ($summary['at_comparison_count'] ?? 0));
+        $this->line('cross_type_comparison_count='.(string) ($summary['cross_type_comparison_count'] ?? 0));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $message, string $code = 'runtime_error'): array
+    {
+        return [
+            'artifact' => 'MBTI-CMS-26-CONTENT15-MIXED-IMPORT-PREFLIGHT',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run_only' => true,
+            'write_supported_in_this_pr' => false,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'search_release_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -194,6 +194,7 @@ use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionPromote;
 use App\Console\Commands\PersonalityTdkNextBatchApprovalDraftGateCommand;
 use App\Console\Commands\PersonalityTdkRuntimePromotionSearchGateReadinessCommand;
+use App\Console\Commands\PersonalityMbtiContent15MixedImportPreflight;
 use App\Console\Commands\PersonalityEnneagramCmsPromote;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
@@ -284,6 +285,7 @@ class Kernel extends ConsoleKernel
         PersonalityMbti64CmsProjectionDraft::class,
         PersonalityMbti64CmsRevisionDraft::class,
         PersonalityMbti64CmsRevisionPromote::class,
+        PersonalityMbtiContent15MixedImportPreflight::class,
         PersonalityTdkNextBatchApprovalDraftGateCommand::class,
         PersonalityTdkRuntimePromotionSearchGateReadinessCommand::class,
         PersonalityMbti64BackendImportContract::class,

--- a/backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php
+++ b/backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php
@@ -1,0 +1,536 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+final class MbtiContent15MixedImportPreflightPlanner
+{
+    private const EXPECTED_SOURCE_PACKAGE_SHA256 = '75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb';
+
+    private const EXPECTED_AUTHORIZATION_PAYLOAD_SHA256 = 'be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15';
+
+    private const EXPECTED_IMPORT_SCOPE_MODE = 'top_blocker_batch_only';
+
+    private const EXPECTED_RECORD_COUNT = 9;
+
+    private const PROFILE_SECTION_KEYS = [
+        'direct_answer',
+        'who_it_fits',
+        'who_it_does_not_fit',
+        'common_misunderstanding',
+        'at_difference',
+        'career_scenario',
+        'relationship_scenario',
+        'stress_scenario',
+    ];
+
+    private const COMPARISON_SECTION_KEYS = [
+        'direct_answer',
+        'quick_judgment_table',
+        'easy_misread',
+        'real_scenario_differences',
+        'do_not_misjudge',
+    ];
+
+    private const FORBIDDEN_PUBLIC_ROUTE_PATTERN =
+        '~(?:^|["\'\s(])/(?:[a-z]{2}/)?(?:result|results|orders|order|share|pay|payment|history|private|account)(?:/|[?#\s)"\']|$)~i';
+
+    private const FORBIDDEN_QUERY_PATTERN =
+        '/(?:[?&]|^)(?:token|session|user|result_id|report_id|order_no)=/i';
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $authorizationPackage
+     * @param  array<string,string>  $options
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, array $authorizationPackage, array $options): array
+    {
+        $errors = [];
+        $warnings = [];
+        $records = $this->records($package, $errors);
+        $authorizationRecords = $this->authorizationRecords($authorizationPackage, $errors);
+
+        $this->validateTopLevel($package, $authorizationPackage, $options, $errors, $warnings);
+        $this->validateForbiddenRoutes($package, $authorizationPackage, $errors);
+
+        $authorizationBySourceId = [];
+        foreach ($authorizationRecords as $record) {
+            if (is_array($record)) {
+                $authorizationBySourceId[(string) ($record['source_dry_run_record_id'] ?? '')] = $record;
+            }
+        }
+
+        $rowPlans = [];
+        foreach ($records as $index => $record) {
+            if (! is_array($record)) {
+                $errors[] = $this->issue('records.'.(string) $index, 'record_not_object', 'Each CONTENT-15 import record must be a JSON object.');
+
+                continue;
+            }
+
+            $rowPlans[] = $this->rowPlan($record, $authorizationBySourceId, $index, $errors, $warnings);
+        }
+
+        $profilePlans = array_values(array_filter(
+            $rowPlans,
+            static fn (array $row): bool => ($row['kind'] ?? null) === 'profile'
+        ));
+        $comparisonPlans = array_values(array_filter(
+            $rowPlans,
+            static fn (array $row): bool => ($row['kind'] ?? null) === 'comparison'
+        ));
+        $atPlans = array_values(array_filter(
+            $comparisonPlans,
+            static fn (array $row): bool => ($row['identity']['comparison_kind'] ?? null) === 'at'
+        ));
+        $crossTypePlans = array_values(array_filter(
+            $comparisonPlans,
+            static fn (array $row): bool => ($row['identity']['comparison_kind'] ?? null) === 'cross_type'
+        ));
+
+        return [
+            'artifact' => 'MBTI-CMS-26-CONTENT15-MIXED-IMPORT-PREFLIGHT',
+            'status' => $errors === [] ? 'pass' : 'fail',
+            'ok' => $errors === [],
+            'dry_run_only' => true,
+            'write_supported_in_this_pr' => false,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'search_release_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'package_file_sha256' => $options['package_file_sha256'] ?? '',
+            'authorization_file_sha256' => $options['authorization_file_sha256'] ?? '',
+            'source_package_sha256' => (string) data_get($package, 'exact_package.package_sha256', ''),
+            'authorization_payload_sha256' => (string) data_get($authorizationPackage, 'authorization_package.exact_authorization_payload_sha256', ''),
+            'import_scope_mode' => (string) data_get($authorizationPackage, 'authorization_package.import_scope_mode', ''),
+            'record_count' => count($records),
+            'authorization_record_count' => count($authorizationRecords),
+            'profile_record_count' => count($profilePlans),
+            'comparison_record_count' => count($comparisonPlans),
+            'at_comparison_count' => count($atPlans),
+            'cross_type_comparison_count' => count($crossTypePlans),
+            'field_mapping_contract' => $this->fieldMappingContract(),
+            'production_import_gate' => $this->productionImportGate(),
+            'rows' => $rowPlans,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  list<array<string,string>>  $errors
+     * @return list<mixed>
+     */
+    private function records(array $package, array &$errors): array
+    {
+        $records = $package['records'] ?? null;
+        if (! is_array($records)) {
+            $errors[] = $this->issue('records', 'records_missing_or_not_array', 'CONTENT-15 final dry-run package must contain records as an array.');
+
+            return [];
+        }
+
+        return array_values($records);
+    }
+
+    /**
+     * @param  array<string,mixed>  $authorizationPackage
+     * @param  list<array<string,string>>  $errors
+     * @return list<mixed>
+     */
+    private function authorizationRecords(array $authorizationPackage, array &$errors): array
+    {
+        $records = data_get($authorizationPackage, 'authorization_package.records');
+        if (! is_array($records)) {
+            $errors[] = $this->issue('authorization_package.records', 'authorization_records_missing_or_not_array', 'CMS-23 authorization package must contain authorization_package.records as an array.');
+
+            return [];
+        }
+
+        return array_values($records);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $authorizationPackage
+     * @param  array<string,string>  $options
+     * @param  list<array<string,string>>  $errors
+     * @param  list<array<string,string>>  $warnings
+     */
+    private function validateTopLevel(array $package, array $authorizationPackage, array $options, array &$errors, array &$warnings): void
+    {
+        if ((string) ($package['id'] ?? '') !== 'MBTI-CMS-22') {
+            $warnings[] = $this->issue('id', 'unexpected_source_artifact_id', 'Expected MBTI-CMS-22 as the final dry-run package source.');
+        }
+
+        if ((string) ($authorizationPackage['id'] ?? '') !== 'MBTI-CMS-23') {
+            $warnings[] = $this->issue('authorization_package.id', 'unexpected_authorization_artifact_id', 'Expected MBTI-CMS-23 as the authorization package source.');
+        }
+
+        $sourceSha = (string) data_get($package, 'exact_package.package_sha256', '');
+        $expectedSourceSha = $options['expected_source_package_sha256'] !== ''
+            ? $options['expected_source_package_sha256']
+            : self::EXPECTED_SOURCE_PACKAGE_SHA256;
+        if ($sourceSha !== $expectedSourceSha) {
+            $errors[] = $this->issue('exact_package.package_sha256', 'source_package_sha256_mismatch', 'CMS-22 exact package sha256 does not match the authorized source package sha256.');
+        }
+
+        $authorizationSourceSha = (string) data_get($authorizationPackage, 'authorization_package.source_package_sha256', '');
+        if ($authorizationSourceSha !== $sourceSha) {
+            $errors[] = $this->issue('authorization_package.source_package_sha256', 'authorization_source_package_sha256_mismatch', 'CMS-23 source package sha256 must match CMS-22 exact package sha256.');
+        }
+
+        $authorizationSha = (string) data_get($authorizationPackage, 'authorization_package.exact_authorization_payload_sha256', '');
+        $expectedAuthorizationSha = $options['expected_authorization_payload_sha256'] !== ''
+            ? $options['expected_authorization_payload_sha256']
+            : self::EXPECTED_AUTHORIZATION_PAYLOAD_SHA256;
+        if ($authorizationSha !== $expectedAuthorizationSha) {
+            $errors[] = $this->issue('authorization_package.exact_authorization_payload_sha256', 'authorization_payload_sha256_mismatch', 'CMS-23 authorization payload sha256 does not match the operator authorization package.');
+        }
+
+        $scopeMode = (string) data_get($authorizationPackage, 'authorization_package.import_scope_mode', '');
+        $expectedScopeMode = $options['expected_import_scope_mode'] !== ''
+            ? $options['expected_import_scope_mode']
+            : self::EXPECTED_IMPORT_SCOPE_MODE;
+        if ($scopeMode !== $expectedScopeMode) {
+            $errors[] = $this->issue('authorization_package.import_scope_mode', 'import_scope_mode_mismatch', 'Import scope mode must remain top_blocker_batch_only.');
+        }
+
+        $expectedRecordCount = $options['expected_record_count'] !== ''
+            ? (int) $options['expected_record_count']
+            : self::EXPECTED_RECORD_COUNT;
+        if (count((array) ($package['records'] ?? [])) !== $expectedRecordCount) {
+            $errors[] = $this->issue('records', 'record_count_mismatch', 'CONTENT-15 final dry-run package must contain exactly '.$expectedRecordCount.' records.');
+        }
+
+        if (count((array) data_get($authorizationPackage, 'authorization_package.records', [])) !== $expectedRecordCount) {
+            $errors[] = $this->issue('authorization_package.records', 'authorization_record_count_mismatch', 'CMS-23 authorization package must contain exactly '.$expectedRecordCount.' records.');
+        }
+
+        if ((bool) data_get($authorizationPackage, 'authorization_package.production_import_authorized', true) !== false) {
+            $errors[] = $this->issue('authorization_package.production_import_authorized', 'unexpected_production_authorization_state', 'MBTI-CMS-26 only accepts the not-authorized package state and never writes CMS.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $authorizationPackage
+     * @param  list<array<string,string>>  $errors
+     */
+    private function validateForbiddenRoutes(array $package, array $authorizationPackage, array &$errors): void
+    {
+        $json = json_encode([$package, $authorizationPackage], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($json)) {
+            $errors[] = $this->issue('package', 'json_encode_failed', 'Packages could not be normalized for route safety scanning.');
+
+            return;
+        }
+
+        if (preg_match(self::FORBIDDEN_PUBLIC_ROUTE_PATTERN, $json) === 1) {
+            $errors[] = $this->issue('package', 'forbidden_public_route_pattern_present', 'CONTENT-15 import payload must not contain result/order/share/payment/history/private/account routes.');
+        }
+
+        if (preg_match(self::FORBIDDEN_QUERY_PATTERN, $json) === 1) {
+            $errors[] = $this->issue('package', 'forbidden_query_pattern_present', 'CONTENT-15 import payload must not contain sensitive query keys.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $record
+     * @param  array<string,array<string,mixed>>  $authorizationBySourceId
+     * @param  list<array<string,string>>  $errors
+     * @param  list<array<string,string>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function rowPlan(array $record, array $authorizationBySourceId, int $index, array &$errors, array &$warnings): array
+    {
+        $kind = (string) ($record['kind'] ?? '');
+        $targetPath = $this->normalizePath((string) ($record['target_path'] ?? ''));
+        $cmsKey = is_array($record['cms_key'] ?? null) ? $record['cms_key'] : [];
+        $payload = is_array(data_get($record, 'dry_run_payload.payload')) ? data_get($record, 'dry_run_payload.payload') : [];
+        $sectionKeys = (array) data_get($record, 'schema_validation.section_keys', []);
+        $authorizationRecord = $authorizationBySourceId[(string) ($record['dry_run_record_id'] ?? '')] ?? null;
+        $identity = $kind === 'comparison'
+            ? $this->comparisonIdentity($record, $cmsKey, $targetPath, $errors, $index)
+            : $this->profileIdentity($record, $cmsKey, $targetPath, $errors, $index);
+
+        $this->validateRecordShape($record, $authorizationRecord, $payload, $sectionKeys, $errors, $warnings, $index);
+
+        return [
+            'position' => $index + 1,
+            'dry_run_record_id' => (string) ($record['dry_run_record_id'] ?? ''),
+            'authorization_record_id' => is_array($authorizationRecord) ? (string) ($authorizationRecord['authorization_record_id'] ?? '') : null,
+            'kind' => $kind,
+            'target_path' => $targetPath,
+            'locale' => (string) ($record['locale'] ?? ''),
+            'slug' => (string) ($record['slug'] ?? ''),
+            'cms_resource' => (string) ($record['cms_resource'] ?? ''),
+            'import_action' => (string) ($record['import_action'] ?? ''),
+            'approval_state' => (string) ($record['approval_state'] ?? ''),
+            'identity' => $identity,
+            'target' => $this->targetFor($kind, $identity),
+            'payload_sha256' => (string) ($record['exact_payload_sha256'] ?? ''),
+            'authorization_payload_sha256' => is_array($authorizationRecord) ? (string) ($authorizationRecord['exact_payload_sha256'] ?? '') : '',
+            'section_keys' => array_values(array_map('strval', $sectionKeys)),
+            'faq_count' => (int) data_get($record, 'schema_validation.faq_count', 0),
+            'internal_link_count' => is_array($payload['internal_links'] ?? null) ? count((array) $payload['internal_links']) : 0,
+            'seo_keys' => is_array($payload['seo'] ?? null) ? array_keys($payload['seo']) : [],
+            'indexability_after_preflight' => [
+                'index_eligible' => (bool) ($payload['index_eligible'] ?? false),
+                'sitemap_eligible' => (bool) ($payload['sitemap_eligible'] ?? false),
+                'llms_eligible' => (bool) ($payload['llms_eligible'] ?? false),
+                'robots' => (string) ($payload['robots'] ?? ''),
+            ],
+            'action' => $this->actionFor($kind, $identity),
+            'write_mode_in_this_pr' => 'not_supported',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $record
+     * @param  array<string,mixed>  $cmsKey
+     * @param  list<array<string,string>>  $errors
+     * @return array<string,mixed>
+     */
+    private function profileIdentity(array $record, array $cmsKey, string $targetPath, array &$errors, int $index): array
+    {
+        $code = strtoupper((string) ($cmsKey['profile_code'] ?? $record['code'] ?? ''));
+        if (! preg_match('/^[EINSFTJP]{4}-[AT]$/', $code)) {
+            $errors[] = $this->issue('records.'.(string) $index.'.cms_key.profile_code', 'invalid_profile_code', 'Profile code must be a 32-personality A/T code.');
+        }
+
+        return [
+            'runtime_type_code' => $code,
+            'base_type_code' => substr($code, 0, 4),
+            'variant_code' => substr($code, -1),
+            'locale' => (string) ($record['locale'] ?? ''),
+            'target_path' => $targetPath,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $record
+     * @param  array<string,mixed>  $cmsKey
+     * @param  list<array<string,string>>  $errors
+     * @return array<string,mixed>
+     */
+    private function comparisonIdentity(array $record, array $cmsKey, string $targetPath, array &$errors, int $index): array
+    {
+        $left = strtoupper((string) ($cmsKey['left_code'] ?? ''));
+        $right = strtoupper((string) ($cmsKey['right_code'] ?? ''));
+        $slug = (string) ($cmsKey['comparison_slug'] ?? $record['slug'] ?? '');
+        $kind = preg_match('/^[A-Z]{4}-A$/', $left) === 1
+            && preg_match('/^[A-Z]{4}-T$/', $right) === 1
+            && substr($left, 0, 4) === substr($right, 0, 4)
+                ? 'at'
+                : 'cross_type';
+
+        if ($left === '' || $right === '') {
+            $errors[] = $this->issue('records.'.(string) $index.'.cms_key', 'comparison_codes_missing', 'Comparison records require left_code and right_code.');
+        }
+
+        return [
+            'comparison_kind' => $kind,
+            'comparison_slug' => $slug,
+            'left_type_code' => $left,
+            'right_type_code' => $right,
+            'base_type_code' => $kind === 'at' ? substr($left, 0, 4) : null,
+            'locale' => (string) ($record['locale'] ?? ''),
+            'target_path' => $targetPath,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $record
+     * @param  array<string,mixed>|null  $authorizationRecord
+     * @param  array<string,mixed>  $payload
+     * @param  list<mixed>  $sectionKeys
+     * @param  list<array<string,string>>  $errors
+     * @param  list<array<string,string>>  $warnings
+     */
+    private function validateRecordShape(array $record, ?array $authorizationRecord, array $payload, array $sectionKeys, array &$errors, array &$warnings, int $index): void
+    {
+        $fieldPrefix = 'records.'.(string) $index;
+        $kind = (string) ($record['kind'] ?? '');
+
+        if (! in_array($kind, ['profile', 'comparison'], true)) {
+            $errors[] = $this->issue($fieldPrefix.'.kind', 'unsupported_record_kind', 'CONTENT-15 mixed import supports only profile and comparison records.');
+        }
+
+        if (! is_array($authorizationRecord)) {
+            $errors[] = $this->issue($fieldPrefix.'.dry_run_record_id', 'authorization_record_missing', 'Each CMS-22 record must have a matching CMS-23 authorization record.');
+        } elseif ((string) ($authorizationRecord['exact_payload_sha256'] ?? '') !== (string) ($record['exact_payload_sha256'] ?? '')) {
+            $errors[] = $this->issue($fieldPrefix.'.exact_payload_sha256', 'authorization_payload_record_sha_mismatch', 'CMS-22 record payload sha must match the CMS-23 authorization record payload sha.');
+        }
+
+        if ((string) ($record['approval_state'] ?? '') !== 'approved_for_final_dry_run') {
+            $errors[] = $this->issue($fieldPrefix.'.approval_state', 'approval_state_not_final_dry_run_approved', 'Records must be approved for final dry-run before production import planning.');
+        }
+
+        if ((string) data_get($record, 'schema_validation.status', '') !== 'pass') {
+            $errors[] = $this->issue($fieldPrefix.'.schema_validation.status', 'schema_validation_not_pass', 'Only schema-validation-pass records can enter the mixed import preflight.');
+        }
+
+        $requiredSections = $kind === 'profile' ? self::PROFILE_SECTION_KEYS : self::COMPARISON_SECTION_KEYS;
+        foreach ($requiredSections as $requiredSection) {
+            if (! in_array($requiredSection, $sectionKeys, true)) {
+                $errors[] = $this->issue($fieldPrefix.'.schema_validation.section_keys', 'required_section_missing', 'Required section key is missing: '.$requiredSection);
+            }
+        }
+
+        if ((int) data_get($record, 'schema_validation.faq_count', 0) < ($kind === 'profile' ? 6 : 4)) {
+            $errors[] = $this->issue($fieldPrefix.'.schema_validation.faq_count', 'faq_count_below_content15_minimum', 'FAQ count is below the CONTENT-15 minimum.');
+        }
+
+        if ((bool) data_get($record, 'schema_validation.indexability_held', false) !== true) {
+            $errors[] = $this->issue($fieldPrefix.'.schema_validation.indexability_held', 'indexability_not_held', 'CONTENT-15 import preflight requires indexability to remain held.');
+        }
+
+        if ((bool) ($payload['index_eligible'] ?? false) !== false || (bool) ($payload['sitemap_eligible'] ?? false) !== false || (bool) ($payload['llms_eligible'] ?? false) !== false) {
+            $errors[] = $this->issue($fieldPrefix.'.dry_run_payload.payload', 'indexability_flags_not_fail_closed', 'index_eligible, sitemap_eligible, and llms_eligible must remain false before MBTI-INDEX-24.');
+        }
+
+        if (trim((string) data_get($payload, 'seo.title', '')) === '') {
+            $errors[] = $this->issue($fieldPrefix.'.dry_run_payload.payload.seo.title', 'seo_title_missing', 'SEO title is required for CMS import preflight.');
+        }
+
+        if (! is_array($payload['internal_links'] ?? null) || count((array) $payload['internal_links']) < 3) {
+            $warnings[] = $this->issue($fieldPrefix.'.dry_run_payload.payload.internal_links', 'internal_link_count_low', 'Expected at least three internal links before import.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $identity
+     * @return array<string,mixed>
+     */
+    private function targetFor(string $kind, array $identity): array
+    {
+        if ($kind === 'profile') {
+            return [
+                'target_table' => 'personality_profile_variant_revisions',
+                'target_model' => 'App\\Models\\PersonalityProfileVariantRevision',
+                'planned_live_tables' => [
+                    'personality_profile_variant_sections',
+                    'personality_profile_variant_seo_meta',
+                ],
+                'lookup' => [
+                    'locale' => $identity['locale'] ?? '',
+                    'runtime_type_code' => $identity['runtime_type_code'] ?? '',
+                ],
+            ];
+        }
+
+        if (($identity['comparison_kind'] ?? null) === 'at') {
+            return [
+                'target_table' => 'personality_profile_sections',
+                'target_model' => 'App\\Models\\PersonalityProfileSection',
+                'section_key' => 'mbti64_comparison_a_vs_t',
+                'lookup' => [
+                    'locale' => $identity['locale'] ?? '',
+                    'base_type_code' => $identity['base_type_code'] ?? '',
+                ],
+            ];
+        }
+
+        return [
+            'target_table' => 'planned_mbti_cross_type_comparison_authority',
+            'target_model' => 'backend_authority_layer',
+            'planned_live_tables' => [
+                'mbti_cross_type_comparison_authority',
+                'comparison_public_projection_v1',
+            ],
+            'lookup' => [
+                'locale' => $identity['locale'] ?? '',
+                'comparison_slug' => $identity['comparison_slug'] ?? '',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $identity
+     */
+    private function actionFor(string $kind, array $identity): string
+    {
+        if ($kind === 'profile') {
+            return 'would_stage_profile_content_draft';
+        }
+
+        return ($identity['comparison_kind'] ?? null) === 'at'
+            ? 'would_stage_at_comparison_content_draft'
+            : 'would_stage_cross_type_comparison_content_draft';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fieldMappingContract(): array
+    {
+        return [
+            'profile_target_tables' => [
+                'personality_profile_variant_revisions',
+                'personality_profile_variant_sections',
+                'personality_profile_variant_seo_meta',
+            ],
+            'at_comparison_target_tables' => [
+                'personality_profile_sections',
+            ],
+            'cross_type_comparison_target_tables' => [
+                'planned_mbti_cross_type_comparison_authority',
+                'comparison_public_projection_v1',
+            ],
+            'runtime_release_blocked_until' => [
+                'MBTI-CMS-27 production import execution',
+                'MBTI-CMS-28 post-import read-only verification',
+                'MBTI-INDEX-24 sitemap/llms/indexability gate',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function productionImportGate(): array
+    {
+        return [
+            'current_pr' => 'MBTI-CMS-26',
+            'write_supported_in_this_pr' => false,
+            'next_write_task' => 'MBTI-CMS-27',
+            'required_exact_authorization' => [
+                'source_package_sha256' => self::EXPECTED_SOURCE_PACKAGE_SHA256,
+                'authorization_payload_sha256' => self::EXPECTED_AUTHORIZATION_PAYLOAD_SHA256,
+                'import_scope_mode' => self::EXPECTED_IMPORT_SCOPE_MODE,
+                'record_count' => self::EXPECTED_RECORD_COUNT,
+            ],
+        ];
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $trimmed = trim($path);
+        if ($trimmed === '') {
+            return '';
+        }
+
+        $parsed = parse_url($trimmed, PHP_URL_PATH);
+        $pathOnly = is_string($parsed) ? $parsed : $trimmed;
+
+        return '/'.ltrim($pathOnly, '/');
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
@@ -1,0 +1,396 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityMbtiContent15MixedImportPreflightCommandTest extends TestCase
+{
+    private const SOURCE_PACKAGE_SHA = '75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb';
+
+    private const AUTHORIZATION_PAYLOAD_SHA = 'be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15';
+
+    public function test_mixed_content15_package_preflights_profile_at_and_cross_type_rows_without_writes(): void
+    {
+        [$packagePath, $authorizationPath] = $this->writeFixturePair($this->validPackage(), $this->validAuthorizationPackage());
+
+        $exitCode = Artisan::call('personality:mbti-content15-mixed-import-preflight', [
+            '--package' => $packagePath,
+            '--authorization-package' => $authorizationPath,
+            '--source-package-sha256' => self::SOURCE_PACKAGE_SHA,
+            '--authorization-payload-sha256' => self::AUTHORIZATION_PAYLOAD_SHA,
+            '--import-scope-mode' => 'top_blocker_batch_only',
+            '--record-count' => '9',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['dry_run_only']);
+        $this->assertFalse($payload['write_supported_in_this_pr']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertSame(9, $payload['record_count']);
+        $this->assertSame(9, $payload['authorization_record_count']);
+        $this->assertSame(4, $payload['profile_record_count']);
+        $this->assertSame(5, $payload['comparison_record_count']);
+        $this->assertSame(1, $payload['at_comparison_count']);
+        $this->assertSame(4, $payload['cross_type_comparison_count']);
+        $this->assertSame([], $payload['errors']);
+
+        $rowsByPath = [];
+        foreach ($payload['rows'] as $row) {
+            $rowsByPath[$row['target_path']] = $row;
+        }
+
+        $profile = $rowsByPath['/zh/personality/istj-a'];
+        $at = $rowsByPath['/zh/personality/intp-a-vs-intp-t'];
+        $crossType = $rowsByPath['/zh/personality/entj-vs-intj'];
+
+        $this->assertSame('personality_profile_variant_revisions', $profile['target']['target_table']);
+        $this->assertSame('ISTJ-A', $profile['identity']['runtime_type_code']);
+        $this->assertSame('would_stage_profile_content_draft', $profile['action']);
+        $this->assertSame('personality_profile_sections', $at['target']['target_table']);
+        $this->assertSame('mbti64_comparison_a_vs_t', $at['target']['section_key']);
+        $this->assertSame('at', $at['identity']['comparison_kind']);
+        $this->assertSame('planned_mbti_cross_type_comparison_authority', $crossType['target']['target_table']);
+        $this->assertSame('cross_type', $crossType['identity']['comparison_kind']);
+        $this->assertContains('personality_profile_variant_revisions', $payload['field_mapping_contract']['profile_target_tables']);
+        $this->assertContains('personality_profile_sections', $payload['field_mapping_contract']['at_comparison_target_tables']);
+        $this->assertContains('comparison_public_projection_v1', $payload['field_mapping_contract']['cross_type_comparison_target_tables']);
+        $this->assertSame(self::SOURCE_PACKAGE_SHA, $payload['production_import_gate']['required_exact_authorization']['source_package_sha256']);
+        $this->assertSame(self::AUTHORIZATION_PAYLOAD_SHA, $payload['production_import_gate']['required_exact_authorization']['authorization_payload_sha256']);
+    }
+
+    public function test_source_sha_mismatch_fails_closed(): void
+    {
+        [$packagePath, $authorizationPath] = $this->writeFixturePair($this->validPackage(), $this->validAuthorizationPackage());
+
+        $exitCode = Artisan::call('personality:mbti-content15-mixed-import-preflight', [
+            '--package' => $packagePath,
+            '--authorization-package' => $authorizationPath,
+            '--source-package-sha256' => str_repeat('0', 64),
+            '--authorization-payload-sha256' => self::AUTHORIZATION_PAYLOAD_SHA,
+            '--import-scope-mode' => 'top_blocker_batch_only',
+            '--record-count' => '9',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('source_package_sha256_mismatch', array_column($payload['errors'], 'code'));
+        $this->assertFalse($payload['cms_write_attempted']);
+    }
+
+    public function test_authorization_sha_mismatch_fails_closed(): void
+    {
+        [$packagePath, $authorizationPath] = $this->writeFixturePair($this->validPackage(), $this->validAuthorizationPackage());
+
+        $exitCode = Artisan::call('personality:mbti-content15-mixed-import-preflight', [
+            '--package' => $packagePath,
+            '--authorization-package' => $authorizationPath,
+            '--source-package-sha256' => self::SOURCE_PACKAGE_SHA,
+            '--authorization-payload-sha256' => str_repeat('f', 64),
+            '--import-scope-mode' => 'top_blocker_batch_only',
+            '--record-count' => '9',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('authorization_payload_sha256_mismatch', array_column($payload['errors'], 'code'));
+        $this->assertFalse($payload['cms_write_attempted']);
+    }
+
+    public function test_record_count_mismatch_fails_closed(): void
+    {
+        $package = $this->validPackage();
+        array_pop($package['records']);
+        [$packagePath, $authorizationPath] = $this->writeFixturePair($package, $this->validAuthorizationPackage());
+
+        $exitCode = Artisan::call('personality:mbti-content15-mixed-import-preflight', [
+            '--package' => $packagePath,
+            '--authorization-package' => $authorizationPath,
+            '--source-package-sha256' => self::SOURCE_PACKAGE_SHA,
+            '--authorization-payload-sha256' => self::AUTHORIZATION_PAYLOAD_SHA,
+            '--import-scope-mode' => 'top_blocker_batch_only',
+            '--record-count' => '9',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('record_count_mismatch', array_column($payload['errors'], 'code'));
+        $this->assertFalse($payload['cms_write_attempted']);
+    }
+
+    public function test_write_mode_is_refused_before_package_reading_or_mutation(): void
+    {
+        $exitCode = Artisan::call('personality:mbti-content15-mixed-import-preflight', [
+            '--package' => '/tmp/does-not-matter.json',
+            '--authorization-package' => '/tmp/does-not-matter-auth.json',
+            '--write' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['write_supported_in_this_pr']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertStringContainsString('--write is intentionally unsupported', (string) ($payload['errors'][0]['message'] ?? ''));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        return [
+            'id' => 'MBTI-CMS-22',
+            'artifact' => 'fixture',
+            'status' => 'final_dry_run_package_ready',
+            'exact_package' => ['package_sha256' => self::SOURCE_PACKAGE_SHA],
+            'records' => [
+                $this->profileRecord('istj-a'),
+                $this->profileRecord('istp-a'),
+                $this->profileRecord('isfp-a'),
+                $this->profileRecord('esfj-a'),
+                $this->comparisonRecord('intp-a-vs-intp-t', 'INTP-A', 'INTP-T'),
+                $this->comparisonRecord('intj-vs-intp', 'INTJ', 'INTP'),
+                $this->comparisonRecord('entj-vs-intj', 'ENTJ', 'INTJ'),
+                $this->comparisonRecord('infj-vs-infp', 'INFJ', 'INFP'),
+                $this->comparisonRecord('istj-vs-isfj', 'ISTJ', 'ISFJ'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validAuthorizationPackage(): array
+    {
+        $records = [];
+        foreach ($this->validPackage()['records'] as $record) {
+            $records[] = [
+                'authorization_record_id' => str_replace('mbti-cms-22:', 'mbti-cms-23:', $record['dry_run_record_id']),
+                'source_dry_run_record_id' => $record['dry_run_record_id'],
+                'target_path' => $record['target_path'],
+                'kind' => $record['kind'],
+                'locale' => $record['locale'],
+                'slug' => $record['slug'],
+                'code' => $record['code'],
+                'cms_resource' => $record['cms_resource'],
+                'cms_key' => $record['cms_key'],
+                'import_action' => $record['import_action'],
+                'exact_payload_sha256' => $record['exact_payload_sha256'],
+                'required_schema_status' => 'pass',
+                'faq_count' => $record['schema_validation']['faq_count'],
+                'section_keys' => $record['schema_validation']['section_keys'],
+                'indexability_held_before_import' => true,
+                'production_import_authorized' => false,
+                'operator_review_required' => true,
+            ];
+        }
+
+        return [
+            'id' => 'MBTI-CMS-23',
+            'artifact' => 'fixture',
+            'status' => 'ready_for_operator_authorization',
+            'authorization_package' => [
+                'status' => 'ready_for_operator_authorization',
+                'production_import_authorized' => false,
+                'exact_authorization_payload_sha256' => self::AUTHORIZATION_PAYLOAD_SHA,
+                'source_package_sha256' => self::SOURCE_PACKAGE_SHA,
+                'import_scope_mode' => 'top_blocker_batch_only',
+                'records' => $records,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function profileRecord(string $slug): array
+    {
+        $code = strtoupper($slug);
+        $payload = $this->payload($slug, 'profile');
+        $sectionKeys = [
+            'direct_answer',
+            'who_it_fits',
+            'who_it_does_not_fit',
+            'common_misunderstanding',
+            'at_difference',
+            'career_scenario',
+            'relationship_scenario',
+            'stress_scenario',
+        ];
+
+        return [
+            'dry_run_record_id' => 'mbti-cms-22:profile:'.$slug,
+            'kind' => 'profile',
+            'target_path' => '/zh/personality/'.$slug,
+            'target_url' => 'https://fermatmind.com/zh/personality/'.$slug,
+            'locale' => 'zh-CN',
+            'slug' => $slug,
+            'code' => $code,
+            'cms_resource' => 'personality_profile',
+            'cms_key' => [
+                'locale' => 'zh-CN',
+                'framework' => 'mbti',
+                'profile_code' => $code,
+                'slug' => $slug,
+            ],
+            'import_action' => 'upsert_profile_content_draft',
+            'approval_state' => 'approved_for_final_dry_run',
+            'exact_payload_sha256' => hash('sha256', $slug.'-profile'),
+            'schema_validation' => [
+                'status' => 'pass',
+                'errors' => [],
+                'section_keys' => $sectionKeys,
+                'faq_count' => 6,
+                'seo_title_present' => true,
+                'canonical_matches_target_url' => true,
+                'indexability_held' => true,
+            ],
+            'dry_run_payload' => ['payload' => $payload],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function comparisonRecord(string $slug, string $left, string $right): array
+    {
+        $payload = $this->payload($slug, 'comparison');
+        $sectionKeys = [
+            'direct_answer',
+            'quick_judgment_table',
+            'easy_misread',
+            'real_scenario_differences',
+            'do_not_misjudge',
+        ];
+
+        return [
+            'dry_run_record_id' => 'mbti-cms-22:comparison:'.$slug,
+            'kind' => 'comparison',
+            'target_path' => '/zh/personality/'.$slug,
+            'target_url' => 'https://fermatmind.com/zh/personality/'.$slug,
+            'locale' => 'zh-CN',
+            'slug' => $slug,
+            'code' => $left.' VS '.$right,
+            'cms_resource' => 'personality_comparison',
+            'cms_key' => [
+                'locale' => 'zh-CN',
+                'framework' => 'mbti',
+                'comparison_slug' => $slug,
+                'left_code' => $left,
+                'right_code' => $right,
+            ],
+            'import_action' => 'upsert_comparison_content_draft',
+            'approval_state' => 'approved_for_final_dry_run',
+            'exact_payload_sha256' => hash('sha256', $slug.'-comparison'),
+            'schema_validation' => [
+                'status' => 'pass',
+                'errors' => [],
+                'section_keys' => $sectionKeys,
+                'faq_count' => 4,
+                'seo_title_present' => true,
+                'canonical_matches_target_url' => true,
+                'indexability_held' => true,
+            ],
+            'dry_run_payload' => ['payload' => $payload],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function payload(string $slug, string $kind): array
+    {
+        return [
+            'title' => strtoupper($slug),
+            'summary' => 'fixture summary',
+            'seo' => [
+                'title' => strtoupper($slug).' | 费马测试',
+                'description' => 'fixture description',
+            ],
+            'canonical' => '/zh/personality/'.$slug,
+            'robots' => 'noindex,nofollow',
+            'launch_state' => 'cms_import_draft_only',
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'sections' => [
+                ['key' => $kind === 'profile' ? 'direct_answer' : 'quick_judgment_table', 'body' => 'fixture section'],
+            ],
+            'faq' => [
+                ['question' => 'Q1', 'answer' => 'A1'],
+                ['question' => 'Q2', 'answer' => 'A2'],
+                ['question' => 'Q3', 'answer' => 'A3'],
+                ['question' => 'Q4', 'answer' => 'A4'],
+                ['question' => 'Q5', 'answer' => 'A5'],
+                ['question' => 'Q6', 'answer' => 'A6'],
+            ],
+            'internal_links' => [
+                ['href' => '/zh/personality', 'anchor_text' => 'MBTI 人格', 'role' => 'hub', 'safe_public_route' => true],
+                ['href' => '/zh/tests/mbti-personality-test-16-personality-types', 'anchor_text' => 'MBTI 测试', 'role' => 'test', 'safe_public_route' => true],
+                ['href' => '/zh/personality/intp-a-vs-intp-t', 'anchor_text' => '热门对比', 'role' => 'comparison', 'safe_public_route' => true],
+            ],
+            'schema' => ['type' => 'WebPage'],
+            'method_boundary' => 'not diagnostic',
+            'evidence_notes' => ['fixture'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $authorizationPackage
+     * @return array{0:string,1:string}
+     */
+    private function writeFixturePair(array $package, array $authorizationPackage): array
+    {
+        $prefix = sys_get_temp_dir().'/mbti-cms26-'.bin2hex(random_bytes(6));
+        $packagePath = $prefix.'-source.json';
+        $authorizationPath = $prefix.'-authorization.json';
+
+        File::put($packagePath, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        File::put($authorizationPath, json_encode($authorizationPackage, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return [$packagePath, $authorizationPath];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -387,6 +387,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_content15_mixed_import_preflight_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityMbtiContent15MixedImportPreflight;',
+            '+        PersonalityMbtiContent15MixedImportPreflight::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_big_five_cms_import_draft_dry_run_files(): void
     {
         $changed = [
@@ -5110,6 +5125,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiContent15MixedImportPreflightFile($file)) {
+                continue;
+            }
+
             if ($this->isBigFiveCmsImportDraftDryRunFile($file)) {
                 continue;
             }
@@ -6414,6 +6433,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsIqNormImportDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsIqMethodPagesCmsDraftImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64BackendImportContractOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsMbtiContent15MixedImportPreflightOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsInternalLinkDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsProjectionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6651,6 +6671,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityMbtiComparisonCmsImportDryRun.php',
             'backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php',
+        ], true);
+    }
+
+    private function isMbtiContent15MixedImportPreflightFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php',
+            'backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php',
         ], true);
     }
 
@@ -10819,6 +10847,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityMbti64BackendImportContract\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsMbtiContent15MixedImportPreflightOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityMbtiContent15MixedImportPreflight\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82490,8 +82490,8 @@
     "depends_on": [
       "MBTI-CMS-13"
     ],
-    "status": "pr_open",
-    "commit_sha": "bd720e93ec09af97ad109fe75cf9a42b49888f51",
+    "status": "ready_to_merge",
+    "commit_sha": "bdaab31ebfe446111fdd884b32a4b60c5da17834",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2771",
     "failure_reason": null,
     "merged_at": null,
@@ -82534,12 +82534,16 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to MBTI-CMS-26 backend command/planner/tests, Kernel command registration, runtime-freeze classifier test allowlist, and authorized docs/codex PR-train metadata."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "GitHub PR #2771 checks passed: Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, hygiene, content-pack-build-validate, supply-chain, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": false
     },
     "transitions": [
@@ -82560,6 +82564,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened PR #2771 for MBTI-CMS-26: https://github.com/fermatmind/fap-api/pull/2771."
+      },
+      {
+        "at": "2026-07-06T04:00:00Z",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2771; ready for squash merge under repo policy. No staging deploy wait or production import was performed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82480,5 +82480,81 @@
         "note": "Opened PR #2744 for read-only production runtime FAQ readback evidence."
       }
     ]
+  },
+  "MBTI-CMS-26": {
+    "id": "MBTI-CMS-26",
+    "repo": "fap-api",
+    "title": "MBTI-CMS-26: add CONTENT-15 mixed package importer preflight",
+    "base": "main",
+    "branch": "codex/mbti-cms-26-content15-mixed-import-preflight",
+    "depends_on": [
+      "MBTI-CMS-13"
+    ],
+    "status": "local_checks_passed",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized MBTI-CMS-26 in the attached /goal execution request for the CMS import gate PR train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "MBTI-CMS-13 is recorded as merged in this fap-api train ledger before MBTI-CMS-26 starts."
+      },
+      "syntax_and_format": {
+        "status": "pass",
+        "command": "php -l backend/app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php && php -l backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php && php -l backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php && php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php && cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "evidence": "PASS: PHP syntax checks passed for all scoped PHP files, and Pint reported PASS for 4 files."
+      },
+      "focused_tests": {
+        "status": "pass_with_phpunit_warnings",
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbtiContent15MixedImportPreflightCommandTest --no-ansi && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_content15_mixed_import_preflight_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
+        "evidence": "PASS exit code 0: 5 command tests with 54 assertions and 2 runtime-freeze tests with 4 assertions completed after rebase. PHPUnit reported warnings from local path/environment reads, not assertion failures."
+      },
+      "real_package_preflight": {
+        "status": "pass",
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:mbti-content15-mixed-import-preflight --package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-22-import-dry-run-final-2026-07-05.json --authorization-package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-23-production-import-authorization-package-2026-07-05.json --source-package-sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb --authorization-payload-sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15 --import-scope-mode=top_blocker_batch_only --record-count=9 --dry-run --json",
+        "evidence": "PASS: real CMS-22/CMS-23 package preflight returned status=pass, record_count=9, profile_record_count=4, comparison_record_count=5, writes_committed=false."
+      },
+      "full_mbti_ci": {
+        "status": "pass",
+        "command": "bash scripts/ci_verify_mbti.sh",
+        "evidence": "PASS: verify_mbti, content_graph rollback, events acceptance, personality full-32 authority gate, payment uniqueness, migration safety, auth guest contract, openapi diff, order security, psychometrics streaming, dependency security, webhook/attempt regression, and related gates completed with exit code 0."
+      },
+      "manifest_and_diff": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "evidence": "PASS: train YAML parses, state JSON parses, and git diff whitespace check passes."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to MBTI-CMS-26 backend command/planner/tests, Kernel command registration, runtime-freeze classifier test allowlist, and authorized docs/codex PR-train metadata."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": false
+    },
+    "transitions": [
+      {
+        "at": "2026-07-06T00:00:00Z",
+        "from": "user_authorized",
+        "to": "in_progress",
+        "note": "Started backend-only CONTENT-15 mixed package importer preflight from an isolated fap-api worktree. Scope excludes production CMS writes, production imports, publish, indexability release, sitemap/llms, GSC submission, frontend runtime, staging deploy, and production deploy."
+      },
+      {
+        "at": "2026-07-06T04:00:00Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Implemented fail-closed CONTENT-15 mixed package preflight command and planner, validated the real 9-record CMS-22/CMS-23 package in dry-run mode, passed focused tests, formatting, manifest parsing, diff check, and full scripts/ci_verify_mbti.sh."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82490,9 +82490,9 @@
     "depends_on": [
       "MBTI-CMS-13"
     ],
-    "status": "local_checks_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "bd720e93ec09af97ad109fe75cf9a42b49888f51",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2771",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -82554,6 +82554,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Implemented fail-closed CONTENT-15 mixed package preflight command and planner, validated the real 9-record CMS-22/CMS-23 package in dry-run mode, passed focused tests, formatting, manifest parsing, diff check, and full scripts/ci_verify_mbti.sh."
+      },
+      {
+        "at": "2026-07-06T04:00:00Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened PR #2771 for MBTI-CMS-26: https://github.com/fermatmind/fap-api/pull/2771."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37773,3 +37773,56 @@ prs:
     deploy_allowed: false
     content_authority: CMS/backend
     next_task: MBTI-MAIN-FAQ-SCHEMA-PARITY-REPAIR-01
+
+  - id: MBTI-CMS-26
+    repo: fap-api
+    depends_on:
+      - MBTI-CMS-13
+    branch: codex/mbti-cms-26-content15-mixed-import-preflight
+    title: "MBTI-CMS-26: add CONTENT-15 mixed package importer preflight"
+    train_scope: mbti_content15_mixed_package_import_preflight
+    status: user_authorized
+    scope:
+      - Add a backend-only CONTENT-15 mixed package preflight command for the 9-record MBTI CMS package.
+      - Read CMS-22 and CMS-23 package artifacts and map profile, A/T comparison, and cross-type comparison records.
+      - Validate exact source package sha256, authorization payload sha256, import scope mode, record count, field mapping, FAQ/section coverage, safe public links, and held indexability.
+      - Keep the command dry-run only; --write must fail closed before any package read or mutation.
+      - Do not write CMS, publish, release sitemap/llms, release indexability, submit GSC, trigger deploy, or modify frontend runtime.
+    allowed_paths:
+      - backend/app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php
+      - backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Add frontend content fallback.
+      - Write CMS, run production imports, run database migrations, publish, enable indexability, release sitemap/llms, submit GSC, trigger staging deploy, trigger production deploy, or add public runtime content.
+      - Change public API routes, runtime personality rendering, content authority, canonical/noindex behavior, JSON-LD runtime, scheduler behavior, permissions, or secrets.
+      - Implement MBTI-CMS-27, MBTI-CMS-28, or MBTI-INDEX-24 scope in this PR.
+    validation:
+      - php -l backend/app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php
+      - php -l backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php
+      - php -l backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbtiContent15MixedImportPreflightCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:mbti-content15-mixed-import-preflight --package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-22-import-dry-run-final-2026-07-05.json --authorization-package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-23-production-import-authorization-package-2026-07-05.json --source-package-sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb --authorization-payload-sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15 --import-scope-mode=top_blocker_batch_only --record-count=9 --dry-run --json
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_content15_mixed_import_preflight_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: MBTI-CMS-27


### PR DESCRIPTION
## What changed
- Added a fail-closed `personality:mbti-content15-mixed-import-preflight` Artisan command for CONTENT-15 mixed CMS packages.
- Added a planner that validates the CMS-22 source package and CMS-23 authorization package, classifies profile, A/T comparison, and cross-type comparison records, and returns dry-run import plans.
- Registered the command and added feature/runtime-freeze tests so MBTI-CMS-26 files are treated as non-runtime Big Five freeze noise.
- Registered MBTI-CMS-26 in the PR train manifest/state ledger.

## Why
MBTI-CMS-27 cannot safely perform production CMS import until fap-api can preflight the exact 9-record CONTENT-15 package, verify hashes/scope/record counts, and prove write/indexability operations are fail-closed by default.

## Validation
- `php -l` on all scoped PHP files
- `vendor/bin/pint --test app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=PersonalityMbtiContent15MixedImportPreflightCommandTest --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_content15_mixed_import_preflight_files|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi`
- real CMS-22/CMS-23 package preflight: `status=pass`, `record_count=9`, `profile_record_count=4`, `comparison_record_count=5`, `writes_committed=false`
- `bash scripts/ci_verify_mbti.sh`
- train YAML parse, state JSON parse, `git diff --check`

## Deferred items
- No production CMS writes/imports in this PR.
- No sitemap, llms, canonical/noindex, schema gate release, GSC submission, staging deploy wait, manual deploy, or production deploy.
- MBTI-CMS-27 remains blocked until separate exact package authorization is provided for production write execution.

## Repository rule impact
This keeps CMS/backend as the authority layer and adds only a dry-run importer/preflight gate. It does not introduce frontend fallback content or publishable local editorial authority.