### PR TITLE
BIG5-SITEMAP-LLMS-PERSONALITY-ASSET-14: enumerate released Big Five personality assets

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -7,6 +7,7 @@ use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
 use App\Models\ContentPage;
+use App\Models\PersonalityPublicContentAsset;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariant;
 use App\Models\TopicProfile;
@@ -98,6 +99,7 @@ class SitemapGenerator
             $this->getCareerJobUrls(),
             $this->getCareerGuideUrls(),
             $this->getPersonalityUrls(),
+            $this->getPersonalityPublicContentAssetUrls(),
             $this->getPersonalityComparisonUrls(),
             $this->getTopicUrls(),
             $this->getContentPageUrls(),
@@ -304,6 +306,56 @@ class SitemapGenerator
                 'loc' => $baseUrl.'/'.$segment.'/personality',
                 'lastmod' => $lastmod->toAtomString(),
                 'slug' => 'personality-list:'.$segment,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return $urls;
+    }
+
+    private function getPersonalityPublicContentAssetUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $rows = PersonalityPublicContentAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
+            ->where('locale', 'zh-CN')
+            ->whereIn('entity_type', [
+                PersonalityPublicContentAsset::ENTITY_DOMAIN,
+                PersonalityPublicContentAsset::ENTITY_POLARITY,
+            ])
+            ->where('is_public', true)
+            ->where('launch_state', PersonalityPublicContentAsset::LAUNCH_PUBLISHED)
+            ->where('robots', PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW)
+            ->where('index_eligible', true)
+            ->where('sitemap_eligible', true)
+            ->where('llms_eligible', true)
+            ->select(['entity_key', 'canonical_json', 'updated_at', 'published_at'])
+            ->orderBy('entity_type')
+            ->orderBy('entity_key')
+            ->get();
+
+        $urls = [];
+
+        foreach ($rows as $row) {
+            $path = trim((string) data_get($row->canonical_json, 'path', ''));
+            if (! str_starts_with($path, '/zh/personality/big-five/')) {
+                continue;
+            }
+
+            $lastmod = $row->updated_at
+                ?? $row->published_at
+                ?? now();
+
+            $urls[] = [
+                'loc' => $baseUrl.$path,
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'personality-public-content:big-five:zh:'.strtolower((string) $row->entity_key),
                 'updated_at' => $lastmod->toDateTimeString(),
             ];
         }

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -8,6 +8,7 @@ use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\CareerJobSeoMeta;
 use App\Models\ContentPage;
+use App\Models\PersonalityPublicContentAsset;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileSeoMeta;
 use App\Models\PersonalityProfileVariant;
@@ -176,6 +177,80 @@ class SitemapGeneratorTest extends TestCase
         }
 
         $this->assertStringNotContainsString('https://fermatmind.com/en/help/about', $xml);
+    }
+
+    public function test_generate_includes_released_zh_big_five_public_content_assets_only(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $traitSlugs = [
+            'openness',
+            'conscientiousness',
+            'extraversion',
+            'agreeableness',
+            'neuroticism',
+        ];
+        $rangeSlugs = [];
+        foreach ($traitSlugs as $traitSlug) {
+            foreach (['high', 'mid', 'low'] as $range) {
+                $rangeSlugs[] = "{$traitSlug}-{$range}";
+            }
+        }
+
+        foreach ($traitSlugs as $slug) {
+            $this->createBigFivePublicContentAsset($slug, PersonalityPublicContentAsset::ENTITY_DOMAIN);
+        }
+        foreach ($rangeSlugs as $slug) {
+            $this->createBigFivePublicContentAsset($slug, PersonalityPublicContentAsset::ENTITY_POLARITY);
+        }
+
+        $this->createBigFivePublicContentAsset('openness-en', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
+            'entity_key' => 'openness',
+            'slug' => 'big-five/openness-en',
+            'locale' => 'en',
+            'canonical_json' => ['path' => '/en/personality/big-five/openness'],
+        ]);
+        $this->createBigFivePublicContentAsset('hub', PersonalityPublicContentAsset::ENTITY_HUB, [
+            'canonical_json' => ['path' => '/zh/personality/big-five'],
+        ]);
+        $this->createBigFivePublicContentAsset('openness-noindex', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'canonical_json' => ['path' => '/zh/personality/big-five/openness-noindex'],
+        ]);
+        $this->createBigFivePublicContentAsset('openness-review', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            'sitemap_eligible' => false,
+            'canonical_json' => ['path' => '/zh/personality/big-five/openness-review'],
+        ]);
+        $this->createBigFivePublicContentAsset('openness-sitemap-off', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
+            'sitemap_eligible' => false,
+            'canonical_json' => ['path' => '/zh/personality/big-five/openness-sitemap-off'],
+        ]);
+        $this->createBigFivePublicContentAsset('openness-llms-off', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
+            'llms_eligible' => false,
+            'canonical_json' => ['path' => '/zh/personality/big-five/openness-llms-off'],
+        ]);
+        $this->createBigFivePublicContentAsset('openness-short-path', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
+            'canonical_json' => ['path' => '/zh/big-five/openness'],
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+        $xml = (string) ($payload['xml'] ?? '');
+        $slugList = (array) ($payload['slug_list'] ?? []);
+
+        foreach (array_merge($traitSlugs, $rangeSlugs) as $slug) {
+            $this->assertStringContainsString("https://fermatmind.com/zh/personality/big-five/{$slug}", $xml);
+            $this->assertContains("personality-public-content:big-five:zh:{$slug}", $slugList);
+        }
+
+        $this->assertStringNotContainsString('https://fermatmind.com/en/personality/big-five/openness', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-noindex', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-review', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-sitemap-off', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-llms-off', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/big-five/openness', $xml);
     }
 
     public function test_generate_excludes_science_content_pages_until_public_readiness_gate_passes(): void
@@ -897,6 +972,60 @@ class SitemapGeneratorTest extends TestCase
             'twitter_image_url' => null,
             'robots' => null,
             'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createBigFivePublicContentAsset(
+        string $entityKey,
+        string $entityType,
+        array $overrides = [],
+    ): PersonalityPublicContentAsset {
+        $canonicalPath = "/zh/personality/big-five/{$entityKey}";
+
+        /** @var PersonalityPublicContentAsset */
+        return PersonalityPublicContentAsset::query()->create(array_merge([
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'entity_type' => $entityType,
+            'entity_key' => $entityKey,
+            'slug' => 'big-five/'.$entityKey,
+            'locale' => 'zh-CN',
+            'title' => 'Big Five '.$entityKey,
+            'summary' => 'Big Five public content asset.',
+            'content_sections_json' => [
+                ['id' => 'overview', 'heading' => 'Overview', 'body' => 'Visible reviewed body.'],
+            ],
+            'seo_json' => [
+                'title' => 'Big Five '.$entityKey,
+                'description' => 'Big Five SEO description.',
+            ],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW,
+            'canonical_json' => ['path' => $canonicalPath],
+            'hreflang_json' => [],
+            'faq_json' => [
+                ['question' => 'What is this page?', 'answer' => 'A reviewed Big Five content asset.'],
+            ],
+            'media_json' => [],
+            'schema_json' => ['runtime_jsonld_enabled' => true],
+            'method_boundary_json' => ['non_diagnostic' => true],
+            'evidence_notes_json' => ['status' => 'reviewed'],
+            'internal_links_json' => [],
+            'is_public' => true,
+            'index_eligible' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_PUBLISHED,
+            'review_state' => 'seo_discoverability_released',
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => 'test-package',
+            'source_hash' => str_repeat('a', 64),
+            'published_at' => Carbon::create(2026, 7, 1, 8, 0, 0, 'UTC'),
+            'last_reviewed_at' => Carbon::create(2026, 7, 1, 8, 0, 0, 'UTC'),
+            'created_at' => Carbon::create(2026, 7, 1, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 7, 2, 8, 0, 0, 'UTC'),
         ], $overrides));
     }
 

--- a/backend/tests/Feature/SEO/SitemapSourceApiTest.php
+++ b/backend/tests/Feature/SEO/SitemapSourceApiTest.php
@@ -9,6 +9,7 @@ use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationFamily;
+use App\Models\PersonalityPublicContentAsset;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\File;
@@ -115,6 +116,46 @@ class SitemapSourceApiTest extends TestCase
         $this->assertNotContains('https://fermatmind.com/zh/career/jobs/backend-engineer', $locs);
         $this->assertNotContains('https://fermatmind.com/en/career/jobs/software-engineer', $locs);
         $this->assertNotContains('https://fermatmind.com/zh/career/jobs/software-engineer', $locs);
+    }
+
+    public function test_sitemap_source_warm_includes_released_zh_big_five_public_content_assets(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        foreach (['openness', 'openness-high', 'neuroticism-low'] as $slug) {
+            $this->createBigFivePublicContentAsset(
+                $slug,
+                str_contains($slug, '-') ? PersonalityPublicContentAsset::ENTITY_POLARITY : PersonalityPublicContentAsset::ENTITY_DOMAIN,
+            );
+        }
+
+        $this->createBigFivePublicContentAsset('openness-en', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
+            'entity_key' => 'openness',
+            'slug' => 'big-five/openness-en',
+            'locale' => 'en',
+            'canonical_json' => ['path' => '/en/personality/big-five/openness'],
+        ]);
+        $this->createBigFivePublicContentAsset('openness-noindex', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'canonical_json' => ['path' => '/zh/personality/big-five/openness-noindex'],
+        ]);
+
+        $this->artisan('seo:warm-sitemap-source-cache --json')
+            ->assertSuccessful();
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+        $response->assertOk();
+
+        $locs = collect($response->json('items'))->pluck('loc')->all();
+
+        $this->assertContains('https://fermatmind.com/zh/personality/big-five/openness', $locs);
+        $this->assertContains('https://fermatmind.com/zh/personality/big-five/openness-high', $locs);
+        $this->assertContains('https://fermatmind.com/zh/personality/big-five/neuroticism-low', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/personality/big-five/openness', $locs);
+        $this->assertNotContains('https://fermatmind.com/zh/personality/big-five/openness-noindex', $locs);
     }
 
     /**
@@ -426,6 +467,52 @@ class SitemapSourceApiTest extends TestCase
         $route = app('router')->getRoutes()->getByName('seo.sitemap-source');
         $this->assertNotNull($route, 'Route seo.sitemap-source must be named');
         $this->assertSame(['GET', 'HEAD'], $route->methods());
+    }
+
+    private function createBigFivePublicContentAsset(string $entityKey, string $entityType, array $overrides = []): PersonalityPublicContentAsset
+    {
+        /** @var PersonalityPublicContentAsset */
+        return PersonalityPublicContentAsset::query()->create(array_merge([
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'entity_type' => $entityType,
+            'entity_key' => $entityKey,
+            'slug' => 'big-five/'.$entityKey,
+            'locale' => 'zh-CN',
+            'title' => 'Big Five '.$entityKey,
+            'summary' => 'Big Five public content asset.',
+            'content_sections_json' => [
+                ['id' => 'overview', 'heading' => 'Overview', 'body' => 'Visible reviewed body.'],
+            ],
+            'seo_json' => [
+                'title' => 'Big Five '.$entityKey,
+                'description' => 'Big Five SEO description.',
+            ],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW,
+            'canonical_json' => ['path' => "/zh/personality/big-five/{$entityKey}"],
+            'hreflang_json' => [],
+            'faq_json' => [
+                ['question' => 'What is this page?', 'answer' => 'A reviewed Big Five content asset.'],
+            ],
+            'media_json' => [],
+            'schema_json' => ['runtime_jsonld_enabled' => true],
+            'method_boundary_json' => ['non_diagnostic' => true],
+            'evidence_notes_json' => ['status' => 'reviewed'],
+            'internal_links_json' => [],
+            'is_public' => true,
+            'index_eligible' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_PUBLISHED,
+            'review_state' => 'seo_discoverability_released',
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => 'test-package',
+            'source_hash' => str_repeat('b', 64),
+            'published_at' => Carbon::create(2026, 7, 1, 8, 0, 0, 'UTC'),
+            'last_reviewed_at' => Carbon::create(2026, 7, 1, 8, 0, 0, 'UTC'),
+            'created_at' => Carbon::create(2026, 7, 1, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 7, 2, 8, 0, 0, 'UTC'),
+        ], $overrides));
     }
 
     private function createDisplayAsset(Occupation $occupation, array $overrides = []): CareerJobDisplayAsset

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -56,5 +56,26 @@
     "why_not_current_pr_scope": "PR-C only adds a read-only Big Five production content audit command, focused tests, and generated evidence. It does not start, stop, configure, or route the local API server.",
     "required_checks_affected": "Local verify_mbti.sh could not run without the expected local server. Targeted PHPUnit, syntax, Pint, command discovery, route list, and scope validation passed.",
     "recommended_follow_up": "Run bash scripts/verify_mbti.sh in an environment where the Laravel API is listening on 127.0.0.1:1827, or use the repository's standard local stack bootstrap before this check."
+  },
+  {
+    "repo": "fermatmind/fap-api",
+    "pr_id": "BIG5-SITEMAP-LLMS-PERSONALITY-ASSET-14",
+    "branch": "codex/big5-sitemap-llms-personality-asset-14",
+    "blocker_type": "existing_broad_seo_test_failure",
+    "evidence": [
+      {
+        "command": "php artisan test --filter=Sitemap",
+        "test": "Tests\\Feature\\SeoIntel\\EnParity03ContentPagesParityImportPackageTest::deferred_missing_english_pages_do_not_enter_sitemap",
+        "failure": "Expected sitemap locs not to contain https://fermatmind.com/en/foundation."
+      },
+      {
+        "command": "php artisan test --filter=Sitemap",
+        "test": "Tests\\Feature\\SeoIntel\\GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest::backend_sitemap_source_does_not_emit_missing_content_help_policy_urls",
+        "failure": "Expected sitemap locs not to contain https://fermatmind.com/en/support."
+      }
+    ],
+    "why_not_current_pr_scope": "PR14 only adds Big Five personality_public_content_assets enumeration and targeted SEO tests. It does not change ContentPage, static index URL policy, English foundation/support content, or SeoIntel parity rules.",
+    "required_checks_affected": "Targeted Big Five checks pass. The broad local Sitemap filter is affected by pre-existing non-Big-Five failures.",
+    "recommended_follow_up": "Create a separate content/help policy sitemap cleanup PR for /en/foundation and /en/support exposure rules."
   }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -84,3 +84,13 @@
 - why not current PR scope: PR-C only adds a read-only Big Five production content audit command, focused tests, and generated evidence. It does not start, stop, configure, or route the local API server.
 - whether required checks are affected: Local `verify_mbti.sh` could not run without the expected local server. Targeted PHPUnit, syntax, Pint, command discovery, route list, and scope validation passed.
 - recommended follow-up: Run `bash scripts/verify_mbti.sh` in an environment where the Laravel API is listening on `127.0.0.1:1827`, or use the repository's standard local stack bootstrap before this check.
+
+## BIG5-SITEMAP-LLMS-PERSONALITY-ASSET-14 broad sitemap filter existing failures
+
+- repo: `fermatmind/fap-api`
+- PR id / branch: BIG5-SITEMAP-LLMS-PERSONALITY-ASSET-14 / `codex/big5-sitemap-llms-personality-asset-14`
+- blocker type: `existing_broad_seo_test_failure`
+- evidence: `php artisan test --filter=Sitemap` failed in `Tests\Feature\SeoIntel\EnParity03ContentPagesParityImportPackageTest::deferred_missing_english_pages_do_not_enter_sitemap` because `/en/foundation` is present, and `Tests\Feature\SeoIntel\GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest::backend_sitemap_source_does_not_emit_missing_content_help_policy_urls` because `/en/support` is present.
+- why not current PR scope: PR14 only adds Big Five `personality_public_content_assets` enumeration and targeted SEO tests. It does not change `ContentPage`, static index URL policy, English foundation/support content, or SeoIntel parity rules.
+- whether required checks are affected: Targeted Big Five checks pass. The broad local `Sitemap` filter is affected by pre-existing non-Big-Five failures.
+- recommended follow-up: Create a separate content/help policy sitemap cleanup PR for `/en/foundation` and `/en/support` exposure rules.


### PR DESCRIPTION
## What changed
- Added Big Five `personality_public_content_assets` to the backend sitemap-source generator.
- Limited enumeration to zh-CN Big Five domain/polarity assets that are public, published, indexable, sitemap eligible, llms eligible, and canonical under `/zh/personality/big-five/`.
- Added sitemap generator coverage for the 5 trait + 15 range pages and exclusion coverage for English, noindex, non-published, sitemap-disabled, llms-disabled, hub, and short-path rows.
- Added sitemap-source warm/readback coverage for released Big Five canonical URLs.
- Appended a sidecar record for existing broad `Sitemap` filter failures outside this PR scope.

## Why
Released Big Five zh-CN CMS assets were available through CMS/API but absent from backend sitemap-source, so frontend sitemap/llms consumers could not discover the authorized 20 pages.

## Validation
- `php artisan test --filter=test_generate_includes_released_zh_big_five_public_content_assets_only` passed with PHPUnit warning status.
- `php artisan test --filter=test_sitemap_source_warm_includes_released_zh_big_five_public_content_assets` passed with PHPUnit warning status.
- `php artisan test --filter=PersonalityBigFiveSeoDiscoverabilityReleaseCommandTest` passed with PHPUnit warning status.
- `php artisan route:list --path=api --except-vendor` passed.
- `git diff --check` passed.
- `php -r 'json_decode(file_get_contents("generated/pr-train-sidecar-issues/sidecar_issues.json"), true, 512, JSON_THROW_ON_ERROR); echo "sidecar json ok\\n";'` passed.\n\n## Deferred items\n- `php artisan test --filter=Sitemap` currently fails in pre-existing non-Big-Five SeoIntel content/help policy cases for `/en/foundation` and `/en/support`; recorded in `generated/pr-train-sidecar-issues/`.\n- No CMS writes, SEO release command changes, frontend deploy, Search Console submission, or English Big Five expansion in this PR.