### PR TITLE
MBTI CMS import gate: close out 26 and register next gates

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82490,13 +82490,13 @@
     "depends_on": [
       "MBTI-CMS-13"
     ],
-    "status": "ready_to_merge",
-    "commit_sha": "bdaab31ebfe446111fdd884b32a4b60c5da17834",
+    "status": "merged",
+    "commit_sha": "63f1f9b35d90d3f409468640fd1ede3604f7e909",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2771",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-07-06T04:12:02Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -82538,6 +82538,10 @@
       "github_checks": {
         "status": "pass",
         "evidence": "GitHub PR #2771 checks passed: Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, hygiene, content-pack-build-validate, supply-chain, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "post_merge_revalidation": {
+        "status": "partial_external_local_main_sync_blocked",
+        "evidence": "PR #2771 is MERGED; origin/main contains merge commit 63f1f9b35d90d3f409468640fd1ede3604f7e909; remote branch codex/mbti-cms-26-content15-mixed-import-preflight is deleted; local task worktree /Users/rainie/Desktop/GitHub/fap-api-mbti-cms-26 and local task branch were deleted. Local main sync is blocked by unrelated staged files in /Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01 and is recorded in generated/pr-train-sidecar-issues."
       }
     },
     "scope_validation": {
@@ -82570,6 +82574,98 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "note": "GitHub checks passed for PR #2771; ready for squash merge under repo policy. No staging deploy wait or production import was performed."
+      },
+      {
+        "at": "2026-07-06T04:12:02Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "note": "PR #2771 was squash merged with merge commit 63f1f9b35d90d3f409468640fd1ede3604f7e909. origin/main contains the merge commit, remote branch is deleted, and local task branch/worktree cleanup was executed. Local main sync remains blocked by unrelated staged files in the separate main worktree."
+      }
+    ]
+  },
+  "MBTI-CMS-27": {
+    "id": "MBTI-CMS-27",
+    "repo": "fap-api",
+    "title": "MBTI-CMS-27: execute CONTENT-15 production CMS import",
+    "base": "main",
+    "branch": "codex/mbti-cms-27-content15-production-import",
+    "depends_on": [
+      "MBTI-CMS-26"
+    ],
+    "status": "blocked_needs_operator_authorization",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": "Production CMS write is explicitly blocked until the operator provides separate exact authorization containing source_package_sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb, authorization_payload_sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15, import_scope_mode=top_blocker_batch_only, and record_count=9.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding MBTI-CMS-27 to the fap-api train in the attached /goal execution request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "MBTI-CMS-26 PR #2771 is merged and origin/main contains merge commit 63f1f9b35d90d3f409468640fd1ede3604f7e909."
+      },
+      "operator_authorization": {
+        "status": "blocked_needs_exact_authorization",
+        "evidence": "The attached /goal requires stopping before MBTI-CMS-27 until separate exact production CMS write authorization is provided. No production CMS write was attempted."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": false
+    },
+    "transitions": [
+      {
+        "at": "2026-07-06T04:12:02Z",
+        "from": "manifest_registered",
+        "to": "blocked_needs_operator_authorization",
+        "note": "Registered MBTI-CMS-27 but stopped before production CMS import because separate exact operator authorization has not been provided in a new explicit write-authorization instruction."
+      }
+    ]
+  },
+  "MBTI-CMS-28": {
+    "id": "MBTI-CMS-28",
+    "repo": "fap-api",
+    "title": "MBTI-CMS-28: verify CONTENT-15 CMS import read-only",
+    "base": "main",
+    "branch": "codex/mbti-cms-28-content15-post-import-readonly-verification",
+    "depends_on": [
+      "MBTI-CMS-27"
+    ],
+    "status": "pending_dependency",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": "Waiting for MBTI-CMS-27 production CMS import to complete after separate exact authorization.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding MBTI-CMS-28 to the fap-api train in the attached /goal execution request."
+      },
+      "dependency": {
+        "status": "pending_dependency",
+        "evidence": "MBTI-CMS-27 has not run because production CMS write authorization is still required."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": false
+    },
+    "transitions": [
+      {
+        "at": "2026-07-06T04:12:02Z",
+        "from": "manifest_registered",
+        "to": "pending_dependency",
+        "note": "Registered MBTI-CMS-28 as the read-only post-import verification step. It cannot start until MBTI-CMS-27 production import is authorized, executed, and merged/evidence-recorded."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37826,3 +37826,111 @@ prs:
     deploy_allowed: false
     content_authority: CMS/backend
     next_task: MBTI-CMS-27
+
+  - id: MBTI-CMS-27
+    repo: fap-api
+    depends_on:
+      - MBTI-CMS-26
+    branch: codex/mbti-cms-27-content15-production-import
+    title: "MBTI-CMS-27: execute CONTENT-15 production CMS import"
+    train_scope: mbti_content15_production_cms_import_execution
+    status: blocked_needs_operator_authorization
+    scope:
+      - Execute the CONTENT-15 production CMS import only after separate exact operator authorization is provided.
+      - Require exact source_package_sha256, authorization_payload_sha256, import_scope_mode, and record_count before any write.
+      - Run dry-run first, then production write only when the dry-run passes and exact authorization matches.
+      - Write only the 9-record top blocker batch from CMS-22/CMS-23.
+      - Produce exact import evidence artifacts.
+      - Do not release sitemap, llms, canonical/noindex gates, schema indexability, GSC submission, deploy, or frontend fallback content.
+    required_exact_authorization:
+      source_package_sha256: 75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb
+      authorization_payload_sha256: be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15
+      import_scope_mode: top_blocker_batch_only
+      record_count: 9
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Services/Cms/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/**
+      - generated/mbti-cms-27-content15-production-import/**
+      - generated/pr-train-sidecar-issues/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Start without separate exact operator authorization.
+      - Modify fap-web.
+      - Add frontend content fallback.
+      - Release sitemap, llms, canonical/noindex gates, schema indexability, Search Channel/GSC, staging deploy, production deploy, or public URL expansion.
+      - Import any package other than the exact authorized 9-record top blocker batch.
+      - Implement MBTI-CMS-28 or MBTI-INDEX-24 scope in this PR.
+    validation:
+      - cd backend && APP_ENV=production php artisan personality:mbti-content15-mixed-import-preflight --package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-22-import-dry-run-final-2026-07-05.json --authorization-package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-23-production-import-authorization-package-2026-07-05.json --source-package-sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb --authorization-payload-sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15 --import-scope-mode=top_blocker_batch_only --record-count=9 --dry-run --json
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    database_mutation: true
+    cms_mutation: true
+    api_runtime_change: false
+    publish_allowed: true
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: MBTI-CMS-28
+
+  - id: MBTI-CMS-28
+    repo: fap-api
+    depends_on:
+      - MBTI-CMS-27
+    branch: codex/mbti-cms-28-content15-post-import-readonly-verification
+    title: "MBTI-CMS-28: verify CONTENT-15 CMS import read-only"
+    train_scope: mbti_content15_post_import_readonly_verification
+    status: pending_dependency
+    scope:
+      - Read-only verify the 9 imported CONTENT-15 URLs from CMS/API authority.
+      - Verify answer block, FAQ, SEO fields, internal links, sections, and schema/source fields exist for each URL.
+      - Verify sitemap_eligible, llms_eligible, and indexability gates have not been released early.
+      - Produce passed / needs_revision artifacts for the 4 profile URLs and 5 comparison URLs.
+      - Stop before MBTI-INDEX-24 if any URL fails verification.
+    urls:
+      profile:
+        - /zh/personality/istj-a
+        - /zh/personality/istp-a
+        - /zh/personality/isfp-a
+        - /zh/personality/esfj-a
+      comparison:
+        - /zh/personality/intp-a-vs-intp-t
+        - /zh/personality/intj-vs-intp
+        - /zh/personality/entj-vs-intj
+        - /zh/personality/infj-vs-infp
+        - /zh/personality/istj-vs-isfj
+    allowed_paths:
+      - backend/app/Console/Commands/**
+      - backend/app/Services/Cms/**
+      - backend/tests/Feature/Console/**
+      - backend/tests/Unit/**
+      - generated/mbti-cms-28-content15-post-import-readonly-verification/**
+      - generated/pr-train-sidecar-issues/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Write CMS, publish, run production imports, release sitemap/llms, release indexability, submit GSC, trigger deploy, or add frontend fallback content.
+      - Implement MBTI-INDEX-24 scope in this PR.
+    validation:
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: MBTI-INDEX-24

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -1,37 +1,19 @@
 [
   {
     "repo": "fap-api",
-    "pr_id": "BIG5-CMS-IMPORT-DRYRUN-01",
-    "branch": "codex/big5-cms-import-dryrun-01",
-    "blocker_type": "local_worktree_branch_diff_interference",
-    "evidence": "After the CI-scope test fix, focused tests and desktop package dry-run passed, but local full scripts/ci_verify_mbti.sh failed in BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with IQ method files: backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php, backend/app/Models/TopicProfileEntry.php, backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php.",
-    "why_not_current_pr_scope": "git diff --name-only origin/main...HEAD in the isolated PR worktree contains only the Big Five CMS import dry-run command, planner, tests, Kernel registration, and PR train metadata; it does not contain the IQ method files.",
-    "required_checks_affected": "Local full-check reproduction was affected. GitHub required checks run in a clean checkout; the current PR fix targets the actual GitHub failure, which was the hardcoded desktop package path in the test.",
-    "recommended_follow_up": "Keep IQ method page work isolated in its own branch/PR and avoid sharing dirty local worktree state with PR-train verification worktrees."
-  },
-  {
-    "repo": "fap-api",
-    "pr_id": "BIG5-CMS-FAQ-DEDUPE-02",
-    "branch": "codex/big5-cms-faq-dedupe-02",
-    "blocker_type": "local_worktree_branch_diff_interference",
-    "evidence": "PR2 focused syntax, PHPUnit, desktop package dry-run, Pint, YAML/JSON parse, and diff checks passed, but local full scripts/ci_verify_mbti.sh failed in BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with IQ method files: backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php, backend/app/Models/TopicProfileEntry.php, backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php.",
-    "why_not_current_pr_scope": "PR2 only changes BigFiveCmsImportDraftDryRunPlanner.php, PersonalityBigFiveCmsImportDraftDryRunCommandTest.php, PR train metadata, and this sidecar record. It does not add or modify the IQ method files.",
-    "required_checks_affected": "Local full-check reproduction was affected. GitHub required checks run in a clean checkout and should validate the actual PR2 scope without the local IQ branch-diff interference.",
-    "recommended_follow_up": "Isolate or merge/close the IQ method branch separately; do not use that local branch state as a blocker for Big Five CMS import readiness PRs."
-  },
-  {
-    "repo": "fap-api",
-    "pr_id": "IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01",
-    "branch": "codex/iq-method-pages-cms-import-01",
-    "blocker_type": "external_full_suite_failure_timeout",
+    "pr_id": "MBTI-CMS-26",
+    "branch": "codex/mbti-cms-26-content15-mixed-import-preflight",
+    "blocker_type": "local_main_sync_blocked_by_unrelated_staged_files",
     "evidence": [
-      "cd backend && composer test exited with code 1 after Composer process timeout at 300 seconds.",
-      "Unrelated failures observed before timeout: Tests\\Unit\\Services\\Content\\CulturalCalibrationLayerServiceTest, Tests\\Feature\\Architecture\\ServiceLayerBoundaryTest, Tests\\Feature\\Career\\CareerCnProxyPublicOwnerApiTest, Tests\\Feature\\Career\\CareerJobDetailApiTest, Tests\\Feature\\CareerCms\\ArticleBaselineImportTest.",
-      "Focused rerun of ServiceLayerBoundaryTest reported existing HTTP helper violations in backend/app/Services/SeoIntel/CrawlerLog/CrawlerLogFixtureParser.php and backend/app/Services/Iq/IqOwnerOriginal30BankService.php."
+      "PR #2771 is merged at 2026-07-06T04:12:02Z.",
+      "origin/main contains merge commit 63f1f9b35d90d3f409468640fd1ede3604f7e909.",
+      "Remote branch codex/mbti-cms-26-content15-mixed-import-preflight is deleted.",
+      "Local task worktree /Users/rainie/Desktop/GitHub/fap-api-mbti-cms-26 and local task branch were deleted.",
+      "Local main is checked out in /Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01 and has unrelated staged files under backend/docs/seo/daily-runs/2026-07-05/."
     ],
-    "why_not_current_pr_scope": "Current PR scope only adds the IQ method pages CMS draft importer command/service/test, registers the command, extends the topic group whitelist, and updates PR-train metadata. The observed failures are in Content, Architecture, Career, and CareerCms surfaces outside the changed IQ method importer files.",
-    "required_checks_affected": "unknown_until_github_checks; local focused validation passed",
-    "recommended_follow_up": "Track and fix the failing Content/Career/Architecture tests under their owning PR scopes. Do not mix those repairs into the IQ method pages CMS import PR."
+    "why_not_current_pr_scope": "The staged files belong to a separate SEO/diagnostic daily-runs task and are outside MBTI-CMS-26, MBTI-CMS-27, and MBTI-CMS-28 scope. Touching, unstaging, stashing, or rebasing that worktree would risk altering user/other-task work.",
+    "required_checks_affected": false,
+    "recommended_follow_up": "Finish, commit, stash, or explicitly discard the unrelated staged daily-runs files in /Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01, then run git -C /Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01 pull --ff-only origin main and verify main == origin/main."
   },
   {
     "repo": "fap-api",

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -1,50 +1,25 @@
 # PR Train Sidecar Issues
 
-## BIG5-CMS-IMPORT-DRYRUN-01 local worktree freeze-test interference
-
-- repo: fap-api
-- PR id / branch: BIG5-CMS-IMPORT-DRYRUN-01 / codex/big5-cms-import-dryrun-01
-- blocker type: local worktree / branch-diff interference during full local `scripts/ci_verify_mbti.sh`
-- evidence: after the CI-scope test fix, focused tests and desktop package dry-run passed, but local full `cd backend && bash scripts/ci_verify_mbti.sh` failed in `BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff` with IQ method files: `backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php`, `backend/app/Models/TopicProfileEntry.php`, and `backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php`.
-- why not current PR scope: `git diff --name-only origin/main...HEAD` in the isolated PR worktree contains only the Big Five CMS import dry-run command, planner, tests, Kernel registration, and PR train metadata. It does not contain the IQ method files.
-- whether required checks are affected: local full-check reproduction was affected; GitHub required checks run in a clean checkout and the current PR fix targets the actual GitHub failure, which was the hardcoded desktop package path in the test.
-- recommended follow-up: keep IQ method page work isolated in its own branch/PR and avoid sharing dirty local worktree state with PR-train verification worktrees.
-
-## BIG5-CMS-FAQ-DEDUPE-02 local worktree freeze-test interference
-
-- repo: fap-api
-- PR id / branch: BIG5-CMS-FAQ-DEDUPE-02 / codex/big5-cms-faq-dedupe-02
-- blocker type: local worktree / branch-diff interference during full local `scripts/ci_verify_mbti.sh`
-- evidence: PR2 focused syntax, PHPUnit, desktop package dry-run, Pint, YAML/JSON parse, and diff checks passed, but local full `cd backend && bash scripts/ci_verify_mbti.sh` failed in `BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff` with the same IQ method files: `backend/app/Console/Commands/ArticleImportIqMethodPagesDraft.php`, `backend/app/Models/TopicProfileEntry.php`, and `backend/app/Services/Cms/IqMethodPages/IqMethodPagesDraftImporter.php`.
-- why not current PR scope: PR2 only changes `BigFiveCmsImportDraftDryRunPlanner.php`, `PersonalityBigFiveCmsImportDraftDryRunCommandTest.php`, PR train metadata, and this sidecar record. It does not add or modify the IQ method files.
-- whether required checks are affected: local full-check reproduction was affected. GitHub required checks run in a clean checkout and should validate the actual PR2 scope without the local IQ branch-diff interference.
-- recommended follow-up: isolate or merge/close the IQ method branch separately; do not use that local branch state as a blocker for Big Five CMS import readiness PRs.
-
-## IQ-METHOD-PAGES-ZH-CN-CMS-IMPORT-01
+## fap-api MBTI CMS import gate local main sync blocker
 
 - repo: `fap-api`
-- branch: `codex/iq-method-pages-cms-import-01`
-- blocker type: `external_full_suite_failure_timeout`
+- PR id / branch: `MBTI-CMS-26` / `codex/mbti-cms-26-content15-mixed-import-preflight`
+- blocker type: `local_main_sync_blocked_by_unrelated_staged_files`
 - evidence:
-  - `cd backend && composer test` exited with code 1 after Composer process timeout at 300 seconds.
-  - Before timeout, unrelated failures were observed in:
-    - `Tests\Unit\Services\Content\CulturalCalibrationLayerServiceTest`
-    - `Tests\Feature\Architecture\ServiceLayerBoundaryTest`
-    - `Tests\Feature\Career\CareerCnProxyPublicOwnerApiTest`
-    - `Tests\Feature\Career\CareerJobDetailApiTest`
-    - `Tests\Feature\CareerCms\ArticleBaselineImportTest`
-  - Focused rerun of `ServiceLayerBoundaryTest` reported existing HTTP helper violations in:
-    - `backend/app/Services/SeoIntel/CrawlerLog/CrawlerLogFixtureParser.php`
-    - `backend/app/Services/Iq/IqOwnerOriginal30BankService.php`
+  - PR #2771 is merged at `2026-07-06T04:12:02Z`.
+  - `origin/main` contains merge commit `63f1f9b35d90d3f409468640fd1ede3604f7e909`.
+  - Remote branch `codex/mbti-cms-26-content15-mixed-import-preflight` is deleted.
+  - Local task worktree `/Users/rainie/Desktop/GitHub/fap-api-mbti-cms-26` and local task branch were deleted.
+  - Local `main` is checked out in `/Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01` and has unrelated staged files under `backend/docs/seo/daily-runs/2026-07-05/...`.
 - why not current PR scope:
-  - Current PR scope only adds the IQ method pages CMS draft importer command/service/test, registers the command, extends the topic group whitelist, and updates PR-train metadata.
-  - The observed full-suite failures are in Content, Architecture, Career, and CareerCms surfaces outside the changed IQ method importer files.
-- whether required checks are affected:
-  - Local focused validation for this PR passed.
-  - GitHub required checks must still be inspected after PR creation; if a required check fails, inspect the failing job before merge.
+  - The staged files belong to a separate SEO/diagnostic daily-runs task and are outside MBTI-CMS-26, MBTI-CMS-27, and MBTI-CMS-28 scope.
+  - Touching, unstaging, stashing, or rebasing that worktree would risk altering user/other-task work.
+- whether required checks are affected: `false`
+  - MBTI-CMS-26 required GitHub checks already passed and PR #2771 is merged.
+  - This affects only local `main` sync cleanliness, not the merged PR content or remote branch cleanup.
 - recommended follow-up:
-  - Track and fix the failing Content/Career/Architecture tests under their owning PR scopes.
-  - Do not mix those repairs into the IQ method pages CMS import PR.
+  - Finish, commit, stash, or explicitly discard the unrelated staged daily-runs files in `/Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01`.
+  - Then run `git -C /Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01 pull --ff-only origin main` and verify `main == origin/main`.
 
 ## IQ-METHOD-PAGES-ZH-CN-CMS-READBACK-01
 


### PR DESCRIPTION
## What changed
- Reconciled MBTI-CMS-26 train state after PR #2771 was merged.
- Registered MBTI-CMS-27 and MBTI-CMS-28 in the fap-api PR train manifest/state from the authorized /goal scope.
- Recorded MBTI-CMS-27 as blocked pending separate exact production CMS write authorization.
- Added sidecar evidence for the local main sync blocker caused by unrelated staged daily-runs files in the separate main worktree.

## Why
The MBTI-CMS-26 implementation PR merged successfully, but its ledger still showed `ready_to_merge`. The next production import gate needs explicit manifest/state entries while preserving the hard stop before CMS writes.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`

## Deferred items
- No production CMS import or write.
- No sitemap, llms, canonical/noindex gate release, schema indexability release, GSC submission, staging deploy wait, manual deploy, or production deploy.
- MBTI-CMS-27 must stop until separate exact authorization is provided with the required sha/import scope/record count values.

## Repository rule impact
Metadata-only PR. It keeps backend/CMS as the authority layer and does not introduce frontend fallback content.