### PR TITLE
SIX-TEST-HUB-BACKEND-AUTHORITY-OWNER-MATRIX-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/AUTHORITY_OWNER_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/AUTHORITY_OWNER_MATRIX.md
@@ -1,0 +1,43 @@
+# Backend Authority Owner Matrix
+
+This matrix is based on repository-visible backend code and prior generated runtime readbacks. It is a planning artifact only.
+
+## Source Evidence
+
+| Evidence | Meaning |
+| --- | --- |
+| `backend/app/Models/ScaleRegistry.php` includes `seo_schema_json`, `seo_i18n_json`, `content_i18n_json`, and `report_summary_i18n_json` casts | Scale registry is a backend-authoritative content/SEO data container for test surfaces. |
+| `backend/database/migrations/2026_02_15_160000_add_i18n_seo_content_fields_to_scales_registry.php` adds `seo_i18n_json`, `content_i18n_json`, and `report_summary_i18n_json` | The backend schema intentionally owns i18n SEO/content fields for scales. |
+| `backend/database/seeders/ScaleRegistrySeeder.php` writes `seo_schema_json` and `content_i18n_json` for scales | Seed/import authority exists in backend. |
+| `ScaleRegistrySeeder::catalogContent()` passes `faq: $zhFaq` only for zh override, otherwise uses generic locale content | Current generic FAQ behavior is backend-originated, not a frontend-only fact. |
+| `ScaleRegistrySeeder::catalogLocaleContent()` returns `faq => $faq ?? $this->genericFaq(...)` | Non-overridden routes inherit generic FAQ from backend seed logic. |
+| `/api/v0.3/scales`, `/api/v0.3/scales/catalog`, `/api/v0.3/scales/lookup`, `/api/v0.3/scales/sitemap-source` | Public scale data read paths are backend-owned. |
+| `/api/v0.5/seo/sitemap-source` | Backend SEO sitemap-source authority exists for discoverability feeds. |
+| `backend/app/Services/Scale/ScaleRegistryWriter.php` writes `seo_schema_json`, `seo_i18n_json`, `content_i18n_json`, and `report_summary_i18n_json` | Backend has a controlled writer path for scale registry fields. |
+
+## Owner Matrix
+
+| Surface | Current backend owner candidate | Current status | Repair implication |
+| --- | --- | --- | --- |
+| Landing title/meta/H1 inputs | `scales_registry.seo_i18n_json` and scale registry payload | backend-owned candidate | Do not repair in fap-web copy. |
+| Landing body/FAQ-like content | `scales_registry.content_i18n_json` | backend-owned; generic fallback in seeder for most routes | Add scale-specific FAQ through backend authority path only. |
+| FAQPage JSON-LD source inputs | scale registry localized FAQ data consumed by frontend/runtime schema renderer | backend-owned input, runtime renderer separate | Repair source data/adapter contract before schema-only changes. |
+| CTA text/target | scale registry catalog/landing content plus frontend product flow wiring | mixed: backend content intent + frontend interaction target | CTA copy changes need backend authority; target-flow changes need frontend PR. |
+| Free full/complete result promise | scale registry result/free-section metadata and product policy | backend/product authority needed | Big Five and IQ require policy/claim review before stronger copy. |
+| Claim boundary | backend content fields plus claim-boundary docs/policy | backend/policy owner | IQ, career/admission, diagnostic, and guarantee claims require explicit review. |
+| Public test route discoverability | `/api/v0.3/scales/sitemap-source`, `/api/v0.5/seo/sitemap-source`, sitemap/llms consumers | backend source, frontend/public surfaces consume | Do not edit sitemap/llms directly in repair PRs. |
+| Result/report private URL boundary | protected attempt/result routes under API plus frontend public/private routing | backend auth and frontend route guard | Public SEO PRs must avoid private attempt/report/order/payment URLs. |
+
+## Repair Sequencing Recommendation
+
+1. Keep `SIX-TEST-HUB-FAQ-CTA-CLAIM-GAP-MATRIX-01` as the gap source.
+2. Use this owner matrix to split repairs by backend authority layer:
+   - scale registry content/FAQ source
+   - claim-boundary/product-policy review
+   - frontend adapter/schema parity only if backend source is already correct
+3. Do not start title/meta/H1 or schema-only PRs until source authority is confirmed.
+4. Do not mutate sitemap, `llms.txt`, or `llms-full.txt` as a proxy for content repair.
+
+## Boundary
+
+This PR does not modify `ScaleRegistrySeeder`, migrations, writer services, controllers, sitemap-source, public APIs, CMS rows, frontend rendering, or any runtime data.

--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,17 @@
+# Executive Decision
+
+Task: `SIX-TEST-HUB-BACKEND-AUTHORITY-OWNER-MATRIX-01`
+
+Final verdict: `AUTHORITY_MATRIX_READY`
+
+This generated-only scan maps the backend authority owners for six-test hub FAQ, CTA, claim boundaries, result promises, schema inputs, sitemap-source, and public lookup data. The current authority pattern is backend scale registry first, with frontend expected to consume public API/runtime data rather than inventing CMS-backed landing content.
+
+Key finding:
+
+- `scales_registry.content_i18n_json` is the current owner candidate for test landing localized content, including FAQ-like landing content.
+- `scales_registry.seo_schema_json` / `seo_i18n_json` are the backend owner candidates for structured SEO inputs.
+- `ScaleRegistrySeeder::catalogContent()` currently supports a zh FAQ override but otherwise falls back to `genericFaq()`.
+- Public lookup routes under `/api/v0.3/scales/*` and sitemap-source routes expose scale registry data to consumers.
+- Any repair to non-MBTI FAQ, claim boundaries, or free-result promises should be backend-authoritative and should not be implemented as fap-web fallback copy.
+
+No code, data, CMS, runtime, sitemap, llms, schema, Search, deploy, or fap-web mutation was performed.

--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,17 @@
+# Next Exact Authorization Prompts
+
+## Continue PR Train
+
+```text
+Continue the 33-card PR train with:
+MONEY-INTENT-OWNER-PAGE-RUNTIME-RECONCILE-01
+
+Use the declared generated-only scope from SMALL_PR_QUEUE.md.
+Do not mutate runtime, CMS, sitemap, llms, schema, fap-web, DB, Search, deploy, title/meta/FAQ/body copy, or URL Truth.
+```
+
+## Later Repair Authorization, Not For This PR
+
+```text
+Authorize a separate backend-authoritative design PR for scale registry FAQ/claim repair. Scope must be limited to planning the authority write path and validation gates; do not write CMS/registry content, schema, sitemap, llms, or fap-web code unless separately authorized.
+```

--- a/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/scan_manifest.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "SIX-TEST-HUB-BACKEND-AUTHORITY-OWNER-MATRIX-01",
+  "repo": "fap-api",
+  "branch": "codex/six-test-hub-backend-authority-owner-matrix-01",
+  "output_path": "backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/",
+  "generated_at": "2026-07-06",
+  "final_verdict": "AUTHORITY_MATRIX_READY",
+  "owner_surfaces_mapped": 8,
+  "backend_authority_candidate": "scales_registry",
+  "primary_fields": [
+    "seo_schema_json",
+    "seo_i18n_json",
+    "content_i18n_json",
+    "report_summary_i18n_json"
+  ],
+  "public_read_paths_reviewed": [
+    "/api/v0.3/scales/catalog",
+    "/api/v0.3/scales/lookup",
+    "/api/v0.3/scales/sitemap-source",
+    "/api/v0.5/seo/sitemap-source"
+  ],
+  "repair_implemented": false,
+  "cms_write_performed": false,
+  "runtime_mutation_performed": false,
+  "database_write_performed": false,
+  "sitemap_mutation_performed": false,
+  "llms_mutation_performed": false,
+  "schema_mutation_performed": false,
+  "fap_web_edit_performed": false,
+  "search_submission_performed": false,
+  "deploy_triggered": false,
+  "staging_deploy_waited": false,
+  "production_deploy_triggered": false,
+  "next_task": "MONEY-INTENT-OWNER-PAGE-RUNTIME-RECONCILE-01"
+}


### PR DESCRIPTION
## What changed
- Added generated-only backend authority owner matrix for six-test FAQ, CTA, claim-boundary, result-promise, schema input, and discoverability ownership.
- Mapped current authority candidates to scale registry fields, scale lookup routes, and sitemap-source routes.

## Why
- Downstream repairs need the correct backend authority owner before any FAQ, claim, metadata, schema, sitemap, llms, or frontend work is proposed.

## Validation commands
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/six-test-hub-backend-authority-owner-matrix-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `AUTHORITY_MATRIX_READY`

## Deferred / prohibited items
- No CMS write, runtime/API mutation, DB write, sitemap mutation, llms mutation, schema mutation, fap-web edit, Search submission, title/meta/FAQ/body copy write, deploy, production import, or cache invalidation.
- No scale registry, seeder, writer, controller, or runtime source file was changed.

## Sidecar issues
- None.
