### PR TITLE
SECURITY-169-API-05: seal IQ answer-key, asset, and claim boundaries

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptQuestionDeliveryController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptQuestionDeliveryController.php
@@ -74,8 +74,6 @@ final class AttemptQuestionDeliveryController extends Controller
         $candidates = [
             $request->attributes->get('anon_id'),
             $request->attributes->get('fm_anon_id'),
-            $request->attributes->get('client_anon_id'),
-            $request->input('anon_id'),
             $context->anonId(),
         ];
 

--- a/backend/app/Http/Controllers/API/V0_3/IqOwnerOriginal30AssetController.php
+++ b/backend/app/Http/Controllers/API/V0_3/IqOwnerOriginal30AssetController.php
@@ -4,18 +4,83 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\API\V0_3;
 
+use App\Exceptions\Api\ApiProblemException;
 use App\Http\Controllers\Controller;
+use App\Models\Attempt;
+use App\Services\Attempts\AttemptSubmitService;
 use App\Services\Iq\IqOwnerOriginal30BankService;
+use App\Support\OrgContext;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 final class IqOwnerOriginal30AssetController extends Controller
 {
     public function __construct(
         private readonly IqOwnerOriginal30BankService $ownerBank,
+        private readonly AttemptSubmitService $attemptSubmitService,
     ) {}
 
-    public function show(string $path): BinaryFileResponse
+    public function show(Request $request, string $path): BinaryFileResponse
     {
+        $attemptId = trim((string) $request->query('attempt_id', ''));
+        if ($attemptId === '') {
+            throw new ApiProblemException(404, 'IQ_OWNER_ASSET_NOT_FOUND', 'owner IQ asset not found.');
+        }
+
+        $context = app(OrgContext::class);
+        $attempt = $this->attemptSubmitService
+            ->ownedAttemptQuery(
+                $context,
+                $attemptId,
+                $this->resolveUserId($request, $context),
+                $this->resolveAnonId($request, $context)
+            )
+            ->first();
+
+        if (! $attempt instanceof Attempt || ! $this->ownerBank->isOwnerOriginalAttempt($attempt)) {
+            throw new ApiProblemException(404, 'IQ_OWNER_ASSET_NOT_FOUND', 'owner IQ asset not found.');
+        }
+
         return $this->ownerBank->publicAssetResponse($path);
+    }
+
+    private function resolveUserId(Request $request, OrgContext $context): ?string
+    {
+        $candidates = [
+            $request->attributes->get('fm_user_id'),
+            $request->attributes->get('user_id'),
+            $context->userId(),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) || is_numeric($candidate)) {
+                $value = trim((string) $candidate);
+                if ($value !== '' && preg_match('/^\d+$/', $value) === 1) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveAnonId(Request $request, OrgContext $context): ?string
+    {
+        $candidates = [
+            $request->attributes->get('anon_id'),
+            $request->attributes->get('fm_anon_id'),
+            $context->anonId(),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) || is_numeric($candidate)) {
+                $value = trim((string) $candidate);
+                if ($value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
+++ b/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
@@ -9,7 +9,6 @@ use App\Exceptions\Api\ApiProblemException;
 use App\Models\Attempt;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 final class IqOwnerOriginal30BankService
@@ -128,7 +127,7 @@ final class IqOwnerOriginal30BankService
             ],
             'questions' => [
                 'schema_version' => 'fm.iq.owner_image_bank.items.public.v1',
-                'items' => [$this->publicItem($item, $this->publicRequestOrigin($request))],
+                'items' => [$this->publicItem($item, $this->publicRequestOrigin(), (string) $attempt->id)],
             ],
             'meta' => [
                 'source' => 'attempt_bound_owner_bank',
@@ -375,12 +374,12 @@ final class IqOwnerOriginal30BankService
      * @param  array<string,mixed>  $item
      * @return array<string,mixed>
      */
-    private function publicItem(array $item, string $publicAssetOrigin): array
+    private function publicItem(array $item, string $publicAssetOrigin, string $attemptId): array
     {
         $options = [];
         foreach (($item['options'] ?? []) as $option) {
             if (is_array($option)) {
-                $options[] = $this->onlyPublicOptionFields($option, $publicAssetOrigin);
+                $options[] = $this->onlyPublicOptionFields($option, $publicAssetOrigin, $attemptId);
             }
         }
 
@@ -396,7 +395,8 @@ final class IqOwnerOriginal30BankService
             'title' => (string) ($item['title'] ?? ''),
             'stem' => $this->onlyPublicMediaFields(
                 is_array($item['stem'] ?? null) ? $item['stem'] : [],
-                $publicAssetOrigin
+                $publicAssetOrigin,
+                $attemptId
             ),
             'options' => $options,
         ];
@@ -427,12 +427,12 @@ final class IqOwnerOriginal30BankService
      * @param  array<string,mixed>  $option
      * @return array<string,mixed>
      */
-    private function onlyPublicOptionFields(array $option, string $publicAssetOrigin): array
+    private function onlyPublicOptionFields(array $option, string $publicAssetOrigin, string $attemptId): array
     {
         return [
             'code' => strtoupper(trim((string) ($option['code'] ?? ''))),
             'label' => (string) ($option['label'] ?? $option['code'] ?? ''),
-            ...$this->onlyPublicMediaFields($option, $publicAssetOrigin),
+            ...$this->onlyPublicMediaFields($option, $publicAssetOrigin, $attemptId),
         ];
     }
 
@@ -440,18 +440,18 @@ final class IqOwnerOriginal30BankService
      * @param  array<string,mixed>  $media
      * @return array<string,mixed>
      */
-    private function onlyPublicMediaFields(array $media, string $publicAssetOrigin): array
+    private function onlyPublicMediaFields(array $media, string $publicAssetOrigin, string $attemptId): array
     {
         $assets = is_array($media['assets'] ?? null) ? $media['assets'] : [];
         $publicUrl = $this->publicAssetUrl(
             is_string($assets['image'] ?? null) ? (string) $assets['image'] : '',
-            $publicAssetOrigin
+            $publicAssetOrigin,
+            $attemptId
         );
 
         return [
             'type' => (string) ($media['type'] ?? 'image'),
             'media_type' => (string) ($media['media_type'] ?? 'image/webp'),
-            'assets' => $assets,
             ...($publicUrl !== null ? [
                 'src' => $publicUrl,
                 'public_url' => $publicUrl,
@@ -463,34 +463,19 @@ final class IqOwnerOriginal30BankService
         ];
     }
 
-    private function publicAssetUrl(string $assetPath, string $publicAssetOrigin): ?string
+    private function publicAssetUrl(string $assetPath, string $publicAssetOrigin, string $attemptId): ?string
     {
         $routePath = $this->publicRoutePathForAsset($assetPath);
-        if ($routePath === null) {
+        if ($routePath === null || $attemptId === '') {
             return null;
         }
 
-        return $publicAssetOrigin.'/api/v0.3/iq-owner-original-30/assets/'.$this->encodePublicPath($routePath);
+        return $publicAssetOrigin.'/api/v0.3/iq-owner-original-30/assets/'.$this->encodePublicPath($routePath)
+            .'?attempt_id='.rawurlencode($attemptId);
     }
 
-    private function publicRequestOrigin(?Request $request): string
+    private function publicRequestOrigin(): string
     {
-        if ($request !== null) {
-            $forwardedProto = trim((string) $request->headers->get('x-forwarded-proto', ''));
-            $forwardedHost = trim((string) $request->headers->get('x-forwarded-host', ''));
-
-            $scheme = $forwardedProto !== ''
-                ? strtolower(trim(Str::before($forwardedProto, ',')))
-                : $request->getScheme();
-            $host = $forwardedHost !== ''
-                ? trim(Str::before($forwardedHost, ','))
-                : $request->getHost();
-
-            if ($host !== '') {
-                return rtrim($scheme.'://'.$host, '/');
-            }
-        }
-
         return rtrim((string) config('app.url'), '/');
     }
 

--- a/backend/app/Services/Report/IqReportBuilder.php
+++ b/backend/app/Services/Report/IqReportBuilder.php
@@ -259,7 +259,7 @@ final class IqReportBuilder
         $scored = $status === 'scored';
         $hasNormAuthority = $this->hasNormAuthority($norms);
         $claimPolicy = $this->normalizeClaimPolicy($norms);
-        $scoreClaimLevel = $this->stringOrNull($norms['score_claim_level'] ?? ($claimPolicy['score_claim_level'] ?? null))
+        $scoreClaimLevel = $this->stringOrNull($claimPolicy['score_claim_level'] ?? null)
             ?? 'raw_score_only';
         $claimWarnings = $this->normalizeStringList($norms['claim_warnings'] ?? ($claimPolicy['claim_warnings'] ?? []));
 
@@ -300,14 +300,15 @@ final class IqReportBuilder
     {
         $claimPolicy = is_array($norms['claim_policy'] ?? null) ? $norms['claim_policy'] : [];
         $claimEligible = ($claimPolicy['claim_eligible'] ?? null) === true;
-        $scoreClaimLevel = $this->stringOrNull($norms['score_claim_level'] ?? ($claimPolicy['score_claim_level'] ?? null))
-            ?? ($claimEligible ? 'iq_estimate' : 'raw_score_only');
+        $scoreClaimLevel = $claimEligible
+            ? ($this->stringOrNull($norms['score_claim_level'] ?? ($claimPolicy['score_claim_level'] ?? null)) ?? 'iq_estimate')
+            : 'raw_score_only';
         $claimWarnings = $this->normalizeStringList($norms['claim_warnings'] ?? ($claimPolicy['claim_warnings'] ?? []));
 
         $claimPolicy['claim_eligible'] = $claimEligible;
         $claimPolicy['score_claim_level'] = $scoreClaimLevel;
         $claimPolicy['claim_warnings'] = $claimWarnings;
-        $claimPolicy['iq_estimate_allowed'] = $scoreClaimLevel !== 'raw_score_only';
+        $claimPolicy['iq_estimate_allowed'] = $claimEligible && $scoreClaimLevel === 'iq_estimate';
         $claimPolicy['source'] = $this->stringOrNull($claimPolicy['source'] ?? null) ?? 'iq_norm_authority';
 
         return $claimPolicy;

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1151,7 +1151,8 @@
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
-                    "App\\Http\\Middleware\\ResolveOrgContext"
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenAuth"
                 ],
                 "x-laravel-name": "api.v0_3.iq_owner_original_30.assets.show"
             }

--- a/backend/docs/iq/iq-production-norm-authority.md
+++ b/backend/docs/iq/iq-production-norm-authority.md
@@ -8,7 +8,8 @@
 
 - Backend `iq_norm_authorities` records are the only source allowed to unlock public IQ estimate, percentile, or confidence interval claims.
 - Frontend, CMS, SEO metadata, and paid-report rendering must not infer norm availability from local content, copy, payment state, or item-bank metadata.
-- A norm authority is claim-eligible only when it is locked, license-verified, not retired, sample-size gated, and in a claim-eligible status.
+- A norm authority is claim-eligible only when the backend gate emits literal boolean `true`; string values such as `"true"` or `"false"` are not authority.
+- A claim-eligible authority must be locked, license-verified, not retired, sample-size gated, and in a claim-eligible status.
 - Future importers must run schema validation and dry-run checks before any authority record can be locked.
 
 ## Claim-eligible statuses

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -235,6 +235,8 @@ Route::prefix('v0.3')->middleware([
         Route::get('/public-gateways/help', [PublicGatewaySurfaceController::class, 'help']);
         Route::get('/public-gateways/help/{slug}', [PublicGatewaySurfaceController::class, 'helpDetail']);
         Route::get('/iq-owner-original-30/assets/{path}', [IqOwnerOriginal30AssetController::class, 'show'])
+            ->middleware([\App\Http\Middleware\FmTokenAuth::class])
+            ->defaults('public_realm', true)
             ->where('path', '.*')
             ->name('api.v0_3.iq_owner_original_30.assets.show');
         Route::get('/scales/{scale_code}/questions', [ScalesController::class, 'questions']);

--- a/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+++ b/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
@@ -86,9 +86,9 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
     }
 
     #[Test]
-    public function current_question_payload_uses_request_origin_instead_of_app_url_for_asset_urls(): void
+    public function current_question_payload_ignores_forwarded_origin_for_asset_urls(): void
     {
-        config(['app.url' => 'https://139.224.130.204']);
+        config(['app.url' => 'https://api.fermatmind.com']);
 
         $attempt = $this->createOwnerAttempt('anon_iq_owner_public_origin');
         $request = Request::create(
@@ -100,13 +100,13 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
             [
                 'HTTPS' => 'on',
                 'HTTP_HOST' => 'api.fermatmind.com',
-                'HTTP_X_FORWARDED_PROTO' => 'https',
-                'HTTP_X_FORWARDED_HOST' => 'api.fermatmind.com',
+                'HTTP_X_FORWARDED_PROTO' => 'http',
+                'HTTP_X_FORWARDED_HOST' => 'evil.example',
             ]
         );
 
         $this->assertSame('api.fermatmind.com', $request->getHost());
-        $this->assertSame('https', $request->headers->get('x-forwarded-proto'));
+        $this->assertSame('http', $request->headers->get('x-forwarded-proto'));
 
         $payload = app(IqOwnerOriginal30BankService::class)->publicQuestionPayload($attempt, 0, $request);
 
@@ -114,6 +114,7 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
             $payload['questions']['items'][0],
             'https://api.fermatmind.com'
         );
+        $this->assertStringNotContainsString('evil.example', json_encode($payload, JSON_THROW_ON_ERROR));
         $this->assertSame(
             ['matrix_reasoning', 'pattern_recognition', 'visual_reasoning'],
             data_get($payload, 'questions.items.0.safe_dimension_aliases')
@@ -124,12 +125,47 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
     #[Test]
     public function owner_original_asset_route_rejects_invalid_paths(): void
     {
-        $response = $this->getJson('/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/../banks/IQ_OWNER_ORIGINAL_30/answer_key.json');
+        $anonId = 'anon_iq_owner_asset_invalid';
+        $token = $this->issueAnonToken($anonId);
+        $attempt = $this->createOwnerAttempt($anonId);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/../banks/IQ_OWNER_ORIGINAL_30/answer_key.json?attempt_id='.$attempt->id);
 
         $response->assertStatus(404);
         $response->assertJson([
             'error_code' => 'IQ_OWNER_ASSET_NOT_FOUND',
         ]);
+    }
+
+    #[Test]
+    public function owner_original_asset_route_requires_token_and_attempt_owner(): void
+    {
+        $attempt = $this->createOwnerAttempt('anon_iq_owner_asset_real');
+        $assetPath = '/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/q01/stem.webp?attempt_id='.$attempt->id;
+
+        $this->getJson($assetPath)->assertStatus(401);
+
+        $wrongToken = $this->issueAnonToken('anon_iq_owner_asset_wrong');
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$wrongToken,
+        ])->getJson($assetPath)->assertStatus(404);
+    }
+
+    #[Test]
+    public function current_question_delivery_rejects_body_anon_id_spoofing(): void
+    {
+        $attempt = $this->createOwnerAttempt('anon_iq_owner_real_body_spoof');
+        $wrongToken = $this->issueAnonToken('anon_iq_owner_wrong_body_spoof');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$wrongToken,
+        ])->json('GET', '/api/v0.3/attempts/'.$attempt->id.'/questions?index=0', [
+            'anon_id' => 'anon_iq_owner_real_body_spoof',
+        ]);
+
+        $response->assertStatus(404);
     }
 
     #[Test]
@@ -490,21 +526,23 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
             $this->assertIsArray($payload, $label.' media payload missing');
             $src = (string) data_get($payload, 'src');
             $publicUrl = (string) data_get($payload, 'public_url');
-            $assetPath = (string) data_get($payload, 'assets.image');
 
             $this->assertNotSame('', $src, $label.' src missing');
             $this->assertSame($src, $publicUrl, $label.' public_url should match src');
+            $this->assertArrayNotHasKey('assets', $payload);
             if ($expectedOrigin !== null) {
                 $this->assertStringStartsWith($expectedOrigin.'/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/q01/', $src);
             }
             $this->assertStringContainsString('/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/q01/', $src);
-            $this->assertStringStartsWith('assets/iq_owner_original_30/q01/', $assetPath);
+            $this->assertStringContainsString('attempt_id=', $src);
             $this->assertStringNotContainsString('139.224.130.204', $src);
             $this->assertStringNotContainsString(base_path(), $src);
             $this->assertStringNotContainsString('/private/', $src);
             $this->assertStringNotContainsString('../', $src);
 
-            $assetResponse = $this->get($this->pathFromPublicUrl($src));
+            $assetResponse = $this->withHeaders([
+                'Authorization' => 'Bearer '.$this->issueAnonToken($this->anonIdFromAttemptUrl($src)),
+            ])->get($this->pathFromPublicUrl($src));
             $assetResponse->assertStatus(200);
             $assetResponse->assertHeader('X-Content-Type-Options', 'nosniff');
             $this->assertStringStartsWith('image/webp', (string) $assetResponse->headers->get('content-type'));
@@ -517,7 +555,17 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         $path = parse_url($url, PHP_URL_PATH);
         $this->assertIsString($path);
         $this->assertStringStartsWith('/api/v0.3/iq-owner-original-30/assets/', $path);
+        $query = parse_url($url, PHP_URL_QUERY);
+        $this->assertIsString($query);
 
-        return $path;
+        return $path.'?'.$query;
+    }
+
+    private function anonIdFromAttemptUrl(string $url): string
+    {
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+        $attempt = Attempt::query()->findOrFail((string) ($query['attempt_id'] ?? ''));
+
+        return (string) $attempt->anon_id;
     }
 }

--- a/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
@@ -142,6 +142,43 @@ final class IqReportBuilderTest extends TestCase
         $this->assertFalse((bool) data_get($lockedPayload, 'report.summary.claim_policy.claim_eligible'));
     }
 
+    public function test_builder_treats_string_false_claim_policy_as_not_eligible(): void
+    {
+        $builder = app(IqReportBuilder::class);
+        $attempt = new Attempt([
+            'id' => 'attempt-iq-report-string-false',
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        ]);
+        $payload = $this->scoredPayloadWithNormClaimPolicy(false);
+        $payload['norms']['status'] = 'production_normed';
+        $payload['norms']['iq_estimate'] = 131.0;
+        $payload['norms']['percentile'] = 98.0;
+        $payload['norms']['confidence_interval'] = [126.5, 135.5];
+        $payload['norms']['score_claim_level'] = 'iq_estimate';
+        $payload['norms']['claim_policy']['claim_eligible'] = 'false';
+        $payload['norms']['claim_policy']['score_claim_level'] = 'iq_estimate';
+        $payload['norms']['claim_policy']['iq_estimate_allowed'] = 'false';
+
+        $result = new Result([
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'result_json' => [
+                'normed_json' => $payload,
+            ],
+        ]);
+
+        $report = $builder->composeVariant($attempt, $result, ReportAccess::VARIANT_FULL, [
+            'report_access_level' => ReportAccess::REPORT_ACCESS_FULL,
+        ]);
+
+        $this->assertNull(data_get($report, 'report.summary.iq_estimate'));
+        $this->assertNull(data_get($report, 'report.summary.percentile'));
+        $this->assertNull(data_get($report, 'report.summary.confidence_interval'));
+        $this->assertSame('raw_score_only', data_get($report, 'report.summary.score_claim_level'));
+        $this->assertSame('raw_score_only', data_get($report, 'report.summary.claim_policy.score_claim_level'));
+        $this->assertFalse((bool) data_get($report, 'report.summary.claim_policy.claim_eligible'));
+        $this->assertFalse((bool) data_get($report, 'report.summary.claim_policy.iq_estimate_allowed'));
+    }
+
     public function test_builder_keeps_blocked_unscored_legacy_demo_report_explicit(): void
     {
         $builder = app(IqReportBuilder::class);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41862,6 +41862,14 @@
       "authorization": {
         "evidence": "Authorized by the 2026-07-03 SECURITY-169 attached /goal.",
         "status": "pass"
+      },
+      "local_validation": {
+        "evidence": "Ran syntax checks, focused IQ owner asset/session and IQ report builder tests, route:list, sqlite migrate, OpenAPI snapshot check, JSON/YAML parsing, git diff --check, and backend/scripts/ci_verify_mbti.sh after rebasing onto latest origin/main.",
+        "status": "pass"
+      },
+      "scope_validation": {
+        "evidence": "Changed files are confined to API-05 allowed IQ owner asset/session delivery, spoofable anon ownership, norm claim authority, OpenAPI snapshot, and train manifest/state paths.",
+        "status": "pass"
       }
     },
     "cms_mutation": false,
@@ -41877,6 +41885,16 @@
         "at": "2026-07-03T00:00:00+08:00",
         "note": "Registered authorized SECURITY-169-API-05; execution waits for declared dependency merge.",
         "status": "planned"
+      },
+      {
+        "at": "2026-07-06T00:00:00+08:00",
+        "note": "Started SECURITY-169-API-05 from latest origin/main in isolated worktree; scope is IQ answer-key, asset delivery, spoofable anon ownership, and norm claim authority boundaries only.",
+        "status": "in_progress"
+      },
+      {
+        "at": "2026-07-06T00:00:00+08:00",
+        "note": "Local validation and scope validation passed after rebasing onto latest origin/main; no staging, manual deploy, production deploy, CMS write, or DB migration was executed.",
+        "status": "validated"
       }
     ],
     "failure_reason": null,
@@ -41888,7 +41906,7 @@
     "publish_allowed": false,
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "status": "planned",
+    "status": "in_progress",
     "title": "SECURITY-169-API-05: seal IQ answer-key, asset, and claim boundaries",
     "train_scope": "security_169_fap_api_audit"
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -35073,14 +35073,19 @@ prs:
       - backend/app/Services/Report/IqReportBuilder.php
       - backend/app/Http/Middleware/FmTokenAuth.php
       - backend/app/Services/Iq/IqNormAuthorityContract.php
+      - backend/docs/contracts/openapi.snapshot.json
       - backend/docs/iq/iq-production-norm-authority.md
+      - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
       - Run deploys, production imports, CMS/search writes, external submissions, or unrelated frontend changes.
     validation:
       - cd backend && php artisan route:list --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-05.sqlite php artisan migrate --force
+      - cd backend && bash scripts/export_openapi.sh --check
       - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool backend/docs/contracts/openapi.snapshot.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - git diff --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }


### PR DESCRIPTION
## What changed
- Protected IQ owner original 30 asset delivery with `FmTokenAuth` and owner-bound `attempt_id` verification before serving files.
- Removed spoofable body `anon_id` ownership candidates from IQ current-question delivery; ownership now comes from token-injected identity context.
- Removed raw answer-key asset paths from public IQ question media payloads and generated asset URLs from configured app URL instead of forwarded headers.
- Hardened IQ report claim policy normalization so only literal boolean `claim_eligible=true` can enable IQ estimate claims.
- Regenerated OpenAPI snapshot and updated SECURITY-169-API-05 train manifest/state scope metadata.

## Why
- Closes SECURITY-169-API-05 findings around answer-key oracle exposure, owner asset access, forwarded URL trust, spoofable anon ownership, and IQ norm claim boundary enforcement.
- Keeps backend as the authority boundary for private IQ assets and claim eligibility.

## Validation
- `php -l` on modified PHP files.
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='IqOwnerOriginal30SessionDeliveryTest|IqReportBuilderTest' --display-warnings --no-ansi`.
- `cd backend && php artisan route:list --no-ansi`.
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-05.sqlite php artisan migrate --force --no-ansi`.
- `cd backend && bash scripts/export_openapi.sh --check`.
- `python3 -m json.tool docs/codex/pr-train-state.json` and `python3 -m json.tool backend/docs/contracts/openapi.snapshot.json`.
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml ok"'`.
- `git diff --check`.
- `bash backend/scripts/ci_verify_mbti.sh` on latest main baseline: passed.

## Deferred items
- No staging deploy wait.
- No manual deploy.
- No production deploy.
- No CMS write or production import.
- Production deploy requires separate exact SHA authorization and is outside this PR.
