### PR TITLE
RESULT-INTERPRETATION-OWNER-ROUTE-MATRIX-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,30 @@
+# RESULT-INTERPRETATION-OWNER-ROUTE-MATRIX-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: OWNER_ROUTE_MATRIX_READY
+
+This PR records the current owner-route evidence for six test result-interpretation journeys. It does not assign new runtime owners, change page copy, update CMS content, modify sitemap/llms, or alter schema.
+
+## Summary
+
+- Tests reviewed: 6
+- Explicit result-interpretation owner routes confirmed: 0/6
+- Existing support routes mapped: 6/6
+- Private result/report URL owner candidates: 0
+- Runtime, CMS, Search Console, GA, sitemap, llms, canonical, noindex, JSON-LD mutations: none
+
+## Decision Rule
+
+Use the matrix in `OWNER_ROUTE_MATRIX.md` as the next planning input. Any future owner assignment or article creation needs a separate authorized PR because this scan is read-only and cannot promote support routes into official owner pages.
+
+## Deferred Items
+
+- Create or promote explicit "how to read results" owner pages.
+- Add internal links from hub pages to selected owner pages.
+- Re-run runtime readback after owner pages are authorized and published.
+- Verify private URL exclusion with the next boundary-guard PR.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,24 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`RESULT-INTERPRETATION-PRIVATE-RESULT-BOUNDARY-GUARD-01`
+
+Scope:
+
+- generated docs only
+- verify private result/report/attempt/order/payment URLs are excluded from public owner route candidacy
+- do not mutate runtime, CMS, sitemap, llms, schema, canonical, noindex, or Search Console state
+
+## Future Repair Authorization
+
+After the boundary guard and Mode C brief queue are complete, authorize a separate content/runtime plan only if a specific owner route per test family is selected.
+
+Required constraints:
+
+- one PR per test family or one docs-only package handoff PR
+- no private URL in sitemap, llms, public internal links, or answer surfaces
+- no claim of diagnostic, hiring, admission, financial, legal, or clinical authority
+- no promotion of support routes into owner routes without backend/CMS authority evidence

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/OWNER_ROUTE_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/OWNER_ROUTE_MATRIX.md
@@ -1,0 +1,45 @@
+# Result Interpretation Owner Route Matrix
+
+Date: 2026-07-06
+Scope: six core test families, read-only evidence
+
+## Guardrails
+
+- Owner route means a public, indexable route that can safely answer "结果怎么看 / how to read results" for one test family.
+- Support route means an existing article or guide that partially explains a result area, but is not yet confirmed as the canonical owner for result interpretation.
+- Private result URLs, attempts, reports, orders, payments, share tokens, and account/history pages are excluded from owner candidacy.
+
+## Matrix
+
+| Test family | Current support route evidence | Explicit owner status | Gap |
+| --- | --- | --- | --- |
+| MBTI | `/zh/articles/mbti-full-report-career-relationship-communication`; `/zh/articles/mbti-growth-guide`; `/zh/articles/mbti-narrative-portrait`; career support via `/zh/articles/from-mbti-to-job-fit` | Not confirmed | Strong support set exists, but no single route is confirmed as the public "how to read MBTI results" owner. |
+| Big Five | `/zh/articles/big-five-growth-guide`; `/zh/articles/big-five-narrative-portrait`; `/zh/articles/big-five-tool-guide`; career support via `/zh/articles/big5-for-career-decisions` | Not confirmed | Support pages cover growth, narrative, and tool framing, but owner-route authority is not closed. |
+| Enneagram | `/zh/articles/enneagram-personality-test-explained` | Not confirmed | Thin support surface; result-reading owner needs explicit route and claim-safe boundaries. |
+| RIASEC | `/zh/articles/riasec-holland-career-interest-test-explained`; gaokao/major/career scenario support pages | Not confirmed | Scenario cluster exists, but "how to read RIASEC results" remains separate from scenario planning pages. |
+| IQ | `/zh/articles/iq-test-score-and-limits-explained`; `/zh/articles/iq-test-growth-guide`; `/zh/articles/iq-test-narrative-portrait`; `/zh/articles/iq-test-tool-guide` | Not confirmed | Strongest limits-bound support set, but still not promoted as a single canonical result-reading owner. |
+| EQ | `/zh/articles/eq-test-tool-guide` | Not confirmed | Thinnest support set; needs explicit result-interpretation owner before growth work. |
+
+## Non-owner Boundaries
+
+These surfaces must not be used as public SEO/GEO owner routes:
+
+- `/results/*`
+- `/reports/*`
+- `/attempts/*`
+- `/orders/*`
+- `/payments/*`
+- authenticated account/history/report recovery pages
+- tokenized share, claim, or private report URLs
+
+## Follow-up Classification
+
+Recommended next PRs:
+
+1. `RESULT-INTERPRETATION-PRIVATE-RESULT-BOUNDARY-GUARD-01`: verify private result/report boundaries remain excluded.
+2. `RESULT-INTERPRETATION-MODE-C-BRIEF-QUEUE-01`: draft a content brief queue for explicit owner pages without runtime mutation.
+3. Future authorized content/runtime PRs: create or promote one public owner route per test family, then run runtime readback.
+
+## Evidence Limits
+
+This report uses repository and existing generated evidence inventory only. It does not use live GSC or GA and does not validate publication state changes outside the recorded evidence scope.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/scan_manifest.json
@@ -1,0 +1,27 @@
+{
+  "pr_id": "RESULT-INTERPRETATION-OWNER-ROUTE-MATRIX-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "OWNER_ROUTE_MATRIX_READY",
+  "tests_reviewed": 6,
+  "explicit_result_owner_routes_confirmed": 0,
+  "support_route_sets_mapped": 6,
+  "private_url_owner_candidates": 0,
+  "runtime_mutation": false,
+  "cms_mutation": false,
+  "search_console_mutation": false,
+  "ga_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "OWNER_ROUTE_MATRIX.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "RESULT-INTERPRETATION-PRIVATE-RESULT-BOUNDARY-GUARD-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only owner-route matrix for six result-interpretation journeys.
- Recorded support routes, explicit owner gaps, private URL exclusions, and next authorization prompts.
- Added machine-readable scan manifest for this read-only audit.

## Why
- The P2 result-interpretation line needs a public owner-route matrix before any content or runtime repair PR.
- This keeps private report/result surfaces out of public SEO/GEO owner candidacy.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/result-interpretation-owner-route-matrix-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `OWNER_ROUTE_MATRIX_READY`

## Deferred items
- No runtime, CMS, sitemap, llms, canonical, noindex, JSON-LD, Search Console, GA, or deploy changes.
- Future owner assignment or content/runtime changes require separate authorization.