### PR TITLE
RESULT-INTERPRETATION-PRIVATE-RESULT-BOUNDARY-GUARD-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,36 @@
+# RESULT-INTERPRETATION-PRIVATE-RESULT-BOUNDARY-GUARD-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: PRIVATE_RESULT_BOUNDARY_GUARD_READY
+
+Private result, report, attempt, order, payment, lookup, share-token, account, history, and recovery routes must remain excluded from result-interpretation owner candidacy. They can provide product functionality, but they are not public SEO/GEO owner routes.
+
+## Summary
+
+- Private route families reviewed: 7
+- Private route families eligible as owner routes: 0
+- Public owner-route mutations: none
+- Runtime, CMS, Search Console, GA, sitemap, llms, canonical, noindex, JSON-LD mutations: none
+
+## Key Evidence
+
+- `backend/routes/api.php` exposes attempt/result/report/report-access/PDF/share endpoints as API product surfaces.
+- `backend/routes/api.php` exposes order checkout, lookup, recovery, resend, provider, payment launch, and order detail endpoints as commerce/support surfaces.
+- Help content drafts warn users not to post full result links, order lookup links, history links, screenshots containing private URLs, or personal access links publicly.
+- RIASEC and Big Five result-agent docs repeatedly require private result/report/share/history/PDF surfaces to stay out of sitemap, llms, canonical promotion, JSON-LD, and search submission.
+
+## Decision Rule
+
+The next content-planning PR may reference private result pages only as excluded boundaries. It must not use private URLs as canonical owners, citation targets, sitemap entries, llms entries, public internal-link targets, or answer-surface evidence.
+
+## Deferred Items
+
+- No runtime route inspection with private credentials was performed.
+- No production private URL was accessed.
+- No noindex/canonical/sitemap/llms changes were made.
+- Future owner pages still need separate public route authorization.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,18 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`RESULT-INTERPRETATION-MODE-C-BRIEF-QUEUE-01`
+
+Scope:
+
+- generated docs only
+- produce a queue of public result-interpretation content briefs for six test families
+- use private result/report/attempt/order/payment surfaces only as exclusion boundaries
+- do not mutate runtime, CMS, sitemap, llms, schema, canonical, noindex, Search Console, GA, or production data
+
+## Future Live Boundary Readback
+
+If live private URL validation is needed later, authorize a separate read-only runtime guard PR with exact URLs or safe synthetic attempts. That PR must not access real user private results, secrets, payment data, or production account data without explicit approval.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/PRIVATE_RESULT_BOUNDARY_GUARD.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/PRIVATE_RESULT_BOUNDARY_GUARD.md
@@ -1,0 +1,35 @@
+# Private Result Boundary Guard
+
+Date: 2026-07-06
+Scope: result-interpretation owner-route guardrail
+
+## Boundary Matrix
+
+| Surface family | Evidence path | Public owner-route eligibility | Notes |
+| --- | --- | --- | --- |
+| Attempts | `backend/routes/api.php` includes `/attempts/start`, `/attempts/submit`, `/attempts/{id}`, `/attempts/{id}/result`, `/attempts/{id}/report`, `/attempts/{id}/report-access`, progress, question delivery, feedback, invite unlocks, PDF, observation, and journey endpoints. | No | Product/API surfaces tied to attempts, identifiers, progress, results, or unlock state. |
+| Results and reports | `backend/routes/api.php`; `backend/app/Http/Controllers/LookupController.php`; result-agent docs under `backend/docs/riasec` and `backend/docs/big5`. | No | May contain score, vector, unlock, report, share, PDF, or private state. |
+| Orders and payments | `backend/routes/api.php` includes `/orders/checkout`, `/orders/lookup`, `/orders/{order_no}`, `/orders/{provider}`, `/orders/{order_no}/pay/alipay`, and recovery/resend paths. | No | Commerce/support surfaces; not SEO/GEO content owners. |
+| Share and public summary variants | `backend/routes/api.php` includes `/attempts/{id}/share`; RIASEC handoff docs require share summaries to be redacted. | No as full owner | Share summaries must remain limited and cannot expose full report or private URL evidence. |
+| Account/history/recovery | Help drafts discuss result recovery, history links, lookup links, and personal access links. | No | Support workflows are not owner-route candidates. |
+| Email-generated report links | `backend/app/Services/Email/EmailOutboxService.php` builds report/report PDF/order lookup URLs. | No | Delivery links are access mechanisms, not public citation surfaces. |
+| Public articles/guides | Existing support articles listed in the owner-route matrix. | Possible after authorization | Only public, indexable, backend/CMS-authorized routes can become owner candidates. |
+
+## Guardrail Tests Applied
+
+1. A candidate owner must be public and intentionally indexable.
+2. A candidate owner must not require an attempt id, order number, payment state, email lookup, account state, token, or private access link.
+3. A candidate owner must not expose raw scores, vectors, percentiles, report unlock state, internal metadata, selector traces, user identifiers, payment identifiers, or support recovery details.
+4. A candidate owner must not be added to sitemap, llms, canonical, JSON-LD, or Search Console submission through this PR.
+
+## Current Status
+
+The boundary is clear enough for planning work:
+
+- Public support routes can be evaluated in future owner-route selection.
+- Private product and commerce routes are blocked from owner candidacy.
+- The next Mode C brief queue should write public content briefs without referencing private result URLs as source or destination pages.
+
+## Evidence Limits
+
+This is a repository/document scan. It does not authenticate into production, access private user data, inspect secrets, or verify live noindex headers for private URLs.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/scan_manifest.json
@@ -1,0 +1,27 @@
+{
+  "pr_id": "RESULT-INTERPRETATION-PRIVATE-RESULT-BOUNDARY-GUARD-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "PRIVATE_RESULT_BOUNDARY_GUARD_READY",
+  "private_route_families_reviewed": 7,
+  "private_route_families_owner_eligible": 0,
+  "public_owner_route_mutation": false,
+  "runtime_mutation": false,
+  "cms_mutation": false,
+  "search_console_mutation": false,
+  "ga_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "production_private_url_access": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "PRIVATE_RESULT_BOUNDARY_GUARD.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "RESULT-INTERPRETATION-MODE-C-BRIEF-QUEUE-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only private result boundary guard for result-interpretation owner-route planning.
- Recorded private route families that are excluded from owner candidacy.
- Added next authorization prompts and scan manifest.

## Why
- The result-interpretation line needs a hard boundary before public content brief work.
- Private product, commerce, lookup, report, and recovery surfaces must not become SEO/GEO owner pages.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/result-interpretation-private-result-boundary-guard-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `PRIVATE_RESULT_BOUNDARY_GUARD_READY`

## Deferred items
- No private production URL access.
- No runtime, CMS, sitemap, llms, canonical, noindex, JSON-LD, Search Console, GA, or deploy changes.