### PR TITLE
MBTI-CMS-26B: add MBTI cross-type comparison authority storage

### DIFF
--- a/backend/app/Models/MbtiCrossTypeComparisonAuthority.php
+++ b/backend/app/Models/MbtiCrossTypeComparisonAuthority.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MbtiCrossTypeComparisonAuthority extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    public const COMPARISON_TYPE = 'mbti_cross_type';
+
+    public const AUTHORITY_CONTRACT_VERSION = 'mbti.cross_type_comparison.authority.v1';
+
+    public const READMODEL_CONTRACT_VERSION = 'mbti.cross_type_comparison.readmodel.v1';
+
+    protected $table = 'mbti_cross_type_comparison_authorities';
+
+    protected $fillable = [
+        'org_id',
+        'locale',
+        'slug',
+        'comparison_type',
+        'left_type_code',
+        'right_type_code',
+        'title',
+        'seo_title',
+        'seo_description',
+        'summary',
+        'content_payload_json',
+        'claim_boundary',
+        'source_package_id',
+        'source_sha256',
+        'authority_contract_version',
+        'readmodel_contract_version',
+        'review_status',
+        'publish_status',
+        'indexability_status',
+        'is_public',
+        'is_indexable',
+        'sitemap_eligible',
+        'llms_eligible',
+        'search_submission_eligible',
+        'published_at',
+        'imported_at',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'content_payload_json' => 'array',
+        'is_public' => 'boolean',
+        'is_indexable' => 'boolean',
+        'sitemap_eligible' => 'boolean',
+        'llms_eligible' => 'boolean',
+        'search_submission_eligible' => 'boolean',
+        'published_at' => 'datetime',
+        'imported_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function publicContextOrgId(): ?int
+    {
+        return 0;
+    }
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return true;
+    }
+
+    protected static function booted(): void
+    {
+        static::saving(function (self $authority): void {
+            $authority->comparison_type = self::COMPARISON_TYPE;
+            $authority->locale = trim((string) $authority->locale);
+            $authority->slug = strtolower(trim((string) $authority->slug));
+            $authority->left_type_code = strtoupper(trim((string) $authority->left_type_code));
+            $authority->right_type_code = strtoupper(trim((string) $authority->right_type_code));
+            $authority->authority_contract_version = trim((string) ($authority->authority_contract_version ?: self::AUTHORITY_CONTRACT_VERSION));
+            $authority->readmodel_contract_version = trim((string) ($authority->readmodel_contract_version ?: self::READMODEL_CONTRACT_VERSION));
+        });
+    }
+}

--- a/backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php
+++ b/backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cms;
 
+use App\Models\MbtiCrossTypeComparisonAuthority;
 use App\Models\PersonalityProfile;
 use App\Support\CanonicalFrontendUrl;
 use Illuminate\Support\Facades\File;
@@ -80,9 +81,10 @@ final class Mbti64CrossTypeComparisonPublicReadModel
             return $this->assetsBySlug;
         }
 
+        $authorityAssets = $this->authorityAssetsBySlug();
         $plan = $this->planner->planSourceDir(self::SOURCE_DIR);
         if (($plan['ok'] ?? false) !== true) {
-            return $this->assetsBySlug = [];
+            return $this->assetsBySlug = $authorityAssets;
         }
 
         $assets = [];
@@ -112,8 +114,90 @@ final class Mbti64CrossTypeComparisonPublicReadModel
         }
 
         ksort($assets);
+        $assets = array_merge($assets, $authorityAssets);
+        ksort($assets);
 
         return $this->assetsBySlug = $assets;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function authorityAssetsBySlug(): array
+    {
+        $assets = [];
+        $rows = MbtiCrossTypeComparisonAuthority::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('locale', self::LOCALE)
+            ->where('comparison_type', self::COMPARISON_TYPE)
+            ->where('is_public', true)
+            ->orderBy('slug')
+            ->get();
+
+        foreach ($rows as $row) {
+            if (! $row instanceof MbtiCrossTypeComparisonAuthority) {
+                continue;
+            }
+
+            $asset = $this->assetFromAuthority($row);
+            if ($asset === null) {
+                continue;
+            }
+
+            $assets[(string) $asset['slug']] = $asset;
+        }
+
+        return $assets;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function assetFromAuthority(MbtiCrossTypeComparisonAuthority $authority): ?array
+    {
+        $slug = $this->stringValue($authority->slug);
+        if ($slug === null || ! $this->isCrossTypeSlug($slug)) {
+            return null;
+        }
+
+        $leftType = strtoupper((string) $authority->left_type_code);
+        $rightType = strtoupper((string) $authority->right_type_code);
+        if (! in_array($leftType, PersonalityProfile::BASE_TYPE_CODES, true)
+            || ! in_array($rightType, PersonalityProfile::BASE_TYPE_CODES, true)
+            || $leftType === $rightType
+        ) {
+            return null;
+        }
+
+        $payload = is_array($authority->content_payload_json) ? $authority->content_payload_json : [];
+
+        return [
+            '_authority_source' => 'database',
+            '_is_public' => (bool) $authority->is_public,
+            '_is_indexable' => (bool) $authority->is_indexable,
+            '_sitemap_eligible' => (bool) $authority->sitemap_eligible,
+            '_llms_eligible' => (bool) $authority->llms_eligible,
+            '_source_sha256' => (string) ($authority->source_sha256 ?? ''),
+            'slug' => $slug,
+            'comparison_type' => self::COMPARISON_TYPE,
+            'locale' => (string) $authority->locale,
+            'left_type' => $leftType,
+            'right_type' => $rightType,
+            'title' => (string) $authority->title,
+            'seo_title' => (string) $authority->seo_title,
+            'seo_description' => (string) $authority->seo_description,
+            'summary' => (string) $authority->summary,
+            'sections' => is_array($payload['sections'] ?? null) ? $payload['sections'] : [],
+            'faq' => is_array($payload['faq'] ?? null) ? $payload['faq'] : [],
+            'internal_links' => is_array($payload['internal_links'] ?? null) ? $payload['internal_links'] : [],
+            'claim_boundary' => (string) ($authority->claim_boundary ?: ($payload['claim_boundary'] ?? '')),
+            'source_notes' => is_array($payload['source_notes'] ?? null) ? $payload['source_notes'] : [],
+            'source_package_id' => (string) ($authority->source_package_id ?? ''),
+            'review_status' => (string) $authority->review_status,
+            'publish_status' => (string) $authority->publish_status,
+            'indexability_status' => (string) $authority->indexability_status,
+        ];
     }
 
     /**
@@ -151,8 +235,10 @@ final class Mbti64CrossTypeComparisonPublicReadModel
             'summary' => (string) $asset['summary'],
             'public_url' => $this->canonicalUrl($slug, $locale),
             'canonical_url' => $this->canonicalUrl($slug, $locale),
-            'is_public' => true,
-            'is_indexable' => false,
+            'is_public' => (bool) ($asset['_is_public'] ?? true),
+            'is_indexable' => (bool) ($asset['_is_indexable'] ?? false),
+            'sitemap_eligible' => (bool) ($asset['_sitemap_eligible'] ?? false),
+            'llms_eligible' => (bool) ($asset['_llms_eligible'] ?? false),
             'status' => 'authority_ready',
             'review_status' => (string) $asset['review_status'],
             'publish_status' => (string) $asset['publish_status'],
@@ -201,13 +287,15 @@ final class Mbti64CrossTypeComparisonPublicReadModel
             'claim_boundary' => (string) $asset['claim_boundary'],
             'source_notes' => $this->sourceNotes($asset),
             'source_refs' => [
-                'mbti-cross-type-comparison-content-assets-draft-20260702',
+                (string) ($asset['source_package_id'] ?? 'mbti-cross-type-comparison-content-assets-draft-20260702'),
                 self::AUTHORITY_CONTRACT_VERSION,
                 self::READMODEL_CONTRACT_VERSION,
             ],
             'source_sha256' => (string) ($asset['_source_sha256'] ?? ''),
-            'is_public' => true,
-            'is_indexable' => false,
+            'is_public' => (bool) ($asset['_is_public'] ?? true),
+            'is_indexable' => (bool) ($asset['_is_indexable'] ?? false),
+            'sitemap_eligible' => (bool) ($asset['_sitemap_eligible'] ?? false),
+            'llms_eligible' => (bool) ($asset['_llms_eligible'] ?? false),
             'review_status' => (string) $asset['review_status'],
             'publish_status' => (string) $asset['publish_status'],
             'indexability_status' => (string) $asset['indexability_status'],
@@ -227,21 +315,29 @@ final class Mbti64CrossTypeComparisonPublicReadModel
             }
 
             $id = $this->stringValue($section['id'] ?? null) ?? 'section-'.($index + 1);
+            $id = $this->stringValue($section['key'] ?? null) ?? $id;
             $title = $this->stringValue($section['title'] ?? null);
+            $bodySource = $section['body'] ?? [];
             $body = array_values(array_filter(array_map(
                 fn (mixed $line): ?string => $this->stringValue($line),
-                (array) ($section['body'] ?? [])
+                is_array($bodySource) ? $bodySource : [$bodySource]
             )));
 
             if ($title === null || $body === []) {
                 continue;
             }
 
-            $sections[] = [
+            $projection = [
                 'id' => $id,
                 'title' => $title,
                 'body' => $body,
             ];
+
+            if (is_array($section['rows'] ?? null)) {
+                $projection['rows'] = array_values((array) $section['rows']);
+            }
+
+            $sections[] = $projection;
         }
 
         return $sections;

--- a/backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php
+++ b/backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php
@@ -355,8 +355,8 @@ final class MbtiComparisonCmsImportDryRunPlanner
         }
 
         return [
-            'target_model' => 'backend_authority.mbti64_cross_type_comparison',
-            'target_table' => 'planned_mbti_cross_type_comparison_authority',
+            'target_model' => 'App\\Models\\MbtiCrossTypeComparisonAuthority',
+            'target_table' => 'mbti_cross_type_comparison_authorities',
             'lookup' => [
                 'org_id' => 0,
                 'scale_code' => 'MBTI',
@@ -388,7 +388,7 @@ final class MbtiComparisonCmsImportDryRunPlanner
     private function firstClassDestinations(): array
     {
         return [
-            'identity' => 'A/T rows map to personality_profile_sections by base type; cross-type rows map to a future comparison authority draft by comparison slug',
+            'identity' => 'A/T rows map to personality_profile_sections by base type; cross-type rows map to mbti_cross_type_comparison_authorities by comparison slug',
             'seo' => 'planned destination: comparison public projection SEO fields after a separate approved promotion/write PR',
             'sections' => 'planned destination: comparison answer/section projection after a separate approved promotion/write PR',
             'draft_payload' => 'this dry-run emits the complete importable draft contract only; it does not write DB rows',
@@ -403,7 +403,7 @@ final class MbtiComparisonCmsImportDryRunPlanner
         return [
             'target_tables' => [
                 'personality_profile_sections',
-                'planned_mbti_cross_type_comparison_authority',
+                'mbti_cross_type_comparison_authorities',
                 'comparison_public_projection_v1',
             ],
             'lookup_contract' => [

--- a/backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php
+++ b/backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php
@@ -438,10 +438,10 @@ final class MbtiContent15MixedImportPreflightPlanner
         }
 
         return [
-            'target_table' => 'planned_mbti_cross_type_comparison_authority',
-            'target_model' => 'backend_authority_layer',
+            'target_table' => 'mbti_cross_type_comparison_authorities',
+            'target_model' => 'App\\Models\\MbtiCrossTypeComparisonAuthority',
             'planned_live_tables' => [
-                'mbti_cross_type_comparison_authority',
+                'mbti_cross_type_comparison_authorities',
                 'comparison_public_projection_v1',
             ],
             'lookup' => [
@@ -480,7 +480,7 @@ final class MbtiContent15MixedImportPreflightPlanner
                 'personality_profile_sections',
             ],
             'cross_type_comparison_target_tables' => [
-                'planned_mbti_cross_type_comparison_authority',
+                'mbti_cross_type_comparison_authorities',
                 'comparison_public_projection_v1',
             ],
             'runtime_release_blocked_until' => [

--- a/backend/database/migrations/2026_07_06_000100_create_mbti_cross_type_comparison_authorities_table.php
+++ b/backend/database/migrations/2026_07_06_000100_create_mbti_cross_type_comparison_authorities_table.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mbti_cross_type_comparison_authorities', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('locale', 16);
+            $table->string('slug', 64);
+            $table->string('comparison_type', 32)->default('mbti_cross_type');
+            $table->string('left_type_code', 8);
+            $table->string('right_type_code', 8);
+            $table->string('title', 255);
+            $table->string('seo_title', 255);
+            $table->text('seo_description');
+            $table->text('summary');
+            $table->json('content_payload_json');
+            $table->string('claim_boundary', 512)->nullable();
+            $table->string('source_package_id', 160)->nullable();
+            $table->string('source_sha256', 64)->nullable();
+            $table->string('authority_contract_version', 96)->default('mbti.cross_type_comparison.authority.v1');
+            $table->string('readmodel_contract_version', 96)->default('mbti.cross_type_comparison.readmodel.v1');
+            $table->string('review_status', 32)->default('draft');
+            $table->string('publish_status', 32)->default('draft');
+            $table->string('indexability_status', 48)->default('held_for_indexability_gate');
+            $table->boolean('is_public')->default(false);
+            $table->boolean('is_indexable')->default(false);
+            $table->boolean('sitemap_eligible')->default(false);
+            $table->boolean('llms_eligible')->default(false);
+            $table->boolean('search_submission_eligible')->default(false);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('imported_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['org_id', 'locale', 'slug'], 'uq_mbti_cross_type_authority_slug');
+            $table->index(['locale', 'is_public', 'publish_status'], 'idx_mbti_cross_type_authority_public');
+            $table->index(
+                ['is_indexable', 'sitemap_eligible', 'llms_eligible'],
+                'idx_mbti_cross_type_authority_index_gate'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        // Forward-only authority migration: rollback should use a forward fix migration.
+    }
+};

--- a/backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php
@@ -52,10 +52,10 @@ final class PersonalityMbtiComparisonCmsImportDryRunCommandTest extends TestCase
         $this->assertSame('cross_type', $crossTypeRow['identity']['comparison_kind'] ?? null);
         $this->assertSame('ENTJ', $crossTypeRow['identity']['left_type_code'] ?? null);
         $this->assertSame('INTJ', $crossTypeRow['identity']['right_type_code'] ?? null);
-        $this->assertSame('planned_mbti_cross_type_comparison_authority', $crossTypeRow['target']['target_table'] ?? null);
+        $this->assertSame('mbti_cross_type_comparison_authorities', $crossTypeRow['target']['target_table'] ?? null);
         $this->assertSame('entj-vs-intj', $crossTypeRow['target']['lookup']['comparison_slug'] ?? null);
         $this->assertContains('personality_profile_sections', $payload['field_mapping_contract']['target_tables']);
-        $this->assertContains('planned_mbti_cross_type_comparison_authority', $payload['field_mapping_contract']['target_tables']);
+        $this->assertContains('mbti_cross_type_comparison_authorities', $payload['field_mapping_contract']['target_tables']);
         $this->assertContains('comparison_public_projection_v1', $payload['field_mapping_contract']['target_tables']);
     }
 

--- a/backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
@@ -65,10 +65,11 @@ final class PersonalityMbtiContent15MixedImportPreflightCommandTest extends Test
         $this->assertSame('personality_profile_sections', $at['target']['target_table']);
         $this->assertSame('mbti64_comparison_a_vs_t', $at['target']['section_key']);
         $this->assertSame('at', $at['identity']['comparison_kind']);
-        $this->assertSame('planned_mbti_cross_type_comparison_authority', $crossType['target']['target_table']);
+        $this->assertSame('mbti_cross_type_comparison_authorities', $crossType['target']['target_table']);
         $this->assertSame('cross_type', $crossType['identity']['comparison_kind']);
         $this->assertContains('personality_profile_variant_revisions', $payload['field_mapping_contract']['profile_target_tables']);
         $this->assertContains('personality_profile_sections', $payload['field_mapping_contract']['at_comparison_target_tables']);
+        $this->assertContains('mbti_cross_type_comparison_authorities', $payload['field_mapping_contract']['cross_type_comparison_target_tables']);
         $this->assertContains('comparison_public_projection_v1', $payload['field_mapping_contract']['cross_type_comparison_target_tables']);
         $this->assertSame(self::SOURCE_PACKAGE_SHA, $payload['production_import_gate']['required_exact_authorization']['source_package_sha256']);
         $this->assertSame(self::AUTHORIZATION_PAYLOAD_SHA, $payload['production_import_gate']['required_exact_authorization']['authorization_payload_sha256']);

--- a/backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php
+++ b/backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\MbtiCrossTypeComparisonAuthority;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class MbtiCrossTypeComparisonAuthorityReadModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cross_type_comparison_index_prefers_database_authority_rows(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $this->createAuthority([
+            'slug' => 'istj-vs-isfj',
+            'left_type_code' => 'ISTJ',
+            'right_type_code' => 'ISFJ',
+            'title' => 'ISTJ 和 ISFJ 的区别：规则执行与照护判断',
+            'seo_title' => 'ISTJ 和 ISFJ 的区别 | FermatMind',
+            'seo_description' => 'ISTJ 和 ISFJ 的区别测试描述',
+            'summary' => 'ISTJ 更容易从规则和责任入口判断，ISFJ 更容易从照护和关系稳定入口判断。',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality/comparisons?locale=zh-CN');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true);
+
+        $items = collect($response->json('cross_type_comparisons'));
+        $authorityItem = $items->firstWhere('slug', 'istj-vs-isfj');
+
+        self::assertIsArray($authorityItem);
+        self::assertSame('ISTJ 和 ISFJ 的区别：规则执行与照护判断', $authorityItem['title']);
+        self::assertSame('https://fermatmind.com/zh/personality/istj-vs-isfj', $authorityItem['public_url']);
+        self::assertTrue((bool) $authorityItem['is_public']);
+        self::assertFalse((bool) $authorityItem['is_indexable']);
+        self::assertFalse((bool) $authorityItem['sitemap_eligible']);
+        self::assertFalse((bool) $authorityItem['llms_eligible']);
+        self::assertStringNotContainsString('/zh/result', (string) $response->getContent());
+        self::assertStringNotContainsString('token=', (string) $response->getContent());
+    }
+
+    public function test_cross_type_comparison_detail_reads_database_authority_payload(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $this->createAuthority([
+            'slug' => 'istj-vs-isfj',
+            'left_type_code' => 'ISTJ',
+            'right_type_code' => 'ISFJ',
+            'title' => 'ISTJ 和 ISFJ 的区别：规则执行与照护判断',
+            'seo_title' => 'ISTJ 和 ISFJ 的区别 | FermatMind',
+            'seo_description' => 'ISTJ 和 ISFJ 的区别测试描述',
+            'summary' => 'ISTJ 更容易从规则和责任入口判断，ISFJ 更容易从照护和关系稳定入口判断。',
+            'source_package_id' => 'mbti-content15-top-blocker-batch',
+            'source_sha256' => hash('sha256', 'istj-vs-isfj-authority-fixture'),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality/comparisons/istj-vs-isfj?locale=zh-CN');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('comparison_public_projection_v1.comparison_slug', 'istj-vs-isfj')
+            ->assertJsonPath('comparison_public_projection_v1.left_type', 'ISTJ')
+            ->assertJsonPath('comparison_public_projection_v1.right_type', 'ISFJ')
+            ->assertJsonPath('comparison_public_projection_v1.title', 'ISTJ 和 ISFJ 的区别：规则执行与照护判断')
+            ->assertJsonPath('comparison_public_projection_v1.sections.0.id', 'direct_answer')
+            ->assertJsonPath('comparison_public_projection_v1.sections.0.title', '最大区别')
+            ->assertJsonPath('comparison_public_projection_v1.sections.1.rows.0.dimension', '判断入口')
+            ->assertJsonPath('comparison_public_projection_v1.faq.0.question', 'ISTJ 和 ISFJ 最大区别是什么？')
+            ->assertJsonPath('comparison_public_projection_v1.internal_links.0.href', '/zh/personality/istj-a')
+            ->assertJsonPath('comparison_public_projection_v1.source_refs.0', 'mbti-content15-top-blocker-batch')
+            ->assertJsonPath('comparison_public_projection_v1.is_indexable', false)
+            ->assertJsonPath('comparison_public_projection_v1.sitemap_eligible', false)
+            ->assertJsonPath('comparison_public_projection_v1.llms_eligible', false);
+
+        self::assertGreaterThanOrEqual(5, count((array) $response->json('comparison_public_projection_v1.sections')));
+        self::assertGreaterThanOrEqual(4, count((array) $response->json('comparison_public_projection_v1.faq')));
+        self::assertGreaterThanOrEqual(3, count((array) $response->json('comparison_public_projection_v1.internal_links')));
+        self::assertStringNotContainsString('/zh/orders', (string) $response->getContent());
+        self::assertStringNotContainsString('order_no=', (string) $response->getContent());
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createAuthority(array $overrides = []): MbtiCrossTypeComparisonAuthority
+    {
+        /** @var MbtiCrossTypeComparisonAuthority */
+        return MbtiCrossTypeComparisonAuthority::query()->create(array_merge([
+            'org_id' => 0,
+            'locale' => 'zh-CN',
+            'slug' => 'intj-vs-intp',
+            'comparison_type' => MbtiCrossTypeComparisonAuthority::COMPARISON_TYPE,
+            'left_type_code' => 'INTJ',
+            'right_type_code' => 'INTP',
+            'title' => 'INTJ 和 INTP 的区别',
+            'seo_title' => 'INTJ 和 INTP 的区别 | FermatMind',
+            'seo_description' => 'INTJ 和 INTP 的区别测试描述',
+            'summary' => 'INTJ 和 INTP 的差异摘要。',
+            'content_payload_json' => $this->contentPayload(),
+            'claim_boundary' => '人格对比仅用于自我理解，不用于诊断、录用或关系预测。',
+            'source_package_id' => 'mbti-content15-top-blocker-batch',
+            'source_sha256' => hash('sha256', 'authority-fixture'),
+            'authority_contract_version' => MbtiCrossTypeComparisonAuthority::AUTHORITY_CONTRACT_VERSION,
+            'readmodel_contract_version' => MbtiCrossTypeComparisonAuthority::READMODEL_CONTRACT_VERSION,
+            'review_status' => 'approved',
+            'publish_status' => 'published',
+            'indexability_status' => 'held_for_indexability_gate',
+            'is_public' => true,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'search_submission_eligible' => false,
+            'published_at' => now()->subMinute(),
+            'imported_at' => now()->subMinute(),
+        ], $overrides));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function contentPayload(): array
+    {
+        return [
+            'sections' => [
+                [
+                    'key' => 'direct_answer',
+                    'title' => '最大区别',
+                    'body' => 'ISTJ 更容易从规则和责任入口判断，ISFJ 更容易从照护和关系稳定入口判断。',
+                ],
+                [
+                    'key' => 'quick_judgment_table',
+                    'title' => '快速判断表',
+                    'rows' => [
+                        [
+                            'dimension' => '判断入口',
+                            'ISTJ' => '规则、流程、责任',
+                            'ISFJ' => '照护、关系、稳定',
+                        ],
+                    ],
+                    'body' => '用判断入口、压力反应和协作偏好快速区分。',
+                ],
+                [
+                    'key' => 'easy_misread',
+                    'title' => '为什么容易误判',
+                    'body' => '两者都重视稳定和责任，所以不能只看是否守规矩。',
+                ],
+                [
+                    'key' => 'real_scenario_differences',
+                    'title' => '真实场景差异',
+                    'body' => '任务变更时，ISTJ 更关注规则是否一致，ISFJ 更关注相关人的稳定感。',
+                ],
+                [
+                    'key' => 'do_not_misjudge',
+                    'title' => '不要这样误判',
+                    'body' => '不要把细心直接等同于 ISFJ，也不要把守时直接等同于 ISTJ。',
+                ],
+            ],
+            'faq' => [
+                [
+                    'question' => 'ISTJ 和 ISFJ 最大区别是什么？',
+                    'answer' => 'ISTJ 更偏规则执行，ISFJ 更偏照护判断。',
+                ],
+                [
+                    'question' => 'ISTJ 和 ISFJ 为什么容易混淆？',
+                    'answer' => '两者都重视稳定、责任和可靠性。',
+                ],
+                [
+                    'question' => '工作中怎么区分 ISTJ 和 ISFJ？',
+                    'answer' => '看他们更先维护流程一致，还是更先维护关系稳定。',
+                ],
+                [
+                    'question' => '这个对比能决定职业选择吗？',
+                    'answer' => '不能，只能作为自我观察线索。',
+                ],
+            ],
+            'internal_links' => [
+                [
+                    'href' => '/zh/personality/istj-a',
+                    'anchor_text' => 'ISTJ-A',
+                    'link_intent' => 'left_variant',
+                ],
+                [
+                    'href' => '/zh/personality/isfj-a',
+                    'anchor_text' => 'ISFJ-A',
+                    'link_intent' => 'right_variant',
+                ],
+                [
+                    'href' => '/zh/personality',
+                    'anchor_text' => 'MBTI 人格',
+                    'link_intent' => 'hub',
+                ],
+            ],
+            'source_notes' => [
+                'MBTI-CMS-26B database authority fixture.',
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -402,6 +402,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_cross_type_authority_storage_readmodel_files(): void
+    {
+        $changed = [
+            'backend/app/Models/MbtiCrossTypeComparisonAuthority.php',
+            'backend/database/migrations/2026_07_06_000100_create_mbti_cross_type_comparison_authorities_table.php',
+            'backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_big_five_cms_import_draft_dry_run_files(): void
     {
         $changed = [
@@ -5129,6 +5140,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiCrossTypeAuthorityStorageReadmodelFile($file)) {
+                continue;
+            }
+
             if ($this->isBigFiveCmsImportDraftDryRunFile($file)) {
                 continue;
             }
@@ -6679,6 +6694,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityMbtiContent15MixedImportPreflight.php',
             'backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php',
+        ], true);
+    }
+
+    private function isMbtiCrossTypeAuthorityStorageReadmodelFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Models/MbtiCrossTypeComparisonAuthority.php',
+            'backend/database/migrations/2026_07_06_000100_create_mbti_cross_type_comparison_authorities_table.php',
+            'backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26843,7 +26843,7 @@
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2467",
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "MBTI-PDF-PRODUCT-05: expand PDF coverage to result-page sections",
     "train_scope": "mbti_pdf_product",
     "transitions": [
@@ -26947,7 +26947,7 @@
 
       ]
     },
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "MBTI-PDF-SNAPSHOT-SYNC-GUARD-H1: add PDF snapshot render-source cache guard",
     "train_scope": "mbti_pdf_snapshot_sync_guard_h1_companion"
   },
@@ -31560,7 +31560,7 @@
     "repo": "fap-api",
     "scope_validation": {
       "allowed_paths_only": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "local_validation_passed": true,
       "post_merge_revalidated": null
     },
@@ -82665,8 +82665,8 @@
         "evidence": "Changed files are limited to MBTI-CMS-26B storage/readmodel/planner/tests plus authorized docs/codex PR-train metadata."
       },
       "github_checks": {
-        "status": "current_scope_fix_pending_remote_checks",
-        "evidence": "PR #2785 verify-bigfive failed because BigFiveResultPageV2CoreBodyPreviewTest classified the new MBTI-CMS-26B authority model and migration as uncommitted runtime diff. The current-scope classifier fix passed locally and will be pushed for GitHub recheck."
+        "status": "pass",
+        "evidence": "PR #2785 GitHub checks passed after the current-scope runtime-freeze classifier fix: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "scope_validation": {
@@ -82699,6 +82699,12 @@
         "from": "pr_open",
         "to": "current_scope_ci_fix_local_checks_passed",
         "note": "Inspected PR #2785 verify-bigfive failure. The failure was in the runtime-freeze classifier and was caused by this PR's new MBTI cross-type authority storage files. Added a scoped allowlist and regression test; focused local validation passed."
+      },
+      {
+        "at": "2026-07-06T00:00:00Z",
+        "from": "current_scope_ci_fix_local_checks_passed",
+        "to": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2785 after the scoped classifier fix. Ready for squash merge under the PR train merge policy; no production CMS write, sitemap/llms/indexability release, GSC submission, staging deploy wait, manual deploy, or production deploy was performed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82616,7 +82616,7 @@
       "MBTI-CMS-26"
     ],
     "status": "pr_open",
-    "commit_sha": "841cccfd26eb914102073ac264c9de450d3d19a1",
+    "commit_sha": null,
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2785",
     "failure_reason": null,
     "merged_at": null,
@@ -82655,13 +82655,18 @@
         "command": "vendor/bin/pint --test ... && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
         "evidence": "PASS: Pint reported PASS for 7 scoped files, train YAML parses, state JSON parses, and git diff whitespace check passes."
       },
+      "runtime_freeze_ci_fix": {
+        "status": "pass_with_phpunit_warnings",
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_cross_type_authority_storage_readmodel_files' --no-ansi",
+        "evidence": "PASS exit code 0: added a scoped runtime-freeze classifier allowlist for MBTI-CMS-26B backend authority storage/readmodel files after PR #2785 verify-bigfive flagged the new model and migration. PHPUnit emitted local fixture-path warnings; assertions passed."
+      },
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to MBTI-CMS-26B storage/readmodel/planner/tests plus authorized docs/codex PR-train metadata."
       },
       "github_checks": {
-        "status": "pending",
-        "evidence": "PR #2785 opened for MBTI-CMS-26B; GitHub checks are pending."
+        "status": "current_scope_fix_pending_remote_checks",
+        "evidence": "PR #2785 verify-bigfive failed because BigFiveResultPageV2CoreBodyPreviewTest classified the new MBTI-CMS-26B authority model and migration as uncommitted runtime diff. The current-scope classifier fix passed locally and will be pushed for GitHub recheck."
       }
     },
     "scope_validation": {
@@ -82688,6 +82693,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened PR #2785 for MBTI-CMS-26B: https://github.com/fermatmind/fap-api/pull/2785."
+      },
+      {
+        "at": "2026-07-06T00:00:00Z",
+        "from": "pr_open",
+        "to": "current_scope_ci_fix_local_checks_passed",
+        "note": "Inspected PR #2785 verify-bigfive failure. The failure was in the runtime-freeze classifier and was caused by this PR's new MBTI cross-type authority storage files. Added a scoped allowlist and regression test; focused local validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82615,9 +82615,9 @@
     "depends_on": [
       "MBTI-CMS-26"
     ],
-    "status": "in_progress",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "841cccfd26eb914102073ac264c9de450d3d19a1",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2785",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -82658,6 +82658,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to MBTI-CMS-26B storage/readmodel/planner/tests plus authorized docs/codex PR-train metadata."
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR #2785 opened for MBTI-CMS-26B; GitHub checks are pending."
       }
     },
     "scope_validation": {
@@ -82678,6 +82682,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Added the cross-type authority table/model, DB-backed list/detail readmodel support, preflight target mapping, and tests. Local validation passed; production CMS write remains deferred."
+      },
+      {
+        "at": "2026-07-06T00:00:00Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened PR #2785 for MBTI-CMS-26B: https://github.com/fermatmind/fap-api/pull/2785."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -82606,6 +82606,81 @@
       }
     ]
   },
+  "MBTI-CMS-26B": {
+    "id": "MBTI-CMS-26B",
+    "repo": "fap-api",
+    "title": "MBTI-CMS-26B: add MBTI cross-type comparison authority storage",
+    "base": "main",
+    "branch": "codex/mbti-cms-26b-cross-type-authority",
+    "depends_on": [
+      "MBTI-CMS-26"
+    ],
+    "status": "in_progress",
+    "commit_sha": null,
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly requested a new prerequisite PR, MBTI-CMS-26B or MBTI-CMS-27A, for cross-type comparison backend authority storage and readmodel without production writes."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "MBTI-CMS-26 is recorded as merged before MBTI-CMS-26B starts."
+      },
+      "production_write_gate": {
+        "status": "held",
+        "evidence": "This PR adds storage/readmodel support only. Production CMS import remains deferred to MBTI-CMS-27 after this prerequisite merges."
+      },
+      "syntax_and_migration": {
+        "status": "pass",
+        "command": "php -l backend/database/migrations/2026_07_06_000100_create_mbti_cross_type_comparison_authorities_table.php && php -l backend/app/Models/MbtiCrossTypeComparisonAuthority.php && php -l backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php && php -l backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php && php -l backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php && php -l backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force --no-ansi",
+        "evidence": "PASS: syntax checks passed for scoped PHP files and full testing SQLite migration created mbti_cross_type_comparison_authorities."
+      },
+      "focused_tests": {
+        "status": "pass_with_phpunit_warnings",
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiCrossTypeComparisonAuthorityReadModelTest --no-ansi && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityMbtiComparisonCmsImportDryRunCommandTest|PersonalityMbtiContent15MixedImportPreflightCommandTest' --no-ansi",
+        "evidence": "PASS exit code 0: cross-type authority readmodel tests passed with 34 assertions; comparison dry-run and mixed preflight tests passed with 109 assertions. PHPUnit reported local path/environment warnings, not assertion failures."
+      },
+      "real_package_preflight": {
+        "status": "pass",
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:mbti-content15-mixed-import-preflight --package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-22-import-dry-run-final-2026-07-05.json --authorization-package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-23-production-import-authorization-package-2026-07-05.json --source-package-sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb --authorization-payload-sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15 --import-scope-mode=top_blocker_batch_only --record-count=9 --dry-run --json",
+        "evidence": "PASS: real CMS-22/CMS-23 preflight returned status=pass, cross_type_comparison_count=4, writes_committed=false, and cross-type rows target mbti_cross_type_comparison_authorities."
+      },
+      "format_and_manifest": {
+        "status": "pass",
+        "command": "vendor/bin/pint --test ... && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\" && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && git diff --check",
+        "evidence": "PASS: Pint reported PASS for 7 scoped files, train YAML parses, state JSON parses, and git diff whitespace check passes."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to MBTI-CMS-26B storage/readmodel/planner/tests plus authorized docs/codex PR-train metadata."
+      }
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": false
+    },
+    "transitions": [
+      {
+        "at": "2026-07-06T00:00:00Z",
+        "from": "user_authorized",
+        "to": "in_progress",
+        "note": "Started a backend-only prerequisite PR for MBTI cross-type comparison authority storage and public readmodel support. Scope excludes production CMS writes, production imports, sitemap/llms/indexability release, GSC submission, deploy, and frontend fallback content."
+      },
+      {
+        "at": "2026-07-06T00:00:00Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Added the cross-type authority table/model, DB-backed list/detail readmodel support, preflight target mapping, and tests. Local validation passed; production CMS write remains deferred."
+      }
+    ]
+  },
   "MBTI-CMS-27": {
     "id": "MBTI-CMS-27",
     "repo": "fap-api",
@@ -82613,12 +82688,12 @@
     "base": "main",
     "branch": "codex/mbti-cms-27-content15-production-import",
     "depends_on": [
-      "MBTI-CMS-26"
+      "MBTI-CMS-26B"
     ],
-    "status": "blocked_needs_operator_authorization",
+    "status": "blocked_dependency",
     "commit_sha": null,
     "pr_url": null,
-    "failure_reason": "Production CMS write is explicitly blocked until the operator provides separate exact authorization containing source_package_sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb, authorization_payload_sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15, import_scope_mode=top_blocker_batch_only, and record_count=9.",
+    "failure_reason": "Production CMS write is explicitly blocked until MBTI-CMS-26B merges and provides cross-type comparison backend authority storage/readmodel support. The operator has provided the exact MBTI-CMS-27 authorization values, but import execution must wait for this prerequisite.",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -82628,12 +82703,12 @@
         "evidence": "User explicitly authorized adding MBTI-CMS-27 to the fap-api train in the attached /goal execution request."
       },
       "dependency": {
-        "status": "pass",
-        "evidence": "MBTI-CMS-26 PR #2771 is merged and origin/main contains merge commit 63f1f9b35d90d3f409468640fd1ede3604f7e909."
+        "status": "blocked_dependency",
+        "evidence": "MBTI-CMS-26B has been inserted as a prerequisite for cross-type comparison authority storage before MBTI-CMS-27 production CMS import can run."
       },
       "operator_authorization": {
-        "status": "blocked_needs_exact_authorization",
-        "evidence": "The attached /goal requires stopping before MBTI-CMS-27 until separate exact production CMS write authorization is provided. No production CMS write was attempted."
+        "status": "pass_held_until_dependency",
+        "evidence": "The operator provided exact authorization values for source_package_sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb, authorization_payload_sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15, import_scope_mode=top_blocker_batch_only, and record_count=9. No production CMS write was attempted because MBTI-CMS-26B must merge first."
       }
     },
     "scope_validation": {
@@ -82647,7 +82722,13 @@
         "at": "2026-07-06T04:12:02Z",
         "from": "manifest_registered",
         "to": "blocked_needs_operator_authorization",
-        "note": "Registered MBTI-CMS-27 but stopped before production CMS import because separate exact operator authorization has not been provided in a new explicit write-authorization instruction."
+        "note": "Registered MBTI-CMS-27 but stopped before production CMS import because separate exact operator authorization had not yet been provided in a new explicit write-authorization instruction."
+      },
+      {
+        "at": "2026-07-06T00:00:00Z",
+        "from": "blocked_needs_operator_authorization",
+        "to": "blocked_dependency",
+        "note": "Operator later provided exact production import authorization, but execution remains blocked until MBTI-CMS-26B merges cross-type comparison backend authority storage and readmodel support."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37856,6 +37856,7 @@ prs:
       - backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php
       - backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php
       - backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
       - generated/pr-train-sidecar-issues/**
@@ -37875,8 +37876,9 @@ prs:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiCrossTypeComparisonAuthorityReadModelTest --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityMbtiComparisonCmsImportDryRunCommandTest|PersonalityMbtiContent15MixedImportPreflightCommandTest' --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_cross_type_authority_storage_readmodel_files' --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:mbti-content15-mixed-import-preflight --package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-22-import-dry-run-final-2026-07-05.json --authorization-package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-23-production-import-authorization-package-2026-07-05.json --source-package-sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb --authorization-payload-sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15 --import-scope-mode=top_blocker_batch_only --record-count=9 --dry-run --json
-      - cd backend && vendor/bin/pint --test app/Models/MbtiCrossTypeComparisonAuthority.php app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
+      - cd backend && vendor/bin/pint --test app/Models/MbtiCrossTypeComparisonAuthority.php app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - git diff --check

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -37830,12 +37830,72 @@ prs:
     search_channel_action: false
     deploy_allowed: false
     content_authority: CMS/backend
+    next_task: MBTI-CMS-26B
+
+  - id: MBTI-CMS-26B
+    repo: fap-api
+    depends_on:
+      - MBTI-CMS-26
+    branch: codex/mbti-cms-26b-cross-type-authority
+    title: "MBTI-CMS-26B: add MBTI cross-type comparison authority storage"
+    train_scope: mbti_cross_type_comparison_authority_storage_readmodel
+    status: user_authorized
+    scope:
+      - Add backend authority storage for MBTI cross-type comparison content.
+      - Add a DB-backed authority model and readmodel path for public MBTI cross-type comparison list/detail projections.
+      - Keep the existing dry-run/draft package fallback when no DB authority row exists.
+      - Update CMS-13/CMS-26 preflight target mapping from planned virtual storage to the real backend authority table.
+      - Add tests proving DB authority rows can power comparison list/detail responses while sitemap, llms, and search submission gates remain closed.
+      - Do not write production CMS content, run production imports, release sitemap/llms/indexability, submit GSC, trigger deploy, or modify frontend fallback/runtime content.
+    allowed_paths:
+      - backend/database/migrations/2026_07_06_000100_create_mbti_cross_type_comparison_authorities_table.php
+      - backend/app/Models/MbtiCrossTypeComparisonAuthority.php
+      - backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php
+      - backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php
+      - backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php
+      - backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php
+      - backend/tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php
+      - backend/tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - generated/pr-train-sidecar-issues/**
+    do_not:
+      - Modify fap-web.
+      - Add frontend content fallback.
+      - Write production CMS content, run production imports, publish, enable indexability, release sitemap/llms, submit GSC, trigger staging deploy, trigger production deploy, or add public runtime content outside the DB-backed readmodel.
+      - Change public API routes, scheduler behavior, permissions, secrets, production authorization hashes, or import execution semantics.
+      - Implement MBTI-CMS-27, MBTI-CMS-28, or MBTI-INDEX-24 scope in this PR.
+    validation:
+      - php -l backend/database/migrations/2026_07_06_000100_create_mbti_cross_type_comparison_authorities_table.php
+      - php -l backend/app/Models/MbtiCrossTypeComparisonAuthority.php
+      - php -l backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php
+      - php -l backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php
+      - php -l backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php
+      - php -l backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiCrossTypeComparisonAuthorityReadModelTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityMbtiComparisonCmsImportDryRunCommandTest|PersonalityMbtiContent15MixedImportPreflightCommandTest' --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:mbti-content15-mixed-import-preflight --package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-22-import-dry-run-final-2026-07-05.json --authorization-package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-23-production-import-authorization-package-2026-07-05.json --source-package-sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb --authorization-payload-sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15 --import-scope-mode=top_blocker_batch_only --record-count=9 --dry-run --json
+      - cd backend && vendor/bin/pint --test app/Models/MbtiCrossTypeComparisonAuthority.php app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: true
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    deploy_allowed: false
+    content_authority: CMS/backend
     next_task: MBTI-CMS-27
 
   - id: MBTI-CMS-27
     repo: fap-api
     depends_on:
-      - MBTI-CMS-26
+      - MBTI-CMS-26B
     branch: codex/mbti-cms-27-content15-production-import
     title: "MBTI-CMS-27: execute CONTENT-15 production CMS import"
     train_scope: mbti_content15_production_cms_import_execution


### PR DESCRIPTION
## What changed
- Added `mbti_cross_type_comparison_authorities` as backend authority storage for MBTI cross-type comparison content.
- Added `MbtiCrossTypeComparisonAuthority` and wired `Mbti64CrossTypeComparisonPublicReadModel` to prefer DB authority rows while preserving the existing draft-package fallback.
- Updated CMS comparison dry-run and CONTENT-15 mixed preflight mapping so cross-type comparisons target the real authority table instead of planned virtual storage.
- Added focused list/detail API projection tests and updated import/preflight contract assertions.
- Registered `MBTI-CMS-26B` in the PR train and made `MBTI-CMS-27` depend on it before production import can proceed.

## Why
`MBTI-CMS-27` has exact production import authorization, but the CONTENT-15 package includes 4 cross-type comparison records. Those records need a backend authority storage/readmodel path before any production CMS write can run safely.

## Validation
- `php -l backend/database/migrations/2026_07_06_000100_create_mbti_cross_type_comparison_authorities_table.php`
- `php -l backend/app/Models/MbtiCrossTypeComparisonAuthority.php`
- `php -l backend/app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php`
- `php -l backend/app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php`
- `php -l backend/app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php`
- `php -l backend/tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=MbtiCrossTypeComparisonAuthorityReadModelTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='PersonalityMbtiComparisonCmsImportDryRunCommandTest|PersonalityMbtiContent15MixedImportPreflightCommandTest' --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan personality:mbti-content15-mixed-import-preflight --package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-22-import-dry-run-final-2026-07-05.json --authorization-package=/Users/rainie/Desktop/GitHub/fap-web/docs/seo/personality/mbti-cms-23-production-import-authorization-package-2026-07-05.json --source-package-sha256=75244fa4af3c234851519eba5a426daf8766c13e7c4b2bc9e94d5a5855ce6ccb --authorization-payload-sha256=be0d1bb584c15f383322c9e5aff560709c46ea1e34d135cb9ced6d1e4601fe15 --import-scope-mode=top_blocker_batch_only --record-count=9 --dry-run --json`
- `cd backend && vendor/bin/pint --test app/Models/MbtiCrossTypeComparisonAuthority.php app/Services/Cms/Mbti64CrossTypeComparisonPublicReadModel.php app/Services/Cms/MbtiComparisonCmsImportDryRunPlanner.php app/Services/Cms/MbtiContent15MixedImportPreflightPlanner.php tests/Feature/V0_5/MbtiCrossTypeComparisonAuthorityReadModelTest.php tests/Feature/Console/PersonalityMbtiComparisonCmsImportDryRunCommandTest.php tests/Feature/Console/PersonalityMbtiContent15MixedImportPreflightCommandTest.php`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Deferred items
- No production CMS import/write in this PR.
- No sitemap, llms, canonical/noindex, schema indexability, or GSC submission changes.
- No staging deploy wait, manual deploy, or production deploy.
- `MBTI-CMS-27` remains blocked until this prerequisite merges, then can use the already provided exact authorization values.

## Repository rule impact
This adds backend/CMS-authoritative storage for MBTI cross-type comparison content and does not add any frontend editorial fallback. Public discoverability/indexability gates remain held until the later CMS import verification and indexability PRs.
