### PR TITLE
RESULT-INTERPRETATION-MODE-C-BRIEF-QUEUE-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,38 @@
+# RESULT-INTERPRETATION-MODE-C-BRIEF-QUEUE-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: MODE_C_BRIEF_QUEUE_READY
+
+This PR converts the result-interpretation inventory, owner-route matrix, and private-boundary guard into a public content brief queue. It does not create article bodies, CMS drafts, runtime routes, sitemap entries, llms entries, schema, metadata, or Search submissions.
+
+## Queue Summary
+
+- Briefs queued: 6
+- Highest priority: MBTI, RIASEC, EQ
+- Private URL candidates: 0
+- CMS/runtime/public SEO mutations: none
+
+## Recommended Execution Order
+
+1. MBTI result interpretation owner brief.
+2. RIASEC result interpretation owner brief.
+3. EQ result interpretation owner brief.
+4. Big Five result interpretation owner brief.
+5. Enneagram result interpretation owner brief.
+6. IQ score/result interpretation owner brief.
+
+## Decision Rule
+
+Each brief must become a separate authorized content-package or owner-route PR before any publication or runtime change. This queue is planning evidence only.
+
+## Deferred Items
+
+- CMS draft/import/write/publish.
+- Article body generation.
+- Runtime route, metadata, sitemap, llms, JSON-LD, canonical, noindex, or Search changes.
+- Live GSC/GA validation.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/MODE_C_BRIEF_QUEUE.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/MODE_C_BRIEF_QUEUE.md
@@ -1,0 +1,61 @@
+# Result Interpretation Mode C Brief Queue
+
+Date: 2026-07-06
+Scope: generated docs-only queue for future public owner-route content packages
+
+## Queue
+
+| Priority | Brief id | Working public angle | Primary intent | Required boundary |
+| --- | --- | --- | --- | --- |
+| P0 | `mbti-result-interpretation-owner-brief` | `MBTI 测试结果怎么看：从类型、偏好到行动复盘` | Help users understand type letters, likely strengths, blind spots, communication, career reflection, and next actions without treating type as identity destiny. | Do not claim clinical, hiring, admission, relationship, salary, or life-outcome prediction. |
+| P0 | `riasec-result-interpretation-owner-brief` | `霍兰德职业兴趣测试结果怎么看：六型、前三代码和专业职业方向` | Explain RIASEC six types, top-three code, score closeness, uncertainty, major/career exploration, and safe next steps. | Do not promise admission, transfer, job, salary, career success, or exact occupational fit. |
+| P1 | `eq-result-interpretation-owner-brief` | `EQ 测试结果怎么看：情绪觉察、调节、同理和沟通复盘` | Turn a thin support set into a clear public explanation of EQ dimensions and practice-oriented next steps. | Do not diagnose mental health, therapy needs, personality defects, or relationship outcomes. |
+| P1 | `big-five-result-interpretation-owner-brief` | `大五人格测试结果怎么看：五个维度、组合画像和成长建议` | Explain OCEAN dimensions, high/low scores, trait combinations, and growth framing. | Do not imply fixed identity, employment suitability, or unsupported norm/percentile precision. |
+| P2 | `enneagram-result-interpretation-owner-brief` | `九型人格测试结果怎么看：核心动机、压力反应和成长方向` | Explain core type, nearby types, wings if supported, motivation, stress/growth reflection, and cautious use. | Do not overstate type certainty or use Enneagram as clinical/diagnostic authority. |
+| P2 | `iq-score-result-interpretation-owner-brief` | `IQ 测试分数怎么看：在线估计、能力边界和训练方向` | Explain online cognitive reasoning score limits, confidence, practice, and non-diagnostic interpretation. | Do not claim official IQ, clinical assessment, admission/employment prediction, or percentile/norm precision unless backend authority exists. |
+
+## Shared Brief Requirements
+
+Every future brief should include:
+
+- one direct answer block near the top;
+- a dimension/type/code explanation table where relevant;
+- "what this result can help you do next";
+- "what this result cannot decide";
+- CTA back to the relevant test owner page;
+- private URL exclusion note for internal reviewers;
+- no hidden-schema-only evidence;
+- no Search submission or index request in the content PR.
+
+## Owner Route Candidate Shape
+
+Future owner pages should be public article or guide routes, not private result/report pages. Candidate slugs should be chosen in a separate authorized PR. Working slug directions:
+
+- `mbti-test-result-meaning-guide`
+- `riasec-test-result-meaning-guide`
+- `eq-test-result-meaning-guide`
+- `big-five-test-result-meaning-guide`
+- `enneagram-test-result-meaning-guide`
+- `iq-test-score-meaning-guide`
+
+These are directions only, not committed route changes.
+
+## Internal Link Direction
+
+When future owner pages exist, each should link to:
+
+- its direct test owner landing page;
+- one support article already found in the inventory when relevant;
+- related high-intent cluster pages only when the reader intent matches.
+
+Do not link from sitemap/llms or public hubs to uncreated routes.
+
+## Hold Conditions
+
+Hold a brief if any of these are true:
+
+- no CMS/backend authority path exists for the route;
+- the brief requires private result payload examples;
+- the brief would need claims about accuracy, norms, clinical validity, admissions, hiring, salary, or guaranteed outcomes;
+- GSC/GA data is being used as purchase truth;
+- the same PR would also mutate title/meta/H1/sitemap/llms/schema/runtime.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,26 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`RIASEC-GAOKAO-CLUSTER-MODE-C-BRIEF-SELECTION-01`
+
+Scope:
+
+- generated docs only
+- choose the next RIASEC / gaokao / major / career scenario brief from existing planning evidence
+- do not write article body, CMS package, runtime route, metadata, sitemap, llms, schema, Search submission, or deploy changes
+
+## Future Content Package Authorization
+
+Authorize one future content package at a time, for example:
+
+`MBTI-RESULT-INTERPRETATION-CONTENT-PACKAGE-01`
+
+Required constraints:
+
+- public CMS/backend-authoritative route only;
+- private result/report/attempt/order/payment surfaces excluded;
+- no unsupported accuracy, clinical, hiring, admission, salary, or guaranteed-outcome claims;
+- no sitemap/llms/schema/canonical/noindex/Search/deploy changes unless separately authorized.

--- a/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/scan_manifest.json
@@ -1,0 +1,32 @@
+{
+  "pr_id": "RESULT-INTERPRETATION-MODE-C-BRIEF-QUEUE-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "MODE_C_BRIEF_QUEUE_READY",
+  "briefs_queued": 6,
+  "highest_priority_briefs": [
+    "mbti-result-interpretation-owner-brief",
+    "riasec-result-interpretation-owner-brief",
+    "eq-result-interpretation-owner-brief"
+  ],
+  "private_url_candidates": 0,
+  "article_body_generated": false,
+  "cms_mutation": false,
+  "runtime_mutation": false,
+  "metadata_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "search_submission": false,
+  "deploy_triggered": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "MODE_C_BRIEF_QUEUE.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "RIASEC-GAOKAO-CLUSTER-MODE-C-BRIEF-SELECTION-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only Mode C brief queue for six public result-interpretation owner-page candidates.
- Prioritized MBTI, RIASEC, EQ, Big Five, Enneagram, and IQ result interpretation briefs.
- Added shared brief requirements, hold conditions, next authorization prompts, and scan manifest.

## Why
- The result-interpretation line needs brief-level sequencing before any content package or route owner work.
- This keeps private result/report/order/payment surfaces excluded from future public owner-route planning.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/result-interpretation-mode-c-brief-queue-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `MODE_C_BRIEF_QUEUE_READY`

## Deferred items
- No article body, CMS draft/import/write/publish, runtime route, metadata, sitemap, llms, schema, canonical, noindex, Search, GA/GSC, or deploy changes.