### PR TITLE
RIASEC-GAOKAO-CLUSTER-MODE-C-BRIEF-SELECTION-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/BRIEF_SELECTION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/BRIEF_SELECTION.md
@@ -1,0 +1,75 @@
+# RIASEC Gaokao Cluster Mode C Brief Selection
+
+Date: 2026-07-06
+Scope: read-only selection for next Chinese RIASEC / gaokao / major scenario brief
+
+## Selection Matrix
+
+| Rank | Candidate | Decision | Reason | Claim risk |
+| --- | --- | --- | --- | --- |
+| 1 | `gaokao-score-major-shortlist-riasec-checklist` | Selected | Upstream of adjustment anxiety; helps users shortlist majors after score/rank is known; clean RIASEC bridge without claiming admission prediction. | Medium if phrased as admission optimization; manageable with checklist boundaries. |
+| 2 | `hot-major-fit-riasec-course-career-checklist` | Alternate | Useful for high-search seasonal anxiety around popular majors; distinct from adjustment topic. | Medium-high because "hot major" can imply outcome promises. |
+| 3 | `math-not-good-computer-ai-major-course-riasec-checklist` | Alternate | Concrete pain point for computer/AI and ability-interest mismatch. | Medium-high because it can drift into academic ability prediction. |
+| 4 | `unwanted-major-adjustment-riasec-transfer-plan` | Hold | Too close to the already selected adjustment article; should be folded into or sequenced after that package. | Medium due to transfer success implication. |
+| 5 | `gaokao-major-adjustment-unacceptable-major-checklist` | Already selected | Covered by daily topic selection and distribution asset package. | Already bounded in previous generated-only artifacts. |
+
+## Selected Brief Shape
+
+Brief id:
+
+`gaokao-score-major-shortlist-riasec-checklist`
+
+Working title direction:
+
+`高考分数出来后怎么筛专业：分数区间、课程和兴趣检查清单`
+
+Primary user job:
+
+The reader has score/rank information and needs to build a realistic major shortlist without treating a test result, a hot-major list, or one family opinion as the final answer.
+
+Answer block direction:
+
+`高考分数出来后，可以先按分数区间和院校专业组划出可选范围，再用课程结构、兴趣类型、转专业规则、家庭成本和未来方向逐项筛选。RIASEC 可以帮助整理兴趣偏好，但不能预测录取、就业或收入。`
+
+Primary CTA:
+
+`/zh/tests/holland-career-interest-test-riasec`
+
+Support links:
+
+- `/zh/articles/riasec-holland-career-interest-test-explained`
+- `/zh/articles/holland-career-interest-test-can-and-cannot-tell-you`
+- `/zh/articles/gaokao-major-adjustment-unacceptable-major-checklist`
+- `/zh/articles/hot-major-fit-riasec-course-career-checklist`
+
+## Brief Requirements
+
+The future content package should include:
+
+- score/rank range first, not personality or interest test first;
+- course table and graduation requirement checks;
+- RIASEC as interest/activity preference reflection only;
+- "major name vs course reality" check;
+- parent discussion checklist;
+- fallback routes: accept, adjust, minor/double degree, transfer rules, graduate school, later career exploration;
+- CTA back to the RIASEC test owner.
+
+## Forbidden Claims
+
+Do not say or imply:
+
+- RIASEC predicts admission, transfer success, job, salary, or career success;
+- the checklist can guarantee the right major;
+- the test can replace school policy, counselor advice, family constraints, or user context;
+- a score/rank range plus test result automatically determines one best major.
+
+## Channel Holds
+
+Held until separate authorization:
+
+- CMS package, draft, import, publish, or unpublish;
+- public article body;
+- title/meta/H1 mutation on a live page;
+- internal-link mutation;
+- sitemap, llms, schema, canonical, noindex, Search submission;
+- deploy or runtime cache invalidation.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,35 @@
+# RIASEC-GAOKAO-CLUSTER-MODE-C-BRIEF-SELECTION-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: RIASEC_GAOKAO_MODE_C_BRIEF_SELECTED
+
+Selected next brief:
+
+`gaokao-score-major-shortlist-riasec-checklist`
+
+Working public angle:
+
+`高考分数出来后怎么筛专业：用分数区间、课程和兴趣做 shortlist`
+
+## Why This Brief
+
+The previous daily topic already selected the "unwanted major adjustment" scenario. The next brief should move upstream in the decision journey to score/rank-based major shortlisting. This avoids repeating the adjustment anxiety angle while preserving the RIASEC bridge and claim-safe checklist shape.
+
+## Queue Decision
+
+- Selected: `gaokao-score-major-shortlist-riasec-checklist`
+- Alternate: `hot-major-fit-riasec-course-career-checklist`
+- Alternate: `math-not-good-computer-ai-major-course-riasec-checklist`
+- Hold: `unwanted-major-adjustment-riasec-transfer-plan`
+- Not repeated: `gaokao-major-adjustment-unacceptable-major-checklist`
+
+## Deferred Items
+
+- No article body.
+- No CMS draft/import/write/publish.
+- No runtime route, metadata, sitemap, llms, schema, canonical, noindex, Search, GA/GSC, or deploy change.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,26 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`RIASEC-GAOKAO-CLUSTER-INTERNAL-LINK-PLAN-01`
+
+Scope:
+
+- generated docs only
+- plan internal link directions across the RIASEC test owner, explainer pages, and gaokao/major scenario pages
+- do not mutate live internal links, CMS rows, sitemap, llms, schema, canonical, noindex, Search, runtime, or deploy state
+
+## Future Content Package Authorization
+
+Authorize a later package:
+
+`GAOKAO-SCORE-MAJOR-SHORTLIST-RIASEC-CONTENT-PACKAGE-01`
+
+Constraints:
+
+- generated package first, operator review before CMS import;
+- RIASEC framed as interest/activity preference reflection only;
+- no admission, transfer, employment, salary, or guaranteed-major claims;
+- no private result/report/order/payment URLs.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/scan_manifest.json
@@ -1,0 +1,36 @@
+{
+  "pr_id": "RIASEC-GAOKAO-CLUSTER-MODE-C-BRIEF-SELECTION-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "RIASEC_GAOKAO_MODE_C_BRIEF_SELECTED",
+  "selected_brief": "gaokao-score-major-shortlist-riasec-checklist",
+  "selected_working_angle": "高考分数出来后怎么筛专业：用分数区间、课程和兴趣做 shortlist",
+  "already_selected_previous_topic": "gaokao-major-adjustment-unacceptable-major-checklist",
+  "alternates": [
+    "hot-major-fit-riasec-course-career-checklist",
+    "math-not-good-computer-ai-major-course-riasec-checklist"
+  ],
+  "held": [
+    "unwanted-major-adjustment-riasec-transfer-plan"
+  ],
+  "article_body_generated": false,
+  "cms_mutation": false,
+  "runtime_mutation": false,
+  "metadata_mutation": false,
+  "internal_link_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "search_submission": false,
+  "deploy_triggered": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "BRIEF_SELECTION.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "RIASEC-GAOKAO-CLUSTER-INTERNAL-LINK-PLAN-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only Mode C brief selection for the Chinese RIASEC / gaokao / major cluster.
- Selected `gaokao-score-major-shortlist-riasec-checklist` as the next brief after the existing adjustment topic.
- Added claim boundaries, channel holds, next authorization prompts, and scan manifest.

## Why
- The cluster needs a next brief that is distinct from the already selected unwanted-adjustment topic.
- Score/rank-based major shortlisting is upstream, high-intent, and can stay claim-safe with checklist framing.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-mode-c-brief-selection-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `RIASEC_GAOKAO_MODE_C_BRIEF_SELECTED`

## Deferred items
- No article body, CMS draft/import/write/publish, runtime route, metadata, internal-link mutation, sitemap, llms, schema, canonical, noindex, Search, GA/GSC, or deploy changes.