### PR TITLE
RIASEC-GAOKAO-CLUSTER-INTERNAL-LINK-PLAN-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,26 @@
+# RIASEC-GAOKAO-CLUSTER-INTERNAL-LINK-PLAN-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: INTERNAL_LINK_PLAN_READY
+
+This PR defines a read-only internal-link direction for the Chinese RIASEC / gaokao / major / career cluster. It does not edit live links, CMS records, article bodies, page blocks, sitemap, llms, schema, metadata, canonical, noindex, Search, or deploy state.
+
+## Link Architecture
+
+- Money owner stays `/zh/tests/holland-career-interest-test-riasec`.
+- Scenario articles link back to the RIASEC owner and relevant explainer/boundary pages.
+- Explainer and boundary pages support the owner, not replace it.
+- Existing and future scenario pages link laterally only when user intent is adjacent and not cannibalizing.
+- Private result/report/attempt/order/payment/share/account/history URLs remain excluded.
+
+## Deferred Items
+
+- No CMS internal-link write.
+- No public page mutation.
+- No sitemap, llms, schema, canonical, noindex, Search, GSC/GA, or deploy change.
+- No use of GSC/GA as purchase truth.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/INTERNAL_LINK_PLAN.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/INTERNAL_LINK_PLAN.md
@@ -1,0 +1,83 @@
+# RIASEC Gaokao Cluster Internal Link Plan
+
+Date: 2026-07-06
+Scope: planning only; no link mutation
+
+## Core Direction
+
+The cluster should preserve a clear hierarchy:
+
+1. `/zh/tests/holland-career-interest-test-riasec` owns direct test and career-interest-test intent.
+2. `/zh/articles/riasec-holland-career-interest-test-explained` explains the model.
+3. `/zh/articles/holland-career-interest-test-can-and-cannot-tell-you` handles boundary and accuracy questions.
+4. Gaokao/major scenario pages handle specific decision situations.
+5. Career guides handle longer career-direction exploration.
+
+## Recommended Link Edges
+
+| Source type | Target | Link role | Notes |
+| --- | --- | --- | --- |
+| RIASEC test owner | Selected high-intent scenario pages | Optional support links after authorization | Do not overload the owner page with every scenario. |
+| Scenario pages | `/zh/tests/holland-career-interest-test-riasec` | Primary CTA | CTA should frame RIASEC as interest/activity reflection. |
+| Scenario pages | Model explainer | Education support | Use when the scenario references RIASEC terms. |
+| Scenario pages | Boundary explainer | Claim safety | Use near "准不准 / 能不能决定专业" claims. |
+| Score shortlist scenario | Adjustment checklist | Downstream decision support | Link only after score/rank shortlist context is covered. |
+| Adjustment checklist | Transfer/repeat/stay pages | Downstream fallback | Hold transfer/repeat links until those pages are authorized or confirmed. |
+| Hot major scenario | Course/career fit support | Adjacent support | Avoid implying hot major equals outcome. |
+| Math/computer/AI scenario | Course task checklist and boundary explainer | Adjacent support | Avoid ability prediction. |
+| Career guides | RIASEC test owner | Optional exploration CTA | Use when career-interest exploration is contextually relevant. |
+
+## Candidate Cluster URLs
+
+Owner and explainers:
+
+- `/zh/tests/holland-career-interest-test-riasec`
+- `/zh/articles/riasec-holland-career-interest-test-explained`
+- `/zh/articles/holland-career-interest-test-can-and-cannot-tell-you`
+- `/zh/articles/career-interest-vs-personality-test-differences`
+
+Gaokao/major scenarios:
+
+- `/zh/articles/gaokao-score-major-shortlist-riasec-checklist`
+- `/zh/articles/gaokao-major-adjustment-unacceptable-major-checklist`
+- `/zh/articles/hot-major-fit-riasec-course-career-checklist`
+- `/zh/articles/math-not-good-computer-ai-major-course-riasec-checklist`
+- `/zh/articles/gaokao-major-choice-parent-conflict-riasec-course-checklist`
+- `/zh/articles/unwanted-major-repeat-or-stay-riasec-decision-checklist`
+- `/zh/articles/unwanted-major-adjustment-riasec-transfer-plan`
+
+Career support:
+
+- `/zh/articles/career-confusion-test-map`
+- `/zh/articles/major-career-mismatch-job-search-skills-plan`
+- `/zh/career/guides/how-to-choose-college-major`
+- `/zh/career/guides/how-to-find-right-career-direction`
+
+## Anti-cannibalization Rules
+
+- Direct `霍兰德职业兴趣测试 / RIASEC测试 / 职业兴趣测试` intent should point to the test owner.
+- `RIASEC是什么 / 霍兰德职业兴趣是什么` should point to the explainer.
+- `准不准 / 能不能决定专业 / 能告诉你什么` should point to the boundary explainer.
+- `高考分数出来后怎么筛专业` should point to score-shortlist content.
+- `被调剂到不想去的专业怎么办` should point to adjustment content.
+- `热门专业适不适合自己` should point to hot-major fit content.
+
+## Prohibited Edges
+
+Do not add public links to:
+
+- private result/report/attempt/share/history URLs;
+- order/payment/account/auth URLs;
+- tokenized preview, admin, or local URLs;
+- uncreated routes;
+- pages that imply deterministic major, admission, job, salary, or career-success prediction.
+
+## Validation Needed Before Any Future Link Mutation
+
+Before a future link-writing PR:
+
+- confirm the target URL exists and is public;
+- confirm the target URL is indexable only if intended;
+- confirm canonical and language are correct;
+- confirm page copy passes claim boundary;
+- confirm no private identifiers or private URLs appear in anchor text or destination.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,27 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`RIASEC-GAOKAO-CLUSTER-CONTENT-PACKAGE-HANDOFF-01`
+
+Scope:
+
+- generated docs only
+- package the selected brief and internal-link plan into an operator handoff
+- do not write CMS, publish content, mutate links, sitemap, llms, schema, metadata, canonical, noindex, Search, runtime, or deploy state
+
+## Future Link Mutation Authorization
+
+Only after CMS/content owner approval, authorize a separate PR:
+
+`RIASEC-GAOKAO-CLUSTER-INTERNAL-LINK-IMPLEMENTATION-01`
+
+Required constraints:
+
+- explicit source and target URLs;
+- path-limited CMS/import/runtime scope;
+- no private URL targets;
+- no uncreated routes;
+- claim boundary review before merge.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/scan_manifest.json
@@ -1,0 +1,29 @@
+{
+  "pr_id": "RIASEC-GAOKAO-CLUSTER-INTERNAL-LINK-PLAN-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "INTERNAL_LINK_PLAN_READY",
+  "money_owner": "/zh/tests/holland-career-interest-test-riasec",
+  "planned_link_mutations": 0,
+  "private_url_targets": 0,
+  "cms_mutation": false,
+  "runtime_mutation": false,
+  "article_body_mutation": false,
+  "metadata_mutation": false,
+  "internal_link_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "search_submission": false,
+  "deploy_triggered": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "INTERNAL_LINK_PLAN.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "RIASEC-GAOKAO-CLUSTER-CONTENT-PACKAGE-HANDOFF-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only internal-link plan for the Chinese RIASEC / gaokao / major cluster.
- Defined hierarchy, recommended link edges, anti-cannibalization rules, prohibited edges, and next authorization prompts.
- Added scan manifest confirming no live link, CMS, runtime, sitemap, llms, schema, Search, or deploy changes.

## Why
- The selected RIASEC/gaokao briefs need a link architecture before any future content package or link implementation PR.
- The plan preserves `/zh/tests/holland-career-interest-test-riasec` as the money owner and keeps private URLs excluded.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-internal-link-plan-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `INTERNAL_LINK_PLAN_READY`

## Deferred items
- No CMS writes, live internal-link mutation, article body, metadata, sitemap, llms, schema, canonical, noindex, Search, GSC/GA, runtime, or deploy changes.