### PR TITLE
RIASEC-GAOKAO-CLUSTER-CONTENT-PACKAGE-HANDOFF-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/CONTENT_PACKAGE_HANDOFF.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/CONTENT_PACKAGE_HANDOFF.md
@@ -1,0 +1,78 @@
+# RIASEC Gaokao Cluster Content Package Handoff
+
+Date: 2026-07-06
+Scope: operator handoff only; no publishable body
+
+## Package Candidate
+
+| Field | Value |
+| --- | --- |
+| Future package id | `GAOKAO-SCORE-MAJOR-SHORTLIST-RIASEC-CONTENT-PACKAGE-01` |
+| Topic id | `gaokao-score-major-shortlist-riasec-checklist` |
+| Locale | `zh-CN` |
+| Working title direction | `高考分数出来后怎么筛专业：分数区间、课程和兴趣检查清单` |
+| Primary user job | Build a realistic major shortlist after score/rank is known. |
+| Primary CTA | `/zh/tests/holland-career-interest-test-riasec` |
+| Operation type | future content package only after explicit authorization |
+
+## Required Article Shape For Future Package
+
+This handoff does not write the article body. A future package should cover:
+
+1. Direct answer block.
+2. Score/rank and school-major-group range screening.
+3. Course table and graduation requirement review.
+4. Interest/activity preference reflection using RIASEC.
+5. Parent/family constraint discussion checklist.
+6. Fallback plan: accept, adjust, minor/double degree, transfer rules, graduate school, later career exploration.
+7. CTA to the RIASEC test owner.
+8. Boundary block: what RIASEC can and cannot decide.
+
+## Required Link Direction For Future Package
+
+Use only public URLs after confirming they exist and are canonical:
+
+- `/zh/tests/holland-career-interest-test-riasec`
+- `/zh/articles/riasec-holland-career-interest-test-explained`
+- `/zh/articles/holland-career-interest-test-can-and-cannot-tell-you`
+- `/zh/articles/gaokao-major-adjustment-unacceptable-major-checklist`
+- `/zh/articles/hot-major-fit-riasec-course-career-checklist`
+
+Do not link to private result/report/attempt/share/history/order/payment/account/auth/token/admin/local URLs.
+
+## Claim Boundary
+
+Allowed:
+
+- RIASEC can help organize interests, activity preferences, and exploration questions.
+- Course structure, score/rank range, school policy, transfer rules, family constraints, and long-term career direction should be checked separately.
+- A checklist can make the major shortlist more concrete.
+
+Forbidden:
+
+- RIASEC predicts admission, transfer success, employment, salary, or career success.
+- RIASEC selects one best major automatically.
+- A checklist guarantees the right decision.
+- FermatMind has official school, ministry, counseling, clinical, or employment endorsement without separate evidence.
+
+## Channel Holds
+
+Held until separate authorization:
+
+- CMS package/draft/import/publish;
+- full article body;
+- live title/meta/H1 update;
+- internal-link implementation;
+- sitemap, llms, schema, canonical, noindex, hreflang;
+- GSC Request Indexing, IndexNow, Baidu, 360, Sogou, Shenma, or Search Channel writes;
+- runtime cache invalidation or deploy.
+
+## Acceptance Criteria For Future Package
+
+A future content-package PR should not merge unless:
+
+- all outbound links are public and canonical;
+- no private URL or identifier appears;
+- no deterministic outcome claim appears;
+- RIASEC is framed as reflection support, not decision authority;
+- the package is explicitly held for operator review before CMS import or publish.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,38 @@
+# RIASEC-GAOKAO-CLUSTER-CONTENT-PACKAGE-HANDOFF-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: CONTENT_PACKAGE_HANDOFF_READY
+
+This PR packages the selected RIASEC / gaokao / major brief into an operator handoff. It is not a content package, CMS draft, article body, publish action, runtime change, internal-link implementation, sitemap/llms/schema update, Search submission, or deploy trigger.
+
+## Handoff Target
+
+Selected future package:
+
+`GAOKAO-SCORE-MAJOR-SHORTLIST-RIASEC-CONTENT-PACKAGE-01`
+
+Working angle:
+
+`高考分数出来后怎么筛专业：分数区间、课程和兴趣检查清单`
+
+Primary owner/CTA:
+
+`/zh/tests/holland-career-interest-test-riasec`
+
+## Ready Inputs
+
+- Brief selection is complete.
+- Internal-link plan is complete.
+- Private URL exclusion is explicit.
+- Claim boundary is explicit.
+- Channel holds are explicit.
+
+## Deferred Items
+
+- No CMS package, draft, import, publish, or operator approval.
+- No article body, title/meta/H1 write, live link mutation, sitemap, llms, schema, canonical, noindex, Search, runtime, GSC/GA, or deploy change.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,27 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`ENTITY-GRAPH-ROUTE-INVENTORY-READONLY-01`
+
+Scope:
+
+- generated docs only
+- inventory entity-graph route families for MBTI types, Big Five dimensions, Enneagram types, RIASEC six types, careers, and majors
+- do not mutate routes, CMS content, sitemap, llms, schema, canonical, noindex, Search, runtime, or deploy state
+
+## Future Content Package Authorization
+
+Authorize:
+
+`GAOKAO-SCORE-MAJOR-SHORTLIST-RIASEC-CONTENT-PACKAGE-01`
+
+Required constraints:
+
+- generated package first, not publish;
+- explicit operator review before CMS import;
+- no unsupported outcome claims;
+- no private URLs;
+- no Search/deploy/discoverability mutation unless separately authorized.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/scan_manifest.json
@@ -1,0 +1,29 @@
+{
+  "pr_id": "RIASEC-GAOKAO-CLUSTER-CONTENT-PACKAGE-HANDOFF-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "CONTENT_PACKAGE_HANDOFF_READY",
+  "future_package_id": "GAOKAO-SCORE-MAJOR-SHORTLIST-RIASEC-CONTENT-PACKAGE-01",
+  "topic_id": "gaokao-score-major-shortlist-riasec-checklist",
+  "primary_cta": "/zh/tests/holland-career-interest-test-riasec",
+  "article_body_generated": false,
+  "cms_mutation": false,
+  "runtime_mutation": false,
+  "metadata_mutation": false,
+  "internal_link_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "search_submission": false,
+  "deploy_triggered": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "CONTENT_PACKAGE_HANDOFF.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "ENTITY-GRAPH-ROUTE-INVENTORY-READONLY-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only operator handoff for the selected RIASEC / gaokao / major content package candidate.
- Packaged the selected score-shortlist brief, required article shape, link direction, claim boundary, channel holds, and next authorization prompts.
- Added scan manifest confirming no CMS, runtime, link, Search, or deploy mutations.

## Why
- The RIASEC gaokao cluster now has a selected brief and internal-link plan; this handoff defines what a future content-package PR may do after explicit authorization.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/riasec-gaokao-cluster-content-package-handoff-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `CONTENT_PACKAGE_HANDOFF_READY`

## Deferred items
- No article body, CMS package/draft/import/publish, live title/meta/H1, internal-link mutation, sitemap, llms, schema, canonical, noindex, Search, GSC/GA, runtime, or deploy changes.