### PR TITLE
ENTITY-GRAPH-ROUTE-INVENTORY-READONLY-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/ENTITY_ROUTE_INVENTORY.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/ENTITY_ROUTE_INVENTORY.md
@@ -1,0 +1,48 @@
+# Entity Graph Route Inventory
+
+Date: 2026-07-06
+Scope: read-only inventory for P4 entity graph route families
+
+## Source Context
+
+Upstream P4 evidence currently says:
+
+- P4 status is `PLANNED_ONLY`.
+- Six entity families still need complete route map, public/runtime status, and internal-link graph proof.
+- Existing contracts and dry-run artifacts are useful governance, but they are not enough to prove public/runtime entity graph completion.
+
+## Family Inventory
+
+| Entity family | Expected entity count | Current evidence type | Current route proof status | Next PR |
+| --- | ---: | --- | --- | --- |
+| MBTI type pages | 16 | Personality/internal-link graph artifacts and MBTI content authority signals exist. | Not proven complete in current runtime/public route matrix. | `MBTI-TYPE-PAGES-ENTITY-GRAPH-RUNTIME-MATRIX-01` |
+| Big Five dimension pages | 5 | Big Five content/import and graph contracts exist in repository evidence. | Published route map and runtime graph proof not yet closed. | `BIG-FIVE-DIMENSION-PAGES-ENTITY-GRAPH-MATRIX-01` |
+| Enneagram type pages | 9 | Enneagram result/explainer and CMS command evidence exists. | Type page inventory and public route status not yet closed. | `ENNEAGRAM-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01` |
+| RIASEC six-type pages | 6 | RIASEC major graph authority and RIASEC cluster planning exist. | Public six-type route status, review status, and link graph not yet closed. | `RIASEC-SIX-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01` |
+| Career pages | To be inventoried | Career guide and career content factory evidence exists. | Complete career page graph and runtime link proof not yet closed. | `CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01` |
+| Major pages | To be inventoried | RIASEC major graph authority package exists with noindex/internal authority status. | Public major route map, claim review, link graph, and indexability gate not yet closed. | `CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01` |
+
+## Readiness Interpretation
+
+This inventory is ready for deeper matrix PRs, but it does not make P4 complete.
+
+To become complete, each family needs:
+
+- canonical entity list;
+- public route list or explicit no-public-route decision;
+- runtime status where applicable;
+- internal-link graph evidence;
+- claim boundary status;
+- sitemap/llms/indexability status where relevant;
+- private URL exclusion.
+
+## Guardrails
+
+Do not advance to implementation from this PR alone. Future family matrix PRs must stay read-only unless separately authorized.
+
+Do not include:
+
+- private result/report/attempt/order/payment/share/account/history URLs;
+- hidden schema-only graph proof;
+- unsupported claim of public completeness;
+- Search submission or deploy verification.

--- a/backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,36 @@
+# ENTITY-GRAPH-ROUTE-INVENTORY-READONLY-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: ENTITY_ROUTE_INVENTORY_READY
+
+This PR creates the first read-only route-inventory matrix for P4 entity graph work. It does not create routes, publish pages, write CMS data, change internal links, update sitemap/llms/schema/canonical/noindex, submit Search URLs, or trigger deploys.
+
+## Inventory Result
+
+- Entity families inventoried: 6
+- Families with complete public/runtime graph proof: 0
+- Families ready for deeper matrix PRs: 6
+- P4 status remains: `PLANNED_ONLY`
+
+## Next Matrix PRs
+
+Proceed family by family:
+
+1. `MBTI-TYPE-PAGES-ENTITY-GRAPH-RUNTIME-MATRIX-01`
+2. `BIG-FIVE-DIMENSION-PAGES-ENTITY-GRAPH-MATRIX-01`
+3. `ENNEAGRAM-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01`
+4. `RIASEC-SIX-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01`
+5. `CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01`
+
+## Deferred Items
+
+- No runtime readback.
+- No public route creation.
+- No CMS import/write/publish.
+- No internal-link implementation.
+- No sitemap, llms, schema, canonical, noindex, Search, GSC/GA, or deploy changes.

--- a/backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,17 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`MBTI-TYPE-PAGES-ENTITY-GRAPH-RUNTIME-MATRIX-01`
+
+Scope:
+
+- generated docs only
+- produce an MBTI 16-type route/runtime/internal-link matrix from available repository and public evidence
+- do not create routes, mutate CMS, update sitemap/llms/schema/canonical/noindex, submit Search URLs, or trigger deploys
+
+## Future Completion Authorization
+
+P4 completion should not be claimed until all family matrix PRs pass and a separate closeout confirms public/runtime graph proof.

--- a/backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/scan_manifest.json
@@ -1,0 +1,29 @@
+{
+  "pr_id": "ENTITY-GRAPH-ROUTE-INVENTORY-READONLY-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "ENTITY_ROUTE_INVENTORY_READY",
+  "p4_status_after_scan": "PLANNED_ONLY",
+  "entity_families_inventoried": 6,
+  "families_with_complete_public_runtime_graph_proof": 0,
+  "families_ready_for_deeper_matrix_prs": 6,
+  "route_mutation": false,
+  "cms_mutation": false,
+  "runtime_mutation": false,
+  "internal_link_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "search_submission": false,
+  "deploy_triggered": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "ENTITY_ROUTE_INVENTORY.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "MBTI-TYPE-PAGES-ENTITY-GRAPH-RUNTIME-MATRIX-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only P4 entity graph route inventory.
- Inventoried six entity families and mapped each to the next deeper matrix PR.
- Added decision summary, guardrails, next authorization prompts, and scan manifest.

## Why
- P4 is still planned-only; the train needs a shared route-family inventory before family-specific matrix PRs.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/entity-graph-route-inventory-readonly-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `ENTITY_ROUTE_INVENTORY_READY`

## Deferred items
- No route creation, CMS write, runtime readback, internal-link implementation, sitemap, llms, schema, canonical, noindex, Search, GSC/GA, or deploy changes.