### PR TITLE
SECURITY-169-API-06: close PR train ledger

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41924,10 +41924,18 @@
       "authorization": {
         "evidence": "Authorized by the 2026-07-03 SECURITY-169 attached /goal.",
         "status": "pass"
+      },
+      "local_validation": {
+        "evidence": "Ran syntax checks, Pint, focused ScaleQuestionsResponseCacheTest, route:list, sqlite migrate, JSON/YAML parsing, git diff --check, and backend/scripts/ci_verify_mbti.sh after rebasing onto latest origin/main.",
+        "status": "pass"
+      },
+      "scope_validation": {
+        "evidence": "Changed files were confined to API-06 tenant/org scale registry and question-pack cache privacy middleware/test and train manifest/state paths. CI-generated BIG5_OCEAN compiled artifacts were restored before commit.",
+        "status": "pass"
       }
     },
     "cms_mutation": false,
-    "commit_sha": null,
+    "commit_sha": "98b3986355bb85491989aa57a55e04d2d0436122",
     "content_authority": "backend",
     "database_mutation": false,
     "depends_on": [
@@ -41954,6 +41962,11 @@
         "at": "2026-07-06T14:18:20+08:00",
         "note": "Rebased onto latest origin/main and reran focused API06 cache privacy test, route:list, JSON/YAML parse, and diff whitespace checks successfully.",
         "status": "post_rebase_local_validation_passed"
+      },
+      {
+        "at": "2026-07-06T14:26:21+08:00",
+        "note": "PR #2790 merged after GitHub checks passed; staging deploy was not waited on and no manual or production deploy was triggered. Remote task branch deleted; local task worktree and branch cleaned.",
+        "status": "merged"
       }
     ],
     "failure_reason": null,
@@ -41970,12 +41983,12 @@
       ],
       "status": "pass"
     },
-    "local_cleanup_executed": false,
-    "merged_at": null,
-    "pr_url": null,
+    "local_cleanup_executed": true,
+    "merged_at": "2026-07-06T06:26:21Z",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2790",
     "production_write_execution": false,
     "publish_allowed": false,
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
     "scope_validation": {
       "changed_files": [
@@ -41987,7 +42000,7 @@
       "local_validation_passed": true,
       "status": "pass"
     },
-    "status": "local_validation_passed",
+    "status": "merged",
     "title": "SECURITY-169-API-06: fix public question pack cache privacy",
     "train_scope": "security_169_fap_api_audit"
   },

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -91,5 +91,16 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Complete GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01 or a separately authorized equivalent before any TDK/CTR selection.",
         "train_continued": true
+    },
+    {
+        "repo": "fermatmind/fap-api",
+        "pr_id": "SECURITY-169-API-06",
+        "branch": "codex/security-169-api-06-fix-public-question-pack-cache-privacy",
+        "blocker_type": "external_dirty_local_main_worktree",
+        "evidence": "/Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01 held main with pre-existing staged files under backend/docs/seo/daily-runs/2026-07-05. The worktree was fast-forwarded to origin/main at 98b3986355bb85491989aa57a55e04d2d0436122, but those staged SEO files remain.",
+        "why_not_current_pr_scope": "The staged files are SEO daily-run documentation paths, unrelated to API06 tenant/org scale registry and question-pack cache privacy.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Finish, stash, or commit the SEO daily-run staged files in their owning task/thread; do not attach them to SECURITY-169 API PR scopes.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -106,3 +106,14 @@
 - recommended follow-up:
   - Complete `GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01` or a separately authorized equivalent before any TDK/CTR selection.
 - whether train continued: `true`
+
+## SECURITY-169-API-06 external dirty main worktree
+
+- repo: `fermatmind/fap-api`
+- PR id / branch: SECURITY-169-API-06 / `codex/security-169-api-06-fix-public-question-pack-cache-privacy`
+- blocker type: `external_dirty_local_main_worktree`
+- evidence: `/Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01` held `main` with pre-existing staged files under `backend/docs/seo/daily-runs/2026-07-05/...`. The worktree was fast-forwarded to `origin/main` at `98b3986355bb85491989aa57a55e04d2d0436122`, but those staged SEO files remain.
+- why not current PR scope: the staged files are SEO daily-run documentation paths, unrelated to API06 tenant/org scale registry and question-pack cache privacy.
+- whether required checks are affected: `false`
+- recommended follow-up: finish, stash, or commit the SEO daily-run staged files in their owning task/thread; do not attach them to SECURITY-169 API PR scopes.
+- whether train continued: `true`


### PR DESCRIPTION
## What changed
- Mark SECURITY-169-API-06 as merged in the PR-train state ledger.
- Record PR #2790, merge commit, cleanup status, and validation evidence.
- Append a sidecar entry for the unrelated dirty local main worktree staged SEO docs.

## Why
- API06 implementation merged successfully and the train ledger needs post-merge closeout before the next SECURITY-169 API item.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`

## Deferred items
- Runtime route/migrate/curl checks are not applicable to this ledger-only closeout.
- No staging deploy wait.
- No manual server deploy.
- No production deploy.
