### PR TITLE
MBTI-TYPE-PAGES-ENTITY-GRAPH-RUNTIME-MATRIX-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,32 @@
+# MBTI-TYPE-PAGES-ENTITY-GRAPH-RUNTIME-MATRIX-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: MBTI_TYPE_RUNTIME_MATRIX_READY
+
+The 16 MBTI base type public profile routes have zh/en runtime evidence through the `*-a` public route form, and the backend personality API returns 200 for each base type in zh-CN and en locales.
+
+## Runtime Summary
+
+- MBTI base types checked: 16
+- Public zh profile routes checked: 16/16 HTTP 200
+- Public en profile routes checked: 16/16 HTTP 200
+- Backend API zh-CN checks: 16/16 HTTP 200
+- Backend API en checks: 16/16 HTTP 200
+- Route mutation: none
+- CMS/runtime/search/discoverability mutation: none
+
+## Important Boundary
+
+This proves route/API presence for base MBTI type profiles. It does not prove full internal-link graph completeness, sitemap/llms inclusion correctness, claim review completeness, or MBTI-A/T and cross-type comparison graph completion.
+
+## Deferred Items
+
+- No route creation or modification.
+- No CMS write/import/publish.
+- No sitemap, llms, schema, canonical, noindex, Search, GSC/GA, or deploy changes.
+- No claim that P4 is complete.

--- a/backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/MBTI_TYPE_RUNTIME_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/MBTI_TYPE_RUNTIME_MATRIX.md
@@ -1,0 +1,64 @@
+# MBTI Type Pages Entity Graph Runtime Matrix
+
+Date: 2026-07-06
+Scope: read-only runtime matrix for 16 MBTI base type profiles
+
+## Route Shape
+
+Observed route shape:
+
+- Base path such as `/zh/personality/intj` resolves to `/zh/personality/intj-a`.
+- Public profile path shape is `/zh/personality/{type}-a` and `/en/personality/{type}-a`.
+- Backend API path shape is `/api/v0.5/personality/{TYPE}?locale={locale}`.
+
+## Matrix
+
+| Type | zh public route | zh status | en public route | en status | API zh-CN | API en |
+| --- | --- | ---: | --- | ---: | ---: | ---: |
+| INTJ | `/zh/personality/intj-a` | 200 | `/en/personality/intj-a` | 200 | 200 | 200 |
+| INTP | `/zh/personality/intp-a` | 200 | `/en/personality/intp-a` | 200 | 200 | 200 |
+| ENTJ | `/zh/personality/entj-a` | 200 | `/en/personality/entj-a` | 200 | 200 | 200 |
+| ENTP | `/zh/personality/entp-a` | 200 | `/en/personality/entp-a` | 200 | 200 | 200 |
+| INFJ | `/zh/personality/infj-a` | 200 | `/en/personality/infj-a` | 200 | 200 | 200 |
+| INFP | `/zh/personality/infp-a` | 200 | `/en/personality/infp-a` | 200 | 200 | 200 |
+| ENFJ | `/zh/personality/enfj-a` | 200 | `/en/personality/enfj-a` | 200 | 200 | 200 |
+| ENFP | `/zh/personality/enfp-a` | 200 | `/en/personality/enfp-a` | 200 | 200 | 200 |
+| ISTJ | `/zh/personality/istj-a` | 200 | `/en/personality/istj-a` | 200 | 200 | 200 |
+| ISFJ | `/zh/personality/isfj-a` | 200 | `/en/personality/isfj-a` | 200 | 200 | 200 |
+| ESTJ | `/zh/personality/estj-a` | 200 | `/en/personality/estj-a` | 200 | 200 | 200 |
+| ESFJ | `/zh/personality/esfj-a` | 200 | `/en/personality/esfj-a` | 200 | 200 | 200 |
+| ISTP | `/zh/personality/istp-a` | 200 | `/en/personality/istp-a` | 200 | 200 | 200 |
+| ISFP | `/zh/personality/isfp-a` | 200 | `/en/personality/isfp-a` | 200 | 200 | 200 |
+| ESTP | `/zh/personality/estp-a` | 200 | `/en/personality/estp-a` | 200 | 200 | 200 |
+| ESFP | `/zh/personality/esfp-a` | 200 | `/en/personality/esfp-a` | 200 | 200 | 200 |
+
+## Repository Evidence
+
+- OpenAPI snapshot exposes `/api/v0.5/personality/{type}`, `/api/v0.5/personality/{type}/seo`, and `/api/v0.5/personality/{type}/desktop-clone`.
+- `PersonalityProfile` model includes MBTI type-code allowlist.
+- `PersonalityController` includes personality profile payload and start-test links back to `/tests/mbti-personality-test-16-personality-types`.
+- Existing generated/import evidence includes MBTI type media and MBTI 64 comparison content packages.
+
+## Runtime Evidence Method
+
+Commands used:
+
+```bash
+curl -L -s -o /dev/null -w '%{http_code} %{url_effective}' https://www.fermatmind.com/zh/personality/intj
+curl -L -s -o /dev/null -w '%{http_code}' 'https://api.fermatmind.com/api/v0.5/personality/INTJ?locale=zh-CN'
+```
+
+The batch check repeated equivalent public zh/en and API zh-CN/en checks for all 16 base MBTI type codes.
+
+## Remaining Gaps
+
+This matrix does not close:
+
+- sitemap/llms inclusion or exclusion correctness;
+- canonical/hreflang parity for all profile routes;
+- visible internal-link graph completeness;
+- claim boundary review for every profile page;
+- MBTI-A/T route graph beyond the observed `*-a` base public route shape;
+- cross-type comparison graph completion.
+
+Those require separate readback or implementation PRs.

--- a/backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,17 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`BIG-FIVE-DIMENSION-PAGES-ENTITY-GRAPH-MATRIX-01`
+
+Scope:
+
+- generated docs only
+- inventory Big Five dimension pages and route/public/runtime graph evidence
+- do not create routes, mutate CMS, update sitemap/llms/schema/canonical/noindex, submit Search URLs, or trigger deploys
+
+## Future MBTI Follow-up
+
+If MBTI profile graph closeout is required later, authorize a separate PR to check sitemap/llms, canonical/hreflang, visible internal-link graph, and claim boundary for all MBTI profile routes.

--- a/backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/scan_manifest.json
@@ -1,0 +1,31 @@
+{
+  "pr_id": "MBTI-TYPE-PAGES-ENTITY-GRAPH-RUNTIME-MATRIX-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "MBTI_TYPE_RUNTIME_MATRIX_READY",
+  "mbti_base_types_checked": 16,
+  "zh_public_routes_200": 16,
+  "en_public_routes_200": 16,
+  "api_zh_cn_200": 16,
+  "api_en_200": 16,
+  "route_mutation": false,
+  "cms_mutation": false,
+  "runtime_mutation": false,
+  "internal_link_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "search_submission": false,
+  "deploy_triggered": false,
+  "p4_complete_after_this_pr": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "MBTI_TYPE_RUNTIME_MATRIX.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "BIG-FIVE-DIMENSION-PAGES-ENTITY-GRAPH-MATRIX-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only MBTI 16-type runtime matrix.
- Recorded zh/en public `*-a` route 200 evidence and zh-CN/en backend API 200 evidence for all 16 base types.
- Added remaining graph gaps, next authorization prompt, and scan manifest.

## Why
- P4 entity graph work needs family-specific route/runtime evidence after the route inventory.
- MBTI type profile routes are present, but full graph closeout still needs sitemap/llms/canonical/hreflang/internal-link/claim checks later.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/mbti-type-pages-entity-graph-runtime-matrix-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `MBTI_TYPE_RUNTIME_MATRIX_READY`

## Deferred items
- No route creation, CMS write, runtime mutation, internal-link implementation, sitemap, llms, schema, canonical, noindex, Search, GSC/GA, or deploy changes.
- P4 is not claimed complete by this PR.