### PR TITLE
BIG-FIVE-DIMENSION-PAGES-ENTITY-GRAPH-MATRIX-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/BIG_FIVE_DIMENSION_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/BIG_FIVE_DIMENSION_MATRIX.md
@@ -1,0 +1,55 @@
+# Big Five Dimension Pages Entity Graph Matrix
+
+Date: 2026-07-06
+Scope: read-only runtime matrix for Big Five dimension public pages
+
+## Route Shape
+
+Observed public route shape:
+
+- `/zh/personality/big-five/{dimension}`
+- `/en/personality/big-five/{dimension}`
+
+Non-owner or not-proven shapes from spot checks:
+
+- `/zh/personality/openness` returned 404.
+- `/en/personality/openness` returned 404.
+- `/api/v0.5/personality-content-assets/big-five/dimension/openness` returned 404.
+- `/api/v0.5/personality-content-assets/big-five/openness` returned 404.
+
+## Matrix
+
+| Dimension | zh public route | zh status | en public route | en status |
+| --- | --- | ---: | --- | ---: |
+| Openness | `/zh/personality/big-five/openness` | 200 | `/en/personality/big-five/openness` | 200 |
+| Conscientiousness | `/zh/personality/big-five/conscientiousness` | 200 | `/en/personality/big-five/conscientiousness` | 200 |
+| Extraversion | `/zh/personality/big-five/extraversion` | 200 | `/en/personality/big-five/extraversion` | 200 |
+| Agreeableness | `/zh/personality/big-five/agreeableness` | 200 | `/en/personality/big-five/agreeableness` | 200 |
+| Neuroticism | `/zh/personality/big-five/neuroticism` | 200 | `/en/personality/big-five/neuroticism` | 200 |
+
+## Repository Evidence
+
+- `ScaleRegistrySeeder` defines `BIG5_OCEAN` and describes the five OCEAN dimensions.
+- Big Five result-page agent docs exist, but they are private result-surface contracts and do not substitute for public profile SEO/GEO authority.
+- `PersonalityBigFivePublicProfileAgentPromote` exists and describes promotion of Big Five public profile CMS draft assets with no index/search side effects.
+
+## Runtime Evidence Method
+
+Commands used:
+
+```bash
+curl -L -s -o /dev/null -w '%{http_code} %{url_effective}' https://www.fermatmind.com/zh/personality/big-five/openness
+curl -L -s -o /dev/null -w '%{http_code} %{url_effective}' https://www.fermatmind.com/en/personality/big-five/openness
+```
+
+The batch check repeated equivalent zh/en public route checks for all five dimensions.
+
+## Remaining Gaps
+
+Still requires separate proof:
+
+- canonical/hreflang parity for each dimension;
+- sitemap/llms inclusion or exclusion correctness;
+- visible internal-link graph between Big Five test owner, dimensions, result guide, and career/support pages;
+- claim boundary review on all dimension pages;
+- schema parity if structured data is intended.

--- a/backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,31 @@
+# BIG-FIVE-DIMENSION-PAGES-ENTITY-GRAPH-MATRIX-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: BIG_FIVE_DIMENSION_RUNTIME_MATRIX_READY
+
+The five Big Five dimension public profile routes have zh/en runtime evidence at `/personality/big-five/{dimension}`.
+
+## Runtime Summary
+
+- Dimensions checked: 5
+- Public zh dimension routes checked: 5/5 HTTP 200
+- Public en dimension routes checked: 5/5 HTTP 200
+- Direct `/personality/{dimension}` route shape: not owner; tested `openness` returned 404
+- `personality-content-assets` API dimension route shape: not proven; tested `openness` returned 404
+- Runtime/CMS/discoverability mutation: none
+
+## Boundary
+
+This proves public route presence for Big Five dimensions. It does not prove full internal-link graph completeness, sitemap/llms inclusion correctness, canonical/hreflang parity, schema parity, or claim review completeness.
+
+## Deferred Items
+
+- No route creation or modification.
+- No CMS write/import/publish.
+- No sitemap, llms, schema, canonical, noindex, Search, GSC/GA, or deploy changes.
+- No claim that P4 is complete.

--- a/backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,17 @@
+# Next Exact Authorization Prompts
+
+## Continue Read-only Train
+
+Authorize Codex to execute:
+
+`ENNEAGRAM-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01`
+
+Scope:
+
+- generated docs only
+- inventory Enneagram type pages and route/public/runtime graph evidence
+- do not create routes, mutate CMS, update sitemap/llms/schema/canonical/noindex, submit Search URLs, or trigger deploys
+
+## Future Big Five Follow-up
+
+If Big Five dimension graph closeout is needed later, authorize a separate PR for sitemap/llms, canonical/hreflang, visible internal-link graph, schema, and claim-boundary readback across the five dimension pages.

--- a/backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/scan_manifest.json
@@ -1,0 +1,31 @@
+{
+  "pr_id": "BIG-FIVE-DIMENSION-PAGES-ENTITY-GRAPH-MATRIX-01",
+  "date": "2026-07-06",
+  "repository": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "final_verdict": "BIG_FIVE_DIMENSION_RUNTIME_MATRIX_READY",
+  "dimensions_checked": 5,
+  "zh_public_routes_200": 5,
+  "en_public_routes_200": 5,
+  "direct_dimension_route_shape_proven": false,
+  "personality_content_assets_api_shape_proven": false,
+  "route_mutation": false,
+  "cms_mutation": false,
+  "runtime_mutation": false,
+  "internal_link_mutation": false,
+  "sitemap_mutation": false,
+  "llms_mutation": false,
+  "schema_mutation": false,
+  "canonical_mutation": false,
+  "noindex_mutation": false,
+  "search_submission": false,
+  "deploy_triggered": false,
+  "p4_complete_after_this_pr": false,
+  "files": [
+    "EXECUTIVE_DECISION.md",
+    "BIG_FIVE_DIMENSION_MATRIX.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "next_recommended_pr": "ENNEAGRAM-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01"
+}


### PR DESCRIPTION
## What changed
- Added generated docs-only Big Five dimension route/runtime matrix.
- Recorded zh/en public 200 evidence for all five OCEAN dimension routes.
- Recorded non-owner/not-proven route shapes and remaining graph closeout gaps.

## Why
- P4 needs family-specific route/runtime evidence for Big Five dimension pages before any graph closeout or implementation work.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/big-five-dimension-pages-entity-graph-matrix-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `BIG_FIVE_DIMENSION_RUNTIME_MATRIX_READY`

## Deferred items
- No route creation, CMS write, runtime mutation, internal-link implementation, sitemap, llms, schema, canonical, noindex, Search, GSC/GA, or deploy changes.
- P4 is not claimed complete by this PR.