### PR TITLE
ENNEAGRAM-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/ENNEAGRAM_TYPE_RUNTIME_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/ENNEAGRAM_TYPE_RUNTIME_MATRIX.md
@@ -1,0 +1,63 @@
+# Enneagram Type Pages Entity Graph Matrix
+
+Date: 2026-07-06
+Scope: read-only runtime matrix for Enneagram type public pages
+
+## Route Shape
+
+Observed public route shape:
+
+- `/zh/personality/enneagram/type-{number}`
+- `/en/personality/enneagram/type-{number}`
+
+Non-owner or not-proven shapes from type 1 spot checks:
+
+- `/zh/personality/enneagram/1` returned 404.
+- `/en/personality/enneagram/1` returned 404.
+- `/zh/personality/enneagram-1` returned 404.
+- `/en/personality/enneagram-1` returned 404.
+- `/zh/personality/type-1` returned 404.
+- `/en/personality/type-1` returned 404.
+- `/zh/personality/enneagram/reformer` returned 404.
+- `/en/personality/enneagram/reformer` returned 404.
+
+## Matrix
+
+| Type | zh public route | zh status | en public route | en status |
+| --- | --- | ---: | --- | ---: |
+| Type 1 | `/zh/personality/enneagram/type-1` | 200 | `/en/personality/enneagram/type-1` | 200 |
+| Type 2 | `/zh/personality/enneagram/type-2` | 200 | `/en/personality/enneagram/type-2` | 200 |
+| Type 3 | `/zh/personality/enneagram/type-3` | 200 | `/en/personality/enneagram/type-3` | 200 |
+| Type 4 | `/zh/personality/enneagram/type-4` | 200 | `/en/personality/enneagram/type-4` | 200 |
+| Type 5 | `/zh/personality/enneagram/type-5` | 200 | `/en/personality/enneagram/type-5` | 200 |
+| Type 6 | `/zh/personality/enneagram/type-6` | 200 | `/en/personality/enneagram/type-6` | 200 |
+| Type 7 | `/zh/personality/enneagram/type-7` | 200 | `/en/personality/enneagram/type-7` | 200 |
+| Type 8 | `/zh/personality/enneagram/type-8` | 200 | `/en/personality/enneagram/type-8` | 200 |
+| Type 9 | `/zh/personality/enneagram/type-9` | 200 | `/en/personality/enneagram/type-9` | 200 |
+
+## Repository Evidence
+
+- `ScaleRegistrySeeder` defines the Enneagram scale with primary slug `enneagram-personality-test-nine-types`.
+- `SitemapSourceController` includes Enneagram test landing source candidates, not type-page graph proof.
+- Enneagram result-page asset and private result services exist, but private result contracts do not substitute for public profile SEO/GEO graph completion.
+
+## Runtime Evidence Method
+
+Commands used:
+
+```bash
+curl -L -s -o /dev/null -w '%{http_code} %{url_effective}' https://www.fermatmind.com/zh/personality/enneagram/type-1
+curl -L -s -o /dev/null -w '%{http_code} %{url_effective}' https://www.fermatmind.com/en/personality/enneagram/type-1
+```
+
+The batch check repeated equivalent zh/en public route checks for all nine Enneagram types.
+
+## Remaining Gaps
+
+Still requires separate proof:
+
+- canonical/hreflang parity for each type page;
+- sitemap/llms inclusion or exclusion correctness;
+- visible internal-link graph between Enneagram test owner, type pages, result guide, and support pages;
+- claim boundary review on all type pages;
+- schema parity if structured data is intended.

--- a/backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,30 @@
+# ENNEAGRAM-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: ENTITY_RUNTIME_MATRIX_READY
+
+The nine Enneagram type public profile routes have zh/en runtime evidence at `/personality/enneagram/type-{1..9}`.
+
+## Runtime Summary
+
+- Types checked: 9
+- Public zh type routes checked: 9/9 HTTP 200
+- Public en type routes checked: 9/9 HTTP 200
+- Non-owner route shapes spot-checked: `/personality/enneagram/{number}`, `/personality/enneagram-{number}`, `/personality/type-{number}`, and `/personality/enneagram/{type-name}` returned 404 for type 1 samples.
+- Runtime/CMS/discoverability mutation: none
+
+## Boundary
+
+This proves public route presence for Enneagram type pages. It does not prove full entity graph completion, sitemap/llms inclusion, canonical/hreflang parity, schema parity, visible internal-link completeness, or claim review completeness.
+
+## Deferred Items
+
+- No route creation or modification.
+- No CMS write/import/publish.
+- No sitemap, llms, schema, canonical, noindex, Search, GSC/GA, or deploy changes.
+- No claim that P4 is complete.

--- a/backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,22 @@
+# Next Exact Authorization Prompts
+
+Use only after this read-only matrix is merged.
+
+## Public Graph Follow-Up
+
+Authorize a generated-only PR to prove Enneagram type-page graph completeness:
+
+`ENNEAGRAM-TYPE-PAGES-DISCOVERABILITY-LINK-GRAPH-READONLY-01`
+
+Scope:
+
+- read-only sitemap and llms presence check for all nine zh/en type pages;
+- read-only canonical and hreflang parity check;
+- read-only visible internal-link source/target matrix;
+- generated docs only.
+
+Forbidden:
+
+- no sitemap, llms, canonical, hreflang, schema, route, CMS, or runtime mutation;
+- no claim edits;
+- no Search submission or deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/scan_manifest.json
@@ -1,0 +1,29 @@
+{
+  "task_id": "ENNEAGRAM-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "output_path": "backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/",
+  "final_verdict": "ENTITY_RUNTIME_MATRIX_READY",
+  "runtime_readback": {
+    "public_route_shape": "/{locale}/personality/enneagram/type-{number}",
+    "zh_routes_checked": 9,
+    "zh_routes_http_200": 9,
+    "en_routes_checked": 9,
+    "en_routes_http_200": 9,
+    "non_owner_shapes_spot_checked": [
+      "/{locale}/personality/enneagram/{number}",
+      "/{locale}/personality/enneagram-{number}",
+      "/{locale}/personality/type-{number}",
+      "/{locale}/personality/enneagram/{type-name}"
+    ]
+  },
+  "changed_runtime": false,
+  "changed_cms": false,
+  "changed_discoverability": false,
+  "sidecar_required": false,
+  "validation": [
+    "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/scan_manifest.json >/dev/null",
+    "git diff --check"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added generated-only Enneagram type-page runtime matrix evidence.
- Recorded zh/en public route status for nine Enneagram type pages.
- Added next authorization prompt for future discoverability/link graph proof.

## Why
- Continue the P4 entity graph evidence train without mutating runtime, CMS, sitemap, llms, schema, or Search surfaces.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/enneagram-type-pages-entity-graph-matrix-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `ENTITY_RUNTIME_MATRIX_READY`

## Deferred / prohibited
- No route, CMS, API, sitemap, llms, schema, canonical, noindex, Search, GSC/GA, fap-web, or deploy changes.
- Does not claim full P4 entity graph completion.