### PR TITLE
RIASEC-SIX-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,30 @@
+# RIASEC-SIX-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: BLOCKED_BY_AUTHORITY_AMBIGUITY
+
+The backend has clear RIASEC scale authority and six-dimension model authority, but this scan did not find enough current evidence to declare public six-type pages complete.
+
+## Evidence Summary
+
+- `ScaleRegistrySeeder` defines `RIASEC` with primary slug `holland-career-interest-test-riasec`.
+- The scale description names the six Holland/RIASEC dimensions: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional.
+- `RiasecPackLoader` and RIASEC public/private result projection services support assessment and result contracts.
+- `SitemapSourceController` lists RIASEC test landing source candidates.
+- Current evidence does not prove a canonical public owner route for each of the six individual RIASEC type/dimension pages.
+
+## Boundary
+
+This PR is a read-only matrix and blocker report. It does not decide the URL scheme, create pages, publish CMS content, alter sitemap/llms, or promote RIASEC six-type pages into public graph completion.
+
+## Deferred Items
+
+- No public route creation or modification.
+- No CMS write/import/publish.
+- No sitemap, llms, schema, canonical, noindex, Search, GSC/GA, fap-web, or deploy changes.
+- No claim that P4 RIASEC six-type graph is complete.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,22 @@
+# Next Exact Authorization Prompts
+
+Use only after this blocked matrix is merged.
+
+## Owner Route Design
+
+Authorize a generated-only design PR:
+
+`RIASEC-SIX-TYPE-PUBLIC-OWNER-ROUTE-DESIGN-01`
+
+Scope:
+
+- decide whether six standalone RIASEC type pages should exist;
+- map CMS/backend authority source;
+- propose route pattern, indexability gate, sitemap/llms eligibility, and claim boundary;
+- generated docs only.
+
+Forbidden:
+
+- no runtime route/page creation;
+- no CMS write/import/publish;
+- no sitemap, llms, schema, canonical, hreflang, noindex, Search, fap-web, or deploy mutation.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/RIASEC_SIX_TYPE_ENTITY_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/RIASEC_SIX_TYPE_ENTITY_MATRIX.md
@@ -1,0 +1,63 @@
+# RIASEC Six-Type Pages Entity Graph Matrix
+
+Date: 2026-07-06
+Scope: generated-only matrix for RIASEC six-type public entity graph readiness
+
+## Canonical Dimension Set
+
+| Code | English label | Chinese label | Backend authority signal | Public page proof status |
+| --- | --- | --- | --- | --- |
+| R | Realistic | 现实型 | Mentioned in RIASEC scale description and scoring model context | Not proven |
+| I | Investigative | 研究型 | Mentioned in RIASEC scale description and scoring model context | Not proven |
+| A | Artistic | 艺术型 | Mentioned in RIASEC scale description and scoring model context | Not proven |
+| S | Social | 社会型 | Mentioned in RIASEC scale description and scoring model context | Not proven |
+| E | Enterprising | 企业型 | Mentioned in RIASEC scale description and scoring model context | Not proven |
+| C | Conventional | 常规型 | Mentioned in RIASEC scale description and scoring model context | Not proven |
+
+## Current Route Authority
+
+Confirmed repository-level authority:
+
+- Test owner slug: `holland-career-interest-test-riasec`
+- Scale code: `RIASEC`
+- Public forms: `riasec_60`, `riasec_140`
+- Default form: `riasec_60`
+- Test landing source candidates exist for `/en/tests/holland-career-interest-test-riasec` and `/zh/tests/holland-career-interest-test-riasec`.
+
+Not proven in this generated-only scan:
+
+- canonical six-type public URL pattern;
+- zh/en route existence for each individual RIASEC type;
+- sitemap or llms inclusion for six-type pages;
+- visible internal links from the RIASEC test landing to six-type pages;
+- claim boundary review for standalone six-type pages;
+- schema strategy for standalone six-type pages.
+
+## Interpretation
+
+The RIASEC six-dimension concept is backend-authoritative for scoring and result interpretation, but public six-type SEO/GEO pages remain authority-ambiguous until a separate PR proves or defines:
+
+- whether standalone public pages should exist;
+- which backend/CMS source owns their content;
+- whether they are indexable;
+- how they connect to the test landing, result explanation, career/major pages, sitemap, and llms surfaces.
+
+## Recommended Next Scope
+
+Use a separate design/readback PR before any implementation:
+
+`RIASEC-SIX-TYPE-PUBLIC-OWNER-ROUTE-DESIGN-01`
+
+Allowed:
+
+- generated-only route owner proposal;
+- backend authority mapping;
+- indexability and discoverability gate proposal;
+- claim boundary matrix.
+
+Forbidden:
+
+- no page creation;
+- no CMS import;
+- no sitemap/llms/schema/canonical/noindex mutation;
+- no Search or deploy action.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/scan_manifest.json
@@ -1,0 +1,24 @@
+{
+  "task_id": "RIASEC-SIX-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "output_path": "backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/",
+  "final_verdict": "BLOCKED_BY_AUTHORITY_AMBIGUITY",
+  "dimension_count": 6,
+  "backend_authority_signals": [
+    "backend/database/seeders/ScaleRegistrySeeder.php",
+    "backend/app/Services/Content/RiasecPackLoader.php",
+    "backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php"
+  ],
+  "public_six_type_route_proof": "not_proven",
+  "changed_runtime": false,
+  "changed_cms": false,
+  "changed_discoverability": false,
+  "sidecar_required": true,
+  "validation": [
+    "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/scan_manifest.json >/dev/null",
+    "python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null",
+    "git diff --check"
+  ]
+}

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -102,5 +102,20 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Finish, stash, or commit the SEO daily-run staged files in their owning task/thread; do not attach them to SECURITY-169 API PR scopes.",
         "train_continued": true
+    },
+    {
+        "repo": "fap-api",
+        "pr_id": "RIASEC-SIX-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01",
+        "branch": "codex/riasec-six-type-pages-entity-graph-matrix-01",
+        "blocker_type": "blocked_by_authority_ambiguity",
+        "evidence": [
+            "ScaleRegistrySeeder defines RIASEC and names the six Holland/RIASEC dimensions.",
+            "RiasecPackLoader and RIASEC result projection services support assessment/result contracts.",
+            "Current generated-only scan did not prove canonical public owner routes for the six individual RIASEC type pages."
+        ],
+        "why_not_current_pr_scope": "Current PR is generated-only evidence reporting. It is not authorized to create routes, write CMS content, mutate sitemap/llms/schema/canonical/noindex, or edit fap-web.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Run RIASEC-SIX-TYPE-PUBLIC-OWNER-ROUTE-DESIGN-01 as a generated-only design PR before any runtime/CMS/discoverability implementation.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -117,3 +117,20 @@
 - whether required checks are affected: `false`
 - recommended follow-up: finish, stash, or commit the SEO daily-run staged files in their owning task/thread; do not attach them to SECURITY-169 API PR scopes.
 - whether train continued: `true`
+
+## RIASEC-SIX-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01 authority ambiguity
+
+- repo: `fap-api`
+- PR id / branch: `RIASEC-SIX-TYPE-PAGES-ENTITY-GRAPH-MATRIX-01` / `codex/riasec-six-type-pages-entity-graph-matrix-01`
+- blocker type: `blocked_by_authority_ambiguity`
+- evidence:
+  - `ScaleRegistrySeeder` defines RIASEC and names the six Holland/RIASEC dimensions.
+  - `RiasecPackLoader` and RIASEC result projection services support assessment/result contracts.
+  - Current generated-only scan did not prove canonical public owner routes for the six individual RIASEC type pages.
+- why not current PR scope:
+  - Current PR is generated-only evidence reporting.
+  - It is not authorized to create routes, write CMS content, mutate sitemap/llms/schema/canonical/noindex, or edit fap-web.
+- whether required checks are affected: `false`
+- recommended follow-up:
+  - Run a separate `RIASEC-SIX-TYPE-PUBLIC-OWNER-ROUTE-DESIGN-01` generated-only design PR before any runtime/CMS/discoverability implementation.
+- whether train continued: `true`


### PR DESCRIPTION
## What changed
- Added generated-only RIASEC six-type entity matrix evidence.
- Recorded that backend scale authority exists, but public six-type owner routes are not proven.
- Added sidecar blocker entry for authority ambiguity and a next authorization prompt.

## Why
- Continue the P4 entity graph evidence train without mutating runtime, CMS, sitemap, llms, schema, Search, or fap-web.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/riasec-six-type-pages-entity-graph-matrix-01/scan_manifest.json >/dev/null`
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `BLOCKED_BY_AUTHORITY_AMBIGUITY`

## Deferred / prohibited
- No route, CMS, API, sitemap, llms, schema, canonical, noindex, Search, GSC/GA, fap-web, or deploy changes.
- Does not claim RIASEC six-type public graph completion.