### PR TITLE
CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/CAREER_MAJOR_ENTITY_GRAPH_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/CAREER_MAJOR_ENTITY_GRAPH_MATRIX.md
@@ -1,0 +1,68 @@
+# Career/Major Pages Entity Graph Matrix
+
+Date: 2026-07-06
+Scope: generated-only matrix for career and major public entity graph readiness
+
+## Family Matrix
+
+| Family | Backend authority evidence | Public graph status | Current blocker |
+| --- | --- | --- | --- |
+| Career jobs | `CareerJobController`, `CareerJobDetailController`, `CareerJobListController`, career job tables, occupation tables, career detail bundle builder | Partially evidenced; route and indexability behavior still needs dedicated runtime/discoverability proof | Not closed in this PR |
+| Career guides | `CareerGuideController`, guide indexability state, career guide mapping tables | Partially evidenced; route inventory and sitemap/llms proof not closed | Not closed in this PR |
+| Career recommendations | `CareerRecommendationController`, recommendation snapshots, context snapshots | Support surface evidenced, not standalone public graph completion | Not closed in this PR |
+| Occupation authority | `occupations`, `occupation_families`, aliases, crosswalks, truth metrics, skill graphs, trust manifests, transition paths | Backend authority evidenced; public graph projection requires separate proof | Not closed in this PR |
+| Major pages | Major-selection modules in topic/personality/recommendation controllers; RIASEC/gaokao cluster planning docs | Standalone major-page owner, route, CMS source, and indexability not proven | Authority ambiguous |
+
+## Career Authority Signals
+
+Career-side evidence is strong enough for a follow-up runtime/discoverability readback, because current repository evidence includes:
+
+- public CMS controllers for career job list/detail and career guides;
+- career detail SEO payload with indexability state;
+- sitemap source filtering for runtime-published career job detail URLs;
+- occupation-family and occupation authority tables;
+- RIASEC profile fields on career job payloads.
+
+This does not prove:
+
+- all career pages that should exist are published;
+- all indexable career pages are in sitemap/llms;
+- no noindex career pages are discoverability-listed;
+- internal links form a complete entity graph;
+- claim boundary review is complete.
+
+## Major Authority Ambiguity
+
+Current generated evidence only supports major selection as a contextual module. It does not prove standalone major pages.
+
+Before implementation, a separate authority design PR must decide:
+
+- whether major pages exist as standalone public entities;
+- whether they belong to backend CMS content pages, topic pages, career content, or a new backend authority model;
+- whether they are indexable;
+- how they connect to RIASEC, gaokao, career job, and topic pages;
+- what claims are allowed for major choice guidance.
+
+## Recommended Next Scope
+
+Use separate PRs:
+
+1. `CAREER-PAGES-RUNTIME-DISCOVERABILITY-READBACK-01`
+   - read-only career route inventory;
+   - indexability and sitemap/llms parity proof;
+   - no content or route mutation.
+
+2. `MAJOR-PAGES-PUBLIC-AUTHORITY-DESIGN-01`
+   - generated-only major-page authority design;
+   - route and CMS owner proposal;
+   - claim boundary and indexability gate proposal.
+
+## Guardrails
+
+Do not use this matrix to:
+
+- publish major pages;
+- index career/major pages;
+- mutate sitemap or llms;
+- create public internal links;
+- claim P4 completion.

--- a/backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,30 @@
+# CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: BLOCKED_BY_AUTHORITY_AMBIGUITY
+
+Career job/detail authority is present in backend APIs and CMS services, but the combined Career/Major public entity graph cannot be declared complete because standalone major-page authority is not proven in current evidence.
+
+## Evidence Summary
+
+- Career job APIs and CMS controllers exist for career job list/detail, guide, recommendation, and detail bundle surfaces.
+- Career job detail SEO contracts include indexability state and `noindex,follow` gating when not eligible.
+- Career jobs connect to occupation authority tables and RIASEC profile fields.
+- Major-selection text appears as support modules in personality, topic, and career recommendation surfaces.
+- Current evidence does not prove canonical standalone major pages, major route owners, major CMS authority, or indexability policy.
+
+## Boundary
+
+This PR is a read-only matrix and blocker report. It does not create or expose career/major pages, change CMS state, change route lists, change sitemap/llms, or decide indexability.
+
+## Deferred Items
+
+- No career or major route creation or modification.
+- No CMS write/import/publish.
+- No sitemap, llms, schema, canonical, noindex, Search, GSC/GA, fap-web, or deploy changes.
+- No claim that P4 career/major graph is complete.

--- a/backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,37 @@
+# Next Exact Authorization Prompts
+
+Use only after this blocked matrix is merged.
+
+## Career Runtime Readback
+
+Authorize:
+
+`CAREER-PAGES-RUNTIME-DISCOVERABILITY-READBACK-01`
+
+Scope:
+
+- read-only career page route inventory;
+- read-only indexability and sitemap/llms parity proof;
+- generated docs only.
+
+Forbidden:
+
+- no CMS writes;
+- no route, sitemap, llms, schema, canonical, noindex, Search, fap-web, or deploy mutation.
+
+## Major Authority Design
+
+Authorize:
+
+`MAJOR-PAGES-PUBLIC-AUTHORITY-DESIGN-01`
+
+Scope:
+
+- generated-only major-page authority design;
+- decide backend owner, route pattern, indexability gate, and claim boundary proposal.
+
+Forbidden:
+
+- no page creation;
+- no CMS import;
+- no discoverability or runtime mutation.

--- a/backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/scan_manifest.json
@@ -1,0 +1,26 @@
+{
+  "task_id": "CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "output_path": "backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/",
+  "final_verdict": "BLOCKED_BY_AUTHORITY_AMBIGUITY",
+  "career_authority_status": "partial_backend_authority_evidenced",
+  "major_authority_status": "standalone_public_authority_not_proven",
+  "backend_authority_signals": [
+    "backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php",
+    "backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php",
+    "backend/app/Http/Controllers/API/V0_5/Cms/CareerGuideController.php",
+    "backend/app/Http/Controllers/API/V0_5/Cms/CareerRecommendationController.php",
+    "backend/database/migrations/2026_04_07_000200_create_occupations_table.php"
+  ],
+  "changed_runtime": false,
+  "changed_cms": false,
+  "changed_discoverability": false,
+  "sidecar_required": true,
+  "validation": [
+    "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/scan_manifest.json >/dev/null",
+    "python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null",
+    "git diff --check"
+  ]
+}

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -117,5 +117,20 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Run RIASEC-SIX-TYPE-PUBLIC-OWNER-ROUTE-DESIGN-01 as a generated-only design PR before any runtime/CMS/discoverability implementation.",
         "train_continued": true
+    },
+    {
+        "repo": "fap-api",
+        "pr_id": "CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01",
+        "branch": "codex/career-major-pages-entity-graph-matrix-01",
+        "blocker_type": "blocked_by_authority_ambiguity",
+        "evidence": [
+            "Career job/detail backend controllers, occupation tables, and indexability fields exist.",
+            "Sitemap source filtering references runtime-published career job detail URLs.",
+            "Standalone major-page owner routes, CMS authority, and indexability policy were not proven in current generated-only scan."
+        ],
+        "why_not_current_pr_scope": "Current PR is generated-only evidence reporting. It is not authorized to create routes, import CMS content, mutate sitemap/llms/schema/canonical/noindex, or edit fap-web.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Run CAREER-PAGES-RUNTIME-DISCOVERABILITY-READBACK-01 for career pages and MAJOR-PAGES-PUBLIC-AUTHORITY-DESIGN-01 before any standalone major-page implementation.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -134,3 +134,21 @@
 - recommended follow-up:
   - Run a separate `RIASEC-SIX-TYPE-PUBLIC-OWNER-ROUTE-DESIGN-01` generated-only design PR before any runtime/CMS/discoverability implementation.
 - whether train continued: `true`
+
+## CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01 authority ambiguity
+
+- repo: `fap-api`
+- PR id / branch: `CAREER-MAJOR-PAGES-ENTITY-GRAPH-MATRIX-01` / `codex/career-major-pages-entity-graph-matrix-01`
+- blocker type: `blocked_by_authority_ambiguity`
+- evidence:
+  - Career job/detail backend controllers, occupation tables, and indexability fields exist.
+  - Sitemap source filtering references runtime-published career job detail URLs.
+  - Standalone major-page owner routes, CMS authority, and indexability policy were not proven in current generated-only scan.
+- why not current PR scope:
+  - Current PR is generated-only evidence reporting.
+  - It is not authorized to create routes, import CMS content, mutate sitemap/llms/schema/canonical/noindex, or edit fap-web.
+- whether required checks are affected: `false`
+- recommended follow-up:
+  - Run `CAREER-PAGES-RUNTIME-DISCOVERABILITY-READBACK-01` for career pages.
+  - Run `MAJOR-PAGES-PUBLIC-AUTHORITY-DESIGN-01` before any standalone major-page implementation.
+- whether train continued: `true`


### PR DESCRIPTION
## What changed
- Added generated-only career/major entity graph matrix evidence.
- Recorded career backend authority signals and major-page authority ambiguity.
- Added sidecar blocker entry and next authorization prompts.

## Why
- Continue the P4 entity graph evidence train without mutating runtime, CMS, sitemap, llms, schema, Search, or fap-web.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/career-major-pages-entity-graph-matrix-01/scan_manifest.json >/dev/null`
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `BLOCKED_BY_AUTHORITY_AMBIGUITY`

## Deferred / prohibited
- No route, CMS, API, sitemap, llms, schema, canonical, noindex, Search, GSC/GA, fap-web, or deploy changes.
- Does not claim career/major public graph completion.