### PR TITLE
GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,31 @@
+# GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: BLOCKED_BY_GSC_DATA_QUALITY
+
+Current repository evidence does not prove passable `seo_intel` read-model rows with `data_origin=live_gsc_api`. The train must keep GSC-derived CTR/TDK repair decisions blocked.
+
+## Evidence Summary
+
+- `gsc-data-quality-gate.v1.json` records current foundation status as `data_origin=fixture`.
+- `opportunity_queue_eligible=false`.
+- The quality gate requires `source_engine=google`, `data_origin=live_gsc_api`, required metric fields, freshness, and finalization lag.
+- The live read-model consumption contract forbids direct sidecar artifact consumption by opportunity queues.
+- This PR did not call Google Search Console, read credentials, import rows, backfill tables, enqueue Search Channel, or write CMS data.
+
+## Boundary
+
+This is a proof attempt using existing generated/read-model evidence only. It is intentionally blocked because the required live read-model proof is absent.
+
+## Deferred Items
+
+- No live GSC API call.
+- No credentials read, printed, validated, or stored.
+- No `seo_gsc_daily` import/backfill.
+- No GSC-derived CTR/TDK repair queue.
+- No CMS, Search Channel, sitemap, URL inspection, fap-web, deploy, or production action.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/LIVE_READMODEL_QUALITY_PROOF.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/LIVE_READMODEL_QUALITY_PROOF.md
@@ -1,0 +1,49 @@
+# GSC / seo_intel Live Readmodel Quality Proof
+
+Date: 2026-07-06
+Scope: generated-only proof attempt from existing repository evidence
+
+## Proof Requirement
+
+To pass, future GSC/seo_intel repair selection must prove all of the following from sanitized read-model evidence:
+
+| Gate | Required value |
+| --- | --- |
+| source engine | `google` |
+| data origin | `live_gsc_api` |
+| forbidden origins | no `fixture`, `mock`, `static_artifact`, or `unknown` |
+| required fields | `canonical_url_hash`, `query_hash`, `clicks`, `impressions` |
+| date quality | satisfies GSC finalization lag and freshness window |
+| queue source | imported `seo_intel` read-model rows only |
+| sensitive fields | no raw query, raw URL, credentials, tokens, cookies, sessions, or raw payloads |
+
+## Current Evidence
+
+| Evidence source | Current result | Pass? |
+| --- | --- | --- |
+| `backend/docs/seo/generated/gsc-data-quality-gate.v1.json` | `data_origin=fixture`, `data_quality_gate_status=blocked`, `opportunity_queue_eligible=false` | No |
+| `backend/docs/seo/generated/gsc-live-readmodel-consumption-contract.v1.json` | Defines future live read-model contract; no live call or import in current evidence | No |
+| `backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-quality-refresh-readonly-01/` | Prior read-only refresh concluded gate blocked | No |
+| `GscDataQualityGate` architecture | Gate logic exists and blocks forbidden origins | Architecture present, data proof absent |
+| `seo_gsc_daily` schema | Supports hashed URL/query metrics and idempotency key | Schema present, passable rows absent |
+
+## Decision
+
+The quality proof fails by design because no allowed live `seo_intel` read-model row set is available in the current repository evidence.
+
+Downstream effects:
+
+- `CTR-REPAIR-LOOP-ELIGIBILITY-READONLY-01` should remain blocked unless separate passable live evidence appears before that card.
+- `CTR-TDK-REPAIR-DRYRUN-QUEUE-01` should remain blocked.
+- Money-intent TDK/CTR repair selection must not use fixture/static/screenshot/UI evidence.
+
+## Non-Actions
+
+This PR did not:
+
+- open Google Search Console;
+- call GSC APIs;
+- read or handle credentials;
+- import or backfill `seo_gsc_daily`;
+- write any CMS, Search Channel, sitemap, or runtime state;
+- infer purchase truth from GSC/GA.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,40 @@
+# Next Exact Authorization Prompts
+
+Use only if the operator wants to unblock GSC-driven repair selection.
+
+## Live Read-Only Evidence Authorization
+
+Authorize a separate read-only live evidence PR:
+
+`GSC-LIVE-READONLY-SANITIZED-EVIDENCE-CAPTURE-01`
+
+Scope:
+
+- capture sanitized GSC evidence only;
+- no raw query, raw URL, credential path, token, cookie, session, or raw payload;
+- prove `source_engine=google` and `data_origin=live_gsc_api`;
+- generated artifact only.
+
+Forbidden:
+
+- no DB import/backfill;
+- no CMS write;
+- no Search Channel enqueue;
+- no URL inspection or sitemap submission;
+- no deploy.
+
+## Dry-Run Import Readback Authorization
+
+Authorize only after live sanitized evidence exists:
+
+`GSC-READMODEL-DRYRUN-IMPORT-READBACK-01`
+
+Scope:
+
+- dry-run importer/readback only;
+- verify quality gate pass before any opportunity queue selection.
+
+Forbidden:
+
+- no production write/import;
+- no CTR/TDK repair queue execution.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/scan_manifest.json
@@ -1,0 +1,23 @@
+{
+  "task_id": "GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "output_path": "backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/",
+  "final_verdict": "BLOCKED_BY_GSC_DATA_QUALITY",
+  "live_gsc_api_call": false,
+  "credential_operation": false,
+  "seo_gsc_daily_import": false,
+  "database_write": false,
+  "search_channel_enqueue": false,
+  "cms_write": false,
+  "current_proven_data_origin": "fixture",
+  "required_data_origin": "live_gsc_api",
+  "opportunity_queue_eligible": false,
+  "sidecar_required": true,
+  "validation": [
+    "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/scan_manifest.json >/dev/null",
+    "python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null",
+    "git diff --check"
+  ]
+}

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -132,5 +132,20 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Run CAREER-PAGES-RUNTIME-DISCOVERABILITY-READBACK-01 for career pages and MAJOR-PAGES-PUBLIC-AUTHORITY-DESIGN-01 before any standalone major-page implementation.",
         "train_continued": true
+    },
+    {
+        "repo": "fap-api",
+        "pr_id": "GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01",
+        "branch": "codex/gsc-seo-intel-live-readmodel-quality-proof-readonly-01",
+        "blocker_type": "blocked_by_gsc_data_quality",
+        "evidence": [
+            "Existing generated gate evidence records data_origin=fixture.",
+            "opportunity_queue_eligible=false.",
+            "Required pass condition is data_origin=live_gsc_api plus sanitized read-model quality gate pass."
+        ],
+        "why_not_current_pr_scope": "Current PR is generated-only proof reporting. It is not authorized to call live GSC, read credentials, import seo_gsc_daily, write CMS, enqueue Search Channel, or submit URLs.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Separately authorize sanitized live read-only GSC evidence capture and dry-run import readback before any CTR/TDK queue.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -152,3 +152,20 @@
   - Run `CAREER-PAGES-RUNTIME-DISCOVERABILITY-READBACK-01` for career pages.
   - Run `MAJOR-PAGES-PUBLIC-AUTHORITY-DESIGN-01` before any standalone major-page implementation.
 - whether train continued: `true`
+
+## GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01 GSC data quality
+
+- repo: `fap-api`
+- PR id / branch: `GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01` / `codex/gsc-seo-intel-live-readmodel-quality-proof-readonly-01`
+- blocker type: `blocked_by_gsc_data_quality`
+- evidence:
+  - Existing generated gate evidence records `data_origin=fixture`.
+  - `opportunity_queue_eligible=false`.
+  - Required pass condition is `data_origin=live_gsc_api` plus sanitized read-model quality gate pass.
+- why not current PR scope:
+  - Current PR is generated-only proof reporting.
+  - It is not authorized to call live GSC, read credentials, import `seo_gsc_daily`, write CMS, enqueue Search Channel, or submit URLs.
+- whether required checks are affected: `false`
+- recommended follow-up:
+  - Separately authorize sanitized live read-only GSC evidence capture and dry-run import readback before any CTR/TDK queue.
+- whether train continued: `true`


### PR DESCRIPTION
## What changed
- Added generated-only GSC/seo_intel live read-model quality proof report.
- Recorded that current evidence remains blocked because proven data origin is fixture, not live_gsc_api.
- Added sidecar blocker entry and next authorization prompts.

## Why
- Continue the P5 train without unauthorized live GSC, credential, DB import, CMS, Search Channel, or deploy actions.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/gsc-seo-intel-live-readmodel-quality-proof-readonly-01/scan_manifest.json >/dev/null`
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `BLOCKED_BY_GSC_DATA_QUALITY`

## Deferred / prohibited
- No live GSC API call, credential operation, seo_gsc_daily import, CMS write, Search Channel enqueue, sitemap/URL submission, fap-web edit, or deploy.