### PR TITLE
GSC-READMODEL-REPAIR-DESIGN-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,32 @@
+# GSC-READMODEL-REPAIR-DESIGN-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: design only / generated docs only
+
+## Decision
+
+Final verdict: READMODEL_REPAIR_DESIGN_READY
+
+The GSC read-model repair path should not start with CTR/TDK edits. It should first prove sanitized live GSC evidence, then dry-run import/readback, then controlled canary import, and only later enable opportunity queue selection.
+
+## Design Summary
+
+Required repair sequence:
+
+1. Sanitized live read-only evidence capture.
+2. Dry-run read-model import/readback against the artifact.
+3. Controlled canary import to `seo_gsc_daily` only after exact operator approval.
+4. Quality gate readback proving `data_origin=live_gsc_api` and `opportunity_queue_eligible=true`.
+5. Separate CTR/TDK queue selection PR.
+
+## Boundary
+
+This PR does not execute any of the sequence. It only records the repair design needed after `BLOCKED_BY_GSC_DATA_QUALITY`.
+
+## Deferred Items
+
+- No live GSC API call.
+- No credentials read, printed, validated, or stored.
+- No `seo_gsc_daily` import/backfill.
+- No scheduler, queue, CMS, Search Channel, sitemap, URL inspection, fap-web, deploy, or production action.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,46 @@
+# Next Exact Authorization Prompts
+
+Use only when ready to unblock GSC-driven SEO repair selection.
+
+## Phase 1
+
+Authorize:
+
+`GSC-LIVE-READONLY-SANITIZED-EVIDENCE-CAPTURE-01`
+
+Scope:
+
+- capture bounded sanitized live GSC artifact;
+- prove `source_engine=google` and `data_origin=live_gsc_api`;
+- no raw query, raw URL, credential, token, cookie, session, service-account JSON, or raw payload;
+- generated artifact only.
+
+Forbidden:
+
+- no DB write/import;
+- no scheduler/queue;
+- no CMS/Search/deploy.
+
+## Phase 2
+
+Authorize after Phase 1:
+
+`GSC-READMODEL-DRYRUN-IMPORT-READBACK-01`
+
+Scope:
+
+- run dry-run importer against exact artifact SHA256;
+- prove quality gate pass on preview rows;
+- no write.
+
+## Phase 3
+
+Authorize after Phase 2:
+
+`GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01`
+
+Scope:
+
+- exact SHA-pinned batch10 canary only;
+- explicit confirmation phrase required;
+- no scheduler, opportunity queue, CMS, Search, or deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/READMODEL_REPAIR_DESIGN.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/READMODEL_REPAIR_DESIGN.md
@@ -1,0 +1,103 @@
+# GSC Readmodel Repair Design
+
+Date: 2026-07-06
+Scope: generated-only repair design after GSC quality proof blocked
+
+## Current Problem
+
+The current proof state is:
+
+- current proven data origin: `fixture`;
+- required data origin: `live_gsc_api`;
+- opportunity queue eligibility: `false`;
+- no safe live `seo_intel` read-model row set is available for CTR/TDK repair selection.
+
+The repair should not bypass the gate. The repair should create enough sanitized evidence for the existing gate to pass.
+
+## Existing Building Blocks
+
+| Building block | Current role | Safe next use |
+| --- | --- | --- |
+| `GscReadonlyLiveAdapter` | Read-only live Search Analytics boundary | Capture sanitized artifact only when explicitly authorized |
+| `gsc-live-readonly-adapter` docs | Defines credential and live-read guardrails | Keep as operator runbook boundary |
+| `seo-intel:gsc-readmodel-import-dry-run` | Validates sanitized artifact and previews `seo_gsc_daily` rows | Run only against a SHA-pinned sanitized artifact |
+| `seo-intel:gsc-readmodel-import-canary` | Controlled batch10 write path | Execute only after exact approval and SHA confirmation |
+| `GscDataQualityGate` | Blocks non-live, stale, or structurally incomplete rows | Remains the only opportunity-queue gate |
+
+## Repair Sequence
+
+### Phase 1: Sanitized Live Evidence
+
+Create a read-only evidence PR or operator run artifact that proves:
+
+- `source_engine=google`;
+- `data_origin=live_gsc_api`;
+- row count is bounded;
+- all rows omit raw query, raw URL, credential, token, cookie, session, and raw payload fields;
+- artifact records no upstream writes, no CMS write, no Search Channel enqueue, and no indexing request.
+
+Output may be generated-only. It must not write the database.
+
+### Phase 2: Dry-Run Import Readback
+
+Use the existing dry-run importer against the exact artifact SHA256:
+
+- validate forbidden-field exclusion;
+- preview future `seo_gsc_daily` rows;
+- verify `would_write=false`;
+- verify quality gate pass on preview rows;
+- keep `canonical_url` null unless separately joined from backend URL Truth by hash.
+
+### Phase 3: Controlled Canary Import
+
+Only after Phase 2 passes, request exact operator approval for a batch10 canary:
+
+- write at most 10 rows to `seo_gsc_daily`;
+- require exact artifact SHA256 and confirmation phrase;
+- no scheduler;
+- no queue;
+- no CMS;
+- no Search or indexing.
+
+### Phase 4: Quality Gate Readback
+
+After the canary import, perform read-only proof:
+
+- imported rows have `metadata_json.data_origin=live_gsc_api`;
+- imported rows have `source_engine=google`;
+- required metric fields are present;
+- report dates satisfy lag and freshness;
+- `GscDataQualityGate.status=pass`;
+- `opportunity_queue_eligible=true`.
+
+### Phase 5: CTR/TDK Queue Selection
+
+Only after Phase 4 passes:
+
+- select CTR/TDK candidates from read-model rows;
+- keep candidate PR dry-run only unless separately authorized;
+- do not infer purchase truth from GSC or GA.
+
+## Failure Handling
+
+If any phase fails:
+
+- record the failure as generated evidence;
+- do not continue to the next phase;
+- do not run Search/CMS/deploy work;
+- keep downstream CTR/TDK cards blocked.
+
+## Non-Goals
+
+This design does not authorize:
+
+- production import;
+- scheduler activation;
+- opportunity queue execution;
+- title/meta/H1/FAQ edits;
+- CMS drafting;
+- Search submission;
+- sitemap submission;
+- URL inspection or request indexing;
+- fap-web mutation;
+- staging or production deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/scan_manifest.json
@@ -1,0 +1,21 @@
+{
+  "task_id": "GSC-READMODEL-REPAIR-DESIGN-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "scope": "design_only_generated_docs",
+  "output_path": "backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/",
+  "final_verdict": "READMODEL_REPAIR_DESIGN_READY",
+  "depends_on_prior_blocker": "GSC-SEO-INTEL-LIVE-READMODEL-QUALITY-PROOF-READONLY-01",
+  "live_gsc_api_call": false,
+  "credential_operation": false,
+  "seo_gsc_daily_import": false,
+  "database_write": false,
+  "search_channel_enqueue": false,
+  "cms_write": false,
+  "changed_runtime": false,
+  "sidecar_required": false,
+  "validation": [
+    "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/scan_manifest.json >/dev/null",
+    "git diff --check"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added generated-only GSC readmodel repair design.
- Sequenced sanitized live evidence, dry-run import/readback, controlled canary, quality gate readback, and later CTR/TDK queue selection.

## Why
- The previous quality proof remains blocked; this records the safe repair design without bypassing GSC gates.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/gsc-readmodel-repair-design-01/scan_manifest.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `READMODEL_REPAIR_DESIGN_READY`

## Deferred / prohibited
- No live GSC API call, credential operation, seo_gsc_daily import, DB write, scheduler, queue, CMS write, Search Channel enqueue, sitemap/URL submission, fap-web edit, or deploy.