### PR TITLE
CTR-REPAIR-LOOP-ELIGIBILITY-READONLY-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/CTR_REPAIR_LOOP_ELIGIBILITY.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/CTR_REPAIR_LOOP_ELIGIBILITY.md
@@ -1,0 +1,46 @@
+# CTR Repair Loop Eligibility
+
+Date: 2026-07-06
+Scope: generated-only eligibility readback
+
+## Eligibility Gate
+
+The CTR repair loop may only run when all gates pass:
+
+| Gate | Required state | Current state | Eligible? |
+| --- | --- | --- | --- |
+| GSC source engine | `google` | Not proven by live read-model rows | No |
+| GSC data origin | `live_gsc_api` | Current generated gate evidence records `fixture` | No |
+| Data quality gate | `pass` | `blocked` | No |
+| Opportunity queue | `opportunity_queue_eligible=true` | `false` | No |
+| Required fields | hash URL, hash query, clicks, impressions | Schema supports fields, passable rows absent | No |
+| Raw/private safety | no raw URL/query/credential/private payload | Contract exists; no eligible artifact | No |
+
+## Result
+
+The loop is blocked. No page should be moved into CTR repair from current evidence.
+
+The current train may continue, but downstream CTR/TDK cards must remain dry-run or blocked until a later PR proves live read-model quality.
+
+## What Would Make This Eligible
+
+Minimum future proof:
+
+1. sanitized live GSC artifact or imported read-model rows;
+2. `data_origin=live_gsc_api`;
+3. `source_engine=google`;
+4. finalization lag and freshness pass;
+5. required metric fields present;
+6. `GscDataQualityGate.status=pass`;
+7. `opportunity_queue_eligible=true`.
+
+## Non-Actions
+
+This PR did not:
+
+- call Google Search Console;
+- import or write `seo_gsc_daily`;
+- select pages for repair;
+- write title/meta/H1/FAQ/CTA;
+- submit URLs;
+- trigger deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,31 @@
+# CTR-REPAIR-LOOP-ELIGIBILITY-READONLY-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: BLOCKED_BY_GSC_DATA_QUALITY
+
+The CTR repair loop is not eligible to run because current GSC/seo_intel evidence does not prove passable `live_gsc_api` read-model rows.
+
+## Eligibility Summary
+
+- Required: `GscDataQualityGate.status=pass`.
+- Required: `opportunity_queue_eligible=true`.
+- Current proven state: `data_origin=fixture`, gate blocked.
+- Current allowed action: record blocked evidence only.
+- Current forbidden action: selecting or writing title/meta/H1/FAQ/internal-link repairs from current GSC evidence.
+
+## Boundary
+
+This PR does not select candidate pages. It does not write CMS fields, Search Channel rows, sitemap, llms, title, meta, H1, FAQ, CTA, or fap-web code.
+
+## Deferred Items
+
+- No live GSC API call.
+- No `seo_gsc_daily` import/backfill.
+- No CTR candidate queue.
+- No TDK dry-run queue.
+- No CMS/Search/deploy action.

--- a/backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,32 @@
+# Next Exact Authorization Prompts
+
+Use only after GSC live read-model quality is proven.
+
+## CTR Eligibility Recheck
+
+Authorize:
+
+`CTR-REPAIR-LOOP-ELIGIBILITY-READONLY-02`
+
+Scope:
+
+- read only from passable `seo_intel` GSC read-model rows;
+- prove `GscDataQualityGate.status=pass`;
+- list eligible pages without writing CMS or Search state.
+
+Forbidden:
+
+- no title/meta/H1/FAQ/CTA edits;
+- no Search submission;
+- no deploy.
+
+## CTR Dry-Run Queue
+
+Authorize only after eligibility passes:
+
+`CTR-TDK-REPAIR-DRYRUN-QUEUE-01`
+
+Scope:
+
+- generated-only candidate queue;
+- no CMS writes.

--- a/backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/scan_manifest.json
@@ -1,0 +1,22 @@
+{
+  "task_id": "CTR-REPAIR-LOOP-ELIGIBILITY-READONLY-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "output_path": "backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/",
+  "final_verdict": "BLOCKED_BY_GSC_DATA_QUALITY",
+  "ctr_loop_eligible": false,
+  "current_proven_data_origin": "fixture",
+  "required_data_origin": "live_gsc_api",
+  "opportunity_queue_eligible": false,
+  "live_gsc_api_call": false,
+  "seo_gsc_daily_import": false,
+  "cms_write": false,
+  "search_channel_enqueue": false,
+  "sidecar_required": true,
+  "validation": [
+    "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/scan_manifest.json >/dev/null",
+    "python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null",
+    "git diff --check"
+  ]
+}

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -147,5 +147,20 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Separately authorize sanitized live read-only GSC evidence capture and dry-run import readback before any CTR/TDK queue.",
         "train_continued": true
+    },
+    {
+        "repo": "fap-api",
+        "pr_id": "CTR-REPAIR-LOOP-ELIGIBILITY-READONLY-01",
+        "branch": "codex/ctr-repair-loop-eligibility-readonly-01",
+        "blocker_type": "blocked_by_gsc_data_quality",
+        "evidence": [
+            "Current GSC quality proof records data_origin=fixture.",
+            "opportunity_queue_eligible=false.",
+            "CTR repair loop requires passable live read-model rows before selecting pages."
+        ],
+        "why_not_current_pr_scope": "Current PR is generated-only eligibility reporting. It is not authorized to call GSC, import rows, write CMS fields, enqueue Search Channel, or edit title/meta/H1/FAQ.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Re-run CTR eligibility only after sanitized live GSC evidence and read-model quality gate pass.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -169,3 +169,20 @@
 - recommended follow-up:
   - Separately authorize sanitized live read-only GSC evidence capture and dry-run import readback before any CTR/TDK queue.
 - whether train continued: `true`
+
+## CTR-REPAIR-LOOP-ELIGIBILITY-READONLY-01 GSC data quality
+
+- repo: `fap-api`
+- PR id / branch: `CTR-REPAIR-LOOP-ELIGIBILITY-READONLY-01` / `codex/ctr-repair-loop-eligibility-readonly-01`
+- blocker type: `blocked_by_gsc_data_quality`
+- evidence:
+  - Current GSC quality proof records `data_origin=fixture`.
+  - `opportunity_queue_eligible=false`.
+  - CTR repair loop requires passable live read-model rows before selecting pages.
+- why not current PR scope:
+  - Current PR is generated-only eligibility reporting.
+  - It is not authorized to call GSC, import rows, write CMS fields, enqueue Search Channel, or edit title/meta/H1/FAQ.
+- whether required checks are affected: `false`
+- recommended follow-up:
+  - Re-run CTR eligibility only after sanitized live GSC evidence and read-model quality gate pass.
+- whether train continued: `true`


### PR DESCRIPTION
## What changed
- Added generated-only CTR repair loop eligibility report.
- Recorded that the loop remains blocked by GSC data quality.
- Added sidecar blocker entry and next authorization prompt.

## Why
- CTR repair cannot select pages from fixture/non-live GSC evidence. The train should record the blocker and continue.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/ctr-repair-loop-eligibility-readonly-01/scan_manifest.json >/dev/null`
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `BLOCKED_BY_GSC_DATA_QUALITY`

## Deferred / prohibited
- No live GSC API call, seo_gsc_daily import, CTR candidate selection, CMS write, Search Channel enqueue, title/meta/H1/FAQ edit, fap-web edit, or deploy.