### PR TITLE
SECURITY-169-API-07: close PR train ledger

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -42026,10 +42026,18 @@
       "scope_validation": {
         "evidence": "Changed files are limited to API07 allowed runtime paths, focused test paths, Big Five runtime freeze classifier test adjustment for the current API07 CI failure, and PR train manifest/state ledger paths.",
         "status": "pass"
+      },
+      "github_checks": {
+        "evidence": "PR #2797 required GitHub checks passed after inspecting and fixing the current-scope verify-bigfive failure.",
+        "status": "pass"
+      },
+      "post_merge_revalidation": {
+        "evidence": "PR #2797 is merged; origin/main contains 4161bef5e7e30930a630b3284ddf4ecb26208692; implementation remote branch is deleted; implementation local task branch was deleted from the isolated worktree. The primary main worktree has unrelated staged SEO daily-run docs and is recorded in generated/pr-train-sidecar-issues as an external blocker that does not affect API07 required checks or merge policy.",
+        "status": "pass_with_external_sidecar"
       }
     },
     "cms_mutation": false,
-    "commit_sha": null,
+    "commit_sha": "4161bef5e7e30930a630b3284ddf4ecb26208692",
     "content_authority": "backend",
     "database_mutation": false,
     "depends_on": [
@@ -42037,6 +42045,11 @@
     ],
     "deploy_allowed": false,
     "events": [
+      {
+        "at": "2026-07-06T15:26:35+08:00",
+        "note": "PR #2797 merged after required GitHub checks passed; origin/main contains 4161bef5e7e30930a630b3284ddf4ecb26208692. Remote implementation branch was deleted by GitHub merge cleanup, local implementation task branch was deleted in the isolated worktree, staging deploy was not waited on, and no manual or production deploy was triggered. An unrelated dirty primary main worktree was recorded in sidecar and did not stop the train.",
+        "status": "merged"
+      },
       {
         "at": "2026-07-06T15:20:09+08:00",
         "note": "Current-scope CI fix local validation passed: BigFiveResultPageV2CoreBodyPreviewTest, Big5RetakeCooldownTest, TestMetricsDailyBuilderTest, and the verify-bigfive equivalent sqlite command sequence all passed; generated Big Five compiled artifacts were restored as out-of-scope test output.",
@@ -42080,14 +42093,45 @@
     ],
     "failure_reason": null,
     "id": "SECURITY-169-API-07",
-    "local_cleanup_executed": false,
-    "merged_at": null,
-    "pr_url": null,
+    "local_cleanup_executed": true,
+    "local_validation": {
+      "commands": [
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Big5RetakeCooldownTest --no-ansi",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=TestMetricsDailyBuilderTest --no-ansi",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi",
+        "cd backend && php artisan route:list --no-ansi",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-07.sqlite php artisan migrate --force --no-ansi",
+        "cd backend && bash scripts/ci_verify_mbti.sh",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-ci-bigfive-api07.sqlite QUEUE_CONNECTION=sync FAP_PACKS_DRIVER=local FAP_PACKS_ROOT=/private/tmp/fap-api-security-169-api-07/content_packages FAP_DEFAULT_REGION=CN_MAINLAND FAP_DEFAULT_LOCALE=zh-CN FAP_DEFAULT_PACK_ID=MBTI.cn-mainland.zh-CN.v0.3 FAP_DEFAULT_DIR_VERSION=MBTI-CN-v0.3 CONTENT_LOADER_CACHE_STORE=array MBTI_RESPONSE_CACHE_STORE=array CONTENT_PACKS_INDEX_ARTIFACT_ENABLED=true CONTENT_PACKS_INDEX_ARTIFACT_PATH=storage/app/private/content_packs_index/content-packs-index.json bash scripts/ci/verify_big5_norms.sh && php -d memory_limit=1024M artisan content:lint --pack=BIG5_OCEAN --pack-version=v1 && php -d memory_limit=1024M artisan content:compile --pack=BIG5_OCEAN --pack-version=v1 && php -d memory_limit=1024M artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi",
+        "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+        "git diff --check"
+      ],
+      "status": "pass"
+    },
+    "merged_at": "2026-07-06T07:26:35Z",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2797",
     "production_write_execution": false,
     "publish_allowed": false,
-    "remote_branch_deleted": false,
+    "remote_branch_deleted": true,
     "repo": "fap-api",
-    "status": "ci_fix_local_checks_passed",
+    "scope_validation": {
+      "changed_files": [
+        "backend/app/Http/Middleware/ResolveAnonId.php",
+        "backend/app/Http/Requests/V0_3/StartAttemptRequest.php",
+        "backend/app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php",
+        "backend/app/Services/Analytics/TestMetricsDailyBuilder.php",
+        "backend/config/fap.php",
+        "backend/tests/Feature/Analytics/TestMetricsDailyBuilderTest.php",
+        "backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train-state.json",
+        "docs/codex/pr-train.yaml"
+      ],
+      "local_validation_passed": true,
+      "status": "pass"
+    },
+    "status": "merged",
     "title": "SECURITY-169-API-07: harden attempt start, retake, analytics abuse controls",
     "train_scope": "security_169_fap_api_audit"
   },

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -177,5 +177,22 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Re-run dry-run queue only after CTR eligibility passes from gated live seo_intel rows.",
         "train_continued": true
+    },
+    {
+        "repo": "fermatmind/fap-api",
+        "pr_id": "SECURITY-169-API-07",
+        "branch": "codex/security-169-api-07-harden-attempt-start-retake-analytics-abuse-cont",
+        "blocker_type": "external_dirty_local_main_worktree",
+        "evidence": [
+            "PR #2797 merged on GitHub with merge commit 4161bef5e7e30930a630b3284ddf4ecb26208692.",
+            "origin/main contains 4161bef5e7e30930a630b3284ddf4ecb26208692.",
+            "Remote task branch codex/security-169-api-07-harden-attempt-start-retake-analytics-abuse-cont was deleted by merge cleanup.",
+            "Local gh pr merge --squash --delete-branch reported fatal: 'main' is already used by worktree at '/Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01' after the remote merge completed.",
+            "That main worktree still has pre-existing staged SEO daily-run docs under backend/docs/seo/daily-runs/2026-07-05."
+        ],
+        "why_not_current_pr_scope": "The staged SEO daily-run docs predate API07 and are unrelated to attempt start, retake, analytics abuse controls, or the scoped Big Five CI classifier fix. API07 implementation and GitHub checks were complete before the local main worktree cleanup conflict surfaced.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Finish, stash, or commit the SEO daily-run staged files in their owning task/thread; do not attach those staged docs to SECURITY-169 API PR scopes. Use an isolated PR-train worktree from origin/main for ledger closeout and next API PRs until the user-owned main worktree is clean.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -203,3 +203,24 @@
 - recommended follow-up:
   - Re-run dry-run queue only after CTR eligibility passes from gated live `seo_intel` rows.
 - whether train continued: `true`
+
+## SECURITY-169-API-07 external dirty main worktree
+
+- repo: `fermatmind/fap-api`
+- PR id / branch: SECURITY-169-API-07 / `codex/security-169-api-07-harden-attempt-start-retake-analytics-abuse-cont`
+- blocker type: `external_dirty_local_main_worktree`
+- evidence:
+  - PR #2797 merged on GitHub with merge commit `4161bef5e7e30930a630b3284ddf4ecb26208692`.
+  - `origin/main` contains `4161bef5e7e30930a630b3284ddf4ecb26208692`.
+  - Remote task branch `codex/security-169-api-07-harden-attempt-start-retake-analytics-abuse-cont` was deleted by merge cleanup.
+  - Local `gh pr merge --squash --delete-branch` reported `fatal: 'main' is already used by worktree at '/Users/rainie/Desktop/GitHub/fap-api-mbti-main-free-faq-content-01'` after the remote merge completed.
+  - That main worktree still has pre-existing staged SEO daily-run docs under `backend/docs/seo/daily-runs/2026-07-05/...`.
+- why not current PR scope:
+  - The staged SEO daily-run docs predate API07 and are unrelated to attempt start, retake, analytics abuse controls, or the scoped Big Five CI classifier fix.
+  - API07 implementation and GitHub checks were complete before the local main worktree cleanup conflict surfaced.
+- whether required checks are affected: `false`
+- recommended follow-up:
+  - Finish, stash, or commit the SEO daily-run staged files in their owning task/thread.
+  - Do not attach those staged docs to SECURITY-169 API PR scopes.
+  - Use an isolated PR-train worktree from `origin/main` for ledger closeout and next API PRs until the user-owned main worktree is clean.
+- whether train continued: `true`


### PR DESCRIPTION
What changed
- Mark SECURITY-169-API-07 as merged in docs/codex/pr-train-state.json after PR #2797 landed.
- Record API07 post-merge cleanup and the external dirty primary main worktree in generated/pr-train-sidecar-issues.

Why
- Close the API07 PR-train ledger after the implementation PR merged and required GitHub checks passed.
- Preserve the external blocker as sidecar evidence without stopping the train.

Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
- git diff --check

Deferred items
- No staging deploy wait.
- No manual deploy.
- No production deploy.
- No CMS, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, permission, or secrets changes.
- Primary main worktree SEO daily-run staged docs remain external sidecar follow-up.