### PR TITLE
CTR-TDK-REPAIR-DRYRUN-QUEUE-01: add readonly evidence report

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,31 @@
+# CTR-TDK-REPAIR-DRYRUN-QUEUE-01
+
+Date: 2026-07-06
+Repository: fermatmind/fap-api
+Scope: generated docs only
+
+## Decision
+
+Final verdict: BLOCKED_BY_GSC_DATA_QUALITY
+
+No CTR/TDK dry-run queue can be produced because CTR eligibility is blocked by missing passable live GSC read-model data.
+
+## Queue Summary
+
+- Candidate source required: gated `seo_intel` GSC read-model rows.
+- Current candidate source status: unavailable.
+- Queue size: 0.
+- TDK changes proposed: 0.
+- CMS writes: 0.
+- Search submissions: 0.
+
+## Boundary
+
+This PR intentionally does not invent candidate pages from screenshots, fixture data, static docs, GSC UI screenshots, GA summaries, or operator intuition.
+
+## Deferred Items
+
+- No TDK dry-run candidate selection.
+- No title/meta/H1/FAQ/body/CTA rewrite.
+- No CMS write/import/publish.
+- No Search Channel, sitemap, URL inspection, fap-web, deploy, or production action.

--- a/backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,22 @@
+# Next Exact Authorization Prompts
+
+Use only after GSC live read-model quality and CTR eligibility pass.
+
+## TDK Dry-Run Queue Recheck
+
+Authorize:
+
+`CTR-TDK-REPAIR-DRYRUN-QUEUE-02`
+
+Scope:
+
+- generate a dry-run-only queue from passable `seo_intel` rows;
+- include candidate evidence and no-write TDK proposals;
+- generated docs only.
+
+Forbidden:
+
+- no CMS write;
+- no title/meta/H1/FAQ runtime mutation;
+- no Search submission;
+- no deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/TDK_DRYRUN_QUEUE.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/TDK_DRYRUN_QUEUE.md
@@ -1,0 +1,59 @@
+# CTR/TDK Repair Dry-Run Queue
+
+Date: 2026-07-06
+Scope: generated-only dry-run queue decision
+
+## Queue Status
+
+Final queue status: blocked
+
+| Field | Value |
+| --- | --- |
+| Eligible source rows | 0 |
+| Candidate pages selected | 0 |
+| Title/meta/H1 changes drafted | 0 |
+| CMS writes | 0 |
+| Search actions | 0 |
+| Reason | `BLOCKED_BY_GSC_DATA_QUALITY` |
+
+## Required Input Not Available
+
+The queue requires all of these:
+
+- `GscDataQualityGate.status=pass`;
+- `opportunity_queue_eligible=true`;
+- `data_origin=live_gsc_api`;
+- `source_engine=google`;
+- safe hashed URL/query fields;
+- clicks and impressions;
+- finalization/freshness pass.
+
+Current evidence does not meet the input contract.
+
+## Safe Interpretation
+
+The correct queue is empty. Producing candidates now would mix future repair scope into a blocked GSC state and risk TDK edits from non-authoritative data.
+
+## Future Queue Rules
+
+When unblocked, each candidate should include:
+
+- page hash or backend URL Truth reference;
+- query hash and masked query display;
+- clicks, impressions, CTR, average position, date window;
+- why CTR repair is plausible;
+- owner page;
+- proposed dry-run title/meta/H1 direction;
+- claim boundary note;
+- explicit no-write status.
+
+## Non-Actions
+
+This PR did not:
+
+- select or rank pages;
+- write title/meta/H1/FAQ/body copy;
+- touch CMS;
+- enqueue Search Channel;
+- submit URLs;
+- deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/scan_manifest.json
@@ -1,0 +1,21 @@
+{
+  "task_id": "CTR-TDK-REPAIR-DRYRUN-QUEUE-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "scope": "generated_docs_only",
+  "output_path": "backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/",
+  "final_verdict": "BLOCKED_BY_GSC_DATA_QUALITY",
+  "queue_status": "blocked",
+  "candidate_pages_selected": 0,
+  "tdk_changes_proposed": 0,
+  "cms_write": false,
+  "search_channel_enqueue": false,
+  "live_gsc_api_call": false,
+  "seo_gsc_daily_import": false,
+  "sidecar_required": true,
+  "validation": [
+    "python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/scan_manifest.json >/dev/null",
+    "python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null",
+    "git diff --check"
+  ]
+}

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -162,5 +162,20 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Re-run CTR eligibility only after sanitized live GSC evidence and read-model quality gate pass.",
         "train_continued": true
+    },
+    {
+        "repo": "fap-api",
+        "pr_id": "CTR-TDK-REPAIR-DRYRUN-QUEUE-01",
+        "branch": "codex/ctr-tdk-repair-dryrun-queue-01",
+        "blocker_type": "blocked_by_gsc_data_quality",
+        "evidence": [
+            "CTR eligibility is blocked.",
+            "No passable live GSC read-model row set exists.",
+            "Candidate queue size is 0."
+        ],
+        "why_not_current_pr_scope": "Current PR is generated-only dry-run queue reporting. It is not authorized to select from fixture/static evidence, edit TDK, write CMS, or enqueue Search Channel.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Re-run dry-run queue only after CTR eligibility passes from gated live seo_intel rows.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -186,3 +186,20 @@
 - recommended follow-up:
   - Re-run CTR eligibility only after sanitized live GSC evidence and read-model quality gate pass.
 - whether train continued: `true`
+
+## CTR-TDK-REPAIR-DRYRUN-QUEUE-01 GSC data quality
+
+- repo: `fap-api`
+- PR id / branch: `CTR-TDK-REPAIR-DRYRUN-QUEUE-01` / `codex/ctr-tdk-repair-dryrun-queue-01`
+- blocker type: `blocked_by_gsc_data_quality`
+- evidence:
+  - CTR eligibility is blocked.
+  - No passable live GSC read-model row set exists.
+  - Candidate queue size is 0.
+- why not current PR scope:
+  - Current PR is generated-only dry-run queue reporting.
+  - It is not authorized to select from fixture/static evidence, edit TDK, write CMS, or enqueue Search Channel.
+- whether required checks are affected: `false`
+- recommended follow-up:
+  - Re-run dry-run queue only after CTR eligibility passes from gated live `seo_intel` rows.
+- whether train continued: `true`


### PR DESCRIPTION
## What changed
- Added generated-only CTR/TDK dry-run queue report.
- Recorded empty/blocked queue because CTR eligibility is blocked by GSC data quality.
- Added sidecar blocker entry.

## Why
- TDK repair candidates must not be invented from fixture/static/screenshot evidence. The queue remains blocked until live gated seo_intel rows exist.

## Validation
- `python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/ctr-tdk-repair-dryrun-queue-01/scan_manifest.json >/dev/null`
- `python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Final verdict
- `BLOCKED_BY_GSC_DATA_QUALITY`

## Deferred / prohibited
- No TDK candidate selection, title/meta/H1/FAQ/body edit, CMS write, Search Channel enqueue, live GSC call, fap-web edit, or deploy.