### PR TITLE
GEO-AEO-ANSWER-BLOCK-GAP-MATRIX-01: add readonly gap matrix

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/ANSWER_BLOCK_GAP_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/ANSWER_BLOCK_GAP_MATRIX.md
@@ -1,0 +1,54 @@
+# GEO / AEO Answer Block Gap Matrix
+
+Date: 2026-07-06
+
+This matrix converts the previous route, `llms-full`, FAQ, CTA, and claim evidence into a P6 answer-block queue. It is a read-only planning artifact.
+
+## Status Legend
+
+- `pass`: visible evidence appears sufficient for the current read-only stage.
+- `partial`: visible evidence exists but is generic, incomplete, or not scale-specific enough.
+- `gap`: public claim-safe answer-block evidence is missing or unsafe to infer.
+
+## Route Matrix
+
+| Route | Visible answer-block status | Main gap | Repair lane |
+| --- | --- | --- | --- |
+| `/zh/tests/mbti-personality-test-16-personality-types` | pass/observe | Strongest current hub: 8 MBTI-specific FAQ questions and visible boundary evidence are present. First-screen position still needs a dedicated readback. | observe, then first-screen readback |
+| `/en/tests/mbti-personality-test-16-personality-types` | partial | FAQPage still uses generic 4-question pattern; MBTI-specific English answer and claim surface are not proven. | English MBTI FAQ/answer-block authority design |
+| `/zh/tests/big-five-personality-test-ocean-model` | partial | Generic FAQ; free-result and commercial authority need reconciliation before money-intent wording. | Big Five free-result and FAQ authority design |
+| `/en/tests/big-five-personality-test-ocean-model` | partial | Generic FAQ; free-result and commercial authority need reconciliation before money-intent wording. | Big Five free-result and FAQ authority design |
+| `/zh/tests/enneagram-personality-test-nine-types` | partial | Generic FAQ; Enneagram-specific definition, result boundary, and next-step answer block are not proven. | Enneagram FAQ/answer-block authority design |
+| `/en/tests/enneagram-personality-test-nine-types` | partial | Generic FAQ; Enneagram-specific definition, result boundary, and next-step answer block are not proven. | Enneagram FAQ/answer-block authority design |
+| `/zh/tests/holland-career-interest-test-riasec` | partial | Generic FAQ; RIASEC-specific career exploration boundary and major/admission outcome boundary need explicit visible answer evidence. | RIASEC FAQ/answer-block authority design |
+| `/en/tests/holland-career-interest-test-riasec` | partial | Generic FAQ; English career/major boundary and next-step answer evidence need review. | RIASEC English FAQ/claim authority design |
+| `/zh/tests/iq-test-intelligence-quotient-assessment` | gap | Online estimate, norm, and intelligence wording require stricter public proof before stronger answer-block claims. | IQ claim-boundary review before answer-block repair |
+| `/en/tests/iq-test-intelligence-quotient-assessment` | gap | Online estimate, norm, and intelligence wording require stricter public proof before stronger answer-block claims. | IQ claim-boundary review before answer-block repair |
+| `/zh/tests/eq-test-emotional-intelligence-assessment` | partial | Generic FAQ; EQ-specific definition, result boundary, and action guidance are not proven. | EQ FAQ/answer-block authority design |
+| `/en/tests/eq-test-emotional-intelligence-assessment` | partial | Generic FAQ; EQ-specific definition, result boundary, and action guidance are not proven. | EQ FAQ/answer-block authority design |
+
+## Cross-Route Findings
+
+1. Discoverability is not the primary blocker. Prior readback found all 12 routes present in public sitemap, `llms.txt`, and `llms-full.txt`.
+2. CTA presence is broadly passing, but CTA presence does not prove AEO/GEO answer readiness.
+3. Generic FAQ cannot close scale-specific answer-block requirements for MBTI English, Big Five, Enneagram, RIASEC, IQ, or EQ.
+4. IQ requires the strictest claim review because "intelligence", estimate, norm, and score language can overstate authority without public proof.
+5. RIASEC requires explicit boundaries around career exploration versus admission, hiring, income, or major-placement guarantees.
+6. No repair should be hidden-schema-only. The answer must be visible on the public page first, with structured data only reflecting visible evidence.
+
+## Recommended Repair Split
+
+These are proposed follow-up scopes only and are not authorized by this read-only PR:
+
+| Candidate repair | Required authority before implementation |
+| --- | --- |
+| `MBTI-EN-FAQ-ANSWER-BLOCK-AUTHORITY-REPAIR-01` | English MBTI FAQ and claim-safe answer copy from backend/CMS authority |
+| `BIG-FIVE-FREE-RESULT-FAQ-AUTHORITY-REPAIR-01` | Free-result promise, commercial boundary, and Big Five-specific FAQ authority |
+| `ENNEAGRAM-FAQ-ANSWER-BLOCK-AUTHORITY-REPAIR-01` | Enneagram-specific result boundary and next-step answer authority |
+| `RIASEC-FAQ-CAREER-BOUNDARY-AUTHORITY-REPAIR-01` | RIASEC career/major/admission boundary authority |
+| `IQ-CLAIM-BOUNDARY-ANSWER-BLOCK-REVIEW-01` | IQ score/estimate/norm claim proof before copy repair |
+| `EQ-FAQ-ANSWER-BLOCK-AUTHORITY-REPAIR-01` | EQ-specific result boundary and action-guidance authority |
+
+## Boundary
+
+This file is not a source of public copy. It must not be imported into CMS or rendered directly on any public page.

--- a/backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,54 @@
+# GEO / AEO Answer Block Gap Matrix Decision
+
+Date: 2026-07-06
+
+PR/task: `GEO-AEO-ANSWER-BLOCK-GAP-MATRIX-01`
+
+Final verdict: `ANSWER_BLOCK_GAP_MATRIX_READY`
+
+## Decision
+
+The P6 GEO / AEO answer-block line should not move directly into copy, schema, sitemap, `llms`, or frontend repair work.
+
+The correct next step is scale-by-scale backend/CMS authority design and then tightly scoped repair PRs for visible answer blocks. The current evidence shows that all 12 hub routes are discoverable and indexable, but only the Chinese MBTI page has a strong scale-specific FAQ/claim surface. The other 11 routes still depend on generic FAQ and partial claim-boundary evidence.
+
+## Evidence Used
+
+- `SIX-TEST-HUB-12-ROUTE-RUNTIME-READBACK-01`
+- `SIX-TEST-HUB-LLMS-FULL-PRESENCE-READBACK-01`
+- `SIX-TEST-HUB-FAQ-CTA-CLAIM-GAP-MATRIX-01`
+- Repository claim-boundary and SEO/GEO authority rules
+
+## Answer-Block Acceptance Definition
+
+A hub answer block is considered ready only when the public visible page, not hidden schema alone, can answer:
+
+1. what this test measures
+2. what the free result includes
+3. what the result cannot decide
+4. whether it is diagnostic, admission, hiring, financial, legal, or clinical advice
+5. what the user should do next
+6. whether private result/order/attempt URLs are excluded from public surfaces
+
+## Queue Decision
+
+The immediate queue should be:
+
+1. Run first-screen answer-block readback for the current public hub pages.
+2. Run visible FAQ and FAQPage JSON-LD parity across all hubs.
+3. Run claim-boundary visible surface matrix.
+4. Split repair PRs only after backend/CMS authority, copy source, and claim guard are explicit.
+
+## Explicit Non-Actions
+
+This PR does not modify:
+
+- public page body copy
+- FAQ content
+- title, meta, H1, canonical, robots, or hreflang
+- JSON-LD
+- sitemap, `llms.txt`, or `llms-full.txt`
+- CMS data
+- runtime rendering
+- frontend code
+- production data or deployment

--- a/backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,52 @@
+# Next Exact Authorization Prompts
+
+Use these only after the remaining readback cards confirm first-screen, FAQ parity, and visible claim-boundary state.
+
+## First-Screen Readback
+
+Authorize `CORE-HUB-FIRST-SCREEN-ANSWER-BLOCK-READBACK-01` as a read-only runtime evidence PR.
+
+Scope:
+
+- Fetch the 12 public hub routes.
+- Record whether the first screen contains a visible direct answer for the test, free-result expectation, claim boundary, and primary CTA.
+- Do not mutate runtime, copy, metadata, CMS, schema, sitemap, or `llms`.
+
+## FAQ Parity Readback
+
+Authorize `FAQ-VISIBLE-PARITY-MATRIX-ALL-HUBS-01` as a read-only runtime evidence PR.
+
+Scope:
+
+- Compare visible FAQ questions with FAQPage JSON-LD `mainEntity` questions on the 12 public hub routes.
+- Record count and question parity.
+- Do not create fallback FAQ or edit JSON-LD.
+
+## Claim Boundary Matrix
+
+Authorize `CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01` as a read-only evidence PR.
+
+Scope:
+
+- Record visible claim-boundary evidence for diagnosis, hiring, admission, financial/legal decisioning, career outcome, IQ score/norm, and private URL exposure.
+- Do not strengthen or rewrite claims.
+
+## Repair Authorization Template
+
+When a specific repair is ready, use this shape:
+
+```text
+Authorize <PR_ID> as a backend/CMS-authoritative repair PR.
+
+Allowed scope:
+- <exact authority source>
+- <exact route set>
+- <exact fields/blocks>
+- <exact local checks>
+
+Forbidden:
+- frontend fallback public content
+- hidden schema-only repair
+- sitemap/llms mutation unless separately authorized
+- production import/deploy without exact SHA authorization
+```

--- a/backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/scan_manifest.json
@@ -1,0 +1,46 @@
+{
+  "task_id": "GEO-AEO-ANSWER-BLOCK-GAP-MATRIX-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "mode": "generated_only_readonly",
+  "final_verdict": "ANSWER_BLOCK_GAP_MATRIX_READY",
+  "inputs": [
+    "backend/docs/seo/daily-runs/2026-07-06/six-test-hub-12-route-runtime-readback-01/RUNTIME_READBACK_MATRIX.md",
+    "backend/docs/seo/daily-runs/2026-07-06/six-test-hub-llms-full-presence-readback-01/LLMS_FULL_READBACK.md",
+    "backend/docs/seo/daily-runs/2026-07-06/six-test-hub-faq-cta-claim-gap-matrix-01/FAQ_CTA_CLAIM_GAP_MATRIX.md",
+    "repository claim-boundary and SEO/GEO authority rules"
+  ],
+  "outputs": [
+    "EXECUTIVE_DECISION.md",
+    "ANSWER_BLOCK_GAP_MATRIX.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "routes_evaluated": [
+    "/zh/tests/mbti-personality-test-16-personality-types",
+    "/en/tests/mbti-personality-test-16-personality-types",
+    "/zh/tests/big-five-personality-test-ocean-model",
+    "/en/tests/big-five-personality-test-ocean-model",
+    "/zh/tests/enneagram-personality-test-nine-types",
+    "/en/tests/enneagram-personality-test-nine-types",
+    "/zh/tests/holland-career-interest-test-riasec",
+    "/en/tests/holland-career-interest-test-riasec",
+    "/zh/tests/iq-test-intelligence-quotient-assessment",
+    "/en/tests/iq-test-intelligence-quotient-assessment",
+    "/zh/tests/eq-test-emotional-intelligence-assessment",
+    "/en/tests/eq-test-emotional-intelligence-assessment"
+  ],
+  "scope_guard": {
+    "runtime_mutation": false,
+    "cms_mutation": false,
+    "schema_mutation": false,
+    "sitemap_or_llms_mutation": false,
+    "frontend_mutation": false,
+    "production_deploy": false
+  },
+  "next_cards": [
+    "CORE-HUB-FIRST-SCREEN-ANSWER-BLOCK-READBACK-01",
+    "FAQ-VISIBLE-PARITY-MATRIX-ALL-HUBS-01",
+    "CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added a generated-only GEO/AEO answer-block gap matrix for the 12 six-test hub routes.
- Added executive decision and exact follow-up authorization prompts.
- Added a scan manifest documenting inputs, outputs, and non-mutation scope guard.

## Why
- The prior route, llms-full, FAQ/CTA/claim evidence shows discoverability is present, but visible scale-specific answer-block readiness is incomplete across most hubs.
- This PR records the correct read-only queue before any backend/CMS-authoritative repair work.

## Validation
- python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/geo-aeo-answer-block-gap-matrix-01/scan_manifest.json >/dev/null
- git diff --check
- git diff --cached --check

## Deferred items
- No runtime, CMS, frontend, FAQ, JSON-LD, sitemap, llms, title/meta, canonical, noindex, production import, or deployment changes.
- First-screen answer-block readback, FAQ parity readback, claim-boundary matrix, and any repair PRs remain separate scopes.