### PR TITLE
CORE-HUB-FIRST-SCREEN-ANSWER-BLOCK-READBACK-01: add runtime readback

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,54 @@
+# Core Hub First-Screen Answer Block Readback Decision
+
+Date: 2026-07-06
+
+PR/task: `CORE-HUB-FIRST-SCREEN-ANSWER-BLOCK-READBACK-01`
+
+Final verdict: `FIRST_SCREEN_READBACK_READY`
+
+## Decision
+
+The 12 six-test hub routes are publicly reachable and expose first-screen candidate text, but first-screen answer-block quality is uneven.
+
+The strongest first-screen surfaces are:
+
+- Chinese MBTI
+- English MBTI
+- Chinese Big Five
+- Chinese Enneagram
+- English RIASEC
+- Chinese IQ
+- Chinese EQ
+
+The routes that remain partial in the bounded readback are:
+
+- English Big Five
+- English Enneagram
+- Chinese RIASEC
+- English IQ
+- English EQ
+
+These partial findings should feed the next FAQ parity and visible claim-boundary cards. They do not authorize content, schema, metadata, sitemap, `llms`, CMS, or frontend changes.
+
+## Method
+
+Unauthenticated public HTTP reads were taken from `https://fermatmind.com` on 2026-07-06.
+
+For each route, the readback captured:
+
+- HTTP status
+- `<title>`
+- meta description
+- `<h1>`
+- first 1,400 characters of stripped page text as a first-screen proxy
+- four answer-block proxy flags:
+  - scale definition present
+  - free result expectation present
+  - visible claim boundary present
+  - primary CTA present
+
+This is a text readback proxy, not a visual screenshot assertion.
+
+## Boundary
+
+This PR does not change any public page, CMS record, API response, JSON-LD, sitemap, `llms`, metadata, canonical, robots policy, frontend runtime, production import, or deployment state.

--- a/backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/FIRST_SCREEN_READBACK_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/FIRST_SCREEN_READBACK_MATRIX.md
@@ -1,0 +1,62 @@
+# Core Hub First-Screen Answer Block Readback Matrix
+
+Date: 2026-07-06
+
+Source: unauthenticated public HTTP reads from `https://fermatmind.com`.
+
+## Acceptance Proxy
+
+Each route was checked for four visible first-screen proxy signals in title, description, H1, and the first 1,400 characters of stripped page text:
+
+1. scale definition
+2. free result expectation
+3. claim boundary
+4. primary CTA
+
+`pass` means all four proxy signals were found. `partial` means two or three were found. This matrix does not assert visual viewport layout.
+
+## Route Matrix
+
+| Route | HTTP | H1 | Definition | Free result | Claim boundary | CTA | Verdict |
+| --- | ---: | --- | --- | --- | --- | --- | --- |
+| `/zh/tests/mbti-personality-test-16-personality-types` | 200 | `免费 MBTI测试：16 型人格完整结果` | yes | yes | yes | yes | pass |
+| `/en/tests/mbti-personality-test-16-personality-types` | 200 | `Free MBTI Personality Test with Full Report` | yes | yes | yes | yes | pass |
+| `/zh/tests/big-five-personality-test-ocean-model` | 200 | `大五人格免费测试` | yes | yes | yes | yes | pass |
+| `/en/tests/big-five-personality-test-ocean-model` | 200 | `Big Five Personality Test 【OCEAN Model】` | yes | no | no | yes | partial |
+| `/zh/tests/enneagram-personality-test-nine-types` | 200 | `九型人格免费测试` | yes | yes | yes | yes | pass |
+| `/en/tests/enneagram-personality-test-nine-types` | 200 | `Enneagram Personality Test 【Nine Types】` | yes | no | no | yes | partial |
+| `/zh/tests/holland-career-interest-test-riasec` | 200 | `免费霍兰德职业兴趣测试：RIASEC完整结果` | yes | yes | no | yes | partial |
+| `/en/tests/holland-career-interest-test-riasec` | 200 | `Free Holland Career Interest Test with Full Report` | yes | yes | yes | yes | pass |
+| `/zh/tests/iq-test-intelligence-quotient-assessment` | 200 | `智商【IQ】测试` | yes | yes | yes | yes | pass |
+| `/en/tests/iq-test-intelligence-quotient-assessment` | 200 | `IQ Test 【Intelligence Quotient Assessment】` | yes | no | no | yes | partial |
+| `/zh/tests/eq-test-emotional-intelligence-assessment` | 200 | `情商【EQ】测试` | yes | yes | yes | yes | pass |
+| `/en/tests/eq-test-emotional-intelligence-assessment` | 200 | `EQ Test 【Emotional Intelligence Assessment】` | yes | yes | no | yes | partial |
+
+## Captured Evidence Samples
+
+| Route | First-screen proxy sample |
+| --- | --- |
+| `/zh/tests/mbti-personality-test-16-personality-types` | `免费完成 MBTI 人格测试，查看 16 型人格结果、偏好维度与后续探索建议。 结果用于自我了解，不作诊断、治疗、招聘筛选或职业保证。` |
+| `/en/tests/mbti-personality-test-16-personality-types` | `After submission, the current release lets users read the full result instead of stopping at a preview. Use for self-understanding and communication reflection, not for hiring, diagnosis, or life-outcome guarantees.` |
+| `/zh/tests/big-five-personality-test-ocean-model` | `用一次测评了解开放性、尽责性、外倾性、宜人性与神经质。 可免费开始，基础结果免费；高级报告如有付费需提前说明。` |
+| `/en/tests/big-five-personality-test-ocean-model` | `Measure your Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism in one assessment.` |
+| `/zh/tests/enneagram-personality-test-nine-types` | `通过结构化测评了解你的九型人格类型排序。 可免费开始，基础结果免费；高级报告如有付费需提前说明。` |
+| `/en/tests/enneagram-personality-test-nine-types` | `Explore your Enneagram profile across the nine personality types.` |
+| `/zh/tests/holland-career-interest-test-riasec` | `免费完成霍兰德职业兴趣测试，查看 RIASEC 兴趣排序和职业探索线索。 结果用于方向参考，不承诺专业、录取、岗位匹配或职业结果。` |
+| `/en/tests/holland-career-interest-test-riasec` | `Interest results reflect preference, not ability, admission odds, or job guarantees.` |
+| `/zh/tests/iq-test-intelligence-quotient-assessment` | `评估矩阵推理、模式识别与抽象问题解决能力。` |
+| `/en/tests/iq-test-intelligence-quotient-assessment` | `Assess your matrix reasoning, pattern recognition, and abstract problem-solving ability.` |
+| `/zh/tests/eq-test-emotional-intelligence-assessment` | `评估情绪觉察、情绪调节、共情与人际沟通倾向。` |
+| `/en/tests/eq-test-emotional-intelligence-assessment` | `Measure emotional awareness, regulation, empathy, and interpersonal communication tendencies.` |
+
+## Findings
+
+1. All 12 hub routes returned HTTP 200.
+2. Every route had a scale-specific H1 and primary CTA evidence.
+3. English Big Five, English Enneagram, English IQ, and English EQ did not expose free-result plus claim-boundary evidence in the bounded first-screen proxy.
+4. Chinese RIASEC exposed strong free-result and career-boundary text, but the bounded keyword proxy did not classify it as a pass because its boundary wording is career/admission specific rather than generic diagnosis-specific.
+5. The next cards should verify FAQ visible/JSON-LD parity and visible claim-boundary coverage before any repair split.
+
+## Boundary
+
+This matrix is evidence only. It is not public copy and must not be imported into CMS or rendered directly.

--- a/backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,46 @@
+# Next Exact Authorization Prompts
+
+## FAQ Parity
+
+Authorize `FAQ-VISIBLE-PARITY-MATRIX-ALL-HUBS-01` as the next read-only runtime evidence PR.
+
+Allowed scope:
+
+- Fetch the 12 public hub routes.
+- Compare visible FAQ question count and labels to FAQPage JSON-LD `mainEntity`.
+- Record mismatch, generic FAQ, and parity status.
+
+Forbidden:
+
+- adding FAQ fallback copy
+- editing JSON-LD
+- editing CMS/runtime/frontend code
+- changing sitemap, `llms`, metadata, canonical, or robots
+
+## Claim Boundary
+
+Authorize `CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01` after FAQ parity.
+
+Allowed scope:
+
+- Record visible public claim boundaries by route.
+- Check diagnosis, treatment, hiring, admission, career-result, IQ score/norm, and private URL boundaries.
+
+Forbidden:
+
+- strengthening claims
+- adding hidden schema-only evidence
+- writing CMS copy
+- production import or deployment
+
+## Repair Split
+
+Do not authorize repair until the FAQ parity and claim-boundary cards are merged.
+
+Likely repair candidates after evidence:
+
+- English Big Five first-screen/free-result/claim-boundary authority repair
+- English Enneagram first-screen/free-result/claim-boundary authority repair
+- English IQ claim-boundary repair before any money-intent wording
+- English EQ claim-boundary authority repair
+- RIASEC career/admission boundary wording review

--- a/backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/scan_manifest.json
@@ -1,0 +1,53 @@
+{
+  "task_id": "CORE-HUB-FIRST-SCREEN-ANSWER-BLOCK-READBACK-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "mode": "read_only_runtime_evidence",
+  "final_verdict": "FIRST_SCREEN_READBACK_READY",
+  "source_host": "https://fermatmind.com",
+  "method": "unauthenticated_public_http_text_readback",
+  "proxy_definition": [
+    "title",
+    "meta_description",
+    "h1",
+    "first_1400_characters_of_stripped_page_text"
+  ],
+  "outputs": [
+    "EXECUTIVE_DECISION.md",
+    "FIRST_SCREEN_READBACK_MATRIX.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "routes_evaluated": [
+    "/zh/tests/mbti-personality-test-16-personality-types",
+    "/en/tests/mbti-personality-test-16-personality-types",
+    "/zh/tests/big-five-personality-test-ocean-model",
+    "/en/tests/big-five-personality-test-ocean-model",
+    "/zh/tests/enneagram-personality-test-nine-types",
+    "/en/tests/enneagram-personality-test-nine-types",
+    "/zh/tests/holland-career-interest-test-riasec",
+    "/en/tests/holland-career-interest-test-riasec",
+    "/zh/tests/iq-test-intelligence-quotient-assessment",
+    "/en/tests/iq-test-intelligence-quotient-assessment",
+    "/zh/tests/eq-test-emotional-intelligence-assessment",
+    "/en/tests/eq-test-emotional-intelligence-assessment"
+  ],
+  "summary": {
+    "http_200_routes": 12,
+    "pass": 7,
+    "partial": 5,
+    "gap": 0
+  },
+  "scope_guard": {
+    "runtime_mutation": false,
+    "cms_mutation": false,
+    "schema_mutation": false,
+    "sitemap_or_llms_mutation": false,
+    "frontend_mutation": false,
+    "production_deploy": false
+  },
+  "next_cards": [
+    "FAQ-VISIBLE-PARITY-MATRIX-ALL-HUBS-01",
+    "CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added generated-only runtime evidence for first-screen answer-block proxy coverage across the 12 six-test hub routes.
- Recorded HTTP status, H1, answer-block proxy flags, findings, and next authorization prompts.
- Added a scan manifest with route list, method, summary, and non-mutation scope guard.

## Why
- P6 GEO/AEO planning needs public runtime evidence before FAQ parity, claim-boundary, or repair PRs.
- This PR documents which hub routes currently expose definition, free-result expectation, claim boundary, and CTA in a bounded first-screen text proxy.

## Validation
- python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/core-hub-first-screen-answer-block-readback-01/scan_manifest.json >/dev/null
- git diff --check
- git diff --cached --check

## Deferred items
- No runtime, CMS, frontend, FAQ, JSON-LD, sitemap, llms, title/meta, canonical, noindex, production import, or deployment changes.
- FAQ visible/JSON-LD parity and visible claim-boundary matrix remain separate PR scopes.