### PR TITLE
FAQ-VISIBLE-PARITY-MATRIX-ALL-HUBS-01: add parity readback

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,27 @@
+# FAQ Visible Parity Matrix Decision
+
+Date: 2026-07-06
+
+PR/task: `FAQ-VISIBLE-PARITY-MATRIX-ALL-HUBS-01`
+
+Final verdict: `FAQ_PARITY_MATRIX_READY`
+
+## Decision
+
+All 12 six-test hub routes currently pass visible FAQ to FAQPage JSON-LD parity by count, question text, and order.
+
+This parity pass does not mean FAQ quality is complete. Eleven routes still expose the generic four-question FAQ pattern. Only the Chinese MBTI hub exposes eight MBTI-specific questions.
+
+## Key Findings
+
+1. `visible_count == jsonld_count` for all 12 routes.
+2. `visible_questions == jsonld_questions` for all 12 routes.
+3. Chinese MBTI has 8 scale-specific FAQ questions.
+4. The other 11 routes have the generic four-question pattern.
+5. No hidden schema-only mismatch was found in this readback.
+
+## Decision Boundary
+
+The correct follow-up is not a JSON-LD repair. The next step is visible claim-boundary evidence and then backend/CMS-authoritative FAQ quality repair split where needed.
+
+This PR does not change FAQ content, JSON-LD, CMS, frontend rendering, sitemap, `llms`, metadata, canonical, noindex, production imports, or deployment state.

--- a/backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/FAQ_VISIBLE_PARITY_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/FAQ_VISIBLE_PARITY_MATRIX.md
@@ -1,0 +1,73 @@
+# FAQ Visible Parity Matrix Across All Hubs
+
+Date: 2026-07-06
+
+Source: unauthenticated public HTTP reads from `https://fermatmind.com`.
+
+## Method
+
+For each route:
+
+1. Fetch public HTML.
+2. Extract visible FAQ questions from the `section id="faq"` rendered payload.
+3. Extract FAQPage JSON-LD `mainEntity[].name`.
+4. Compare count, question text, and order.
+5. Flag the known generic four-question pattern.
+
+## Route Matrix
+
+| Route | HTTP | Visible FAQ count | JSON-LD FAQ count | Question parity | FAQ quality flag |
+| --- | ---: | ---: | ---: | --- | --- |
+| `/zh/tests/mbti-personality-test-16-personality-types` | 200 | 8 | 8 | pass | scale-specific |
+| `/en/tests/mbti-personality-test-16-personality-types` | 200 | 4 | 4 | pass | generic |
+| `/zh/tests/big-five-personality-test-ocean-model` | 200 | 4 | 4 | pass | generic |
+| `/en/tests/big-five-personality-test-ocean-model` | 200 | 4 | 4 | pass | generic |
+| `/zh/tests/enneagram-personality-test-nine-types` | 200 | 4 | 4 | pass | generic |
+| `/en/tests/enneagram-personality-test-nine-types` | 200 | 4 | 4 | pass | generic |
+| `/zh/tests/holland-career-interest-test-riasec` | 200 | 4 | 4 | pass | generic |
+| `/en/tests/holland-career-interest-test-riasec` | 200 | 4 | 4 | pass | generic |
+| `/zh/tests/iq-test-intelligence-quotient-assessment` | 200 | 4 | 4 | pass | generic |
+| `/en/tests/iq-test-intelligence-quotient-assessment` | 200 | 4 | 4 | pass | generic |
+| `/zh/tests/eq-test-emotional-intelligence-assessment` | 200 | 4 | 4 | pass | generic |
+| `/en/tests/eq-test-emotional-intelligence-assessment` | 200 | 4 | 4 | pass | generic |
+
+## Captured Questions
+
+### Chinese MBTI
+
+1. `MBTI 测试免费吗？`
+2. `MBTI 完整结果能看到什么？`
+3. `MBTI 测试一般多久？`
+4. `MBTI 能决定职业吗？`
+5. `MBTI 是心理诊断吗？`
+6. `16 型人格结果会变吗？`
+7. `MBTI 和大五人格有什么区别？`
+8. `做完 MBTI 后下一步看什么？`
+
+### Generic Chinese Pattern
+
+Used by Chinese Big Five, Enneagram, RIASEC, IQ, and EQ:
+
+1. `需要多久？`
+2. `每道题都要回答吗？`
+3. `可以重复测试吗？`
+4. `这是诊断吗？`
+
+### Generic English Pattern
+
+Used by English MBTI, Big Five, Enneagram, RIASEC, IQ, and EQ:
+
+1. `How long does it take?`
+2. `Do I need to answer every question?`
+3. `Can I retake it?`
+4. `Is this a diagnosis?`
+
+## Interpretation
+
+FAQ parity is healthy at the structured-data boundary: visible FAQ and FAQPage JSON-LD match on all sampled hub routes.
+
+The growth blocker is FAQ specificity, not parity. Generic FAQ can be claim-safe, but it does not close the P0/P6 requirement for scale-specific visible answers across all six hubs and both locales.
+
+## Boundary
+
+This report is evidence only. It is not public FAQ copy and must not be imported into CMS or rendered directly.

--- a/backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,39 @@
+# Next Exact Authorization Prompts
+
+## Visible Claim-Boundary Matrix
+
+Authorize `CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01` as the next read-only evidence PR.
+
+Allowed scope:
+
+- Fetch the 12 public hub routes.
+- Record visible claim-boundary evidence for diagnosis, treatment, hiring, admission, professional advice, career outcomes, IQ score/norms, and private URL exposure.
+- Summarize route-level pass/partial/gap status.
+
+Forbidden:
+
+- rewriting claims
+- adding FAQ content
+- editing JSON-LD
+- editing CMS or frontend runtime
+- changing sitemap, `llms`, metadata, canonical, noindex, or deployment state
+
+## FAQ Quality Repair Authorization Template
+
+Use only after claim-boundary matrix is merged:
+
+```text
+Authorize <PR_ID> as a backend/CMS-authoritative scale-specific FAQ repair.
+
+Allowed scope:
+- exact scale and locale
+- exact backend/CMS authority source
+- exact public route(s)
+- visible FAQ and matching JSON-LD generated from the same authority source
+
+Forbidden:
+- frontend fallback FAQ
+- hidden schema-only FAQ
+- title/meta/canonical/sitemap/llms changes
+- production import/deploy without exact SHA authorization
+```

--- a/backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/scan_manifest.json
@@ -1,0 +1,47 @@
+{
+  "task_id": "FAQ-VISIBLE-PARITY-MATRIX-ALL-HUBS-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "mode": "read_only_runtime_evidence",
+  "final_verdict": "FAQ_PARITY_MATRIX_READY",
+  "source_host": "https://fermatmind.com",
+  "method": "unauthenticated_public_http_visible_faq_vs_jsonld_readback",
+  "outputs": [
+    "EXECUTIVE_DECISION.md",
+    "FAQ_VISIBLE_PARITY_MATRIX.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "routes_evaluated": [
+    "/zh/tests/mbti-personality-test-16-personality-types",
+    "/en/tests/mbti-personality-test-16-personality-types",
+    "/zh/tests/big-five-personality-test-ocean-model",
+    "/en/tests/big-five-personality-test-ocean-model",
+    "/zh/tests/enneagram-personality-test-nine-types",
+    "/en/tests/enneagram-personality-test-nine-types",
+    "/zh/tests/holland-career-interest-test-riasec",
+    "/en/tests/holland-career-interest-test-riasec",
+    "/zh/tests/iq-test-intelligence-quotient-assessment",
+    "/en/tests/iq-test-intelligence-quotient-assessment",
+    "/zh/tests/eq-test-emotional-intelligence-assessment",
+    "/en/tests/eq-test-emotional-intelligence-assessment"
+  ],
+  "summary": {
+    "http_200_routes": 12,
+    "parity_pass_routes": 12,
+    "parity_fail_routes": 0,
+    "scale_specific_faq_routes": 1,
+    "generic_faq_routes": 11
+  },
+  "scope_guard": {
+    "runtime_mutation": false,
+    "cms_mutation": false,
+    "schema_mutation": false,
+    "sitemap_or_llms_mutation": false,
+    "frontend_mutation": false,
+    "production_deploy": false
+  },
+  "next_cards": [
+    "CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added read-only runtime evidence comparing visible FAQ questions with FAQPage JSON-LD across all 12 six-test hub routes.
- Recorded parity status, generic FAQ flags, captured question patterns, and next authorization prompts.
- Added a scan manifest with route list, summary, and scope guard.

## Why
- The prior answer-block readback identified first-screen quality gaps; this card verifies whether the FAQ structured-data boundary itself is aligned with visible page content.

## Validation
- python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/faq-visible-parity-matrix-all-hubs-01/scan_manifest.json >/dev/null
- git diff --check
- git diff --cached --check

## Deferred items
- No FAQ copy, JSON-LD, CMS, frontend, sitemap, llms, metadata, canonical, noindex, production import, or deployment changes.
- Visible claim-boundary matrix and any backend/CMS-authoritative FAQ quality repairs remain separate scopes.