### PR TITLE
CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01: add visible boundary matrix

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/CLAIM_BOUNDARY_VISIBLE_SURFACE_MATRIX.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/CLAIM_BOUNDARY_VISIBLE_SURFACE_MATRIX.md
@@ -1,0 +1,58 @@
+# Claim Boundary Visible Surface Matrix
+
+Date: 2026-07-06
+
+Source: unauthenticated public HTTP reads from `https://fermatmind.com`.
+
+## Method
+
+For each route, the public page text was stripped from HTML and scanned for visible claim-boundary evidence.
+
+This matrix checks page-level visible text, not only the first screen.
+
+Boundary classes:
+
+- diagnosis / treatment boundary
+- professional-advice boundary
+- hiring / screening boundary
+- admission / major / job guarantee boundary
+- career outcome guarantee boundary
+- IQ score / norm / estimate caution context
+
+## Route Matrix
+
+| Route | HTTP | Page-level boundary status | Strongest visible boundary evidence | Remaining concern |
+| --- | ---: | --- | --- | --- |
+| `/zh/tests/mbti-personality-test-16-personality-types` | 200 | pass | `不作诊断、治疗、招聘筛选或职业保证` | none for current read-only stage |
+| `/en/tests/mbti-personality-test-16-personality-types` | 200 | pass | `not for hiring, diagnosis, or life-outcome guarantees` | keep MBTI-specific English FAQ repair separate |
+| `/zh/tests/big-five-personality-test-ocean-model` | 200 | pass | `不是。本测评用于教育性自我理解，不替代专业建议。` | boundary exists but FAQ remains generic |
+| `/en/tests/big-five-personality-test-ocean-model` | 200 | pass | `does not replace professional advice` | first-screen boundary was partial in previous card |
+| `/zh/tests/enneagram-personality-test-nine-types` | 200 | pass | `不应被当成专业诊断、招聘筛选或职业成功预测` plus professional-advice FAQ boundary | boundary exists but route still uses generic FAQ |
+| `/en/tests/enneagram-personality-test-nine-types` | 200 | partial/pass | generic FAQ/professional-advice boundary is visible | Enneagram-specific claim surface is not proven |
+| `/zh/tests/holland-career-interest-test-riasec` | 200 | pass | `不承诺专业、录取、岗位匹配或职业结果` | diagnosis boundary appears generic/lower page, not first-screen |
+| `/en/tests/holland-career-interest-test-riasec` | 200 | pass | `not ability, admission odds, or job guarantees` | English career/major boundary should stay claim-reviewed |
+| `/zh/tests/iq-test-intelligence-quotient-assessment` | 200 | pass with caution | `不替代专业建议` and IQ score article context | IQ score/norm/estimate claims still require stricter proof before amplification |
+| `/en/tests/iq-test-intelligence-quotient-assessment` | 200 | pass with caution | `does not replace professional advice` and qualified guidance note | IQ score/norm/estimate claims still require stricter proof before amplification |
+| `/zh/tests/eq-test-emotional-intelligence-assessment` | 200 | pass | `不替代专业建议` and treatment/professional opinion note | route still uses generic FAQ |
+| `/en/tests/eq-test-emotional-intelligence-assessment` | 200 | pass | `does not replace professional advice` and treatment/professional guidance note | first-screen boundary was partial in previous card |
+
+## Cross-Route Findings
+
+1. Page-level claim-boundary evidence exists on all 12 routes.
+2. First-screen claim-boundary evidence is weaker than page-level evidence on several English routes.
+3. FAQ parity is healthy, but 11 routes still use generic FAQ; this limits scale-specific AEO/GEO readiness.
+4. RIASEC has the most important non-diagnostic route-specific boundary: admission, major, job, and career-result claims must remain constrained.
+5. IQ should remain in the strictest lane: do not strengthen score, norm, intelligence, or estimate language without explicit public proof and claim review.
+
+## Repair Implications
+
+This card does not create a runtime blocker. It creates a prioritization signal:
+
+1. keep Chinese MBTI in observe/readback mode
+2. improve English and non-MBTI first-screen boundary placement only through backend/CMS authority
+3. repair generic FAQ quality separately from claim-boundary placement
+4. run IQ claim review before any money-intent or answer-block amplification
+
+## Boundary
+
+This report is evidence only. It is not public copy and must not be imported into CMS or rendered directly.

--- a/backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,35 @@
+# Claim Boundary Visible Surface Matrix Decision
+
+Date: 2026-07-06
+
+PR/task: `CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01`
+
+Final verdict: `CLAIM_BOUNDARY_MATRIX_READY`
+
+## Decision
+
+The 12 six-test hub routes have page-level visible claim-boundary evidence. The boundary issue is not total absence. The remaining risk is placement, specificity, and scale-by-scale completeness.
+
+The current page-level readback supports:
+
+- basic non-diagnosis / professional-advice boundary across the hub set
+- MBTI hiring / career guarantee boundary
+- RIASEC admission / major / job guarantee boundary
+- IQ professional guidance and score/norm caution context
+
+This does not authorize stronger claims, copy changes, JSON-LD edits, metadata edits, sitemap or `llms` changes, CMS writes, frontend fallback, production import, or deployment.
+
+## Follow-Up Decision
+
+The next repair planning should separate:
+
+1. first-screen placement gaps
+2. generic FAQ specificity gaps
+3. scale-specific claim-boundary wording gaps
+4. IQ estimate/score/norm proof gap
+
+Any repair must be backend/CMS-authoritative and visible on-page before structured data reflects it.
+
+## Boundary
+
+This PR is read-only evidence. It does not change public claims or runtime behavior.

--- a/backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,46 @@
+# Next Exact Authorization Prompts
+
+## Repair Queue Selection
+
+Authorize a generated-only repair planning PR before any copy/runtime change:
+
+```text
+Authorize SIX-TEST-HUB-ANSWER-BLOCK-REPAIR-SPLIT-PLAN-01 as a generated-only planning PR.
+
+Scope:
+- Combine first-screen readback, FAQ parity, and claim-boundary matrix.
+- Propose backend/CMS-authoritative repair PR split by scale and locale.
+- Include required authority source, route set, fields/blocks, and validation for each proposed repair.
+
+Forbidden:
+- runtime mutation
+- CMS write
+- frontend fallback content
+- FAQ copy generation for production
+- JSON-LD-only repair
+- sitemap/llms/metadata/canonical/noindex changes
+- production import or deploy
+```
+
+## IQ Claim Review
+
+Use a separate IQ review before any IQ money-intent or answer-block amplification:
+
+```text
+Authorize IQ-CLAIM-BOUNDARY-ANSWER-BLOCK-REVIEW-01 as a read-only claim review PR.
+
+Scope:
+- Review current visible IQ wording around score, norm, estimate, quotient, formal testing, and professional guidance.
+- Identify exact forbidden claim patterns.
+- Propose safe copy constraints only.
+
+Forbidden:
+- rewriting IQ public copy
+- adding score/norm claims
+- metadata or schema changes
+- production import or deploy
+```
+
+## Immediate Train Continuation
+
+Continue to competitor-alternative held/readiness cards as generated-only artifacts. Do not start repair work from this PR without exact authorization.

--- a/backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/scan_manifest.json
@@ -1,0 +1,49 @@
+{
+  "task_id": "CLAIM-BOUNDARY-VISIBLE-SURFACE-MATRIX-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "mode": "read_only_runtime_evidence",
+  "final_verdict": "CLAIM_BOUNDARY_MATRIX_READY",
+  "source_host": "https://fermatmind.com",
+  "method": "unauthenticated_public_http_visible_text_claim_boundary_scan",
+  "outputs": [
+    "EXECUTIVE_DECISION.md",
+    "CLAIM_BOUNDARY_VISIBLE_SURFACE_MATRIX.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "routes_evaluated": [
+    "/zh/tests/mbti-personality-test-16-personality-types",
+    "/en/tests/mbti-personality-test-16-personality-types",
+    "/zh/tests/big-five-personality-test-ocean-model",
+    "/en/tests/big-five-personality-test-ocean-model",
+    "/zh/tests/enneagram-personality-test-nine-types",
+    "/en/tests/enneagram-personality-test-nine-types",
+    "/zh/tests/holland-career-interest-test-riasec",
+    "/en/tests/holland-career-interest-test-riasec",
+    "/zh/tests/iq-test-intelligence-quotient-assessment",
+    "/en/tests/iq-test-intelligence-quotient-assessment",
+    "/zh/tests/eq-test-emotional-intelligence-assessment",
+    "/en/tests/eq-test-emotional-intelligence-assessment"
+  ],
+  "summary": {
+    "http_200_routes": 12,
+    "page_level_boundary_present_routes": 12,
+    "strict_pass_routes": 11,
+    "partial_pass_routes": 1,
+    "iq_caution_routes": 2
+  },
+  "scope_guard": {
+    "runtime_mutation": false,
+    "cms_mutation": false,
+    "schema_mutation": false,
+    "sitemap_or_llms_mutation": false,
+    "frontend_mutation": false,
+    "production_deploy": false
+  },
+  "next_cards": [
+    "COMPETITOR-ALTERNATIVE-HELD-READINESS-01",
+    "COMPETITOR-ALTERNATIVE-SOURCE-LEDGER-GAP-AUDIT-01",
+    "COMPETITOR-ALTERNATIVE-LEGAL-CLAIM-REVIEW-HANDOFF-01"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added read-only visible claim-boundary matrix across the 12 six-test hub routes.
- Recorded page-level boundary evidence, route-level concerns, and repair planning prompts.
- Added a scan manifest with method, route list, summary, and non-mutation scope guard.

## Why
- After first-screen and FAQ parity readbacks, the train needs claim-boundary evidence before any repair planning or content changes.

## Validation
- python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/claim-boundary-visible-surface-matrix-01/scan_manifest.json >/dev/null
- git diff --check
- git diff --cached --check

## Deferred items
- No public copy, FAQ, JSON-LD, CMS, frontend, sitemap, llms, metadata, canonical, noindex, production import, or deployment changes.
- Any answer-block/FAQ/claim repair split requires separate exact authorization.