### PR TITLE
SECURITY-169-API-08: harden EQ agent runtime safety and cost controls

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -3319,20 +3319,25 @@ class AttemptReadController extends Controller
         ]);
 
         $contract = $this->eqJourneyStateService->submit($attempt, $result, $payload);
-        $request->merge(['attempt_id' => (string) $attempt->id]);
-        $this->eventRecorder->recordFromRequest($request, 'eq_journey_feedback_submitted', $this->resolveUserId($request), [
-            'scale_code' => 'EQ_60',
-            'eq_report_mode' => data_get($contract, 'eq_journey_state_v1.eq_report_mode'),
-            'status' => data_get($contract, 'eq_journey_state_v1.status'),
-            'persisted' => data_get($contract, 'eq_journey_state_v1.persisted'),
-            'read_depth' => data_get($contract, 'eq_journey_state_v1.signals.read_depth'),
-            'result_resonance' => data_get($contract, 'eq_journey_state_v1.signals.result_resonance'),
-            'action_completion' => data_get($contract, 'eq_journey_state_v1.signals.action_completion'),
-            'retest_intent' => data_get($contract, 'eq_journey_state_v1.signals.retest_intent'),
-            'low_confidence_caution' => data_get($contract, 'eq_journey_state_v1.interpretation_guard.low_confidence_caution'),
-            'affects_scores' => false,
-            'profile_memory_write' => false,
-        ]);
+        $consentToStore = (bool) data_get($contract, 'eq_journey_state_v1.consent.consent_to_store', false);
+        $persisted = (bool) data_get($contract, 'eq_journey_state_v1.persisted', false);
+        if ($consentToStore && $persisted) {
+            $request->merge(['attempt_id' => (string) $attempt->id]);
+            $this->eventRecorder->recordFromRequest($request, 'eq_journey_feedback_submitted', $this->resolveUserId($request), [
+                'scale_code' => 'EQ_60',
+                'eq_report_mode' => data_get($contract, 'eq_journey_state_v1.eq_report_mode'),
+                'status' => data_get($contract, 'eq_journey_state_v1.status'),
+                'persisted' => $persisted,
+                'consent_to_store' => $consentToStore,
+                'read_depth' => data_get($contract, 'eq_journey_state_v1.signals.read_depth'),
+                'result_resonance' => data_get($contract, 'eq_journey_state_v1.signals.result_resonance'),
+                'action_completion' => data_get($contract, 'eq_journey_state_v1.signals.action_completion'),
+                'retest_intent' => data_get($contract, 'eq_journey_state_v1.signals.retest_intent'),
+                'low_confidence_caution' => data_get($contract, 'eq_journey_state_v1.interpretation_guard.low_confidence_caution'),
+                'affects_scores' => false,
+                'profile_memory_write' => false,
+            ]);
+        }
 
         return response()->json([
             'ok' => true,

--- a/backend/app/Services/Eq/EqAgentProviderManager.php
+++ b/backend/app/Services/Eq/EqAgentProviderManager.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Services\Eq;
 
+use App\Services\Abuse\RateLimiter;
 use Illuminate\Support\Facades\Log;
 
 final class EqAgentProviderManager
 {
     public function __construct(
         private OpenAiEqAgentProviderClient $openAiProvider,
+        private RateLimiter $rateLimiter,
     ) {}
 
     public function enabled(): bool
@@ -49,6 +51,15 @@ final class EqAgentProviderManager
             return null;
         }
 
+        if (! $this->consumeAttemptBudget($request)) {
+            Log::notice('EQ_AGENT_PROVIDER_THROTTLED', [
+                'provider' => $this->providerName(),
+                'reason' => 'attempt_rate_limit',
+            ]);
+
+            return null;
+        }
+
         try {
             return $this->openAiProvider->generate($request);
         } catch (\Throwable $e) {
@@ -59,5 +70,19 @@ final class EqAgentProviderManager
 
             return null;
         }
+    }
+
+    private function consumeAttemptBudget(EqAgentProviderRequest $request): bool
+    {
+        $limit = max(0, (int) config('ai.eq_agent.provider_limits.max_calls_per_attempt_hour', 6));
+        if ($limit <= 0) {
+            return true;
+        }
+
+        $decaySeconds = max(60, (int) config('ai.eq_agent.provider_limits.attempt_decay_seconds', 3600));
+        $attemptId = trim((string) ($request->context['attempt_id'] ?? $request->deterministicPayload['attempt_id'] ?? ''));
+        $subject = $attemptId !== '' ? $attemptId : 'unknown';
+
+        return $this->rateLimiter->hit('eq_agent_provider:attempt:'.sha1($subject), $limit, $decaySeconds);
     }
 }

--- a/backend/app/Services/Eq/EqAgentRuntimeResponder.php
+++ b/backend/app/Services/Eq/EqAgentRuntimeResponder.php
@@ -80,13 +80,15 @@ final class EqAgentRuntimeResponder
             ],
         ];
 
-        $providerResponse = $this->providerManager->tryGenerate(new EqAgentProviderRequest(
-            $context,
-            $payload,
-            $messageText,
-            $intent,
-            $resolvedLocale,
-        ));
+        $providerResponse = $this->shouldTryProvider($detectedClaimIds, $intentContext)
+            ? $this->providerManager->tryGenerate(new EqAgentProviderRequest(
+                $context,
+                $payload,
+                $messageText,
+                $intent,
+                $resolvedLocale,
+            ))
+            : null;
 
         if ($providerResponse !== null && $this->providerResponseIsSafe($providerResponse, $agentKnowledge, $sourceAssetIds, $boundaryIds)) {
             $payload['mode'] = 'llm_provider_read_only';
@@ -100,6 +102,21 @@ final class EqAgentRuntimeResponder
         }
 
         return $payload;
+    }
+
+    /**
+     * @param  list<string>  $detectedClaimIds
+     * @param  array<string,mixed>  $intentContext
+     */
+    private function shouldTryProvider(array $detectedClaimIds, array $intentContext): bool
+    {
+        if ($detectedClaimIds !== []) {
+            return false;
+        }
+
+        $mode = strtolower(trim((string) ($intentContext['allowed_response_mode'] ?? '')));
+
+        return ! in_array($mode, ['boundary_refusal', 'planned_unavailable_boundary'], true);
     }
 
     /**
@@ -258,7 +275,11 @@ final class EqAgentRuntimeResponder
 
                 continue;
             }
-            foreach ($this->stringList($claim['blocked_patterns'] ?? null) as $pattern) {
+            $patterns = array_values(array_unique(array_merge(
+                $this->stringList($claim['blocked_patterns'] ?? null),
+                $this->fallbackForbiddenClaimPatterns((string) $claimId)
+            )));
+            foreach ($patterns as $pattern) {
                 if ($pattern !== '' && str_contains($normalizedMessage, mb_strtolower($pattern))) {
                     $detected[] = (string) $claimId;
                     break;
@@ -267,6 +288,31 @@ final class EqAgentRuntimeResponder
         }
 
         return array_values(array_unique($detected));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fallbackForbiddenClaimPatterns(string $claimId): array
+    {
+        return match ($claimId) {
+            'true_emotional_ability' => [
+                'true emotional ability',
+                'objective emotional ability',
+                'real emotional ability',
+                'emotional ability test',
+            ],
+            'msceit_like' => ['msceit'],
+            'certified_ei' => ['certified emotional intelligence', 'ei certification', 'eq certification'],
+            'job_performance_prediction' => [
+                'job performance',
+                'predict work performance',
+                'predict job performance',
+                '预测工作表现',
+                '工作表现',
+            ],
+            default => [],
+        };
     }
 
     /**

--- a/backend/app/Services/Eq/OpenAiEqAgentProviderClient.php
+++ b/backend/app/Services/Eq/OpenAiEqAgentProviderClient.php
@@ -151,7 +151,10 @@ final class OpenAiEqAgentProviderClient implements EqAgentProviderClient
 
     private function maxOutputTokens(): int
     {
-        return max(256, (int) config('ai.eq_agent.openai.max_output_tokens', 900));
+        $configured = max(128, (int) config('ai.eq_agent.openai.max_output_tokens', 900));
+        $cap = max(128, (int) config('ai.eq_agent.openai.max_output_tokens_cap', 900));
+
+        return min($configured, $cap);
     }
 
     private function systemPrompt(string $locale): string

--- a/backend/config/ai.php
+++ b/backend/config/ai.php
@@ -41,6 +41,10 @@ return [
         'staging_only' => env('EQ_AGENT_LLM_STAGING_ONLY', true),
         'model' => env('EQ_AGENT_LLM_MODEL', env('AI_MODEL', '')),
         'fail_open_mode' => env('EQ_AGENT_LLM_FAIL_OPEN_MODE', 'deterministic'),
+        'provider_limits' => [
+            'max_calls_per_attempt_hour' => (int) env('EQ_AGENT_PROVIDER_MAX_CALLS_PER_ATTEMPT_HOUR', 6),
+            'attempt_decay_seconds' => (int) env('EQ_AGENT_PROVIDER_ATTEMPT_DECAY_SECONDS', 3600),
+        ],
         'openai' => [
             'base_url' => rtrim((string) env('EQ_AGENT_OPENAI_BASE_URL', env('OPENAI_BASE_URL', 'https://api.openai.com/v1')), '/'),
             'api_key' => env('EQ_AGENT_OPENAI_API_KEY', env('OPENAI_API_KEY', '')),
@@ -50,6 +54,7 @@ return [
             'max_retries' => (int) env('EQ_AGENT_OPENAI_MAX_RETRIES', 0),
             'retry_sleep_milliseconds' => (int) env('EQ_AGENT_OPENAI_RETRY_SLEEP_MS', 250),
             'max_output_tokens' => (int) env('EQ_AGENT_OPENAI_MAX_OUTPUT_TOKENS', 900),
+            'max_output_tokens_cap' => (int) env('EQ_AGENT_OPENAI_MAX_OUTPUT_TOKENS_CAP', 900),
         ],
     ],
 ];

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -42144,6 +42144,15 @@
       "authorization": {
         "evidence": "Authorized by the 2026-07-03 SECURITY-169 attached /goal.",
         "status": "pass"
+      },
+      "dependency": {
+        "evidence": "SECURITY-169-API-07 implementation PR #2797 and ledger closeout PR #2802 are merged into origin/main.",
+        "status": "pass"
+      },
+      "external_main_advances": {
+        "evidence": "Rebased over external docs-only origin/main commits fcbc67594 and 11b5d888e; changed paths were backend/docs/seo/daily-runs/... and did not intersect API08 runtime scope.",
+        "required_checks_affected": false,
+        "status": "pass"
       }
     },
     "cms_mutation": false,
@@ -42156,6 +42165,36 @@
     "deploy_allowed": false,
     "events": [
       {
+        "at": "2026-07-06T16:25:00+08:00",
+        "note": "GitHub verify-bigfive failed because the initial API08 commit touched backend/app/Services/Analytics/EventRecorder.php, which BigFive runtime freeze treats as MBTI-impacting runtime. Inspected failing job and fixed within current scope by removing the EventRecorder change; EQ feedback analytics suppression remains at the only eq_journey_feedback_submitted call site in AttemptReadController.",
+        "status": "ci_fix_in_progress"
+      },
+      {
+        "at": "2026-07-06T16:16:00+08:00",
+        "note": "Rebased SECURITY-169-API-08 onto latest origin/main 11b5d888e after external docs-only main advances; reran focused EQ tests, route list, SQLite migrate, and diff check on the final base.",
+        "status": "local_validation_passed"
+      },
+      {
+        "at": "2026-07-06T16:15:42+08:00",
+        "note": "Full required CI passed on rebased main before the external docs-only parity readback commit advanced origin/main again: cd backend && bash scripts/ci_verify_mbti.sh.",
+        "status": "local_validation_passed"
+      },
+      {
+        "at": "2026-07-06T16:09:38+08:00",
+        "note": "Initial full required CI passed for SECURITY-169-API-08: cd backend && bash scripts/ci_verify_mbti.sh.",
+        "status": "local_validation_passed"
+      },
+      {
+        "at": "2026-07-06T15:54:00+08:00",
+        "note": "Implemented API08 runtime hardening: forbidden-claim provider bypass, fallback forbidden-claim phrase coverage, per-attempt provider throttle, OpenAI max-output cap, and no-consent EQ journey analytics suppression.",
+        "status": "in_progress"
+      },
+      {
+        "at": "2026-07-06T15:50:00+08:00",
+        "note": "Started SECURITY-169-API-08 from latest origin/main after SECURITY-169-API-07 ledger closeout.",
+        "status": "in_progress"
+      },
+      {
         "at": "2026-07-03T00:00:00+08:00",
         "note": "Registered authorized SECURITY-169-API-08; execution waits for declared dependency merge.",
         "status": "planned"
@@ -42164,13 +42203,48 @@
     "failure_reason": null,
     "id": "SECURITY-169-API-08",
     "local_cleanup_executed": false,
+    "local_validation": {
+      "commands": [
+        "php -l backend/app/Services/Eq/EqAgentRuntimeResponder.php",
+        "php -l backend/app/Services/Eq/EqAgentProviderManager.php",
+        "php -l backend/app/Services/Eq/OpenAiEqAgentProviderClient.php",
+        "php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php",
+        "php -l backend/config/ai.php",
+        "cd backend && ./vendor/bin/pint app/Services/Eq/EqAgentRuntimeResponder.php app/Services/Eq/EqAgentProviderManager.php app/Services/Eq/OpenAiEqAgentProviderClient.php app/Http/Controllers/API/V0_3/AttemptReadController.php config/ai.php",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=EqAgentContextApiTest --no-ansi",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60JourneyStateContractTest --no-ansi",
+        "cd backend && php artisan route:list --no-ansi",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-08.sqlite php artisan migrate --force --no-ansi",
+        "cd backend && bash scripts/ci_verify_mbti.sh",
+        "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+        "git diff --check"
+      ],
+      "status": "pass"
+    },
     "merged_at": null,
     "pr_url": null,
     "production_write_execution": false,
     "publish_allowed": false,
     "remote_branch_deleted": false,
     "repo": "fap-api",
-    "status": "planned",
+    "scope_validation": {
+      "changed_files": [
+        "backend/app/Http/Controllers/API/V0_3/AttemptReadController.php",
+        "backend/app/Services/Eq/EqAgentProviderManager.php",
+        "backend/app/Services/Eq/EqAgentRuntimeResponder.php",
+        "backend/app/Services/Eq/OpenAiEqAgentProviderClient.php",
+        "backend/config/ai.php",
+        "docs/codex/pr-train-state.json"
+      ],
+      "generated_artifacts_restored": [
+        "backend/content_packs/EQ_60/v1/compiled/*.json",
+        "backend/content_packs/BIG5_OCEAN/v1/compiled/*.json"
+      ],
+      "local_validation_passed": true,
+      "status": "pass"
+    },
+    "status": "local_validation_passed",
     "title": "SECURITY-169-API-08: harden EQ agent runtime safety and cost controls",
     "train_scope": "security_169_fap_api_audit"
   },


### PR DESCRIPTION
## What changed
- Skip the EQ LLM provider when forbidden claims are detected or the intent context requires a boundary-only response.
- Add deterministic fallback phrase coverage for EQ forbidden claims that must not depend only on compiled content-pack wording.
- Add per-attempt EQ provider throttling and clamp OpenAI max output tokens through runtime config.
- Suppress `eq_journey_feedback_submitted` analytics unless consent-to-store is true and the journey state persisted.
- Update the SECURITY-169 API08 train ledger with validation and scope evidence.

## Why
- API08 closes the EQ agent runtime safety/cost scope by keeping forbidden-claim and unavailable-plan responses deterministic, bounding provider spend, and preventing no-consent feedback from entering analytics.

## Validation
- `php -l backend/app/Services/Eq/EqAgentRuntimeResponder.php`
- `php -l backend/app/Services/Eq/EqAgentProviderManager.php`
- `php -l backend/app/Services/Eq/OpenAiEqAgentProviderClient.php`
- `php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `php -l backend/app/Services/Analytics/EventRecorder.php`
- `php -l backend/config/ai.php`
- `cd backend && ./vendor/bin/pint app/Services/Eq/EqAgentRuntimeResponder.php app/Services/Eq/EqAgentProviderManager.php app/Services/Eq/OpenAiEqAgentProviderClient.php app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/Analytics/EventRecorder.php config/ai.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=EqAgentContextApiTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=Eq60JourneyStateContractTest --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-security-169-api-08.sqlite php artisan migrate --force --no-ansi`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Deferred items
- No staging deploy wait.
- No manual deploy.
- No production deploy.
- No CMS, search, sitemap, llms, canonical, noindex, JSON-LD, or production import work.
- External docs-only main advances were rebased over and recorded in the ledger as outside API08 scope.