### PR TITLE
COMPETITOR-ALTERNATIVE-LEGAL-CLAIM-REVIEW-HANDOFF-01: add review handoff

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,29 @@
+# Competitor Alternative Legal Claim Review Handoff Decision
+
+Date: 2026-07-06
+
+PR/task: `COMPETITOR-ALTERNATIVE-LEGAL-CLAIM-REVIEW-HANDOFF-01`
+
+Final verdict: `LEGAL_CLAIM_REVIEW_HANDOFF_READY`
+
+## Decision
+
+Competitor Alternative pages remain blocked from implementation until legal/brand/operator review approves exact routes, sources, claims, and indexability.
+
+This handoff is ready as a generated-only artifact. It does not authorize page creation, CMS writes, copy drafting for publication, schema, metadata, sitemap, `llms`, frontend work, production import, or deployment.
+
+## Review Required
+
+The reviewer must approve:
+
+1. competitor set
+2. source ledger
+3. claim mapping
+4. allowed comparison framing
+5. forbidden claim list
+6. route and indexability policy
+7. manual review and expiry policy
+
+## Train Decision
+
+This completes the competitor Alternative dry-run/held segment for the current train. Continue to MBTI FAQ D7/D28 observation cards, which are date-window blocked generated-only evidence cards unless the observation window has arrived.

--- a/backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/LEGAL_CLAIM_REVIEW_HANDOFF.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/LEGAL_CLAIM_REVIEW_HANDOFF.md
@@ -1,0 +1,76 @@
+# Competitor Alternative Legal Claim Review Handoff
+
+Date: 2026-07-06
+
+## Scope
+
+This handoff covers held competitor Alternative page candidates:
+
+- 16P alternative
+- Truity alternative
+- 123test alternative
+
+It does not approve implementation.
+
+## Review Checklist
+
+| Review area | Required reviewer decision |
+| --- | --- |
+| Competitor naming | Approve exact names, capitalization, and route slugs |
+| Source ledger | Approve every source URL, retrieved date, and claim mapping |
+| Comparison framing | Approve whether "alternative" framing is allowed and under what language |
+| FermatMind claims | Confirm every FermatMind claim is backed by backend/CMS public authority |
+| Competitor claims | Confirm every competitor claim is backed by approved source ledger evidence |
+| Superiority claims | Reject unless specifically approved with strong evidence |
+| Free/paid claims | Require current source evidence for both sides |
+| Methodology claims | Require source evidence and avoid overstating scientific/clinical authority |
+| Legal/privacy claims | Require official policy sources and conservative wording |
+| Indexability | Approve index/noindex, sitemap, `llms`, canonical, and schema policy |
+| Expiry | Define source recrawl/review expiration date |
+
+## Default Forbidden Claims
+
+The following are forbidden unless explicitly approved:
+
+- `FermatMind is more accurate than <competitor>`
+- `best alternative`
+- `official alternative`
+- `clinical-grade`
+- `validated replacement`
+- `trusted by more users`
+- `guaranteed free full result` as a competitor comparison
+- implied affiliation, endorsement, certification, or partnership
+- hidden schema claims not visible on-page
+- unsupported claims about competitor pricing, methodology, privacy, reports, or user count
+
+## Required Approval Record
+
+Any future implementation PR must link a review record containing:
+
+```json
+{
+  "review_id": "",
+  "reviewer": "",
+  "approved_competitors": [],
+  "approved_routes": [],
+  "approved_sources": [],
+  "approved_claims": [],
+  "rejected_claims": [],
+  "indexability_policy": "",
+  "expires_at": ""
+}
+```
+
+## Stop Lines
+
+Stop before implementation if:
+
+- source ledger is missing or stale
+- legal/brand review is incomplete
+- route/indexability policy is unclear
+- claim mapping does not cover both FermatMind and competitor sides
+- implementation would require production import/deploy without exact SHA authorization
+
+## Boundary
+
+This handoff is not legal advice and not publication approval. It is an internal review checklist.

--- a/backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/NEXT_EXACT_AUTHORIZATION_PROMPTS.md
@@ -1,0 +1,34 @@
+# Next Exact Authorization Prompts
+
+## Future Implementation Authorization
+
+Do not use this until source ledger and legal review are approved.
+
+```text
+Authorize COMPETITOR-ALTERNATIVE-<COMPETITOR>-IMPLEMENTATION-01.
+
+Allowed scope:
+- exact approved competitor
+- exact approved route
+- exact backend/CMS authority source
+- exact approved claim ledger
+- exact indexability policy
+- exact validation commands
+
+Forbidden:
+- unsupported superiority claims
+- hidden schema-only claims
+- frontend fallback public content
+- sitemap/llms inclusion beyond approved policy
+- production import/deploy without exact SHA authorization
+```
+
+## Current Train Continuation
+
+Continue to:
+
+- `MBTI-MAIN-FAQ-D7-OBSERVATION-01`
+- `MBTI-MAIN-FAQ-D28-OBSERVATION-01`
+- `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01`
+
+Use generated-only blocked/held reports if date windows or operator authorization are not satisfied.

--- a/backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/scan_manifest.json
@@ -1,0 +1,32 @@
+{
+  "task_id": "COMPETITOR-ALTERNATIVE-LEGAL-CLAIM-REVIEW-HANDOFF-01",
+  "date": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "mode": "generated_only_legal_claim_review_handoff",
+  "final_verdict": "LEGAL_CLAIM_REVIEW_HANDOFF_READY",
+  "outputs": [
+    "EXECUTIVE_DECISION.md",
+    "LEGAL_CLAIM_REVIEW_HANDOFF.md",
+    "NEXT_EXACT_AUTHORIZATION_PROMPTS.md",
+    "scan_manifest.json"
+  ],
+  "candidate_pages_held": [
+    "16P alternative",
+    "Truity alternative",
+    "123test alternative"
+  ],
+  "implementation_authorized": false,
+  "scope_guard": {
+    "runtime_mutation": false,
+    "cms_mutation": false,
+    "schema_mutation": false,
+    "sitemap_or_llms_mutation": false,
+    "frontend_mutation": false,
+    "production_deploy": false
+  },
+  "next_cards": [
+    "MBTI-MAIN-FAQ-D7-OBSERVATION-01",
+    "MBTI-MAIN-FAQ-D28-OBSERVATION-01",
+    "RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01"
+  ]
+}


### PR DESCRIPTION
## What changed
- Added generated-only legal/claim review handoff for held competitor Alternative candidates.
- Added reviewer checklist, forbidden claims, required approval record, stop lines, and next authorization prompts.
- Added a scan manifest with implementation authorization set to false.

## Why
- Competitor Alternative pages need legal/brand/operator review before any public implementation or discoverability work.

## Validation
- python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/competitor-alternative-legal-claim-review-handoff-01/scan_manifest.json >/dev/null
- git diff --check
- git diff --cached --check

## Deferred items
- No public copy, routes, CMS writes, comparative claims, JSON-LD, sitemap, llms, metadata, canonical, noindex, frontend code, production import, or deployment changes.
- Future implementation requires exact source ledger and legal/operator approval.