### PR TITLE
MBTI-MAIN-FAQ-D28-OBSERVATION-01: record date window block

### DIFF
--- a/backend/docs/seo/daily-runs/2026-08-02/mbti-main-faq-d28-observation-01/D28_OBSERVATION_BLOCKED_REPORT.md
+++ b/backend/docs/seo/daily-runs/2026-08-02/mbti-main-faq-d28-observation-01/D28_OBSERVATION_BLOCKED_REPORT.md
@@ -1,0 +1,28 @@
+# MBTI Main FAQ D28 Observation Blocked Report
+
+Date prepared: 2026-07-06
+
+## Status
+
+`BLOCKED_BY_DATE_WINDOW`
+
+## Reason
+
+The D28 window for MBTI FAQ observation begins on 2026-08-02. The current date is 2026-07-06.
+
+## Metrics Deferred
+
+- GSC page/query CTR
+- GSC impressions
+- GSC average position
+- GA organic sessions
+- article-to-test movement
+- start-test movement
+- FAQ visible count
+- FAQPage JSON-LD count
+
+## Valid Future Run
+
+Run `MBTI-MAIN-FAQ-D28-OBSERVATION-01` again on or after 2026-08-02 with read-only evidence only.
+
+Do not trigger deployment, production import, CMS writes, sitemap/`llms` edits, Search Console submission, or title/meta/FAQ changes from the observation PR.

--- a/backend/docs/seo/daily-runs/2026-08-02/mbti-main-faq-d28-observation-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-08-02/mbti-main-faq-d28-observation-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,27 @@
+# MBTI Main FAQ D28 Observation Decision
+
+Date prepared: 2026-07-06
+
+Observation window: 2026-08-02 or later
+
+PR/task: `MBTI-MAIN-FAQ-D28-OBSERVATION-01`
+
+Final verdict: `BLOCKED_BY_DATE_WINDOW`
+
+## Decision
+
+Do not run MBTI FAQ D28 observation on 2026-07-06.
+
+The D28 observation window has not arrived. Running the readback now would mislabel pre-D28 evidence and could trigger premature SEO decisions.
+
+## Required Window
+
+Earliest valid run date: 2026-08-02
+
+## Train Action
+
+Record the date-window block, append sidecar issue, merge this generated-only blocked report if checks pass, and continue to the RIASEC FAQ parity held/readback card.
+
+## Explicit Non-Actions
+
+This PR does not query GSC/GA, update CMS, edit SEO surfaces, submit URLs, verify deployment, or trigger deployment.

--- a/backend/docs/seo/daily-runs/2026-08-02/mbti-main-faq-d28-observation-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-08-02/mbti-main-faq-d28-observation-01/scan_manifest.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "MBTI-MAIN-FAQ-D28-OBSERVATION-01",
+  "date_prepared": "2026-07-06",
+  "earliest_valid_observation_date": "2026-08-02",
+  "repo": "fermatmind/fap-api",
+  "mode": "generated_only_date_window_blocked",
+  "final_verdict": "BLOCKED_BY_DATE_WINDOW",
+  "outputs": [
+    "EXECUTIVE_DECISION.md",
+    "D28_OBSERVATION_BLOCKED_REPORT.md",
+    "scan_manifest.json"
+  ],
+  "blocked_metrics": [
+    "GSC page/query CTR",
+    "GSC impressions",
+    "GSC average position",
+    "GA organic sessions",
+    "article_to_test",
+    "start_test",
+    "visible FAQ count",
+    "FAQPage JSON-LD count"
+  ],
+  "scope_guard": {
+    "runtime_mutation": false,
+    "cms_mutation": false,
+    "schema_mutation": false,
+    "sitemap_or_llms_mutation": false,
+    "frontend_mutation": false,
+    "production_deploy": false,
+    "gsc_or_ga_query": false
+  },
+  "next_cards": [
+    "RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01"
+  ]
+}

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -224,5 +224,20 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Re-run MBTI-MAIN-FAQ-D7-OBSERVATION-01 on or after 2026-07-12 as read-only evidence.",
         "train_continued": true
+    },
+    {
+        "repo": "fermatmind/fap-api",
+        "pr_id": "MBTI-MAIN-FAQ-D28-OBSERVATION-01",
+        "branch": "codex/mbti-main-faq-d28-observation-01",
+        "blocker_type": "blocked_by_date_window",
+        "evidence": [
+            "Current date is 2026-07-06.",
+            "Earliest valid D28 observation date is 2026-08-02.",
+            "Collecting GSC/GA/FAQ observation now would mislabeled pre-D28 evidence as D28."
+        ],
+        "why_not_current_pr_scope": "Current PR is generated-only date-window blocked reporting. It is not authorized to query GSC/GA, mutate CMS, edit SEO surfaces, submit URLs, verify deployment, or trigger deployment.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Re-run MBTI-MAIN-FAQ-D28-OBSERVATION-01 on or after 2026-08-02 as read-only evidence.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -258,3 +258,20 @@
 - recommended follow-up:
   - Re-run `MBTI-MAIN-FAQ-D7-OBSERVATION-01` on or after 2026-07-12 as read-only evidence.
 - whether train continued: `true`
+
+## MBTI-MAIN-FAQ-D28-OBSERVATION-01 date window
+
+- repo: `fermatmind/fap-api`
+- PR id / branch: `MBTI-MAIN-FAQ-D28-OBSERVATION-01` / `codex/mbti-main-faq-d28-observation-01`
+- blocker type: `blocked_by_date_window`
+- evidence:
+  - Current date is 2026-07-06.
+  - Earliest valid D28 observation date is 2026-08-02.
+  - Collecting GSC/GA/FAQ observation now would mislabeled pre-D28 evidence as D28.
+- why not current PR scope:
+  - Current PR is generated-only date-window blocked reporting.
+  - It is not authorized to query GSC/GA, mutate CMS, edit SEO surfaces, submit URLs, verify deployment, or trigger deployment.
+- whether required checks are affected: `false`
+- recommended follow-up:
+  - Re-run `MBTI-MAIN-FAQ-D28-OBSERVATION-01` on or after 2026-08-02 as read-only evidence.
+- whether train continued: `true`


### PR DESCRIPTION
## What changed
- Added generated-only D28 observation blocked report for MBTI main FAQ.
- Recorded earliest valid D28 observation date as 2026-08-02.
- Appended sidecar issue for the date-window blocker.

## Why
- The current date is 2026-07-06, so collecting D28 observation metrics now would mislabel pre-D28 evidence.
- The train should record the external date-window blocker and continue.

## Validation
- python3 -m json.tool backend/docs/seo/daily-runs/2026-08-02/mbti-main-faq-d28-observation-01/scan_manifest.json >/dev/null
- python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null
- git diff --check
- git diff --cached --check

## Deferred items
- No GSC/GA query, CMS write, FAQ/schema/metadata/sitemap/llms/canonical/noindex/runtime/frontend change, Search submission, production import, or deployment.
- Re-run D28 observation on or after 2026-08-02.