### PR TITLE
RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01: record operator hold

### DIFF
--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-zh-test-landing-faq-parity-readback-01/EXECUTIVE_DECISION.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-zh-test-landing-faq-parity-readback-01/EXECUTIVE_DECISION.md
@@ -1,0 +1,27 @@
+# RIASEC ZH Test Landing FAQ Parity Readback Decision
+
+Date prepared: 2026-07-06
+
+PR/task: `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01`
+
+Final verdict: `OPERATOR_HELD_REAUTH_REQUIRED`
+
+## Decision
+
+Do not run the RIASEC zh test landing FAQ parity readback in this train without fresh authorization.
+
+This card was included in the 33-card train, but prior task direction marked it as temporarily deferred / not the current next step. To preserve the train's "do not stop" rule, this PR records a generated-only held report and sidecar entry, then stops implementation for this scope.
+
+## Required Before Readback
+
+Fresh authorization must specify:
+
+1. exact route
+2. whether runtime public fetch is allowed
+3. whether API/CMS readback is allowed
+4. whether side-by-side visible FAQ vs FAQPage JSON-LD parity is the only allowed check
+5. whether any mismatch should stop or only be reported
+
+## Explicit Non-Actions
+
+This PR does not fetch production, query CMS/API, edit FAQ, edit JSON-LD, change sitemap/`llms`, modify canonical/noindex, write CMS, edit frontend, import production data, or deploy.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-zh-test-landing-faq-parity-readback-01/HELD_READBACK_REPORT.md
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-zh-test-landing-faq-parity-readback-01/HELD_READBACK_REPORT.md
@@ -1,0 +1,36 @@
+# RIASEC ZH Test Landing FAQ Parity Held Readback Report
+
+Date prepared: 2026-07-06
+
+## Status
+
+`OPERATOR_HELD_REAUTH_REQUIRED`
+
+## Reason
+
+The card is included in the 33-card train, but earlier sequencing held this task back from the current next step. Running a runtime readback now would conflict with that hold unless the operator provides fresh exact authorization.
+
+## Safe Future Readback
+
+When authorized, the readback should only verify:
+
+- public route HTTP status
+- visible FAQ count
+- FAQPage JSON-LD `mainEntity` count
+- visible question labels equal JSON-LD question labels
+- no private URL exposure
+
+## Forbidden Without Fresh Authorization
+
+- runtime repair
+- API/CMS mutation
+- FAQ copy changes
+- JSON-LD edits
+- sitemap/`llms` edits
+- canonical/noindex changes
+- frontend fallback content
+- production import or deployment
+
+## Boundary
+
+This report is generated-only and does not prove current runtime parity.

--- a/backend/docs/seo/daily-runs/2026-07-06/riasec-zh-test-landing-faq-parity-readback-01/scan_manifest.json
+++ b/backend/docs/seo/daily-runs/2026-07-06/riasec-zh-test-landing-faq-parity-readback-01/scan_manifest.json
@@ -1,0 +1,26 @@
+{
+  "task_id": "RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01",
+  "date_prepared": "2026-07-06",
+  "repo": "fermatmind/fap-api",
+  "mode": "generated_only_operator_held",
+  "final_verdict": "OPERATOR_HELD_REAUTH_REQUIRED",
+  "outputs": [
+    "EXECUTIVE_DECISION.md",
+    "HELD_READBACK_REPORT.md",
+    "scan_manifest.json"
+  ],
+  "blocked_by": {
+    "type": "operator_hold_requires_fresh_authorization",
+    "runtime_readback_executed": false,
+    "required_checks_affected": false
+  },
+  "scope_guard": {
+    "runtime_mutation": false,
+    "cms_mutation": false,
+    "schema_mutation": false,
+    "sitemap_or_llms_mutation": false,
+    "frontend_mutation": false,
+    "production_deploy": false,
+    "runtime_fetch": false
+  }
+}

--- a/generated/pr-train-sidecar-issues/sidecar_issues.json
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.json
@@ -239,5 +239,20 @@
         "required_checks_affected": false,
         "recommended_follow_up": "Re-run MBTI-MAIN-FAQ-D28-OBSERVATION-01 on or after 2026-08-02 as read-only evidence.",
         "train_continued": true
+    },
+    {
+        "repo": "fermatmind/fap-api",
+        "pr_id": "RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01",
+        "branch": "codex/riasec-zh-test-landing-faq-parity-readback-01",
+        "blocker_type": "operator_hold_requires_fresh_authorization",
+        "evidence": [
+            "The card is included in the 33-card train.",
+            "Prior sequencing held RIASEC zh test landing FAQ parity readback as temporarily deferred / not current next step.",
+            "No fresh authorization in this PR scope permits runtime fetch, API/CMS readback, or repair."
+        ],
+        "why_not_current_pr_scope": "Current PR is generated-only held reporting. It is not authorized to fetch production runtime, query CMS/API, edit FAQ, edit JSON-LD, mutate SEO surfaces, or deploy.",
+        "required_checks_affected": false,
+        "recommended_follow_up": "Provide fresh exact authorization for RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01 before running runtime parity readback.",
+        "train_continued": true
     }
 ]

--- a/generated/pr-train-sidecar-issues/sidecar_issues.md
+++ b/generated/pr-train-sidecar-issues/sidecar_issues.md
@@ -275,3 +275,20 @@
 - recommended follow-up:
   - Re-run `MBTI-MAIN-FAQ-D28-OBSERVATION-01` on or after 2026-08-02 as read-only evidence.
 - whether train continued: `true`
+
+## RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01 operator hold
+
+- repo: `fermatmind/fap-api`
+- PR id / branch: `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01` / `codex/riasec-zh-test-landing-faq-parity-readback-01`
+- blocker type: `operator_hold_requires_fresh_authorization`
+- evidence:
+  - The card is included in the 33-card train.
+  - Prior sequencing held RIASEC zh test landing FAQ parity readback as temporarily deferred / not current next step.
+  - No fresh authorization in this PR scope permits runtime fetch, API/CMS readback, or repair.
+- why not current PR scope:
+  - Current PR is generated-only held reporting.
+  - It is not authorized to fetch production runtime, query CMS/API, edit FAQ, edit JSON-LD, mutate SEO surfaces, or deploy.
+- whether required checks are affected: `false`
+- recommended follow-up:
+  - Provide fresh exact authorization for `RIASEC-ZH-TEST-LANDING-FAQ-PARITY-READBACK-01` before running runtime parity readback.
+- whether train continued: `true`


### PR DESCRIPTION
## What changed
- Added generated-only held report for RIASEC zh test landing FAQ parity readback.
- Recorded that fresh exact authorization is required before runtime/API/CMS readback.
- Appended sidecar issue for the operator hold.

## Why
- This card was included in the 33-card train, but prior sequencing held it as deferred/not current next step.
- The train should record the hold without doing runtime readback or repair.

## Validation
- python3 -m json.tool backend/docs/seo/daily-runs/2026-07-06/riasec-zh-test-landing-faq-parity-readback-01/scan_manifest.json >/dev/null
- python3 -m json.tool generated/pr-train-sidecar-issues/sidecar_issues.json >/dev/null
- git diff --check
- git diff --cached --check

## Deferred items
- No runtime fetch, API/CMS readback, FAQ edits, JSON-LD edits, sitemap/llms/canonical/noindex changes, frontend work, production import, or deployment.
- Fresh exact authorization is required before running the parity readback.