### PR TITLE
fix(seo): keep stale sitemap cache and schedule sitemap source warm

### DIFF
--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -527,6 +527,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('norms:big5:roll --window_days=365')->monthlyOn(1, '04:30')->withoutOverlapping();
         $schedule->command('norms:big5:monthly-drift-check')->monthlyOn(1, '04:50')->withoutOverlapping();
         $schedule->command('norms:eq60:drift-check --from=active --to=candidate')->monthlyOn(1, '05:00')->withoutOverlapping();
+        $schedule->command('seo:warm-sitemap-source-cache --json')->everyTenMinutes()->withoutOverlapping();
     }
 
     /**

--- a/backend/app/Services/SEO/SeoDiscoverabilityCacheInvalidator.php
+++ b/backend/app/Services/SEO/SeoDiscoverabilityCacheInvalidator.php
@@ -10,13 +10,18 @@ use Illuminate\Support\Facades\Cache;
 final class SeoDiscoverabilityCacheInvalidator
 {
     /**
+     * Flush article discoverability caches.
+     *
+     * Deletes the fresh sitemap-source cache and backend XML sitemap/ETag caches,
+     * but KEEPS the stale sitemap-source cache as a safety net during the gap window
+     * between publish and the next seo:warm-sitemap-source-cache run.
+     *
      * @return list<string>
      */
     public function flushArticleDiscoverabilityCaches(): array
     {
         $keys = [
             SitemapSourceController::CACHE_KEY_FRESH,
-            SitemapSourceController::CACHE_KEY_STALE,
             SitemapCache::XML_CACHE_KEY,
             SitemapCache::ETAG_CACHE_KEY,
         ];

--- a/backend/tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
+++ b/backend/tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
@@ -78,7 +78,7 @@ final class ArticlePublishDiscoverabilityCacheInvalidationTest extends TestCase
     private function assertDiscoverabilityCachesFlushed(): void
     {
         $this->assertNull(Cache::get(SitemapSourceController::CACHE_KEY_FRESH));
-        $this->assertNull(Cache::get(SitemapSourceController::CACHE_KEY_STALE));
+        $this->assertNotNull(Cache::get(SitemapSourceController::CACHE_KEY_STALE), 'Stale sitemap-source cache must be retained as safety net during gap window.');
         $this->assertNull(Cache::get(SitemapCache::XML_CACHE_KEY));
         $this->assertNull(Cache::get(SitemapCache::ETAG_CACHE_KEY));
     }


### PR DESCRIPTION
## Problem

- Sitemap-source cache had a permanent stale gap: 2,387 cached entries vs 2,389 generator output (observed 2026-06-03)
- After article publish, the sitemap-source API returned only \~20 fallback paths — not \~2,389 actual paths
- The warm command existed but was never scheduled, so caches never auto-rebuilt

## Root Cause

Two bugs:

1. **`seo:warm-sitemap-source-cache` never scheduled** — the command was implemented but never added to `Kernel::schedule()`. After the fresh cache TTL (10 min) expired, the API fell back to stale; after stale expired (24h) or article publish flushed both, the API fell back to \~20 hardcoded paths — and stayed there.

2. **`flushArticleDiscoverabilityCaches()` deleted both fresh AND stale** — on article publish, both `CACHE_KEY_FRESH` and `CACHE_KEY_STALE` were deleted, leaving only the fallback. Since no scheduled warm existed, this was effectively permanent.

## Fix

| File | Change |
|---|---|
| `SeoDiscoverabilityCacheInvalidator.php` | Stop deleting `CACHE_KEY_STALE` — retain as safety net during gap window |
| `Kernel.php` | Schedule `seo:warm-sitemap-source-cache --json` every 10 min, `withoutOverlapping()` |
| `ArticlePublishDiscoverabilityCacheInvalidationTest.php` | Assert stale cache is retained after publish |

## Runtime Impact

**Before:** Article publish → fallback (\~20 paths) until manual warm

**After:** Article publish → stale cache (\~2,389 paths) for max 10 min gap, then fresh. If warm fails, stale retained.

## Validation

```
php artisan test --filter ArticlePublishDiscoverabilityCacheInvalidationTest
# 3/3 PASS

php artisan test --filter "Sitemap|sitemap"
# 79/81 PASS (2 pre-existing failures unrelated)
#   - EnParity03ContentPagesParityImportPackageTest
#   - GlobalEnZhParityP001ContentHelpPolicyDiscoverabilityTest
```

## Impact

- **Search submission**: none
- **Deployment**: takes effect on next normal fap-api deploy
- **CMS**: no changes

## Explicitly Deferred

- Non-article content type cache invalidation (personality, career, topics, content pages)
- Frontend sitemap.xml rebuild trigger
- Search submission (Google/Baidu/Bing/IndexNow)
- IQ scoring remediation
- MBTI funnel analysis