### PR TITLE
fix(scheduler): register seo:warm-sitemap-source-cache in bootstrap/app.php

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -60,6 +60,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('norms:big5:roll --window_days=365')->monthlyOn(1, '04:30')->withoutOverlapping();
         $schedule->command('norms:big5:monthly-drift-check')->monthlyOn(1, '04:50')->withoutOverlapping();
         $schedule->command('norms:eq60:drift-check --from=active --to=candidate')->monthlyOn(1, '05:00')->withoutOverlapping();
+        $schedule->command('seo:warm-sitemap-source-cache --json')->everyTenMinutes()->withoutOverlapping();
     })
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->alias([

--- a/backend/tests/Feature/SEO/SitemapWarmSchedulerBootstrapTest.php
+++ b/backend/tests/Feature/SEO/SitemapWarmSchedulerBootstrapTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+final class SitemapWarmSchedulerBootstrapTest extends TestCase
+{
+    public function test_sitemap_warm_command_is_registered_in_scheduler(): void
+    {
+        $events = $this->scheduleListEvents();
+        $event = collect($events)->first(
+            fn (array $event): bool => str_contains((string) ($event['command'] ?? ''), 'seo:warm-sitemap-source-cache')
+        );
+
+        $this->assertNotNull($event, 'schedule:list did not include seo:warm-sitemap-source-cache.');
+        $command = (string) $event['command'];
+
+        $this->assertStringContainsString('seo:warm-sitemap-source-cache', $command);
+        $this->assertStringContainsString('--json', $command);
+        $this->assertSame('*/10 * * * *', $event['expression']);
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function scheduleListEvents(): array
+    {
+        $process = new Process([PHP_BINARY, base_path('artisan'), 'schedule:list', '--json', '--no-ansi'], base_path());
+        $process->mustRun();
+
+        $decoded = json_decode($process->getOutput(), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
Add `seo:warm-sitemap-source-cache --json` to `bootstrap/app.php` `->withSchedule()` closure.

## Why
The application uses Laravel 11+ `bootstrap/app.php` `->withSchedule()` pattern for schedule registration, which takes precedence over `Kernel::schedule()`. PR #2816 added the warm command to `Kernel::schedule()` (dead code path) but not to `bootstrap/app.php` (active path).

**Impact**: Since deployment, the scheduler has never executed `seo:warm-sitemap-source-cache`. The sitemap-source cache was populated by the deploy-time warm only. The stale cache (24h TTL) provided a safety net, but the fresh cache expired after 10 minutes with no automatic rebuild.

## Validation
- `php artisan test --filter='SitemapWarm|SitemapSource|TestMetricsScheduler'` — 20 tests passed
- `php artisan schedule:list | grep 'seo:warm-sitemap'` — command now visible at `*/10 * * * *`
- `git diff --check` — clean

## Deferred
- `email:lifecycle-rollout`, `commerce:repair-paid-orders`, and `commerce:repair-post-commit-failed` have the same root cause (in Kernel but not in bootstrap/app.php) — separate follow-up PR.