### PR TITLE
fix(seo): include published Big Five hub in sitemap and llms discovery

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -326,6 +326,7 @@ class SitemapGenerator
             ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
             ->where('locale', 'zh-CN')
             ->whereIn('entity_type', [
+                PersonalityPublicContentAsset::ENTITY_HUB,
                 PersonalityPublicContentAsset::ENTITY_DOMAIN,
                 PersonalityPublicContentAsset::ENTITY_POLARITY,
             ])
@@ -344,7 +345,8 @@ class SitemapGenerator
 
         foreach ($rows as $row) {
             $path = trim((string) data_get($row->canonical_json, 'path', ''));
-            if (! str_starts_with($path, '/zh/personality/big-five/')) {
+            if (! str_starts_with($path, '/zh/personality/big-five/')
+                && $path !== '/zh/personality/big-five') {
                 continue;
             }
 

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -213,6 +213,17 @@ class SitemapGeneratorTest extends TestCase
         $this->createBigFivePublicContentAsset('hub', PersonalityPublicContentAsset::ENTITY_HUB, [
             'canonical_json' => ['path' => '/zh/personality/big-five'],
         ]);
+        $this->createBigFivePublicContentAsset('hub-noindex', PersonalityPublicContentAsset::ENTITY_HUB, [
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'canonical_json' => ['path' => '/zh/personality/big-five-noindex'],
+        ]);
+        $this->createBigFivePublicContentAsset('hub-draft', PersonalityPublicContentAsset::ENTITY_HUB, [
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            'sitemap_eligible' => false,
+            'canonical_json' => ['path' => '/zh/personality/big-five-draft'],
+        ]);
         $this->createBigFivePublicContentAsset('openness-noindex', PersonalityPublicContentAsset::ENTITY_DOMAIN, [
             'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
             'index_eligible' => false,
@@ -245,12 +256,20 @@ class SitemapGeneratorTest extends TestCase
             $this->assertContains("personality-public-content:big-five:zh:{$slug}", $slugList);
         }
 
+        // Hub should be included when published and eligible
+        $this->assertStringContainsString('https://fermatmind.com/zh/personality/big-five', $xml);
+        $this->assertContains('personality-public-content:big-five:zh:hub', $slugList);
+
         $this->assertStringNotContainsString('https://fermatmind.com/en/personality/big-five/openness', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-noindex', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-review', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-sitemap-off', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-llms-off', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/big-five/openness', $xml);
+
+        // Hub should NOT be included when noindex or draft
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five-noindex', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five-draft', $xml);
     }
 
     public function test_generate_excludes_science_content_pages_until_public_readiness_gate_passes(): void


### PR DESCRIPTION
## Problem
/zh/personality/big-five Hub has index_eligible=1, robots=index,follow, sitemap_eligible=1, llms_eligible=1, launch_state=published, review_state=seo_discoverability_released. But the Hub was excluded from sitemap.xml, llms.txt, and llms-full.txt.

## Root cause
1. SitemapGenerator::getPersonalityPublicContentAssetUrls() had `whereIn('entity_type', ['domain', 'polarity'])` — hub excluded.
2. The path guard `str_starts_with(/Applications/WorkBuddy.app/Contents/Resources/app.asar.unpacked/cli/vendor/shim/safe-bin /Users/rainie/.workbuddy/binaries/node/versions/22.22.2/bin /Users/rainie/.workbuddy/binaries/python/versions/3.13.12/bin /Users/rainie/.workbuddy/binaries/node/cli-connector-packages/bin /Applications/WorkBuddy.app/Contents/Resources/app.asar.unpacked/cli/vendor/shim/safe-bin /usr/local/bin /Users/rainie/.local/node20/bin /Users/rainie/bin /Users/rainie/bin /Users/rainie/.npm-global/bin /usr/local/bin /Users/rainie/.local/node20/bin /opt/homebrew/bin /opt/homebrew/sbin /usr/local/bin /System/Cryptexes/App/usr/bin /usr/bin /bin /usr/sbin /sbin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin /pkg/env/global/bin /Users/rainie/.local/node20/bin /Users/rainie/bin /Users/rainie/.npm-global/bin, '/zh/personality/big-five/')` required trailing slash — Hub path (`/zh/personality/big-five`) failed.

## Fix
- Add `ENTITY_HUB` to `whereIn` filter
- Accept path `/zh/personality/big-five` without trailing slash

## Safety gates
- All existing strictness gates preserved
- Only published, eligible hubs are included
- noindex/draft hubs remain excluded (tested)
- Domain/polarity pages unaffected (no regression)

## Tests
- Hub included in sitemap when published and eligible
- noindex hub excluded
- draft hub excluded
- All 9 existing SitemapGeneratorTest tests pass
- All 43 related tests pass

## Runtime impact
- sitemap-source will include Hub on next warm
- sitemap.xml, llms.txt, llms-full.txt will include Hub

## Search submission impact: none
## Deployment impact: not executed

## Explicitly deferred
- facet_hub discoverability
- Enneagram/RIASEC hubs
- BigFiveSeoDiscoverabilityReleaseWriter hub gate (DB already fixed)
- content changes
- search submission