### PR TITLE
feat(enneagram): support generic content sections in CMS draft writer

### DIFF
--- a/backend/app/Services/Cms/EnneagramCmsDraftWriter.php
+++ b/backend/app/Services/Cms/EnneagramCmsDraftWriter.php
@@ -365,6 +365,13 @@ final class EnneagramCmsDraftWriter
      */
     private function contentSections(string $quickAnswer, array $recommendations): array
     {
+        // Generic sections array takes priority when present.
+        $genericSections = $recommendations['sections'] ?? null;
+        if (is_array($genericSections) && $genericSections !== []) {
+            return $this->normalizeSections($genericSections);
+        }
+
+        // Legacy: quick_answer + differentiation_notes
         $sections = [];
         if ($quickAnswer !== '') {
             $sections[] = [
@@ -387,6 +394,24 @@ final class EnneagramCmsDraftWriter
         }
 
         return $sections;
+    }
+
+    /**
+     * @param  list<array{key?:string,title?:string,body_md?:string,body_html?:string}>  $sections
+     * @return list<array{key:string,title:string,body_md:string}>
+     */
+    private function normalizeSections(array $sections): array
+    {
+        return array_values(array_filter(
+            array_map(static function (array $section): array {
+                return [
+                    'key' => trim((string) ($section['key'] ?? '')),
+                    'title' => trim((string) ($section['title'] ?? '')),
+                    'body_md' => trim((string) ($section['body_md'] ?? $section['body_html'] ?? '')),
+                ];
+            }, $sections),
+            static fn (array $section): bool => $section['key'] !== ''
+        ));
     }
 
     private function qaDecisionPasses(string $decision): bool


### PR DESCRIPTION
## Problem

`EnneagramCmsDraftWriter::contentSections()` only supports two section types: `quick_answer` and `differentiation_notes`. This blocks importing full-fidelity multi-section content (type_overview, core_motivation, strengths_and_blind_spots, stress_and_growth, etc.) that the FermatMind Enneagram content draft contains.

## Fix

Add generic sections support with backward compatibility:
- When `recommendations.sections[]` is present, use it directly
- Each section: `{key, title, body_md}`
- Falls back to legacy `quick_answer` + `differentiation_notes` when sections is absent
- New `normalizeSections()` method for sanitization

## Changed

1 file, +25 lines: `backend/app/Services/Cms/EnneagramCmsDraftWriter.php`

## Validation

```
php artisan test --filter PersonalityEnneagramCmsDraftCommandTest
# 6/6 PASS (backward compatible)

php artisan test --filter Enneagram
# 228/228 PASS, 39 skipped
```

## Impact

- **CMS:** no writes (this is infrastructure only)
- **No CMS drafts created** by this PR
- **No publish, no index, no sitemap changes**
- Enables next step: importing the 13-page ZH Enneagram content draft as CMS draft assets

## Deferred

- Actual CMS draft import (separate task, uses this PR's sections support)
- CMS draft → content_ready promotion
- Index/sitemap enablement