### PR TITLE
feat(api): add facet_detail entity type to Big Five content assets

### DIFF
--- a/backend/app/Models/PersonalityPublicContentAsset.php
+++ b/backend/app/Models/PersonalityPublicContentAsset.php
@@ -34,6 +34,8 @@ final class PersonalityPublicContentAsset extends Model
 
     public const ENTITY_FACET = 'facet';
 
+    public const ENTITY_FACET_DETAIL = 'facet_detail';
+
     public const ENTITY_CENTER = 'center';
 
     public const ENTITY_CORE_TYPE = 'core_type';
@@ -48,6 +50,7 @@ final class PersonalityPublicContentAsset extends Model
         self::ENTITY_POLARITY,
         self::ENTITY_FACET_HUB,
         self::ENTITY_FACET,
+        self::ENTITY_FACET_DETAIL,
         self::ENTITY_CENTER,
         self::ENTITY_CORE_TYPE,
         self::ENTITY_WING,
@@ -61,6 +64,7 @@ final class PersonalityPublicContentAsset extends Model
             self::ENTITY_POLARITY,
             self::ENTITY_FACET_HUB,
             self::ENTITY_FACET,
+            self::ENTITY_FACET_DETAIL,
         ],
         self::FRAMEWORK_ENNEAGRAM => [
             self::ENTITY_HUB,

--- a/backend/content_assets/personality_public/big_five_v1_seed.json
+++ b/backend/content_assets/personality_public/big_five_v1_seed.json
@@ -10180,6 +10180,7026 @@
           "body_md": "脆弱性是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
         }
       ]
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "achievement-striving",
+      "entity_key": "achievement-striving",
+      "slug": "big-five/facets/achievement-striving",
+      "locale": "zh-CN",
+      "title": "成就追求（尽责性）",
+      "summary": "成就追求描述设立高目标并努力达成的倾向，是尽责性维度中与抱负和进取心相关的细分面向。",
+      "seo": {
+        "title": "成就追求｜大五人格 30 个细分面向",
+        "description": "成就追求描述设立高目标并努力达成的倾向，是尽责性维度中与抱负和进取心相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/achievement-striving",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/achievement-striving"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/achievement-striving",
+        "en": "/en/personality/big-five/facets/achievement-striving"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "成就追求描述设立高目标并努力达成的倾向，是尽责性维度中与抱负和进取心相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是成就追求？",
+          "body": "成就追求是尽责性维度中与目标设定和进取心相关的细分面向。高分通常表示有强烈的成就感驱动，喜欢设立具有挑战性的目标并为之努力，对自身进步和成就感到满足。低分通常表示对成就的追求较温和，不一定需要不断挑战更高目标来获得满足，能在不施加额外成就压力的情况下保持平衡。高成就追求带来动力，但也可能带来倦怠风险。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：经常为自己设定更高的目标，对职业和个人成长有明确的抱负，完成任务后很快开始寻找下一个挑战，在竞争性环境和需要持续进步的岗位中有优势，可能因为过度追求而忽视休息和关系。\n\n**偏低时**：更看重过程而非结果，能在不刻意追求的情况下享受工作和生活，不容易因外部成就标准而焦虑，在需要稳定输出和长期平衡的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "achievement-striving-faq-1",
+          "question": "成就追求分数低就是不上进吗？",
+          "answer": "不是。低成就追求不等于不上进，只是不太以高标准目标作为主要驱动力。你可能更关注工作本身的意义、关系的质量或生活的平衡，这些同样是积极的人生态度。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "成就追求的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "尽责性",
+          "href": "/zh/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "actions",
+      "entity_key": "actions",
+      "slug": "big-five/facets/actions",
+      "locale": "zh-CN",
+      "title": "行动尝试（开放性）",
+      "summary": "行动尝试描述愿意尝试新活动、新体验和不同生活方式的倾向，是开放性维度中与行为探索相关的细分面向。",
+      "seo": {
+        "title": "行动尝试｜大五人格 30 个细分面向",
+        "description": "行动尝试描述愿意尝试新活动、新体验和不同生活方式的倾向，是开放性维度中与行为探索相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/actions",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/actions"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/actions",
+        "en": "/en/personality/big-five/facets/actions"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "行动尝试描述愿意尝试新活动、新体验和不同生活方式的倾向，是开放性维度中与行为探索相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是行动尝试？",
+          "body": "行动尝试是开放性维度中与行为层面探索相关的细分面向。高分通常表示愿意尝试新的活动、食物、旅行目的地和生活方式，在实际行为中体现对新体验的开放。低分通常表示偏好熟悉的活动和稳定的生活节奏，在已知范围内找到满意和舒适。行动尝试不同于冲动——前者是有意识的探索意愿，后者是缺乏控制的即时反应。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：经常主动寻找新体验，旅行、饮食、兴趣爱好等方面变化较多，面对新活动时第一反应是“试试看”，可能因为追求多样性而难以长期坚持单一项目。\n\n**偏低时**：偏好稳定和可预测的活动模式，在熟悉的环境中感到舒适和安全，喜欢深入而非广泛探索，在需要长期专注和持续深入的任务中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "actions-faq-1",
+          "question": "行动尝试高会不会导致不专一？",
+          "answer": "不必然。行动尝试反映的是探索意愿的广度，而非坚持能力的强弱。高行动尝试的人可以通过结构化的方式管理探索——比如在不同领域交替深入，或在主业之外保留探索空间。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "行动尝试的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "开放性",
+          "href": "/zh/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "activity",
+      "entity_key": "activity",
+      "slug": "big-five/facets/activity",
+      "locale": "zh-CN",
+      "title": "活跃度（外向性）",
+      "summary": "活跃度描述保持忙碌、快节奏和高能量水平的倾向，是外向性维度中与精力水平和行动速度相关的细分面向。",
+      "seo": {
+        "title": "活跃度｜大五人格 30 个细分面向",
+        "description": "活跃度描述保持忙碌、快节奏和高能量水平的倾向，是外向性维度中与精力水平和行动速度相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/activity",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/activity"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/activity",
+        "en": "/en/personality/big-five/facets/activity"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "活跃度描述保持忙碌、快节奏和高能量水平的倾向，是外向性维度中与精力水平和行动速度相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是活跃度？",
+          "body": "活跃度是外向性维度中与精力水平和行动节奏相关的细分面向。高分通常表示喜欢忙碌和快节奏的生活，难以忍受无所事事的状态，总是在寻找下一个任务或活动。低分通常表示偏好较慢的节奏，能在安静和休息中感到自在，不需要持续的活动来维持满足感。活跃度反映的是能量输出的节奏偏好，不是效率或产出。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：日程排得较满，精力充沛，不喜欢长时间闲着，在快节奏和多任务环境中表现良好，可能因为持续高速运转而忽略休息和恢复。\n\n**偏低时**：偏好适中的节奏，能接受甚至享受无所事事的时刻，在需要耐心和持续稳定输出的任务中有优势，但可能在需要快速响应和高强度输出的场景中感到吃力。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "activity-faq-1",
+          "question": "活跃度低代表效率低吗？",
+          "answer": "不是。活跃度反映的是你偏好保持多快的节奏，不是你在单位时间内完成多少。一个低活跃度的人可能用更少的时间完成更高质量的工作，因为他/她更注重深度而非速度。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "活跃度的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "外向性",
+          "href": "/zh/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "aesthetics",
+      "entity_key": "aesthetics",
+      "slug": "big-five/facets/aesthetics",
+      "locale": "zh-CN",
+      "title": "审美（开放性）",
+      "summary": "审美描述对艺术、美感和自然之美的敏感度，是开放性维度中与感知和欣赏相关的细分面向。",
+      "seo": {
+        "title": "审美｜大五人格 30 个细分面向",
+        "description": "审美描述对艺术、美感和自然之美的敏感度，是开放性维度中与感知和欣赏相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/aesthetics",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/aesthetics"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/aesthetics",
+        "en": "/en/personality/big-five/facets/aesthetics"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "审美描述对艺术、美感和自然之美的敏感度，是开放性维度中与感知和欣赏相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是审美？",
+          "body": "审美是开放性维度中与艺术和美感体验相关的细分面向。高分通常表示对音乐、视觉艺术、文学和自然之美有强烈的感受和兴趣，美的事物能带来深层的情绪反应。低分通常表示对艺术和美感的关注较少，更重视功能性和实用性。审美不是品位高低——低审美并不等于“缺乏欣赏能力”，只是美感和艺术在日常决策中的权重不同。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：容易被建筑、音乐、设计或自然景观触动，在选择环境和物品时美感和氛围是重要的考虑因素，可能投入时间和精力在艺术欣赏和创作上。\n\n**偏低时**：美感不是决策的主要依据，对环境外观和艺术表达的敏感度较低，更看重功能、效率和实用性，这在需要快速决策和资源优化的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "aesthetics-faq-1",
+          "question": "审美分数低代表没有艺术细胞吗？",
+          "answer": "不代表。审美分数反映的是你对美感和艺术的重视程度，不是你的艺术能力或品位。许多优秀的工程师和设计师在审美上得分并不高——他们更关注功能和逻辑，但仍然能做出优秀的设计。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "审美的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "开放性",
+          "href": "/zh/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "altruism",
+      "entity_key": "altruism",
+      "slug": "big-five/facets/altruism",
+      "locale": "zh-CN",
+      "title": "利他（宜人性）",
+      "summary": "利他描述主动关心和帮助他人的倾向，是宜人性维度中与助人动机相关的细分面向。",
+      "seo": {
+        "title": "利他｜大五人格 30 个细分面向",
+        "description": "利他描述主动关心和帮助他人的倾向，是宜人性维度中与助人动机相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/altruism",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/altruism"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/altruism",
+        "en": "/en/personality/big-five/facets/altruism"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "利他描述主动关心和帮助他人的倾向，是宜人性维度中与助人动机相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是利他？",
+          "body": "利他是宜人性维度中与助人行为相关的细分面向。高分通常表示愿意主动帮助他人，在看到他人需要时会产生帮助的内在驱动力，从助人中获得满足感。低分通常表示帮助他人的内在驱动力较弱，更倾向于让每个人自己解决问题，不认为牺牲自己来帮助他人是必要的。利他反映的是助人的内在动机而非实际助人行为——你不一定有内在驱动力但仍然会在需要时伸出援手。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：主动关注他人的困难并提供帮助，在团队中承担额外的支持性工作，从他人的改善中获得满足感，在需要高度协作和人本关怀的角色中有优势，但可能因为过度付出而忽视自身需求。\n\n**偏低时**：认为每个人应该首先为自己负责，帮助他人更多是基于理性判断而非情感驱动，在需要保持独立判断和资源优化的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "altruism-faq-1",
+          "question": "利他分数低就是自私吗？",
+          "answer": "不是。低利他只表示帮助他人的内在驱动力较弱，不等于你自私或不会帮助别人。你可能基于原则或理性决策来帮助他人，只是不觉得这是天经地义的义务。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "利他的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "宜人性",
+          "href": "/zh/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "anger",
+      "entity_key": "anger",
+      "slug": "big-five/facets/anger",
+      "locale": "zh-CN",
+      "title": "愤怒（神经质 / 情绪敏感性）",
+      "summary": "愤怒描述体验到愤怒、挫折和怨恨情绪的倾向，是神经质维度中与敌意反应相关的细分面向。",
+      "seo": {
+        "title": "愤怒｜大五人格 30 个细分面向",
+        "description": "愤怒描述体验到愤怒、挫折和怨恨情绪的倾向，是神经质维度中与敌意反应相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/anger",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/anger"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/anger",
+        "en": "/en/personality/big-five/facets/anger"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "愤怒描述体验到愤怒、挫折和怨恨情绪的倾向，是神经质维度中与敌意反应相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是愤怒？",
+          "body": "愤怒是神经质维度中与敌意和挫折感相关的细分面向。高分通常表示容易因为不公平、受阻或失望而体验到愤怒，愤怒情绪的触发阈值较低，在受挫后可能较难平复。低分通常表示不容易被激怒，对挫折和冒犯的容忍度较高，负面情绪恢复较快。愤怒本身是正常且有时必要的情绪——这个 facet 测量的是愤怒被触发和持续的容易程度。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：对不公平和不合理的事情反应强烈，挫折感容易被触发，在需要维护正义和挑战不公的场景中有优势——高愤怒者往往是推动改变的重要力量，但也需要管理愤怒的表达方式以避免关系破坏。\n\n**偏低时**：不容易因为外界事件而发怒，对挫折和冒犯有较高的容忍度，在需要耐心和情绪稳定的沟通场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "anger-faq-1",
+          "question": "愤怒分数低就是没脾气吗？",
+          "answer": "不是。低愤怒只是意味着你不容易因为外部事件而体验到愤怒情绪。这在面对挑衅时可能是优势，但也可能意味着你在应该愤怒的时候没有及时表达——适当的愤怒对于维护边界和正义是有价值的。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "愤怒的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "神经质 / 情绪敏感性",
+          "href": "/zh/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "anxiety",
+      "entity_key": "anxiety",
+      "slug": "big-five/facets/anxiety",
+      "locale": "zh-CN",
+      "title": "焦虑（神经质 / 情绪敏感性）",
+      "summary": "焦虑描述对未来和不确定性感到担忧和紧张的倾向，是神经质维度中与预期性担忧相关的细分面向。",
+      "seo": {
+        "title": "焦虑｜大五人格 30 个细分面向",
+        "description": "焦虑描述对未来和不确定性感到担忧和紧张的倾向，是神经质维度中与预期性担忧相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/anxiety",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/anxiety"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/anxiety",
+        "en": "/en/personality/big-five/facets/anxiety"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "焦虑描述对未来和不确定性感到担忧和紧张的倾向，是神经质维度中与预期性担忧相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是焦虑？",
+          "body": "焦虑是神经质维度中与未来导向的担忧和紧张相关的细分面向。高分通常表示对未来和不确定性容易产生担忧，脑海中经常预演负面可能性，在面对不明确的情境时紧张感较强。低分通常表示对未来的担忧较少，能在不确定性中保持平静，不容易陷入反复的负面预演。焦虑反映的是担忧的倾向性，不是焦虑障碍的判断标准——后者需要专业诊断。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：在不确定情境下容易产生紧张和担忧，倾向于预演各种负面可能性，在需要风险预警和细致把关的任务中有价值——高焦虑者往往是最先注意到潜在问题的人，但也因为持续的高警觉状态消耗大量心理资源。\n\n**偏低时**：在面临不确定性和风险时保持相对平静，不容易被“what if”式的担忧干扰注意力，在需要冷静判断和快速决策的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "anxiety-faq-1",
+          "question": "焦虑分数高就是焦虑症吗？",
+          "answer": "不是。焦虑分数反映的是担忧的倾向性，是一种人格特质。焦虑症是临床诊断，需要达到特定的症状标准和功能损害程度。如果你对焦虑水平感到困扰，建议咨询专业心理健康服务。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "焦虑的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "神经质 / 情绪敏感性",
+          "href": "/zh/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "assertiveness",
+      "entity_key": "assertiveness",
+      "slug": "big-five/facets/assertiveness",
+      "locale": "zh-CN",
+      "title": "果断性（外向性）",
+      "summary": "果断性描述在群体中表达立场、主导方向和影响他人的倾向，是外向性维度中与领导力表达相关的细分面向。",
+      "seo": {
+        "title": "果断性｜大五人格 30 个细分面向",
+        "description": "果断性描述在群体中表达立场、主导方向和影响他人的倾向，是外向性维度中与领导力表达相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/assertiveness",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/assertiveness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/assertiveness",
+        "en": "/en/personality/big-five/facets/assertiveness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "果断性描述在群体中表达立场、主导方向和影响他人的倾向，是外向性维度中与领导力表达相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是果断性？",
+          "body": "果断性是外向性维度中与主导和影响力表达相关的细分面向。高分通常表示在群体中敢于表达观点和引导方向，不回避冲突和竞争，善于争取资源和机会。低分通常表示在群体中偏好跟随而非主导，不急于表达立场，在决策时更愿意倾听各方意见后再表态。果断性不是能力判断——一个低调的人同样可以具有深远的影响力。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：在会议和讨论中积极发言，敢于对不同意见说“不”，在需要快速决策和领导力的场景中有优势，可能因为过于主导而压制了他人表达的空间。\n\n**偏低时**：倾向于先观察和倾听再做判断，不急于抢占发言权，在需要多方协调和共识构建的场景中有优势，但可能在需要快速抢占机会时行动不够迅速。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "assertiveness-faq-1",
+          "question": "果断性低的人不能做领导吗？",
+          "answer": "不是。领导力有多种风格。低果断性的领导者通常以提问、赋能和共识构建的方式引导团队，在需要长期战略和团队深度的场景中可能比高果断性更有效。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "果断性的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "外向性",
+          "href": "/zh/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "competence",
+      "entity_key": "competence",
+      "slug": "big-five/facets/competence",
+      "locale": "zh-CN",
+      "title": "胜任感（尽责性）",
+      "summary": "胜任感描述对自己能够有效完成任务的确信程度，是尽责性维度中与自我效能感相关的细分面向。",
+      "seo": {
+        "title": "胜任感｜大五人格 30 个细分面向",
+        "description": "胜任感描述对自己能够有效完成任务的确信程度，是尽责性维度中与自我效能感相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/competence",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/competence"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/competence",
+        "en": "/en/personality/big-five/facets/competence"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "胜任感描述对自己能够有效完成任务的确信程度，是尽责性维度中与自我效能感相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是胜任感？",
+          "body": "胜任感是尽责性维度中与自我效能感相关的细分面向。高分通常表示对自己完成任务的能力有信心，相信自己的努力能产生预期结果，遇到困难时倾向于坚持而非放弃。低分通常表示对自己能力的信心较低，做决策时常伴随犹豫和自我怀疑。胜任感反映的是主观信念而非客观能力——一个实际能力很强的人也可能胜任感偏低。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：面对新任务时倾向于认为自己能处理好，在挑战面前保持积极的心态，对自己的判断和决策有信心，可能因为过度自信而低估任务的真实难度。\n\n**偏低时**：对自己的能力持审慎态度，做事之前倾向于充分准备和反复确认，在需要谨慎规划和风险控制的场景中有优势，但可能因自我怀疑而错过机会。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "competence-faq-1",
+          "question": "胜任感和实际能力是一回事吗？",
+          "answer": "不是。胜任感是你对自己能力的主观信念，实际能力是客观的技能和知识水平。两者不一定同步——有些能力很强的人胜任感偏低，反之亦然。提升胜任感的一种方式是记录自己成功完成任务的经历。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "胜任感的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "尽责性",
+          "href": "/zh/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "compliance",
+      "entity_key": "compliance",
+      "slug": "big-five/facets/compliance",
+      "locale": "zh-CN",
+      "title": "顺从（宜人性）",
+      "summary": "顺从描述在冲突中让步和配合的倾向，是宜人性维度中与冲突处理风格相关的细分面向。",
+      "seo": {
+        "title": "顺从｜大五人格 30 个细分面向",
+        "description": "顺从描述在冲突中让步和配合的倾向，是宜人性维度中与冲突处理风格相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/compliance",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/compliance"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/compliance",
+        "en": "/en/personality/big-five/facets/compliance"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "顺从描述在冲突中让步和配合的倾向，是宜人性维度中与冲突处理风格相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是顺从？",
+          "body": "顺从是宜人性维度中与冲突回避和配合意愿相关的细分面向。高分通常表示在冲突中倾向于退让和寻求和解，不喜欢对抗和竞争，认为维持关系和谐比争赢更重要。低分通常表示在冲突中不回避对抗，敢于坚持立场和挑战不同意见，认为把问题说清楚比表面的和谐更重要。顺从不是软弱——它是在冲突中优先选择关系还是立场的差异。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：冲突中首先考虑如何维护关系，不介意做出让步以达成共识，在需要协调多方利益和化解矛盾的场景中有优势，可能因为过度退让而压抑了自己的合理需求。\n\n**偏低时**：在冲突中不回避争论，愿意直面分歧并坚持自己的立场，在需要维护原则和推动变革的场景中有优势，但可能在关系维护上付出较高的沟通成本。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "compliance-faq-1",
+          "question": "顺从和讨好有什么不同？",
+          "answer": "顺从是在冲突中选择配合和退让的策略倾向，前提是你清楚自己的立场并自愿选择退让。讨好则是出于对被拒绝或不被喜欢的恐惧而压抑真实需求，常常伴随焦虑和自我否定。前者是策略，后者是防御。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "顺从的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "宜人性",
+          "href": "/zh/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "deliberation",
+      "entity_key": "deliberation",
+      "slug": "big-five/facets/deliberation",
+      "locale": "zh-CN",
+      "title": "审慎（尽责性）",
+      "summary": "审慎描述在做决定前仔细思考、评估后果的倾向，是尽责性维度中与决策谨慎度相关的细分面向。",
+      "seo": {
+        "title": "审慎｜大五人格 30 个细分面向",
+        "description": "审慎描述在做决定前仔细思考、评估后果的倾向，是尽责性维度中与决策谨慎度相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/deliberation",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/deliberation"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/deliberation",
+        "en": "/en/personality/big-five/facets/deliberation"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "审慎描述在做决定前仔细思考、评估后果的倾向，是尽责性维度中与决策谨慎度相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是审慎？",
+          "body": "审慎是尽责性维度中与决策前的思考过程相关的细分面向。高分通常表示在行动前会仔细权衡利弊，倾向于收集充分信息后再做决定，不容易冲动行事。低分通常表示决策速度较快，不倾向于花太多时间在权衡和分析上，更信任自己的直觉和即时判断。审慎和决断力是同一维度的两端——两者的价值取决于任务性质。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：重大决策前会进行系统性的分析和信息收集，不容易被冲动或情绪驱动做出仓促决定，在高风险和高后果的场景中有显著优势，可能因为反复权衡而错过时间窗口。\n\n**偏低时**：决策果断、行动迅速，在需要快速反应和灵活调整的场景中有优势，不因过多分析而陷入决策瘫痪，但可能在重要决策中因为缺乏充分思考而付出代价。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "deliberation-faq-1",
+          "question": "审慎和优柔寡断有什么区别？",
+          "answer": "审慎是有意识地在行动前考虑后果，是一种可控的策略选择。优柔寡断则是在已经掌握足够信息后仍然无法做出决定，通常伴随焦虑和回避。高审慎的人可以在信息充分后果断决策。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "审慎的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "尽责性",
+          "href": "/zh/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "depression",
+      "entity_key": "depression",
+      "slug": "big-five/facets/depression",
+      "locale": "zh-CN",
+      "title": "抑郁（神经质 / 情绪敏感性）",
+      "summary": "抑郁描述体验到悲伤、低落和无力感的倾向，是神经质维度中与负面心境相关的细分面向。",
+      "seo": {
+        "title": "抑郁｜大五人格 30 个细分面向",
+        "description": "抑郁描述体验到悲伤、低落和无力感的倾向，是神经质维度中与负面心境相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/depression",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/depression"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/depression",
+        "en": "/en/personality/big-five/facets/depression"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "抑郁描述体验到悲伤、低落和无力感的倾向，是神经质维度中与负面心境相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是抑郁？",
+          "body": "抑郁是神经质维度中与悲伤和低落情绪相关的细分面向。高分通常表示较容易体验到悲伤、无力和挫败感，在遇到挫折后有较长的低落期，对未来可能持有较悲观的预期。低分通常表示较少体验到悲伤和低落情绪，在遭遇挫折后能较快恢复。需要明确区分：这个 facet 测量的是体验悲伤的倾向性，不是抑郁症的判断标准。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：对损失和挫折有更强烈的情绪反应，悲伤和失落的体验较深且恢复较慢，在需要深度情感理解和艺术表达的活动中有独特的敏锐度，但也因为较长的恢复周期而消耗较多心理资源。\n\n**偏低时**：在遭遇挫折后能较快恢复到正常状态，较少被低落情绪占据，在需要持续稳定输出的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "depression-faq-1",
+          "question": "抑郁分数高和抑郁症有什么关系？",
+          "answer": "抑郁 facet 反映的是体验悲伤和低落的倾向性，是一种人格特质维度。抑郁症是临床诊断，需要专业评估。高分数不表示你患有抑郁症，但如果你长期感到无法摆脱的低落情绪，建议寻求专业帮助。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "抑郁的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "神经质 / 情绪敏感性",
+          "href": "/zh/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "dutifulness",
+      "entity_key": "dutifulness",
+      "slug": "big-five/facets/dutifulness",
+      "locale": "zh-CN",
+      "title": "责任感（尽责性）",
+      "summary": "责任感描述遵守规则、履行承诺和遵循道德准则的倾向，是尽责性维度中与义务意识相关的细分面向。",
+      "seo": {
+        "title": "责任感｜大五人格 30 个细分面向",
+        "description": "责任感描述遵守规则、履行承诺和遵循道德准则的倾向，是尽责性维度中与义务意识相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/dutifulness",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/dutifulness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/dutifulness",
+        "en": "/en/personality/big-five/facets/dutifulness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "责任感描述遵守规则、履行承诺和遵循道德准则的倾向，是尽责性维度中与义务意识相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是责任感？",
+          "body": "责任感是尽责性维度中与义务和规则遵守相关的细分面向。高分通常表示重视承诺和规则，认为遵守约定和社会规范是重要的，在团队中是可以信赖的成员。低分通常表示对规则和约定持更灵活的态度，倾向于根据具体情况调整行为，不一定认为所有规则都需要严格遵循。责任感不是道德判断——它反映的是你多大程度上以内化的义务感驱动行为。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：承诺过的事会尽力完成，重视守时和诚信，倾向于遵守流程和规范，在需要可靠性和一致性的角色中有显著优势，可能因为过于坚守规则而在需要灵活变通时感到困难。\n\n**偏低时**：对规则和承诺持更弹性的态度，能根据情境判断什么是更合理的做法，在需要突破常规和创新解决方案的场景中有优势，但可能在需要长期承诺和稳定交付的任务中出现断档。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "dutifulness-faq-1",
+          "question": "责任感和道德水平有关吗？",
+          "answer": "责任感是人格特质，描述的是你倾向于遵守承诺和规则的程度，不是道德水平的高低。一个低责任感的人可能有很强的个人道德准则，只是不认为所有形式的规则和承诺都需要同等对待。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "责任感的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "尽责性",
+          "href": "/zh/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "excitement-seeking",
+      "entity_key": "excitement-seeking",
+      "slug": "big-five/facets/excitement-seeking",
+      "locale": "zh-CN",
+      "title": "刺激寻求（外向性）",
+      "summary": "刺激寻求描述对兴奋、新奇和刺激体验的需求和欣赏，是外向性维度中与感官刺激偏好相关的细分面向。",
+      "seo": {
+        "title": "刺激寻求｜大五人格 30 个细分面向",
+        "description": "刺激寻求描述对兴奋、新奇和刺激体验的需求和欣赏，是外向性维度中与感官刺激偏好相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/excitement-seeking",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/excitement-seeking"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/excitement-seeking",
+        "en": "/en/personality/big-five/facets/excitement-seeking"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "刺激寻求描述对兴奋、新奇和刺激体验的需求和欣赏，是外向性维度中与感官刺激偏好相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是刺激寻求？",
+          "body": "刺激寻求是外向性维度中与兴奋和新奇刺激相关的细分面向。高分通常表示享受高强度的感官体验和兴奋感，喜欢刺激的环境、新的冒险和令人心跳加速的活动。低分通常表示偏好平静和可预测的环境，对高强度刺激的需求较低，在安静和舒缓的环境中感到舒适。刺激寻求与冒险行为有一定关联，但不是同一回事。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：喜欢令人兴奋的活动，如旅行冒险、极限运动或热闹的社交场合，对感官刺激有较高的需求，在需要快速适应变化和接受挑战的场景中有优势，可能因为追求刺激而忽视风险评估。\n\n**偏低时**：偏好安静和舒适的环境，对高强度感官刺激的需求较低，在需要稳定、耐心和精细操作的任务中有优势，能在日常生活中找到满足而非依赖外部刺激。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "excitement-seeking-faq-1",
+          "question": "刺激寻求高的人更容易冒险吗？",
+          "answer": "有一定相关性，但不是因果关系。刺激寻求高的人更容易被冒险带来的兴奋感吸引，但实际是否行动还受到审慎（尽责性 facet）、风险评估和具体情境的影响。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "刺激寻求的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "外向性",
+          "href": "/zh/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "feelings",
+      "entity_key": "feelings",
+      "slug": "big-five/facets/feelings",
+      "locale": "zh-CN",
+      "title": "情感体验（开放性）",
+      "summary": "情感体验描述对自己内心情绪状态的觉察和重视程度，是开放性维度中与情绪觉察相关的细分面向。",
+      "seo": {
+        "title": "情感体验｜大五人格 30 个细分面向",
+        "description": "情感体验描述对自己内心情绪状态的觉察和重视程度，是开放性维度中与情绪觉察相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/feelings",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/feelings"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/feelings",
+        "en": "/en/personality/big-five/facets/feelings"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "情感体验描述对自己内心情绪状态的觉察和重视程度，是开放性维度中与情绪觉察相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是情感体验？",
+          "body": "情感体验是开放性维度中与内在情绪觉察相关的细分面向。高分通常表示重视自己的情绪体验，认为情绪是生活中重要的信息来源，愿意花时间理解和表达内心感受。低分通常表示对情绪的重视程度较低，认为情绪不应过多影响判断和决策。这个 facet 描述的是“是否重视情绪”而非“情绪是否强烈”——后者更多与神经质维度相关。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：能细致分辨不同的情绪状态，愿意表达和分享自己的内心感受，认为情感体验是充实生活的重要部分，可能在做决策时将直觉和情绪感受纳入考量。\n\n**偏低时**：更倾向于依据逻辑和事实做决策，不太花时间分析自己的情绪状态，表达内心感受的频率较低，在需要冷静和理性判断的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "feelings-faq-1",
+          "question": "情感体验分数高代表情绪化吗？",
+          "answer": "不是。情感体验描述的是你对情绪的重视和觉察程度，神经质维度描述的是情绪反应强度和恢复速度。一个高情感体验的人可能善于理解和表达情绪但情绪状态稳定。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "情感体验的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "开放性",
+          "href": "/zh/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "gregariousness",
+      "entity_key": "gregariousness",
+      "slug": "big-five/facets/gregariousness",
+      "locale": "zh-CN",
+      "title": "合群性（外向性）",
+      "summary": "合群性描述喜欢和别人在一起、在社交中感到舒适的倾向，是外向性维度中与社交偏好相关的细分面向。",
+      "seo": {
+        "title": "合群性｜大五人格 30 个细分面向",
+        "description": "合群性描述喜欢和别人在一起、在社交中感到舒适的倾向，是外向性维度中与社交偏好相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/gregariousness",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/gregariousness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/gregariousness",
+        "en": "/en/personality/big-five/facets/gregariousness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "合群性描述喜欢和别人在一起、在社交中感到舒适的倾向，是外向性维度中与社交偏好相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是合群性？",
+          "body": "合群性是外向性维度中与社交数量和频率相关的细分面向。高分通常表示享受与他人相处，在人群中感到精力充沛，主动寻找社交机会。低分通常表示不特别依赖社交来获得满足，独处时同样舒适或更舒适，对大规模社交活动的需要较低。合群性不是社交能力——你完全可以在社交技能上很熟练但同时偏好独处。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：在人群中感到自在和充实，主动组织和参与社交活动，独处时间过长会感到压抑，在需要频繁人际互动和团队协作的角色中有优势。\n\n**偏低时**：享受独处的时间，不需要频繁的社交来维持心理平衡，小范围或一对一的交流比大群体更舒适，在需要独立专注的任务中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "gregariousness-faq-1",
+          "question": "合群性低就是社恐吗？",
+          "answer": "不是。合群性低只是你对社交数量而非质量的需求较低。社交焦虑是对社交的恐惧和回避，两者不同。一个合群性低的人可能在社交场合中感到舒适，只是不主动寻求大量社交。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "合群性的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "外向性",
+          "href": "/zh/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "ideas",
+      "entity_key": "ideas",
+      "slug": "big-five/facets/ideas",
+      "locale": "zh-CN",
+      "title": "想法探索（开放性）",
+      "summary": "想法探索描述对抽象概念、哲学问题和智力挑战的兴趣，是开放性维度中与认知好奇心相关的细分面向。",
+      "seo": {
+        "title": "想法探索｜大五人格 30 个细分面向",
+        "description": "想法探索描述对抽象概念、哲学问题和智力挑战的兴趣，是开放性维度中与认知好奇心相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/ideas",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/ideas"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/ideas",
+        "en": "/en/personality/big-five/facets/ideas"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "想法探索描述对抽象概念、哲学问题和智力挑战的兴趣，是开放性维度中与认知好奇心相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是想法探索？",
+          "body": "想法探索是开放性维度中与智力好奇心相关的细分面向。高分通常表示享受抽象思考，对哲学问题、理论框架和复杂概念有天然兴趣，喜欢讨论和辩论观点。低分通常表示对抽象思考的兴趣较低，更倾向于关注具体、实际、可操作的问题。这个 facet 描述的是思考内容的偏好（抽象 vs. 具体），而不是思考能力的差异。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：喜欢探讨“为什么”类的问题，对理论框架和概念模型感到兴奋，享受智力挑战和观点辩论，可能因为思路过于抽象而在实际操作中遇到困难。\n\n**偏低时**：偏好处理具体、明确的问题，对抽象理论的兴趣有限，更重视实践经验和可验证的结果，在需要聚焦执行和解决实际问题的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "ideas-faq-1",
+          "question": "想法探索和智商有关系吗？",
+          "answer": "想法探索是对抽象思考的兴趣程度，不是智力水平。一个智商高的人可能想法探索分数低，因为他更喜欢将精力集中在具体问题上。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "想法探索的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "开放性",
+          "href": "/zh/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "imagination",
+      "entity_key": "imagination",
+      "slug": "big-five/facets/imagination",
+      "locale": "zh-CN",
+      "title": "想象力（开放性）",
+      "summary": "想象力描述内心世界丰富、幻想和创造性想象的倾向，是开放性维度中与内在体验相关的细分面向。",
+      "seo": {
+        "title": "想象力｜大五人格 30 个细分面向",
+        "description": "想象力描述内心世界丰富、幻想和创造性想象的倾向，是开放性维度中与内在体验相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/imagination",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/imagination"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/imagination",
+        "en": "/en/personality/big-five/facets/imagination"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "想象力描述内心世界丰富、幻想和创造性想象的倾向，是开放性维度中与内在体验相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是想象力？",
+          "body": "想象力是开放性维度中最偏向内在体验的细分面向。高分通常表示内心世界丰富、善于生成意象和替代情景，在头脑中构思和推演是自然的思维方式。低分通常表示更关注现实和当下事实，思维更接地气、偏好务实。想象力不是创造力的唯一来源——务实和专注同样是创造性工作不可或缺的部分。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：容易在脑海中构建丰富的场景和替代方案，阅读小说或欣赏艺术作品时能产生强烈的内心体验，白日梦和幻想频繁出现，可能因为沉浸于想象而忽略当前任务。\n\n**偏低时**：更关注眼前事实和实际问题，思维偏向具体和实用，不太依赖内心意象来辅助思考，在需要操作现实细节和落地执行的任务中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "imagination-faq-1",
+          "question": "想象力和创造力是一回事吗？",
+          "answer": "不完全。想象力是生成丰富内心意象的能力，创造力还包括将想法落地为实际成果的执行层面。高想象力带来灵感，但创造力需要开放性中其他 facet（如行动尝试、想法探索）和尽责性维度的配合。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "想象力的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "开放性",
+          "href": "/zh/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "impulsiveness",
+      "entity_key": "impulsiveness",
+      "slug": "big-five/facets/impulsiveness",
+      "locale": "zh-CN",
+      "title": "冲动性（神经质 / 情绪敏感性）",
+      "summary": "冲动性描述在面对诱惑和欲望时控制冲动的能力，是神经质维度中与自我控制相关的细分面向。",
+      "seo": {
+        "title": "冲动性｜大五人格 30 个细分面向",
+        "description": "冲动性描述在面对诱惑和欲望时控制冲动的能力，是神经质维度中与自我控制相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/impulsiveness",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/impulsiveness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/impulsiveness",
+        "en": "/en/personality/big-five/facets/impulsiveness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "冲动性描述在面对诱惑和欲望时控制冲动的能力，是神经质维度中与自我控制相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是冲动性？",
+          "body": "冲动性是神经质维度中与冲动控制相关的细分面向。高分通常表示在面对即时诱惑时较难控制冲动，容易做出事后后悔的决定，对满足即时需求的渴望较强。低分通常表示有较好的冲动控制能力，能抵抗短期诱惑以追求长期目标，在需要等待和延迟满足的场景中有优势。冲动性描述的是对冲动的控制难度，不是道德判断——高冲动性不等于意志薄弱。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：面对即时诱惑（如美食、购物、社交媒体）时较难抵抗，倾向于即兴而为而非提前规划，在需要快速反应和即时行动的领域可能有优势，但在需要长期自律和延迟满足的领域可能遇到困难。\n\n**偏低时**：对冲动有较好的控制能力，不容易被即时诱惑左右，在需要长期规划和持续自律的任务中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "impulsiveness-faq-1",
+          "question": "冲动性高就是自制力差吗？",
+          "answer": "冲动性反映的是你在面对诱惑时感到冲动的强度，而不是你最终是否屈服。一个高冲动性的人仍然可以通过环境策略（如移除诱惑、设定明确规则）来有效管理行为。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "冲动性的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "神经质 / 情绪敏感性",
+          "href": "/zh/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "modesty",
+      "entity_key": "modesty",
+      "slug": "big-five/facets/modesty",
+      "locale": "zh-CN",
+      "title": "谦逊（宜人性）",
+      "summary": "谦逊描述对自己成就的低调呈现和自我评价的倾向，是宜人性维度中与自我展示风格相关的细分面向。",
+      "seo": {
+        "title": "谦逊｜大五人格 30 个细分面向",
+        "description": "谦逊描述对自己成就的低调呈现和自我评价的倾向，是宜人性维度中与自我展示风格相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/modesty",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/modesty"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/modesty",
+        "en": "/en/personality/big-five/facets/modesty"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "谦逊描述对自己成就的低调呈现和自我评价的倾向，是宜人性维度中与自我展示风格相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是谦逊？",
+          "body": "谦逊是宜人性维度中与自我呈现相关的细分面向。高分通常表示不倾向于谈论自己的成就和优势，在评价自己时偏保守和克制，让他人有机会展示。低分通常表示对自己的成就和优势有较高的认知和表达意愿，不回避展示自己的实力。谦逊不是自卑——高谦逊者可以清楚地知道自己的优势，只是选择不主动展示。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：不喜欢成为关注焦点，对自己的成就轻描淡写，倾向于将成功归因于外部因素，在需要团队协作和低调领导的场景中有优势，可能在需要自我推销的环境中吃亏。\n\n**偏低时**：对自己的能力有自信的表达，不回避谈论自己的成就和优势，在需要突出个人能力和竞争性展示的场景中有优势，但可能在强调团队和谐的文化中被视为不够谦虚。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "modesty-faq-1",
+          "question": "谦逊分数高代表自卑吗？",
+          "answer": "完全不是。谦逊是一种社交风格——你选择如何呈现自己。一个高谦逊的人可以非常自信，只是觉得没有必要大声说出来。自卑则是内心深处对自己的否定，两者的心理机制完全不同。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "谦逊的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "宜人性",
+          "href": "/zh/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "order",
+      "entity_key": "order",
+      "slug": "big-five/facets/order",
+      "locale": "zh-CN",
+      "title": "秩序（尽责性）",
+      "summary": "秩序描述对条理、整洁和组织性的偏好，是尽责性维度中与结构化环境相关的细分面向。",
+      "seo": {
+        "title": "秩序｜大五人格 30 个细分面向",
+        "description": "秩序描述对条理、整洁和组织性的偏好，是尽责性维度中与结构化环境相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/order",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/order"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/order",
+        "en": "/en/personality/big-five/facets/order"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "秩序描述对条理、整洁和组织性的偏好，是尽责性维度中与结构化环境相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是秩序？",
+          "body": "秩序是尽责性维度中与结构化偏好相关的细分面向。高分通常表示喜欢整洁有序的环境，做事有条理，日程安排清楚，混乱和无序会带来不适。低分通常表示对环境的秩序要求不高，能在相对随意和灵活的空间中高效工作，不一定认为“整齐”等同于“高效”。秩序偏好反映的是对结构化环境的舒适度，不是自律能力。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：桌面整洁、文件分类清楚、计划安排有序，环境中物品各有其位，在需要规范流程和精确管理的任务中有天然优势，可能因为过度追求秩序而花费过多时间整理。\n\n**偏低时**：能在相对随意的环境中保持高效，不因为物品摆放或流程细节的不完美而分心，在创意工作和需要灵活适应的场景中有优势，但可能因为缺乏整理而遗漏关键信息。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "order-faq-1",
+          "question": "秩序分数高的人一定更有效率吗？",
+          "answer": "不一定。秩序偏好反映的是对结构化环境的舒适度，效率取决于任务性质。有些创造性工作需要一定的“有序的混乱”来激发灵感，而精确的流程性工作则更适合高秩序偏好。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "秩序的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "尽责性",
+          "href": "/zh/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "positive-emotions",
+      "entity_key": "positive-emotions",
+      "slug": "big-five/facets/positive-emotions",
+      "locale": "zh-CN",
+      "title": "积极情绪（外向性）",
+      "summary": "积极情绪描述体验快乐、热情和满足等正面情绪的频率和强度，是外向性维度中与主观幸福感相关的细分面向。",
+      "seo": {
+        "title": "积极情绪｜大五人格 30 个细分面向",
+        "description": "积极情绪描述体验快乐、热情和满足等正面情绪的频率和强度，是外向性维度中与主观幸福感相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/positive-emotions",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/positive-emotions"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/positive-emotions",
+        "en": "/en/personality/big-five/facets/positive-emotions"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "积极情绪描述体验快乐、热情和满足等正面情绪的频率和强度，是外向性维度中与主观幸福感相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是积极情绪？",
+          "body": "积极情绪是外向性维度中与正面情绪体验相关的细分面向。高分通常表示经常体验到快乐、热情、感激和满足，对生活持有积极期待，低谷时也有较强的恢复倾向。低分通常表示正面情绪的体验频率和强度较低，情绪基调偏平稳和中立。这个 facet 与神经质维度中负面情绪的体验频率是互补的——一个人可以同时体验到较多积极和消极情绪。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：经常感到快乐和满足，对未来持乐观态度，在日常小事中能找到愉悦，情绪恢复速度较快，在面对挫折时能更快地重新进入积极状态。\n\n**偏低时**：情绪体验偏平稳，不常有强烈的快乐或兴奋感，但也不容易因外部事件而大幅波动，在需要冷静分析和客观判断的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "positive-emotions-faq-1",
+          "question": "积极情绪分数低代表不快乐吗？",
+          "answer": "不一定。这个 facet 测量的是积极情绪的体验频率和强度。有些人不需要频繁的强烈正面情绪也能感到满足——他们的幸福感来自平静、意义感或关系深度。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "积极情绪的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "外向性",
+          "href": "/zh/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "self-consciousness",
+      "entity_key": "self-consciousness",
+      "slug": "big-five/facets/self-consciousness",
+      "locale": "zh-CN",
+      "title": "自我意识（神经质 / 情绪敏感性）",
+      "summary": "自我意识描述在社交场合中感到尴尬、不自在和被审视的倾向，是神经质维度中与社交敏感性相关的细分面向。",
+      "seo": {
+        "title": "自我意识｜大五人格 30 个细分面向",
+        "description": "自我意识描述在社交场合中感到尴尬、不自在和被审视的倾向，是神经质维度中与社交敏感性相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/self-consciousness",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/self-consciousness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/self-consciousness",
+        "en": "/en/personality/big-five/facets/self-consciousness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "自我意识描述在社交场合中感到尴尬、不自在和被审视的倾向，是神经质维度中与社交敏感性相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是自我意识？",
+          "body": "自我意识是神经质维度中与社交场合的自我觉察和不自在感相关的细分面向。高分通常表示在社交场合中容易感到被注视和评判，在意他人对自己的看法，在人群中常有“大家都在看我”的感觉。低分通常表示在社交场合中较少感到不自在，不会过度担心他人怎么看待自己，在公众场合表现自然。自我意识与害羞相关但不完全相同——你可以很害羞但没有过强的自我意识。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：在社交场合中容易感到不自在和被审视，对自己的外表和言行高度关注，在需要精确自我监控和社交礼仪的场景中有优势，但在需要自然和放松表达的场合中可能过于紧张。\n\n**偏低时**：在社交和公众场合中自然放松，不过度在意他人的目光，在需要公众表达和即兴发挥的场景中有优势，但可能在需要精细化礼仪和社交敏感度的场景中不够警觉。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "self-consciousness-faq-1",
+          "question": "自我意识高就是社交焦虑障碍吗？",
+          "answer": "不是。自我意识高只是在社交场合中会更加在意自己的表现，但通常不会因此回避社交。如果这种在意已经严重到让你回避社交活动、影响生活质量，才可能涉及社交焦虑障碍，建议咨询专业帮助。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "自我意识的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "神经质 / 情绪敏感性",
+          "href": "/zh/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "self-discipline",
+      "entity_key": "self-discipline",
+      "slug": "big-five/facets/self-discipline",
+      "locale": "zh-CN",
+      "title": "自律（尽责性）",
+      "summary": "自律描述开始任务并坚持完成的能力，是尽责性维度中与执行力和毅力相关的细分面向。",
+      "seo": {
+        "title": "自律｜大五人格 30 个细分面向",
+        "description": "自律描述开始任务并坚持完成的能力，是尽责性维度中与执行力和毅力相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/self-discipline",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/self-discipline"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/self-discipline",
+        "en": "/en/personality/big-five/facets/self-discipline"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "自律描述开始任务并坚持完成的能力，是尽责性维度中与执行力和毅力相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是自律？",
+          "body": "自律是尽责性维度中与执行坚持力相关的细分面向。高分通常表示能够主动开始不愉快的任务并坚持到底，不容易被干扰和诱惑打断，在需要长期投入的项目中有稳定的执行力。低分通常表示在开始和坚持任务方面存在困难，容易被外界干扰或内在分心打断，倾向于在截止日期临近时集中完成任务。自律是可以训练的能力，不完全由天生的倾向决定。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：即使任务枯燥或不愉快也能坚持下去，能抵抗短期诱惑以完成长期目标，日常行为有较强的内在驱动力，在需要持续纪律性的任务中有显著优势，可能因为过于严格而给自己带来不必要的压力。\n\n**偏低时**：倾向于在动力充沛时高效完成工作，在截止日期压力下能快速产出，在需要快速反应和灵活调整的任务中有优势，但可能在需要持续投入的长期项目中遇到困难。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "self-discipline-faq-1",
+          "question": "自律分数低的人就是懒吗？",
+          "answer": "不是。自律反映的是在缺乏外部约束时自我驱动的容易程度。很多低自律者在有明确外部结构（如截止日期、团队协作、责任分工）的环境中表现优异。了解自己的自律模式后，可以用环境设计来补偿——比如分批设定小目标、寻找问责伙伴。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "自律的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "尽责性",
+          "href": "/zh/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "straightforwardness",
+      "entity_key": "straightforwardness",
+      "slug": "big-five/facets/straightforwardness",
+      "locale": "zh-CN",
+      "title": "直接性（宜人性）",
+      "summary": "直接性描述以坦诚、直接的方式与人交流的倾向，是宜人性维度中与沟通风格相关的细分面向。",
+      "seo": {
+        "title": "直接性｜大五人格 30 个细分面向",
+        "description": "直接性描述以坦诚、直接的方式与人交流的倾向，是宜人性维度中与沟通风格相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/straightforwardness",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/straightforwardness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/straightforwardness",
+        "en": "/en/personality/big-five/facets/straightforwardness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "直接性描述以坦诚、直接的方式与人交流的倾向，是宜人性维度中与沟通风格相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是直接性？",
+          "body": "直接性是宜人性维度中与沟通坦诚度相关的细分面向。高分通常表示交流时坦诚直接，不喜欢绕弯子或策略性表达，认为实话实说是尊重对方的表现。低分通常表示沟通时更讲究方式和策略，倾向于考虑表达可能带来的影响后再选择措辞。直接性反映的是沟通风格而非诚实程度——一个策略性表达的人同样可以是诚实的。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：有话直说，不喜欢拐弯抹角，在需要快速澄清和透明沟通的场景中有优势，可能在敏感话题上因为表达方式直接而引发对方不适。\n\n**偏低时**：在表达前会考虑措辞和时机，善于用对方容易接受的方式传递信息，在需要关系维护和敏感沟通的场景中有优势，但可能因为表达不够直接而导致信息失真。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "straightforwardness-faq-1",
+          "question": "直接性高就是说话不好听吗？",
+          "answer": "不是。直接性反映的是你倾向于多直接地表达想法，不是你是否关心对方的感受。一个高直接性的人可以既坦诚又友善——关键在于坦诚的内容是建设性的还是攻击性的。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "直接性的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "宜人性",
+          "href": "/zh/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "tender-mindedness",
+      "entity_key": "tender-mindedness",
+      "slug": "big-five/facets/tender-mindedness",
+      "locale": "zh-CN",
+      "title": "温和（宜人性）",
+      "summary": "温和描述对他人处境产生同情和关怀的倾向，是宜人性维度中与共情敏感性相关的细分面向。",
+      "seo": {
+        "title": "温和｜大五人格 30 个细分面向",
+        "description": "温和描述对他人处境产生同情和关怀的倾向，是宜人性维度中与共情敏感性相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/tender-mindedness",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/tender-mindedness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/tender-mindedness",
+        "en": "/en/personality/big-five/facets/tender-mindedness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "温和描述对他人处境产生同情和关怀的倾向，是宜人性维度中与共情敏感性相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是温和？",
+          "body": "温和是宜人性维度中与共情和关怀相关的细分面向。高分通常表示容易被他人的困境和情绪所触动，对弱势群体有较强的关怀和保护欲，在做涉及人的决策时优先考虑感受因素。低分通常表示在做决策时更依赖逻辑和原则，不太容易被情绪或他人的处境所影响，能在需要客观判断的场景中保持理性。温和不是冷漠——低温和者仍然可以关心他人，只是方式更偏向理性和原则导向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：容易被感人的故事或他人的困境触动，在做决定时优先考虑对人的影响，在需要人本关怀的角色（如护理、教育、心理咨询）中有天然优势，可能在需要做出艰难决策时因为情感因素而犹豫。\n\n**偏低时**：决策时更依赖逻辑和客观标准，不容易因情感诉求而改变立场，在需要秉公处理、严格执行标准和危机决策的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "tender-mindedness-faq-1",
+          "question": "温和分数低就是冷酷无情吗？",
+          "answer": "不是。低温和的人更倾向于用理性和原则而非情感来指导对他人的关怀。一个外科医生可能温和分数不高，但他/她能通过专业能力和精准判断来救人——这是另一种形式的关心。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "温和的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "宜人性",
+          "href": "/zh/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "trust",
+      "entity_key": "trust",
+      "slug": "big-five/facets/trust",
+      "locale": "zh-CN",
+      "title": "信任（宜人性）",
+      "summary": "信任描述相信他人意图是善意的倾向，是宜人性维度中与对人基本态度相关的细分面向。",
+      "seo": {
+        "title": "信任｜大五人格 30 个细分面向",
+        "description": "信任描述相信他人意图是善意的倾向，是宜人性维度中与对人基本态度相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/trust",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/trust"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/trust",
+        "en": "/en/personality/big-five/facets/trust"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "信任描述相信他人意图是善意的倾向，是宜人性维度中与对人基本态度相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是信任？",
+          "body": "信任是宜人性维度中最基础的人际态度细分面向。高分通常表示倾向于相信他人的动机是善意的，认为大多数人值得信赖，在初次交往中持开放和友好的态度。低分通常表示对他人动机持审慎态度，倾向于先观察再判断，不轻易假设他人出于善意。信任不是天真——高信任者同样能够识别恶意，只是默认假设不同。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：与人交往时持开放和善意的预设，愿意先给予信任而非等待对方证明，在需要快速建立合作和信任关系的场景中有优势，可能在有过负面经历后仍然保持较高的信任基线。\n\n**偏低时**：对自己和他人的界限更警觉，倾向于先验证再信任，在需要风险控制和批判性评估的场景中有优势，但可能因为信任门槛过高而错过建立深度关系的机会。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "trust-faq-1",
+          "question": "信任和判断力有冲突吗？",
+          "answer": "不必然。高信任反映的是你的默认假设——你认为大多数人的意图是善意的。这不等于你失去了判断和识别恶意的能力。信任是一种社交策略，判断力是一种认知能力，两者可以共存。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "信任的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "宜人性",
+          "href": "/zh/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "values",
+      "entity_key": "values",
+      "slug": "big-five/facets/values",
+      "locale": "zh-CN",
+      "title": "价值观开放（开放性）",
+      "summary": "价值观开放描述愿意重新审视社会规范、传统和权威的倾向，是开放性维度中与态度灵活性相关的细分面向。",
+      "seo": {
+        "title": "价值观开放｜大五人格 30 个细分面向",
+        "description": "价值观开放描述愿意重新审视社会规范、传统和权威的倾向，是开放性维度中与态度灵活性相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/values",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/values"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/values",
+        "en": "/en/personality/big-five/facets/values"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "价值观开放描述愿意重新审视社会规范、传统和权威的倾向，是开放性维度中与态度灵活性相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是价值观开放？",
+          "body": "价值观开放是开放性维度中与态度和信念灵活性相关的细分面向。高分通常表示愿意挑战传统看法、重新审视社会规范，对不同价值观和生活方式持包容态度。低分通常表示更尊重传统和既有规范，倾向于维护稳定和可预测的社会结构。价值观开放不意味着“没有立场”或“什么都可以”，而是对“事情可能不是我认为的那样”保持开放。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：对社会议题和价值观讨论持开放态度，愿意从不同角度重新审视自己的立场，对不同文化、宗教和生活方式有较高的接受度。\n\n**偏低时**：更看重传统、规则和既有秩序的稳定性，倾向于维护已被验证的社会规范，在需要一致性、规则执行和维护集体认同的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "values-faq-1",
+          "question": "价值观开放代表没有自己的原则吗？",
+          "answer": "不是。价值观高开放意味着你愿意审视和重新评估自己的价值观，不等于你没有坚定的信念。这种开放是一种认知灵活性，不是立场的缺失。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "价值观开放的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "开放性",
+          "href": "/zh/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "vulnerability",
+      "entity_key": "vulnerability",
+      "slug": "big-five/facets/vulnerability",
+      "locale": "zh-CN",
+      "title": "脆弱性（神经质 / 情绪敏感性）",
+      "summary": "脆弱性描述在压力下应对和恢复正常的能力，是神经质维度中与压力耐受相关的细分面向。",
+      "seo": {
+        "title": "脆弱性｜大五人格 30 个细分面向",
+        "description": "脆弱性描述在压力下应对和恢复正常的能力，是神经质维度中与压力耐受相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/vulnerability",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/vulnerability"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/vulnerability",
+        "en": "/en/personality/big-five/facets/vulnerability"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "脆弱性描述在压力下应对和恢复正常的能力，是神经质维度中与压力耐受相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是脆弱性？",
+          "body": "脆弱性是神经质维度中与压力应对能力相关的细分面向。高分通常表示在压力下容易感到无助和不知所措，面对紧急和高压情境时应对能力下降，需要较长时间恢复到正常状态。低分通常表示在压力下能保持相对冷静和有效应对，紧急情况下能维持判断力和行动力，恢复速度较快。脆弱性反映的是压力下的应对容易程度，不是软弱或坚强的人格判断。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：在高压情境下容易感到不知所措和资源枯竭，需要明确的支援和恢复时间，在需要高度警觉和风险敏感的任务中有预警价值，但高压场景本身会带来较高的恢复成本。\n\n**偏低时**：在压力和紧急情况下能保持相对稳定的判断和执行力，恢复速度较快，在需要危机处理和高压决策的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "vulnerability-faq-1",
+          "question": "脆弱性高的人是不是抗压能力差？",
+          "answer": "脆弱性反映的是压力下你感到吃力程度的主观体验。一些看起来“抗压能力差”的人，在其他条件相同的情况下，可能只是需要更多的恢复时间而不是能力不足。而且高脆弱性在需要高度警觉和风险敏感的工作中可能是一种优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "脆弱性的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "神经质 / 情绪敏感性",
+          "href": "/zh/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "warmth",
+      "entity_key": "warmth",
+      "slug": "big-five/facets/warmth",
+      "locale": "zh-CN",
+      "title": "热情（外向性）",
+      "summary": "热情描述与他人建立友好、温暖关系的倾向，是外向性维度中与亲和力和友好度相关的细分面向。",
+      "seo": {
+        "title": "热情｜大五人格 30 个细分面向",
+        "description": "热情描述与他人建立友好、温暖关系的倾向，是外向性维度中与亲和力和友好度相关的细分面向。"
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/zh/personality/big-five/facets/warmth",
+      "canonical": {
+        "path": "/zh/personality/big-five/facets/warmth"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/warmth",
+        "en": "/en/personality/big-five/facets/warmth"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "快速回答",
+          "body": "热情描述与他人建立友好、温暖关系的倾向，是外向性维度中与亲和力和友好度相关的细分面向。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "什么是热情？",
+          "body": "热情是外向性维度中与人际温暖相关的细分面向。高分通常表示容易与他人建立友好的关系，在初次交往中表现出真诚的关心和善意，使人感到舒适和被接纳。低分通常表示在人际关系中保持一定的距离感，不太主动表达友善，但在已建立的深度关系中同样真诚。热情更多是主动释放善意的倾向，而非共情能力——后者更多与宜人性相关。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "偏高与偏低",
+          "body": "**偏高时**：主动对人表达友好和关心，容易与新认识的人建立融洽的关系，在社交场合中让他人感到受欢迎，在需要快速建立信任的服务和协作场景中有优势。\n\n**偏低时**：对他人的友好表达较含蓄，不急于展示亲近感，更看重关系的真实性和深度而非广度，在需要保持专业距离和客观判断的场景中有优势。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "warmth-faq-1",
+          "question": "热情分数低代表不友好吗？",
+          "answer": "不是。热情反映的是你主动释放善意的频率和强度，不是你对他人的真实态度。一个低热情的人可能很关心他人，只是表达方式更内敛和含蓄。",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "热情的大五人格中性占位图，不使用 MBTI 品牌视觉。"
+      },
+      "method_boundary": {
+        "summary": "本页解释大五人格的公共知识和沟通语言，不解读个人测评结果，也不替代专业判断。",
+        "not_for": [
+          "临床诊断",
+          "心理治疗建议",
+          "招聘筛选",
+          "能力或智力判断",
+          "职业或伴侣关系决定"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "大五人格",
+          "href": "/zh/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 个细分面向",
+          "href": "/zh/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "外向性",
+          "href": "/zh/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "本页依据大五人格作为连续特质模型的公开研究脉络撰写，参考 BFI-2、五因素模型综述、IPIP 公开量表生态和 30 facets 文献。"
+        },
+        {
+          "note": "这些说明用于理解人格语言和沟通差异，不用于临床诊断、心理治疗、招聘筛选、能力判断或职业决定。"
+        },
+        {
+          "note": "竞品页面只用于发现用户问题和内容缺口，不复制其结构、示例或措辞。"
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "achievement-striving",
+      "entity_key": "achievement-striving",
+      "slug": "big-five/facets/achievement-striving",
+      "locale": "en",
+      "title": "Achievement Striving (Conscientiousness)",
+      "summary": "Achievement striving describes tendency to set high goals and work hard to achieve them. It is the facet of Conscientiousness related to ambition and drive.",
+      "seo": {
+        "title": "Achievement Striving | Big Five 30 Facets",
+        "description": "Achievement striving describes tendency to set high goals and work hard to achieve them. It is the facet of Conscientiousness related to ambition and drive."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/achievement-striving",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/achievement-striving"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/achievement-striving",
+        "en": "/en/personality/big-five/facets/achievement-striving"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Achievement striving describes tendency to set high goals and work hard to achieve them. It is the facet of Conscientiousness related to ambition and drive.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Achievement Striving?",
+          "body": "Achievement striving is the facet of Conscientiousness related to goal-setting and drive. High-scoring individuals typically have strong achievement motivation, enjoy setting challenging goals and working toward them, and find satisfaction in progress and accomplishments. Low-scoring individuals tend to pursue achievement more moderately, not necessarily needing constant higher goals for satisfaction, and can maintain balance without imposing additional achievement pressure. High achievement striving brings drive but may also bring burnout risk.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: frequently set higher goals for themselves, have clear aspirations for career and personal growth, quickly seek the next challenge after completing tasks, have advantage in competitive environments and roles requiring continuous progress, and may neglect rest and relationships due to over-pursuit.\n\n**Low-scoring individuals** tend to: value process over outcomes, can enjoy work and life without deliberate pursuit, are less anxious about external achievement standards, and have advantage in situations requiring steady output and long-term balance.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "achievement-striving-faq-1",
+          "question": "Does low achievement striving mean lack of ambition?",
+          "answer": "No. Low achievement striving does not equal lack of ambition, just that high-standard goals are not your primary driver. You may care more about the meaning of work itself, relationship quality, or life balance — these are equally positive life attitudes.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Achievement Striving, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Conscientiousness",
+          "href": "/en/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "actions",
+      "entity_key": "actions",
+      "slug": "big-five/facets/actions",
+      "locale": "en",
+      "title": "Actions (Openness)",
+      "summary": "Actions describes willingness to try new activities, experiences, and different lifestyles. It is the facet of Openness related to behavioral exploration.",
+      "seo": {
+        "title": "Actions | Big Five 30 Facets",
+        "description": "Actions describes willingness to try new activities, experiences, and different lifestyles. It is the facet of Openness related to behavioral exploration."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/actions",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/actions"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/actions",
+        "en": "/en/personality/big-five/facets/actions"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Actions describes willingness to try new activities, experiences, and different lifestyles. It is the facet of Openness related to behavioral exploration.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Actions?",
+          "body": "Actions is the facet of Openness related to behavioral exploration. High-scoring individuals typically enjoy trying new activities, foods, travel destinations, and lifestyles, embodying openness to new experiences in actual behavior. Low-scoring individuals tend to prefer familiar activities and stable life rhythms, finding satisfaction and comfort within known boundaries. Actions is different from impulsiveness — the former is conscious exploratory intent, the latter is uncontrolled immediate reaction.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: actively seek new experiences, frequently vary travel, food, and hobbies, respond to new activities with a try it attitude, and may struggle to sustain a single project long-term due to pursuit of variety.\n\n**Low-scoring individuals** tend to: prefer stable and predictable activity patterns, feel comfortable and safe in familiar environments, enjoy depth over breadth in exploration, and have an advantage in tasks requiring long-term focus and sustained depth.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "actions-faq-1",
+          "question": "Does high actions lead to a lack of focus?",
+          "answer": "Not necessarily. Actions reflects breadth of exploratory desire, not strength of persistence. High-actions individuals can manage exploration structurally — alternating depth across domains, or preserving exploration space outside their main focus.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Actions, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Openness",
+          "href": "/en/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "activity",
+      "entity_key": "activity",
+      "slug": "big-five/facets/activity",
+      "locale": "en",
+      "title": "Activity (Extraversion)",
+      "summary": "Activity describes tendency to stay busy, maintain fast pace, and have high energy. It is the facet of Extraversion related to energy level and action speed.",
+      "seo": {
+        "title": "Activity | Big Five 30 Facets",
+        "description": "Activity describes tendency to stay busy, maintain fast pace, and have high energy. It is the facet of Extraversion related to energy level and action speed."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/activity",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/activity"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/activity",
+        "en": "/en/personality/big-five/facets/activity"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Activity describes tendency to stay busy, maintain fast pace, and have high energy. It is the facet of Extraversion related to energy level and action speed.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Activity?",
+          "body": "Activity is the facet of Extraversion related to energy level and action rhythm. High-scoring individuals typically enjoy being busy and having a fast-paced life, cannot stand being idle, and are always looking for the next task or activity. Low-scoring individuals tend to prefer a slower pace, feel comfortable in quietness and rest, and do not need constant activity to maintain satisfaction. Activity reflects rhythm preference of energy output, not efficiency or output.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: have a full schedule, abundant energy, dislike being idle for long periods, perform well in fast-paced multi-tasking environments, and may neglect rest and recovery due to sustained high-speed operation.\n\n**Low-scoring individuals** tend to: prefer moderate pace, can accept or even enjoy idle moments, have advantage in tasks requiring patience and sustained steady output, but may struggle in scenarios requiring quick response and high-intensity output.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "activity-faq-1",
+          "question": "Does low activity mean low efficiency?",
+          "answer": "No. Activity reflects how fast a pace you prefer to maintain, not how much you accomplish per unit time. A low-activity person may complete higher quality work in less time because they focus more on depth than speed.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Activity, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Extraversion",
+          "href": "/en/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "aesthetics",
+      "entity_key": "aesthetics",
+      "slug": "big-five/facets/aesthetics",
+      "locale": "en",
+      "title": "Aesthetics (Openness)",
+      "summary": "Aesthetics describes sensitivity to art, beauty, and natural beauty. It is the facet of Openness related to perception and appreciation.",
+      "seo": {
+        "title": "Aesthetics | Big Five 30 Facets",
+        "description": "Aesthetics describes sensitivity to art, beauty, and natural beauty. It is the facet of Openness related to perception and appreciation."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/aesthetics",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/aesthetics"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/aesthetics",
+        "en": "/en/personality/big-five/facets/aesthetics"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Aesthetics describes sensitivity to art, beauty, and natural beauty. It is the facet of Openness related to perception and appreciation.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Aesthetics?",
+          "body": "Aesthetics is the facet of Openness related to artistic and aesthetic experience. High-scoring individuals typically have strong responses to music, visual art, literature, and natural beauty, with beautiful things evoking deep emotional reactions. Low-scoring individuals tend to pay less attention to art and aesthetics, valuing functionality and practicality more. Aesthetics is not about taste — low levels do not mean a lack of appreciation ability, only that beauty and art carry less weight in daily decisions.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: be moved by architecture, music, design, or natural landscapes, consider beauty and atmosphere important when choosing environments and objects, and may invest time and energy in art appreciation and creation.\n\n**Low-scoring individuals** tend to: not use aesthetics as a primary decision criterion, have lower sensitivity to environmental appearance and artistic expression, and value function, efficiency, and practicality more, which is advantageous in scenarios requiring fast decisions and resource optimization.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "aesthetics-faq-1",
+          "question": "Does a low aesthetics level mean no artistic talent?",
+          "answer": "No. Your aesthetics level reflects how much you value beauty and art, not your artistic ability or taste. Many excellent engineers and designers level low on aesthetics — they focus more on function and logic but can still produce excellent designs.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Aesthetics, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Openness",
+          "href": "/en/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "altruism",
+      "entity_key": "altruism",
+      "slug": "big-five/facets/altruism",
+      "locale": "en",
+      "title": "Altruism (Agreeableness)",
+      "summary": "Altruism describes tendency to proactively care for and help others. It is the facet of Agreeableness related to helping motivation.",
+      "seo": {
+        "title": "Altruism | Big Five 30 Facets",
+        "description": "Altruism describes tendency to proactively care for and help others. It is the facet of Agreeableness related to helping motivation."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/altruism",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/altruism"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/altruism",
+        "en": "/en/personality/big-five/facets/altruism"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Altruism describes tendency to proactively care for and help others. It is the facet of Agreeableness related to helping motivation.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Altruism?",
+          "body": "Altruism is the facet of Agreeableness related to helping behavior. High-scoring individuals typically are willing to proactively help others, feel an internal drive to help when seeing others in need, and derive satisfaction from helping. Low-scoring individuals tend to have weaker internal drive to help others, preferring to let each person solve their own problems, and not seeing self-sacrifice to help others as necessary. Altruism reflects internal motivation for helping, not actual helping behavior — you may not have internal drive but still lend a hand when needed.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: proactively notice others' difficulties and offer help, take on additional supportive work in teams, derive satisfaction from others' improvement, have advantage in roles requiring high collaboration and humanistic care, and may neglect their own needs due to over-giving.\n\n**Low-scoring individuals** tend to: believe each person should first be responsible for themselves, help others more based on rational judgment than emotional drive, and have advantage in situations requiring independent judgment and resource optimization.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "altruism-faq-1",
+          "question": "Does low altruism mean selfishness?",
+          "answer": "No. Low altruism only means weaker internal drive to help others, not that you are selfish or would not help. You may help others based on principle or rational decision, just not seeing it as an automatic obligation.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Altruism, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Agreeableness",
+          "href": "/en/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "anger",
+      "entity_key": "anger",
+      "slug": "big-five/facets/anger",
+      "locale": "en",
+      "title": "Anger (Neuroticism)",
+      "summary": "Anger describes tendency to experience feelings of anger, frustration, and resentment. It is the facet of Neuroticism related to hostile reactions.",
+      "seo": {
+        "title": "Anger | Big Five 30 Facets",
+        "description": "Anger describes tendency to experience feelings of anger, frustration, and resentment. It is the facet of Neuroticism related to hostile reactions."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/anger",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/anger"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/anger",
+        "en": "/en/personality/big-five/facets/anger"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Anger describes tendency to experience feelings of anger, frustration, and resentment. It is the facet of Neuroticism related to hostile reactions.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Anger?",
+          "body": "Anger is the facet of Neuroticism related to hostility and frustration. High-scoring individuals typically easily experience anger due to unfairness, blockage, or disappointment, have a lower threshold for anger trigger, and may find it harder to calm down after frustration. Low-scoring individuals tend to not be easily provoked, have higher tolerance for frustration and offense, and recover from negative emotions faster. Anger itself is a normal and sometimes necessary emotion — this facet measures how easily anger is triggered and sustained.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: react strongly to unfairness and unreasonable situations, have frustration easily triggered, have advantage in situations requiring justice maintenance and challenging injustice — high-anger individuals are often important forces driving change, but also need to manage anger expression to avoid damaging relationships.\n\n**Low-scoring individuals** tend to: not easily angered by external events, have high tolerance for frustration and offense, and have advantage in communication situations requiring patience and emotional stability.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "anger-faq-1",
+          "question": "Does low anger mean having no temper?",
+          "answer": "No. Low anger simply means you are not easily triggered to experience anger by external events. This can be an advantage when facing provocation, but may also mean you do not express anger when you should — appropriate anger is valuable for maintaining boundaries and justice.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Anger, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Neuroticism / Emotional Sensitivity",
+          "href": "/en/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "anxiety",
+      "entity_key": "anxiety",
+      "slug": "big-five/facets/anxiety",
+      "locale": "en",
+      "title": "Anxiety (Neuroticism)",
+      "summary": "Anxiety describes tendency to feel worried and tense about the future and uncertainty. It is the facet of Neuroticism related to anticipatory worry.",
+      "seo": {
+        "title": "Anxiety | Big Five 30 Facets",
+        "description": "Anxiety describes tendency to feel worried and tense about the future and uncertainty. It is the facet of Neuroticism related to anticipatory worry."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/anxiety",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/anxiety"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/anxiety",
+        "en": "/en/personality/big-five/facets/anxiety"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Anxiety describes tendency to feel worried and tense about the future and uncertainty. It is the facet of Neuroticism related to anticipatory worry.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Anxiety?",
+          "body": "Anxiety is the facet of Neuroticism related to future-oriented worry and tension. High-scoring individuals typically easily worry about the future and uncertainty, frequently mentally rehearse negative possibilities, and feel stronger tension in ambiguous situations. Low-scoring individuals tend to worry less about the future, can stay calm amid uncertainty, and do not easily fall into repetitive negative rehearsal. Anxiety reflects worry tendency, not a criterion for anxiety disorders — the latter requires professional diagnosis.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: easily feel tension and worry in uncertain situations, tend to rehearse various negative possibilities, have value in tasks requiring risk alertness and detailed checking — high-anxiety individuals are often the first to spot potential problems, but also consume significant psychological resources through sustained high alertness.\n\n**Low-scoring individuals** tend to: stay relatively calm when facing uncertainty and risk, are less easily distracted by what-if worries, and have advantage in situations requiring calm judgment and quick decisions.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "anxiety-faq-1",
+          "question": "Does high anxiety mean anxiety disorder?",
+          "answer": "No. Anxiety level reflects worry tendency — a personality trait. Anxiety disorder is a clinical diagnosis requiring specific symptom criteria and functional impairment. If you are troubled by your anxiety level, we recommend consulting professional mental health services.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Anxiety, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Neuroticism / Emotional Sensitivity",
+          "href": "/en/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "assertiveness",
+      "entity_key": "assertiveness",
+      "slug": "big-five/facets/assertiveness",
+      "locale": "en",
+      "title": "Assertiveness (Extraversion)",
+      "summary": "Assertiveness describes tendency to express positions, take charge, and influence others in groups. It is the facet of Extraversion related to leadership expression.",
+      "seo": {
+        "title": "Assertiveness | Big Five 30 Facets",
+        "description": "Assertiveness describes tendency to express positions, take charge, and influence others in groups. It is the facet of Extraversion related to leadership expression."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/assertiveness",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/assertiveness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/assertiveness",
+        "en": "/en/personality/big-five/facets/assertiveness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Assertiveness describes tendency to express positions, take charge, and influence others in groups. It is the facet of Extraversion related to leadership expression.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Assertiveness?",
+          "body": "Assertiveness is the facet of Extraversion related to dominance and influence expression. High-scoring individuals typically dare to express views and guide direction in groups, do not avoid conflict and competition, and are good at securing resources and opportunities. Low-scoring individuals tend to prefer following rather than leading in groups, not rushing to express positions, and preferring to listen to all perspectives before stating their view. Assertiveness is not a judgment of ability — a low-key person can have equally profound influence.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: actively speak in meetings and discussions, dare to say no to differing opinions, have advantage in situations requiring quick decisions and leadership, and may suppress others' space for expression by being overly dominant.\n\n**Low-scoring individuals** tend to: observe and listen before judging, not rush to claim speaking rights, have advantage in situations requiring multi-party coordination and consensus-building, but may not act quickly enough when quick opportunity capture is needed.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "assertiveness-faq-1",
+          "question": "Can people low in assertiveness be leaders?",
+          "answer": "Yes. Leadership has many styles. Low-assertiveness leaders typically guide teams through questioning, empowerment, and consensus-building, which can be more effective than high assertiveness in scenarios requiring long-term strategy and team depth.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Assertiveness, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Extraversion",
+          "href": "/en/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "competence",
+      "entity_key": "competence",
+      "slug": "big-five/facets/competence",
+      "locale": "en",
+      "title": "Competence (Conscientiousness)",
+      "summary": "Competence describes confidence in one's ability to effectively complete tasks. It is the facet of Conscientiousness related to self-efficacy.",
+      "seo": {
+        "title": "Competence | Big Five 30 Facets",
+        "description": "Competence describes confidence in one's ability to effectively complete tasks. It is the facet of Conscientiousness related to self-efficacy."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/competence",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/competence"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/competence",
+        "en": "/en/personality/big-five/facets/competence"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Competence describes confidence in one's ability to effectively complete tasks. It is the facet of Conscientiousness related to self-efficacy.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Competence?",
+          "body": "Competence is the facet of Conscientiousness related to self-efficacy. High-scoring individuals typically feel confident in their ability to complete tasks, believe their efforts will produce expected results, and tend to persist rather than give up when facing difficulties. Low-scoring individuals tend to have lower confidence in their abilities, often accompanied by hesitation and self-doubt when making decisions. Competence reflects subjective belief, not objective ability — someone with strong actual abilities may also level low on competence.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: believe they can handle new tasks, maintain a positive mindset in the face of challenges, have confidence in their judgment and decisions, and may underestimate task difficulty due to overconfidence.\n\n**Low-scoring individuals** tend to: take a cautious attitude toward their abilities, prefer thorough preparation and repeated verification before acting, have an advantage in situations requiring careful planning and risk control, but may miss opportunities due to self-doubt.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "competence-faq-1",
+          "question": "Are competence and actual ability the same?",
+          "answer": "No. Competence is your subjective belief in your abilities. Actual ability is objective skill and knowledge. The two are not always aligned — some highly capable people level low on competence, and vice versa. One way to build competence is to record experiences of successfully completing tasks.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Competence, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Conscientiousness",
+          "href": "/en/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "compliance",
+      "entity_key": "compliance",
+      "slug": "big-five/facets/compliance",
+      "locale": "en",
+      "title": "Compliance (Agreeableness)",
+      "summary": "Compliance describes tendency to yield and cooperate in conflicts. It is the facet of Agreeableness related to conflict-handling style.",
+      "seo": {
+        "title": "Compliance | Big Five 30 Facets",
+        "description": "Compliance describes tendency to yield and cooperate in conflicts. It is the facet of Agreeableness related to conflict-handling style."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/compliance",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/compliance"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/compliance",
+        "en": "/en/personality/big-five/facets/compliance"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Compliance describes tendency to yield and cooperate in conflicts. It is the facet of Agreeableness related to conflict-handling style.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Compliance?",
+          "body": "Compliance is the facet of Agreeableness related to conflict avoidance and cooperation willingness. High-scoring individuals typically tend to yield and seek reconciliation in conflicts, dislike confrontation and competition, and believe maintaining relationship harmony matters more than winning the argument. Low-scoring individuals tend to not avoid confrontation in conflicts, dare to stand their ground and challenge differing opinions, and believe clarifying the issue matters more than superficial harmony. Compliance is not weakness — it is a difference in whether you prioritize relationship or position in conflict.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: first consider how to maintain the relationship in conflict, do not mind making concessions to reach consensus, have advantage in situations requiring multi-stakeholder coordination and conflict resolution, and may suppress their own legitimate needs due to excessive concession.\n\n**Low-scoring individuals** tend to: not avoid debate in conflict, willingly face disagreements and stand their ground, have advantage in situations requiring principle maintenance and driving change, but may pay higher communication costs in relationship maintenance.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "compliance-faq-1",
+          "question": "What is the difference between compliance and people-pleasing?",
+          "answer": "Compliance is the strategic tendency to choose cooperation and concession in conflict, presupposing you know your position and voluntarily choose to yield. People-pleasing is suppressing genuine needs out of fear of rejection or being disliked, often accompanied by anxiety and self-negation. The former is strategy; the latter is defense.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Compliance, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Agreeableness",
+          "href": "/en/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "deliberation",
+      "entity_key": "deliberation",
+      "slug": "big-five/facets/deliberation",
+      "locale": "en",
+      "title": "Deliberation (Conscientiousness)",
+      "summary": "Deliberation describes tendency to think carefully and evaluate consequences before making decisions. It is the facet of Conscientiousness related to decision caution.",
+      "seo": {
+        "title": "Deliberation | Big Five 30 Facets",
+        "description": "Deliberation describes tendency to think carefully and evaluate consequences before making decisions. It is the facet of Conscientiousness related to decision caution."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/deliberation",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/deliberation"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/deliberation",
+        "en": "/en/personality/big-five/facets/deliberation"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Deliberation describes tendency to think carefully and evaluate consequences before making decisions. It is the facet of Conscientiousness related to decision caution.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Deliberation?",
+          "body": "Deliberation is the facet of Conscientiousness related to pre-decision thinking. High-scoring individuals typically weigh pros and cons carefully before acting, prefer gathering sufficient information before deciding, and are not prone to impulsive actions. Low-scoring individuals tend to decide more quickly, not inclined to spend much time weighing and analyzing, and trust their intuition and immediate judgment more. Deliberation and decisiveness are two ends of the same dimension — the value of each depends on task nature.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: conduct systematic analysis and information gathering before major decisions, are not easily driven by impulse or emotion into hasty decisions, have significant advantage in high-risk, high-consequence scenarios, and may miss time windows due to repeated deliberation.\n\n**Low-scoring individuals** tend to: decide decisively and act quickly, have advantage in situations requiring quick response and flexible adjustment, do not fall into analysis paralysis, but may pay a price in important decisions due to insufficient deliberation.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "deliberation-faq-1",
+          "question": "What is the difference between deliberation and indecisiveness?",
+          "answer": "Deliberation is consciously considering consequences before acting — a controllable strategic choice. Indecisiveness is inability to decide even after having sufficient information, usually accompanied by anxiety and avoidance. Highly deliberative people can decide decisively once information is sufficient.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Deliberation, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Conscientiousness",
+          "href": "/en/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "depression",
+      "entity_key": "depression",
+      "slug": "big-five/facets/depression",
+      "locale": "en",
+      "title": "Depression (Neuroticism)",
+      "summary": "Depression describes tendency to experience sadness, low mood, and feelings of helplessness. It is the facet of Neuroticism related to negative mood.",
+      "seo": {
+        "title": "Depression | Big Five 30 Facets",
+        "description": "Depression describes tendency to experience sadness, low mood, and feelings of helplessness. It is the facet of Neuroticism related to negative mood."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/depression",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/depression"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/depression",
+        "en": "/en/personality/big-five/facets/depression"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Depression describes tendency to experience sadness, low mood, and feelings of helplessness. It is the facet of Neuroticism related to negative mood.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Depression?",
+          "body": "Depression is the facet of Neuroticism related to sadness and low mood. High-scoring individuals typically more easily experience sadness, helplessness, and defeat, have longer low periods after setbacks, and may hold more pessimistic expectations for the future. Low-scoring individuals tend to experience sadness and low mood less frequently and recover faster after setbacks. Important distinction: this facet measures sadness experience tendency, not a depression diagnosis criterion.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: have stronger emotional reactions to loss and setbacks, experience sadness and loss more deeply and recover more slowly, have unique sensitivity in activities requiring deep emotional understanding and artistic expression, but also consume more psychological resources due to longer recovery cycles.\n\n**Low-scoring individuals** tend to: recover to normal state faster after setbacks, are less occupied by low mood, and have advantage in situations requiring sustained steady output.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "depression-faq-1",
+          "question": "What is the relationship between high depression level and clinical depression?",
+          "answer": "The depression facet reflects tendency to experience sadness and low mood — a personality trait dimension. Clinical depression is a diagnosis requiring professional assessment. A high level does not mean you have depression, but if you chronically feel unshakable low mood, we recommend seeking professional help.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Depression, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Neuroticism / Emotional Sensitivity",
+          "href": "/en/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "dutifulness",
+      "entity_key": "dutifulness",
+      "slug": "big-five/facets/dutifulness",
+      "locale": "en",
+      "title": "Dutifulness (Conscientiousness)",
+      "summary": "Dutifulness describes tendency to follow rules, honor commitments, and adhere to ethical principles. It is the facet of Conscientiousness related to sense of obligation.",
+      "seo": {
+        "title": "Dutifulness | Big Five 30 Facets",
+        "description": "Dutifulness describes tendency to follow rules, honor commitments, and adhere to ethical principles. It is the facet of Conscientiousness related to sense of obligation."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/dutifulness",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/dutifulness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/dutifulness",
+        "en": "/en/personality/big-five/facets/dutifulness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Dutifulness describes tendency to follow rules, honor commitments, and adhere to ethical principles. It is the facet of Conscientiousness related to sense of obligation.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Dutifulness?",
+          "body": "Dutifulness is the facet of Conscientiousness related to obligation and rule-following. High-scoring individuals typically value commitments and rules, see honoring agreements and social norms as important, and are reliable team members. Low-scoring individuals tend to hold more flexible attitudes toward rules and agreements, preferring to adjust behavior based on specific situations, and may not believe all rules must be strictly followed. Dutifulness is not a moral judgment — it reflects the degree to which you are driven by internalized sense of obligation.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: try to complete what they commit to, value punctuality and integrity, prefer following processes and standards, have significant advantage in roles requiring reliability and consistency, and may struggle when flexibility is needed due to rigid rule adherence.\n\n**Low-scoring individuals** tend to: take a more elastic attitude toward rules and commitments, judge what is more reasonable based on context, have advantage in situations requiring breaking conventions and innovative solutions, but may have gaps in tasks requiring long-term commitment and stable delivery.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "dutifulness-faq-1",
+          "question": "Is dutifulness related to moral level?",
+          "answer": "Dutifulness is a personality trait describing your tendency to follow commitments and rules, not your moral level. Someone low in dutifulness may have strong personal ethical principles but simply not believe all forms of rules and commitments need equal treatment.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Dutifulness, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Conscientiousness",
+          "href": "/en/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "excitement-seeking",
+      "entity_key": "excitement-seeking",
+      "slug": "big-five/facets/excitement-seeking",
+      "locale": "en",
+      "title": "Excitement Seeking (Extraversion)",
+      "summary": "Excitement seeking describes need for and appreciation of exciting, novel, and stimulating experiences. It is the facet of Extraversion related to sensory stimulation preference.",
+      "seo": {
+        "title": "Excitement Seeking | Big Five 30 Facets",
+        "description": "Excitement seeking describes need for and appreciation of exciting, novel, and stimulating experiences. It is the facet of Extraversion related to sensory stimulation preference."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/excitement-seeking",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/excitement-seeking"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/excitement-seeking",
+        "en": "/en/personality/big-five/facets/excitement-seeking"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Excitement seeking describes need for and appreciation of exciting, novel, and stimulating experiences. It is the facet of Extraversion related to sensory stimulation preference.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Excitement Seeking?",
+          "body": "Excitement seeking is the facet of Extraversion related to excitement and novelty stimulation. High-scoring individuals typically enjoy high-intensity sensory experiences and excitement, like stimulating environments, new adventures, and heart-pounding activities. Low-scoring individuals tend to prefer calm and predictable environments, have lower need for high-intensity stimulation, and feel comfortable in quiet and soothing settings. Excitement seeking has some correlation with risk-taking behavior but is not the same thing.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: enjoy exciting activities like travel adventures, extreme sports, or lively social occasions, have high need for sensory stimulation, have advantage in situations requiring quick adaptation to change and accepting challenges, and may neglect risk assessment in pursuit of excitement.\n\n**Low-scoring individuals** tend to: prefer quiet and comfortable environments, have lower need for high-intensity sensory stimulation, have advantage in tasks requiring stability, patience, and fine operations, and can find satisfaction in daily life rather than relying on external stimulation.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "excitement-seeking-faq-1",
+          "question": "Are high excitement seekers more likely to take risks?",
+          "answer": "There is some correlation but not causation. High excitement seekers are more attracted to the thrill of risk, but whether they actually act depends on deliberation (a Conscientiousness facet), risk assessment, and specific context.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Excitement Seeking, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Extraversion",
+          "href": "/en/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "feelings",
+      "entity_key": "feelings",
+      "slug": "big-five/facets/feelings",
+      "locale": "en",
+      "title": "Feelings (Openness)",
+      "summary": "Feelings describes awareness of and attention to one's own inner emotional states. It is the facet of Openness related to emotional awareness.",
+      "seo": {
+        "title": "Feelings | Big Five 30 Facets",
+        "description": "Feelings describes awareness of and attention to one's own inner emotional states. It is the facet of Openness related to emotional awareness."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/feelings",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/feelings"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/feelings",
+        "en": "/en/personality/big-five/facets/feelings"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Feelings describes awareness of and attention to one's own inner emotional states. It is the facet of Openness related to emotional awareness.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Feelings?",
+          "body": "Feelings is the facet of Openness related to inner emotional awareness. High-scoring individuals typically value their emotional experiences, see emotions as important sources of information in life, and are willing to spend time understanding and expressing inner feelings. Low-scoring individuals tend to place less value on emotions, believing emotions should not overly influence judgment and decisions. This facet describes how much you value emotions, not how intense your emotions are — the latter relates more to the Neuroticism dimension.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: finely distinguish different emotional states, willingly express and share inner feelings, see emotional experience as an important part of a fulfilling life, and may incorporate intuition and emotional feelings into decision-making.\n\n**Low-scoring individuals** tend to: rely more on logic and facts for decisions, spend less time analyzing their emotional states, express inner feelings less frequently, and have an advantage in situations requiring calm and rational judgment.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "feelings-faq-1",
+          "question": "Does a high feelings level mean being emotional?",
+          "answer": "No. Feelings describes how much you value and attend to emotions. The Neuroticism dimension describes emotional reaction intensity and recovery speed. Someone high in Feelings may be skilled at understanding and expressing emotions while remaining emotionally stable.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Feelings, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Openness",
+          "href": "/en/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "gregariousness",
+      "entity_key": "gregariousness",
+      "slug": "big-five/facets/gregariousness",
+      "locale": "en",
+      "title": "Gregariousness (Extraversion)",
+      "summary": "Gregariousness describes preference for being with others and feeling comfortable in social settings. It is the facet of Extraversion related to social preference.",
+      "seo": {
+        "title": "Gregariousness | Big Five 30 Facets",
+        "description": "Gregariousness describes preference for being with others and feeling comfortable in social settings. It is the facet of Extraversion related to social preference."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/gregariousness",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/gregariousness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/gregariousness",
+        "en": "/en/personality/big-five/facets/gregariousness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Gregariousness describes preference for being with others and feeling comfortable in social settings. It is the facet of Extraversion related to social preference.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Gregariousness?",
+          "body": "Gregariousness is the facet of Extraversion related to social quantity and frequency. High-scoring individuals typically enjoy being with others, feel energized in crowds, and actively seek social opportunities. Low-scoring individuals tend to not particularly rely on social interaction for satisfaction, are equally or more comfortable alone, and have lower need for large-scale social activities. Gregariousness is not social ability — you can be highly skilled socially while preferring solitude.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: feel comfortable and fulfilled in crowds, actively organize and participate in social activities, feel stifled by too much alone time, and have advantage in roles requiring frequent interpersonal interaction and team collaboration.\n\n**Low-scoring individuals** tend to: enjoy alone time, do not need frequent socializing to maintain psychological balance, are more comfortable in small groups or one-on-one interactions than large groups, and have advantage in tasks requiring independent focus.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "gregariousness-faq-1",
+          "question": "Does low gregariousness mean social anxiety?",
+          "answer": "No. Low gregariousness simply means you have lower need for social quantity rather than quality. Social anxiety is fear and avoidance of social situations. They are different. Someone low in gregariousness may feel comfortable in social settings but just not actively seek lots of socializing.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Gregariousness, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Extraversion",
+          "href": "/en/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "ideas",
+      "entity_key": "ideas",
+      "slug": "big-five/facets/ideas",
+      "locale": "en",
+      "title": "Ideas (Openness)",
+      "summary": "Ideas describes interest in abstract concepts, philosophical questions, and intellectual challenges. It is the facet of Openness related to cognitive curiosity.",
+      "seo": {
+        "title": "Ideas | Big Five 30 Facets",
+        "description": "Ideas describes interest in abstract concepts, philosophical questions, and intellectual challenges. It is the facet of Openness related to cognitive curiosity."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/ideas",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/ideas"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/ideas",
+        "en": "/en/personality/big-five/facets/ideas"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Ideas describes interest in abstract concepts, philosophical questions, and intellectual challenges. It is the facet of Openness related to cognitive curiosity.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Ideas?",
+          "body": "Ideas is the facet of Openness related to intellectual curiosity. High-scoring individuals typically enjoy abstract thinking, have natural interest in philosophical questions, theoretical frameworks, and complex concepts, and enjoy discussing and debating ideas. Low-scoring individuals tend to have less interest in abstract thinking, preferring to focus on concrete, practical, actionable problems. This facet describes preference in thinking content (abstract vs. concrete), not thinking ability.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: enjoy exploring why-type questions, feel excited by theoretical frameworks and conceptual models, enjoy intellectual challenges and viewpoint debates, and may encounter practical difficulties from overly abstract thinking.\n\n**Low-scoring individuals** tend to: prefer handling specific, clear problems, have limited interest in abstract theories, value practical experience and verifiable results more, and have an advantage in situations requiring focused execution and practical problem-solving.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "ideas-faq-1",
+          "question": "Is ideas related to IQ?",
+          "answer": "Ideas is your degree of interest in abstract thinking, not your intelligence level. Someone with a high IQ may level low on Ideas because they prefer focusing their energy on concrete problems.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Ideas, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Openness",
+          "href": "/en/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "imagination",
+      "entity_key": "imagination",
+      "slug": "big-five/facets/imagination",
+      "locale": "en",
+      "title": "Imagination (Openness)",
+      "summary": "Imagination describes the tendency toward a rich inner world, fantasy, and creative imagination. It is the facet of Openness related to inner experience.",
+      "seo": {
+        "title": "Imagination | Big Five 30 Facets",
+        "description": "Imagination describes the tendency toward a rich inner world, fantasy, and creative imagination. It is the facet of Openness related to inner experience."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/imagination",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/imagination"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/imagination",
+        "en": "/en/personality/big-five/facets/imagination"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Imagination describes the tendency toward a rich inner world, fantasy, and creative imagination. It is the facet of Openness related to inner experience.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Imagination?",
+          "body": "Imagination is the facet of Openness most oriented toward inner experience. High-scoring individuals typically have a rich inner world, readily generate imagery and alternative scenarios, and find mental simulation and ideation to be natural ways of thinking. Low-scoring individuals tend to focus more on reality and present facts, with more grounded, practical thinking. Imagination is not the only source of creativity — pragmatism and focus are equally essential to creative work.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: easily construct rich scenarios and alternatives in their mind, experience strong inner responses when reading fiction or viewing art, have frequent daydreams and fantasies, and may sometimes get lost in imagination at the expense of present tasks.\n\n**Low-scoring individuals** tend to: focus more on immediate facts and practical problems, think in concrete and utilitarian terms, rely less on mental imagery to support thinking, and have an advantage in tasks requiring real-world detail and execution.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "imagination-faq-1",
+          "question": "Are imagination and creativity the same thing?",
+          "answer": "Not exactly. Imagination is the ability to generate rich mental imagery. Creativity also includes the execution side — turning ideas into actual outcomes. High imagination provides inspiration, but creativity requires coordination with other Openness facets (like Actions, Ideas) and Conscientiousness.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Imagination, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Openness",
+          "href": "/en/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "impulsiveness",
+      "entity_key": "impulsiveness",
+      "slug": "big-five/facets/impulsiveness",
+      "locale": "en",
+      "title": "Impulsiveness (Neuroticism)",
+      "summary": "Impulsiveness describes ability to control impulses when facing temptation and desire. It is the facet of Neuroticism related to self-control.",
+      "seo": {
+        "title": "Impulsiveness | Big Five 30 Facets",
+        "description": "Impulsiveness describes ability to control impulses when facing temptation and desire. It is the facet of Neuroticism related to self-control."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/impulsiveness",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/impulsiveness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/impulsiveness",
+        "en": "/en/personality/big-five/facets/impulsiveness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Impulsiveness describes ability to control impulses when facing temptation and desire. It is the facet of Neuroticism related to self-control.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Impulsiveness?",
+          "body": "Impulsiveness is the facet of Neuroticism related to impulse control. High-scoring individuals typically find it harder to control impulses when facing immediate temptation, easily make decisions they later regret, and have stronger cravings for immediate gratification. Low-scoring individuals tend to have better impulse control, can resist short-term temptations to pursue long-term goals, and have advantage in situations requiring waiting and delayed gratification. Impulsiveness describes difficulty controlling impulses, not a moral judgment — high impulsiveness does not equal weak will.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: have difficulty resisting immediate temptations (food, shopping, social media), prefer spontaneity over pre-planning, may have advantage in fields requiring quick reaction and immediate action, but may struggle in areas requiring long-term self-discipline and delayed gratification.\n\n**Low-scoring individuals** tend to: have good impulse control, are not easily swayed by immediate temptations, and have advantage in tasks requiring long-term planning and sustained self-discipline.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "impulsiveness-faq-1",
+          "question": "Does high impulsiveness mean poor self-control?",
+          "answer": "Impulsiveness reflects how strongly you feel impulses when facing temptation, not whether you ultimately give in. Someone high in impulsiveness can still effectively manage behavior through environmental strategies (removing temptations, setting clear rules).",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Impulsiveness, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Neuroticism / Emotional Sensitivity",
+          "href": "/en/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "modesty",
+      "entity_key": "modesty",
+      "slug": "big-five/facets/modesty",
+      "locale": "en",
+      "title": "Modesty (Agreeableness)",
+      "summary": "Modesty describes tendency toward understated self-presentation of achievements. It is the facet of Agreeableness related to self-presentation style.",
+      "seo": {
+        "title": "Modesty | Big Five 30 Facets",
+        "description": "Modesty describes tendency toward understated self-presentation of achievements. It is the facet of Agreeableness related to self-presentation style."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/modesty",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/modesty"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/modesty",
+        "en": "/en/personality/big-five/facets/modesty"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Modesty describes tendency toward understated self-presentation of achievements. It is the facet of Agreeableness related to self-presentation style.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Modesty?",
+          "body": "Modesty is the facet of Agreeableness related to self-presentation. High-scoring individuals typically do not tend to talk about their achievements and strengths, evaluate themselves conservatively and with restraint, and let others have the chance to shine. Low-scoring individuals tend to have higher awareness and willingness to express their achievements and strengths, and do not avoid showcasing their capabilities. Modesty is not low self-esteem — highly modest people can clearly know their strengths but choose not to actively display them.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: dislike being the center of attention, understate their achievements, tend to attribute success to external factors, have advantage in situations requiring team collaboration and low-key leadership, and may lose out in environments requiring self-promotion.\n\n**Low-scoring individuals** tend to: express confidence in their abilities, do not avoid talking about their achievements and strengths, have advantage in situations requiring personal capability highlighting and competitive display, but may be seen as insufficiently humble in cultures emphasizing team harmony.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "modesty-faq-1",
+          "question": "Does high modesty mean low self-esteem?",
+          "answer": "Absolutely not. Modesty is a social style — how you choose to present yourself. A highly modest person can be very confident but just feel no need to say it out loud. Low self-esteem is deep internal self-negation. The psychological mechanisms are completely different.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Modesty, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Agreeableness",
+          "href": "/en/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "order",
+      "entity_key": "order",
+      "slug": "big-five/facets/order",
+      "locale": "en",
+      "title": "Order (Conscientiousness)",
+      "summary": "Order describes preference for organization, tidiness, and structure. It is the facet of Conscientiousness related to structured environments.",
+      "seo": {
+        "title": "Order | Big Five 30 Facets",
+        "description": "Order describes preference for organization, tidiness, and structure. It is the facet of Conscientiousness related to structured environments."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/order",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/order"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/order",
+        "en": "/en/personality/big-five/facets/order"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Order describes preference for organization, tidiness, and structure. It is the facet of Conscientiousness related to structured environments.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Order?",
+          "body": "Order is the facet of Conscientiousness related to structural preference. High-scoring individuals typically like clean, organized environments, work methodically, keep clear schedules, and find chaos and disorder uncomfortable. Low-scoring individuals tend to not require high environmental order, can work efficiently in relatively casual and flexible spaces, and may not equate tidy with efficient. Order preference reflects comfort with structured environments, not self-discipline ability.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: keep a clean desk, clearly categorized files, organized plans, items in their designated places, have natural advantage in tasks requiring standardized processes and precise management, and may spend excessive time organizing due to over-pursuit of order.\n\n**Low-scoring individuals** tend to: maintain efficiency in relatively casual environments, not get distracted by imperfect item placement or process details, have advantage in creative work and situations requiring flexible adaptation, but may miss key information due to lack of organization.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "order-faq-1",
+          "question": "Are high-order people necessarily more efficient?",
+          "answer": "Not necessarily. Order preference reflects comfort with structured environments. Efficiency depends on task type. Some creative work needs a certain organized chaos for inspiration, while precise process work suits high-order preference better.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Order, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Conscientiousness",
+          "href": "/en/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "positive-emotions",
+      "entity_key": "positive-emotions",
+      "slug": "big-five/facets/positive-emotions",
+      "locale": "en",
+      "title": "Positive Emotions (Extraversion)",
+      "summary": "Positive emotions describes frequency and intensity of experiencing positive emotions like joy, enthusiasm, and contentment. It is the facet of Extraversion related to subjective well-being.",
+      "seo": {
+        "title": "Positive Emotions | Big Five 30 Facets",
+        "description": "Positive emotions describes frequency and intensity of experiencing positive emotions like joy, enthusiasm, and contentment. It is the facet of Extraversion related to subjective well-being."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/positive-emotions",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/positive-emotions"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/positive-emotions",
+        "en": "/en/personality/big-five/facets/positive-emotions"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Positive emotions describes frequency and intensity of experiencing positive emotions like joy, enthusiasm, and contentment. It is the facet of Extraversion related to subjective well-being.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Positive Emotions?",
+          "body": "Positive emotions is the facet of Extraversion related to positive emotional experience. High-scoring individuals typically frequently experience joy, enthusiasm, gratitude, and contentment, hold positive expectations for life, and have strong recovery tendencies during low points. Low-scoring individuals tend to experience positive emotions less frequently and less intensely, with a more even and neutral emotional tone. This facet is complementary to the experience frequency of negative emotions in the Neuroticism dimension — a person can simultaneously experience high levels of both positive and negative emotions.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: frequently feel happy and content, hold optimistic attitudes toward the future, find joy in small daily things, recover emotionally quickly, and re-enter positive states faster when facing setbacks.\n\n**Low-scoring individuals** tend to: have more even emotional experiences, not frequently feel intense joy or excitement, but also not fluctuate greatly due to external events, and have advantage in situations requiring calm analysis and objective judgment.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "positive-emotions-faq-1",
+          "question": "Does low positive emotions mean unhappiness?",
+          "answer": "Not necessarily. This facet measures frequency and intensity of positive emotional experience. Some people do not need frequent intense positive emotions to feel content — their well-being comes from calmness, meaning, or relationship depth.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Positive Emotions, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Extraversion",
+          "href": "/en/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "self-consciousness",
+      "entity_key": "self-consciousness",
+      "slug": "big-five/facets/self-consciousness",
+      "locale": "en",
+      "title": "Self-Consciousness (Neuroticism)",
+      "summary": "Self-consciousness describes tendency to feel awkward, uncomfortable, and scrutinized in social situations. It is the facet of Neuroticism related to social sensitivity.",
+      "seo": {
+        "title": "Self-Consciousness | Big Five 30 Facets",
+        "description": "Self-consciousness describes tendency to feel awkward, uncomfortable, and scrutinized in social situations. It is the facet of Neuroticism related to social sensitivity."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/self-consciousness",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/self-consciousness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/self-consciousness",
+        "en": "/en/personality/big-five/facets/self-consciousness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Self-consciousness describes tendency to feel awkward, uncomfortable, and scrutinized in social situations. It is the facet of Neuroticism related to social sensitivity.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Self-Consciousness?",
+          "body": "Self-consciousness is the facet of Neuroticism related to self-awareness and discomfort in social situations. High-scoring individuals typically easily feel watched and judged in social settings, care about how others perceive them, and often have the feeling that everyone is looking at me in crowds. Low-scoring individuals tend to feel less uncomfortable in social situations, do not overly worry about how others see them, and appear natural in public settings. Self-consciousness relates to but is not identical to shyness — you can be shy without strong self-consciousness.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: easily feel uncomfortable and scrutinized in social situations, have high attention to their appearance and behavior, have advantage in situations requiring precise self-monitoring and social etiquette, but may be overly nervous in contexts requiring natural and relaxed expression.\n\n**Low-scoring individuals** tend to: be naturally relaxed in social and public situations, not overly care about others' gaze, have advantage in situations requiring public expression and improvisation, but may not be alert enough in contexts requiring refined etiquette and social sensitivity.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "self-consciousness-faq-1",
+          "question": "Is high self-consciousness social anxiety disorder?",
+          "answer": "No. High self-consciousness only means you care more about your performance in social situations but typically do not avoid socializing because of it. If this concern has become so severe that you avoid social activities and it affects your quality of life, it may involve social anxiety disorder. We recommend consulting professional help.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Self-Consciousness, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Neuroticism / Emotional Sensitivity",
+          "href": "/en/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "self-discipline",
+      "entity_key": "self-discipline",
+      "slug": "big-five/facets/self-discipline",
+      "locale": "en",
+      "title": "Self-Discipline (Conscientiousness)",
+      "summary": "Self-discipline describes ability to start tasks and persist in completing them. It is the facet of Conscientiousness related to execution and perseverance.",
+      "seo": {
+        "title": "Self-Discipline | Big Five 30 Facets",
+        "description": "Self-discipline describes ability to start tasks and persist in completing them. It is the facet of Conscientiousness related to execution and perseverance."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/self-discipline",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/self-discipline"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/self-discipline",
+        "en": "/en/personality/big-five/facets/self-discipline"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Self-discipline describes ability to start tasks and persist in completing them. It is the facet of Conscientiousness related to execution and perseverance.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Self-Discipline?",
+          "body": "Self-discipline is the facet of Conscientiousness related to execution persistence. High-scoring individuals typically can proactively start unpleasant tasks and persist to completion, are not easily interrupted by distractions and temptations, and have stable execution in projects requiring long-term investment. Low-scoring individuals tend to have difficulty starting and persisting in tasks, are easily interrupted by external distractions or internal diversions, and prefer concentrating effort near deadlines. Self-discipline is a trainable capacity, not entirely determined by innate tendencies.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: persist even when tasks are boring or unpleasant, resist short-term temptations to achieve long-term goals, have strong internal drive in daily behavior, have significant advantage in tasks requiring sustained discipline, and may impose unnecessary pressure on themselves due to excessive strictness.\n\n**Low-scoring individuals** tend to: work efficiently when motivated, produce quickly under deadline pressure, have advantage in tasks requiring quick response and flexible adjustment, but may struggle in long-term projects requiring sustained investment.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "self-discipline-faq-1",
+          "question": "Are low self-discipline people lazy?",
+          "answer": "No. Self-discipline reflects how easily you self-drive in the absence of external constraints. Many low self-discipline individuals perform excellently in environments with clear external structure (deadlines, team collaboration, role division). Understanding your self-discipline pattern allows you to compensate through environmental design — like breaking goals into small steps or finding accountability partners.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Self-Discipline, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Conscientiousness",
+          "href": "/en/personality/big-five/conscientiousness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "straightforwardness",
+      "entity_key": "straightforwardness",
+      "slug": "big-five/facets/straightforwardness",
+      "locale": "en",
+      "title": "Straightforwardness (Agreeableness)",
+      "summary": "Straightforwardness describes tendency to communicate in a candid, direct manner. It is the facet of Agreeableness related to communication style.",
+      "seo": {
+        "title": "Straightforwardness | Big Five 30 Facets",
+        "description": "Straightforwardness describes tendency to communicate in a candid, direct manner. It is the facet of Agreeableness related to communication style."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/straightforwardness",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/straightforwardness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/straightforwardness",
+        "en": "/en/personality/big-five/facets/straightforwardness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Straightforwardness describes tendency to communicate in a candid, direct manner. It is the facet of Agreeableness related to communication style.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Straightforwardness?",
+          "body": "Straightforwardness is the facet of Agreeableness related to communication candor. High-scoring individuals typically communicate candidly and directly, do not like beating around the bush or strategic expression, and believe honesty is a form of respect. Low-scoring individuals tend to be more nuanced and strategic in communication, preferring to consider the potential impact of expression before choosing words. Straightforwardness reflects communication style, not honesty level — someone who expresses strategically can equally be honest.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: speak directly, dislike indirect communication, have advantage in situations requiring quick clarification and transparent communication, and may cause discomfort in sensitive topics due to direct expression style.\n\n**Low-scoring individuals** tend to: consider wording and timing before expressing, are good at conveying information in ways the other person can accept, have advantage in situations requiring relationship maintenance and sensitive communication, but may cause information distortion due to insufficiently direct expression.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "straightforwardness-faq-1",
+          "question": "Does high straightforwardness mean speaking harshly?",
+          "answer": "No. Straightforwardness reflects how directly you tend to express thoughts, not whether you care about others' feelings. A high-straightforwardness person can be both candid and kind — the key is whether the candid content is constructive or aggressive.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Straightforwardness, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Agreeableness",
+          "href": "/en/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "tender-mindedness",
+      "entity_key": "tender-mindedness",
+      "slug": "big-five/facets/tender-mindedness",
+      "locale": "en",
+      "title": "Tender-Mindedness (Agreeableness)",
+      "summary": "Tender-mindedness describes tendency to feel sympathy and care for others' situations. It is the facet of Agreeableness related to empathic sensitivity.",
+      "seo": {
+        "title": "Tender-Mindedness | Big Five 30 Facets",
+        "description": "Tender-mindedness describes tendency to feel sympathy and care for others' situations. It is the facet of Agreeableness related to empathic sensitivity."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/tender-mindedness",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/tender-mindedness"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/tender-mindedness",
+        "en": "/en/personality/big-five/facets/tender-mindedness"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Tender-mindedness describes tendency to feel sympathy and care for others' situations. It is the facet of Agreeableness related to empathic sensitivity.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Tender-Mindedness?",
+          "body": "Tender-mindedness is the facet of Agreeableness related to empathy and care. High-scoring individuals typically are easily moved by others' difficulties and emotions, have strong care and protective instincts toward vulnerable groups, and prioritize feeling factors when making decisions involving people. Low-scoring individuals tend to rely more on logic and principles in decision-making, are less easily influenced by emotions or others' situations, and can maintain rationality in situations requiring objective judgment. Tender-mindedness is not coldness — low-scoring individuals can still care about others, just in a more rational and principle-oriented way.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: easily be moved by touching stories or others' difficult situations, prioritize impact on people when making decisions, have natural advantage in humanistic care roles (nursing, education, counseling), and may hesitate in tough decisions due to emotional factors.\n\n**Low-scoring individuals** tend to: rely more on logic and objective criteria in decision-making, are less easily swayed by emotional appeals, and have advantage in situations requiring impartial handling, strict standard enforcement, and crisis decision-making.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "tender-mindedness-faq-1",
+          "question": "Does low tender-mindedness mean cold and heartless?",
+          "answer": "No. Low tender-minded individuals tend to guide care for others through rationality and principles rather than emotions. A surgeon may level low on tender-mindedness but can save lives through professional ability and precise judgment — that is another form of care.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Tender-Mindedness, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Agreeableness",
+          "href": "/en/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "trust",
+      "entity_key": "trust",
+      "slug": "big-five/facets/trust",
+      "locale": "en",
+      "title": "Trust (Agreeableness)",
+      "summary": "Trust describes tendency to believe others' intentions are benevolent. It is the facet of Agreeableness related to basic interpersonal attitude.",
+      "seo": {
+        "title": "Trust | Big Five 30 Facets",
+        "description": "Trust describes tendency to believe others' intentions are benevolent. It is the facet of Agreeableness related to basic interpersonal attitude."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/trust",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/trust"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/trust",
+        "en": "/en/personality/big-five/facets/trust"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Trust describes tendency to believe others' intentions are benevolent. It is the facet of Agreeableness related to basic interpersonal attitude.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Trust?",
+          "body": "Trust is the most foundational interpersonal attitude facet of Agreeableness. High-scoring individuals typically tend to believe others' motives are benevolent, think most people are trustworthy, and hold open and friendly attitudes in initial interactions. Low-scoring individuals tend to be cautious about others' motives, prefer to observe before judging, and do not easily assume others mean well. Trust is not naivety — high-trust individuals can equally recognize malice, they just have different default assumptions.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: hold open and benevolent presuppositions when interacting with others, willingly extend trust before waiting for the other to prove themselves, have advantage in situations requiring rapid cooperation and trust-building, and may maintain a high trust baseline even after negative experiences.\n\n**Low-scoring individuals** tend to: be more vigilant about their own and others' boundaries, prefer to verify before trusting, have advantage in situations requiring risk control and critical assessment, but may miss opportunities for deep relationships due to overly high trust thresholds.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "trust-faq-1",
+          "question": "Does trust conflict with judgment?",
+          "answer": "Not necessarily. High trust reflects your default assumption — you believe most people's intentions are benevolent. This does not mean you lose the ability to judge and identify malice. Trust is a social strategy; judgment is a cognitive ability. Both can coexist.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Trust, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Agreeableness",
+          "href": "/en/personality/big-five/agreeableness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "values",
+      "entity_key": "values",
+      "slug": "big-five/facets/values",
+      "locale": "en",
+      "title": "Values (Openness)",
+      "summary": "Values describes willingness to re-examine social norms, traditions, and authority. It is the facet of Openness related to attitudinal flexibility.",
+      "seo": {
+        "title": "Values | Big Five 30 Facets",
+        "description": "Values describes willingness to re-examine social norms, traditions, and authority. It is the facet of Openness related to attitudinal flexibility."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/values",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/values"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/values",
+        "en": "/en/personality/big-five/facets/values"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Values describes willingness to re-examine social norms, traditions, and authority. It is the facet of Openness related to attitudinal flexibility.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Values?",
+          "body": "Values is the facet of Openness related to attitudinal and belief flexibility. High-scoring individuals typically are willing to challenge traditional views and re-examine social norms, holding inclusive attitudes toward different values and lifestyles. Low-scoring individuals tend to respect tradition and established norms more, preferring to maintain stable and predictable social structures. Values openness does not mean having no stance or anything goes — it means staying open to the possibility that things may not be as I thought.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: hold open attitudes toward social issues and value discussions, willingly re-examine their own positions from different angles, and have high acceptance of different cultures, religions, and lifestyles.\n\n**Low-scoring individuals** tend to: value tradition, rules, and the stability of established order more, prefer maintaining verified social norms, and have an advantage in situations requiring consistency, rule enforcement, and maintaining collective identity.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "values-faq-1",
+          "question": "Does values openness mean having no principles?",
+          "answer": "No. High values openness means you are willing to examine and re-evaluate your values, not that you lack firm beliefs. This openness is cognitive flexibility, not an absence of stance.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Values, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Openness",
+          "href": "/en/personality/big-five/openness",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "vulnerability",
+      "entity_key": "vulnerability",
+      "slug": "big-five/facets/vulnerability",
+      "locale": "en",
+      "title": "Vulnerability (Neuroticism)",
+      "summary": "Vulnerability describes ability to cope and recover under stress. It is the facet of Neuroticism related to stress tolerance.",
+      "seo": {
+        "title": "Vulnerability | Big Five 30 Facets",
+        "description": "Vulnerability describes ability to cope and recover under stress. It is the facet of Neuroticism related to stress tolerance."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/vulnerability",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/vulnerability"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/vulnerability",
+        "en": "/en/personality/big-five/facets/vulnerability"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Vulnerability describes ability to cope and recover under stress. It is the facet of Neuroticism related to stress tolerance.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Vulnerability?",
+          "body": "Vulnerability is the facet of Neuroticism related to stress coping ability. High-scoring individuals typically easily feel helpless and overwhelmed under stress, have decreased coping ability in emergency and high-pressure situations, and need longer time to return to normal. Low-scoring individuals tend to stay relatively calm and cope effectively under stress, maintain judgment and action ability in emergencies, and recover faster. Vulnerability reflects ease of coping under stress, not a judgment of weakness or strength.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: easily feel overwhelmed and resource-depleted in high-pressure situations, need clear support and recovery time, have alerting value in tasks requiring high vigilance and risk sensitivity, but high-pressure scenarios themselves bring higher recovery cost.\n\n**Low-scoring individuals** tend to: maintain relatively stable judgment and execution under stress and emergency, recover faster, and have advantage in situations requiring crisis handling and high-pressure decisions.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "vulnerability-faq-1",
+          "question": "Are people high in vulnerability poor at handling pressure?",
+          "answer": "Vulnerability reflects your subjective experience of difficulty under stress. Some people who appear to handle pressure poorly may, all else being equal, just need more recovery time rather than lacking ability. Moreover, high vulnerability can be an advantage in jobs requiring high vigilance and risk sensitivity.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Vulnerability, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Neuroticism / Emotional Sensitivity",
+          "href": "/en/personality/big-five/neuroticism",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
+    },
+    {
+      "framework": "big_five",
+      "entity_type": "facet_detail",
+      "code": "warmth",
+      "entity_key": "warmth",
+      "slug": "big-five/facets/warmth",
+      "locale": "en",
+      "title": "Warmth (Extraversion)",
+      "summary": "Warmth describes tendency to build friendly, warm relationships with others. It is the facet of Extraversion related to affiliation and friendliness.",
+      "seo": {
+        "title": "Warmth | Big Five 30 Facets",
+        "description": "Warmth describes tendency to build friendly, warm relationships with others. It is the facet of Extraversion related to affiliation and friendliness."
+      },
+      "robots": "noindex,follow",
+      "canonical_path": "/en/personality/big-five/facets/warmth",
+      "canonical": {
+        "path": "/en/personality/big-five/facets/warmth"
+      },
+      "hreflang": {
+        "zh-CN": "/zh/personality/big-five/facets/warmth",
+        "en": "/en/personality/big-five/facets/warmth"
+      },
+      "sections": [
+        {
+          "key": "quick_answer",
+          "title": "Quick Answer",
+          "body": "Warmth describes tendency to build friendly, warm relationships with others. It is the facet of Extraversion related to affiliation and friendliness.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "what_is",
+          "title": "What is Warmth?",
+          "body": "Warmth is the facet of Extraversion related to interpersonal warmth. High-scoring individuals typically easily build friendly relationships, show genuine care and goodwill in initial interactions, and make others feel comfortable and accepted. Low-scoring individuals tend to maintain some distance in relationships, not proactively expressing friendliness, but are equally sincere in established deep relationships. Warmth is more about the tendency to actively extend goodwill, rather than empathy ability — the latter relates more to Agreeableness.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        },
+        {
+          "key": "high_low",
+          "title": "High vs Low",
+          "body": "**High-scoring individuals** tend to: proactively express friendliness and care to others, easily build rapport with new acquaintances, make others feel welcome in social situations, and have advantage in service and collaboration scenarios requiring rapid trust-building.\n\n**Low-scoring individuals** tend to: express friendliness more subtly, not rush to show closeness, value relationship authenticity and depth over breadth, and have advantage in situations requiring professional distance and objective judgment.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "faq": [
+        {
+          "id": "warmth-faq-1",
+          "question": "Does low warmth mean unfriendly?",
+          "answer": "No. Warmth reflects the frequency and intensity with which you actively extend goodwill, not your true attitude toward others. Someone low in warmth may care deeply about others but express it more reservedly and subtly.",
+          "evidence_ids": [
+            "A1",
+            "A8"
+          ]
+        }
+      ],
+      "media": {
+        "status": "placeholder",
+        "image_url": null,
+        "alt": "Big Five placeholder image for Warmth, no MBTI branding."
+      },
+      "method_boundary": {
+        "summary": "This page explains public knowledge about Big Five personality. It does not interpret individual assessment results or substitute for professional judgment.",
+        "not_for": [
+          "Clinical diagnosis",
+          "Psychological treatment advice",
+          "Hiring or screening",
+          "Ability or intelligence assessment",
+          "Career or relationship decisions"
+        ]
+      },
+      "internal_links": [
+        {
+          "label": "Big Five",
+          "href": "/en/personality/big-five",
+          "relationship": "hub",
+          "target_code": null
+        },
+        {
+          "label": "30 Facets",
+          "href": "/en/personality/big-five/facets",
+          "relationship": "facet_overview",
+          "target_code": null
+        },
+        {
+          "label": "Extraversion",
+          "href": "/en/personality/big-five/extraversion",
+          "relationship": "domain",
+          "target_code": null
+        }
+      ],
+      "evidence_notes": [
+        {
+          "note": "This page is written based on the public research tradition of the Big Five as a continuous trait model, referencing BFI-2, Five-Factor Model reviews, the IPIP public item pool ecosystem, and 30-facet literature."
+        },
+        {
+          "note": "These explanations are for understanding personality language and communication differences, not for clinical diagnosis, psychological treatment, hiring, ability assessment, or career decisions."
+        },
+        {
+          "note": "Competitor pages are used only to identify user problems and content gaps, not to copy their structure, examples, or wording."
+        }
+      ],
+      "launch_state": "content_ready",
+      "review_state": "reviewed",
+      "index_eligible": false,
+      "sitemap_eligible": false,
+      "llms_eligible": false,
+      "is_public": true,
+      "schema_runtime_eligible": false,
+      "org_id": 0
     }
   ]
 }

--- a/backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
@@ -19,8 +19,8 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
     {
         $this->artisan('personality-public-assets:import')
             ->expectsOutputToContain('dry_run=1')
-            ->expectsOutputToContain('assets_found=94')
-            ->expectsOutputToContain('valid_count=94')
+            ->expectsOutputToContain('assets_found=154')
+            ->expectsOutputToContain('valid_count=154')
             ->expectsOutputToContain('errors_count=0')
             ->expectsOutputToContain('indexable_count=0')
             ->expectsOutputToContain('sitemap_eligible_count=0')
@@ -36,18 +36,18 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
             '--write' => true,
         ])
             ->expectsOutputToContain('dry_run=0')
-            ->expectsOutputToContain('will_create=94')
+            ->expectsOutputToContain('will_create=154')
             ->expectsOutputToContain('indexable_count=0')
             ->expectsOutputToContain('sitemap_eligible_count=0')
             ->expectsOutputToContain('llms_eligible_count=0')
             ->assertExitCode(0);
 
-        $this->assertSame(94, PersonalityPublicContentAsset::query()->count());
+        $this->assertSame(154, PersonalityPublicContentAsset::query()->count());
 
         $this->artisan('personality-public-assets:import', [
             '--write' => true,
         ])
-            ->expectsOutputToContain('will_skip=94')
+            ->expectsOutputToContain('will_skip=154')
             ->assertExitCode(0);
 
         $asset = PersonalityPublicContentAsset::query()
@@ -101,21 +101,26 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
         $payload = json_decode((string) file_get_contents(base_path('content_assets/personality_public/big_five_v1_seed.json')), true);
         $assets = collect(is_array($payload['assets'] ?? null) ? $payload['assets'] : []);
 
-        $this->assertSame(94, $assets->count());
-        $this->assertSame(['en' => 47, 'zh-CN' => 47], $assets->countBy('locale')->sortKeys()->all());
+        $this->assertSame(154, $assets->count());
+        $this->assertSame(['en' => 77, 'zh-CN' => 77], $assets->countBy('locale')->sortKeys()->all());
         $this->assertSame([
             'domain' => 10,
             'facet' => 60,
+            'facet_detail' => 60,
             'facet_hub' => 2,
             'hub' => 2,
             'polarity' => 20,
         ], $assets->countBy('entity_type')->sortKeys()->all());
 
-        $renderCandidates = $assets->where('launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)->values();
+        $renderCandidates = $assets->where('launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)
+            ->whereNotIn('entity_type', [PersonalityPublicContentAsset::ENTITY_FACET_DETAIL])
+            ->values();
         $facetStubs = $assets->where('entity_type', PersonalityPublicContentAsset::ENTITY_FACET)->values();
+        $facetDetails = $assets->where('entity_type', PersonalityPublicContentAsset::ENTITY_FACET_DETAIL)->values();
 
         $this->assertSame(34, $renderCandidates->count());
         $this->assertSame(60, $facetStubs->count());
+        $this->assertSame(60, $facetDetails->count());
         $this->assertTrue($assets->every(fn (array $asset): bool => $asset['robots'] === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW));
         $this->assertTrue($assets->every(fn (array $asset): bool => $asset['index_eligible'] === false && $asset['sitemap_eligible'] === false && $asset['llms_eligible'] === false));
         $this->assertTrue($renderCandidates->every(fn (array $asset): bool => $asset['robots'] === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW));
@@ -137,6 +142,32 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
         $enCodes = $renderCandidates->where('locale', 'en')->pluck('code')->sort()->values()->all();
         $zhCodes = $renderCandidates->where('locale', 'zh-CN')->pluck('code')->sort()->values()->all();
         $this->assertSame($enCodes, $zhCodes);
+
+        // facet_detail-specific assertions
+        $this->assertTrue($facetDetails->every(fn (array $asset): bool => $asset['launch_state'] === PersonalityPublicContentAsset::LAUNCH_CONTENT_READY));
+        $this->assertTrue($facetDetails->every(fn (array $asset): bool => $asset['robots'] === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW));
+        $this->assertTrue($facetDetails->every(fn (array $asset): bool => $asset['index_eligible'] === false && $asset['sitemap_eligible'] === false && $asset['llms_eligible'] === false));
+        $this->assertTrue($facetDetails->every(fn (array $asset): bool => count($asset['sections'] ?? []) >= 3));
+        $this->assertTrue($facetDetails->every(fn (array $asset): bool => count($asset['faq'] ?? []) >= 1));
+        $this->assertTrue($facetDetails->every(fn (array $asset): bool => count($asset['internal_links'] ?? []) >= 3));
+        $this->assertTrue($facetDetails->every(function (array $asset): bool {
+            $canonicalPath = (string) data_get($asset, 'canonical.path', '');
+            $code = (string) ($asset['code'] ?? '');
+
+            return $asset['locale'] === 'zh-CN'
+                ? str_starts_with($canonicalPath, '/zh/personality/big-five/facets/')
+                    && str_ends_with($canonicalPath, '/' . $code)
+                : str_starts_with($canonicalPath, '/en/personality/big-five/facets/')
+                    && str_ends_with($canonicalPath, '/' . $code);
+        }));
+        $this->assertTrue($facetDetails->every(fn (array $asset): bool =>
+            str_starts_with((string) ($asset['slug'] ?? ''), 'big-five/facets/')
+            && str_ends_with((string) ($asset['slug'] ?? ''), (string) ($asset['code'] ?? ''))
+        ));
+        $facetDetailEnCodes = $facetDetails->where('locale', 'en')->pluck('code')->sort()->values()->all();
+        $facetDetailZhCodes = $facetDetails->where('locale', 'zh-CN')->pluck('code')->sort()->values()->all();
+        $this->assertSame($facetDetailEnCodes, $facetDetailZhCodes);
+        $this->assertCount(30, $facetDetailEnCodes);
 
         $serializedSeed = strtolower((string) json_encode($assets->all(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
         foreach ([


### PR DESCRIPTION
## What changed

- Add `ENTITY_FACET_DETAIL` constant to `PersonalityPublicContentAsset` model
- Register `facet_detail` in `ENTITY_TYPES` and `FRAMEWORK_ENTITY_TYPES[big_five]`
- Add 60 facet_detail seed entries (30 facets × 2 locales) — total 94→154
- Update contract tests with facet_detail-specific assertions, locale parity, canonical path checks

## Why

Frontend (fap-web PR #1631) has already registered `facet_detail` entity type and 30 facet routes. This PR provides the backend API endpoint support so `GET /v0.5/personality-content-assets/big_five/facet_detail/{code}?locale=zh-CN` returns content.

## Validation

```
php artisan test --filter=seed_has_expected_counts  # 2 passed, 271 assertions
```

## Deployment

After merge:
1. Run `php artisan personality-public-assets:import --write` to populate DB
2. Verify: `GET /v0.5/personality-content-assets/big_five/facet_detail/imagination?locale=zh-CN&org_id=0`