### PR TITLE
feat: add --update-existing flag to personality:enneagram-cms-draft

### DIFF
--- a/backend/app/Console/Commands/PersonalityEnneagramCmsDraft.php
+++ b/backend/app/Console/Commands/PersonalityEnneagramCmsDraft.php
@@ -36,7 +36,8 @@ final class PersonalityEnneagramCmsDraft extends Command
         {--no-sitemap : Required for --write; confirms no sitemap action}
         {--no-llms : Required for --write; confirms no llms action}
         {--no-search-release : Required for --write; confirms no search release action}
-        {--operator-approved= : Required exact approval token for --write}';
+        {--operator-approved= : Required exact approval token for --write}
+        {--update-existing : Update content on existing content_ready assets instead of blocking (use with --write for production backfill)}';
 
     protected $description = 'Create Enneagram public profile CMS draft assets with explicit no-publish/no-index guards.';
 
@@ -90,8 +91,8 @@ final class PersonalityEnneagramCmsDraft extends Command
         }
 
         $summary = $write
-            ? $writer->write($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw))
-            : $writer->plan($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw));
+            ? $writer->write($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw), (bool) $this->option('update-existing'))
+            : $writer->plan($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw), (bool) $this->option('update-existing'));
 
         return array_merge($summary, [
             'package_path' => $packagePath,
@@ -151,6 +152,7 @@ final class PersonalityEnneagramCmsDraft extends Command
         $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
         $this->line('row_count='.(string) ($summary['row_count'] ?? 0));
         $this->line('created_asset_count='.(string) ($summary['created_asset_count'] ?? 0));
+        $this->line('updated_asset_count='.(string) ($summary['updated_asset_count'] ?? 0));
         $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
     }
 

--- a/backend/app/Services/Cms/EnneagramCmsDraftWriter.php
+++ b/backend/app/Services/Cms/EnneagramCmsDraftWriter.php
@@ -34,9 +34,9 @@ final class EnneagramCmsDraftWriter
      * @param  array<string,mixed>  $qa
      * @return array<string,mixed>
      */
-    public function plan(array $package, array $qa, string $sourceSha256, string $qaSha256): array
+    public function plan(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $updateExisting = false): array
     {
-        return $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, false);
+        return $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, false, $updateExisting);
     }
 
     /**
@@ -44,9 +44,9 @@ final class EnneagramCmsDraftWriter
      * @param  array<string,mixed>  $qa
      * @return array<string,mixed>
      */
-    public function write(array $package, array $qa, string $sourceSha256, string $qaSha256): array
+    public function write(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $updateExisting = false): array
     {
-        return DB::transaction(fn (): array => $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, true));
+        return DB::transaction(fn (): array => $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, true, $updateExisting));
     }
 
     /**
@@ -54,7 +54,7 @@ final class EnneagramCmsDraftWriter
      * @param  array<string,mixed>  $qa
      * @return array<string,mixed>
      */
-    private function buildSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write): array
+    private function buildSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write, bool $updateExisting = false): array
     {
         $qaRows = $this->qaRowsByUrl($qa);
         $errors = [];
@@ -102,11 +102,25 @@ final class EnneagramCmsDraftWriter
 
             $existing = $this->existingAsset($identity);
             if ($existing instanceof PersonalityPublicContentAsset && ! $this->existingAssetIsWritableDraft($existing, $sourceSha256)) {
-                $errors[] = [
-                    'field' => 'recommendations.'.((string) $position).'.target_url',
-                    'code' => 'existing_live_or_foreign_asset_blocks_draft_write',
-                    'message' => 'Existing public/content-ready/published/indexable or foreign-source asset blocks draft-only writes.',
-                ];
+                if ($updateExisting && $this->assetIsUpdatableContentReady($existing)) {
+                    // Allow: updating an existing content_ready asset with new content.
+                } else {
+                    $errors[] = [
+                        'field' => 'recommendations.'.((string) $position).'.target_url',
+                        'code' => 'existing_live_or_foreign_asset_blocks_draft_write',
+                        'message' => 'Existing public/content-ready/published/indexable or foreign-source asset blocks draft-only writes. Use --update-existing to backfill content_ready assets.',
+                    ];
+                }
+            }
+
+            if ($errors === [] || $write) {
+                // Determine action for existing assets
+                $action = 'create_draft_asset';
+                if ($existing instanceof PersonalityPublicContentAsset) {
+                    $action = $updateExisting && $this->assetIsUpdatableContentReady($existing)
+                        ? 'update_existing_content_ready'
+                        : ($this->existingAssetIsWritableDraft($existing, $sourceSha256) ? 'skip_existing_same_source_draft' : 'blocked_existing');
+                }
             }
 
             $rows[] = [
@@ -121,7 +135,7 @@ final class EnneagramCmsDraftWriter
                 'qa_source_sha256' => $qaSha256,
                 'recommendation_sha256' => hash('sha256', $recommendationJson),
                 'existing_asset_id' => $existing?->id !== null ? (int) $existing->id : null,
-                'action' => $existing instanceof PersonalityPublicContentAsset ? 'skip_existing_same_source_draft' : 'create_draft_asset',
+                'action' => $action,
                 'asset_preview' => $this->assetPayload($recommendation, $identity, $sourceSha256, $qaSha256),
             ];
         }
@@ -144,12 +158,37 @@ final class EnneagramCmsDraftWriter
         }
 
         $created = 0;
+        $updated = 0;
         $skipped = 0;
         if ($write) {
             foreach ($rows as &$row) {
-                if (($row['existing_asset_id'] ?? null) !== null) {
+                if ($row['action'] === 'skip_existing_same_source_draft') {
                     $row['action'] = 'skipped_existing';
                     $skipped++;
+
+                    continue;
+                }
+
+                if ($row['action'] === 'blocked_existing') {
+                    continue;
+                }
+
+                if ($row['action'] === 'update_existing_content_ready' && ($row['existing_asset_id'] ?? null) !== null) {
+                    $payload = (array) $row['asset_preview'];
+                    // Only update content fields; preserve state fields on existing content_ready assets.
+                    unset(
+                        $payload['org_id'], $payload['framework'], $payload['entity_type'], $payload['entity_key'],
+                        $payload['slug'], $payload['locale'],
+                        $payload['is_public'], $payload['index_eligible'], $payload['sitemap_eligible'],
+                        $payload['llms_eligible'], $payload['launch_state'], $payload['review_state'],
+                        $payload['robots'], $payload['contract_version'], $payload['source_package'], $payload['source_hash'],
+                    );
+                    PersonalityPublicContentAsset::query()
+                        ->withoutGlobalScopes()
+                        ->whereKey((int) $row['existing_asset_id'])
+                        ->update($payload);
+                    $row['action'] = 'updated_content_ready_asset';
+                    $updated++;
 
                     continue;
                 }
@@ -170,8 +209,9 @@ final class EnneagramCmsDraftWriter
             'core_type_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CORE_TYPE),
             'would_create_asset_count' => $write ? 0 : count(array_filter($rows, static fn (array $row): bool => ($row['existing_asset_id'] ?? null) === null)),
             'created_asset_count' => $created,
+            'updated_asset_count' => $updated,
             'skipped_existing_count' => $skipped,
-            'writes_committed' => $write && $created > 0,
+            'writes_committed' => $write && ($created > 0 || $updated > 0),
             'rows' => $rows,
             'errors' => [],
             'warnings' => [],
@@ -296,6 +336,16 @@ final class EnneagramCmsDraftWriter
                 PersonalityPublicContentAsset::LAUNCH_DRAFT,
                 PersonalityPublicContentAsset::LAUNCH_REVIEW,
             ], true);
+    }
+
+    private function assetIsUpdatableContentReady(PersonalityPublicContentAsset $asset): bool
+    {
+        return (bool) $asset->is_public === true
+            && (bool) $asset->index_eligible === false
+            && (bool) $asset->sitemap_eligible === false
+            && (bool) $asset->llms_eligible === false
+            && $asset->launch_state === PersonalityPublicContentAsset::LAUNCH_CONTENT_READY
+            && $asset->robots === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW;
     }
 
     /**


### PR DESCRIPTION
## What

Add `--update-existing` flag to `personality:enneagram-cms-draft` command, enabling content updates on existing `content_ready` Enneagram assets.

## Why

The current draft writer blocks writes when a `content_ready` or `published` asset already exists. This is correct for the normal draft→promote workflow, but blocks legitimate content backfill scenarios where we need to update placeholder seed content on already-promoted assets.

## Changes

- **`PersonalityEnneagramCmsDraft`**: Add `--update-existing` option, pass through to writer
- **`EnneagramCmsDraftWriter`**: 
  - Add `assetIsUpdatableContentReady()` gate method
  - When `--update-existing`: allow update of existing `content_ready` assets (is_public=true, launch_state=content_ready, robots=noindex,follow)
  - UPDATE path strips state fields — only content fields are updated (title, summary, content_sections_json, faq_json, internal_links_json, seo_json)
  - Preserves: launch_state, is_public, robots, index/sitemap/llms eligibility

## Safety guarantees

- All existing safety flags still required
- Only enneagram framework + matching entity_type/entity_key/locale
- State fields explicitly stripped from update payload
- Never touches published/indexable assets

## Validation

```bash
# Local dry-run (with existing content_ready assets):
php artisan personality:enneagram-cms-draft --dry-run --update-existing --package=... --qa=...
# → ok=1, status=pass, row_count=10, action=update_existing_content_ready

# Local write:
php artisan personality:enneagram-cms-draft --write --update-existing --draft-only   --no-publish --no-index --no-sitemap --no-llms --no-search-release   --operator-approved=ENNEAGRAM-CMS-DRAFT-WRITER-CONTRACT-01 --package=... --qa=...
# → updated_asset_count=10, created_asset_count=0
```

## Deferred items

- Center pages (gut/heart/head) — no content drafts exist yet
- noindex removal on type pages — separate PR
- Sitemap/LLMs enneagram framework support — separate PR (blocker B3)