### PR TITLE
ENNEAGRAM-SITEMAP-LLMS-ELIGIBILITY-DECOUPLE-01

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -340,7 +340,6 @@ class SitemapGenerator
             ->where('robots', PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW)
             ->where('index_eligible', true)
             ->where('sitemap_eligible', true)
-            ->where('llms_eligible', true)
             ->select(['entity_key', 'framework', 'canonical_json', 'updated_at', 'published_at'])
             ->orderBy('entity_type')
             ->orderBy('entity_key')

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -264,7 +264,7 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-noindex', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-review', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-sitemap-off', $xml);
-        $this->assertStringNotContainsString('https://fermatmind.com/zh/personality/big-five/openness-llms-off', $xml);
+        $this->assertStringContainsString('https://fermatmind.com/zh/personality/big-five/openness-llms-off', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/big-five/openness', $xml);
 
         // Hub should NOT be included when noindex or draft


### PR DESCRIPTION
## Fix: Decouple SitemapGenerator from llms_eligible

SitemapGenerator required `llms_eligible=true`, coupling sitemap membership to LLM eligibility. This prevented Enneagram with `llms_eligible=false` from appearing in sitemap.

### Change (-1 line)

Remove `where('llms_eligible', true)` from SitemapGenerator `getPersonalityPublicContentAssetUrls` query.

### Sitemap eligibility after fix

| Gate | Required |
|------|:---:|
| `is_public` | ✅ |
| `launch_state=published` | ✅ |
| `robots=index,follow` | ✅ |
| `index_eligible` | ✅ |
| `sitemap_eligible` | ✅ |
| `llms_eligible` | ❌ removed |

### LLMs remain gated

`llms_eligible` still required for LLM feed surfaces.

### Post-deploy

After deploy + `seo:warm-sitemap-source-cache`:
- sitemap.xml: 13/13 Enneagram ✅
- llms.txt: 0/13 ✅
- llms-full.txt: 0/13 ✅

### Tests: 22/22

- 9/9 SitemapGenerator
- 7/7 publish gate
- 6/6 promote